### PR TITLE
Image-level epoch clock: one instant across stores (#168)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Superpowers SDD scratch (ledger, briefs, reports) -- regenerable
 /.superpowers/
+
+# Local git worktrees for parallel unit work (superpowers:using-git-worktrees)
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,35 @@ between releases; cutting a release renames it to the new version and dates it.
   transaction. See docs/vivace-graph-v3-doc.org, Chapter 17, "The
   image-level system clock (optional)".
 
+- **Epoch leases and the store lifecycle journal** (#168). `clock-lease-epochs`
+  reserves a range `[start, end)` on a system clock and skips the clock past
+  it, so a store being detached can allocate offline from its own range with
+  no further coordination — the mechanism #170's shadow-generation swap will
+  use. `journal-append` / `journal-records` keep a small append-only journal
+  of store lifecycle events (`:create`, `:detach`, `:swap`, `:attach`,
+  `:retire`) beside the clock's own counter file; `attach-to-system-clock`
+  already appends an `:attach` record. `journal-records` reads with
+  `*read-eval*` bound to `nil` — the journal is data and is never evaluated.
+  Both are new, currently-unconsumed primitives that #170/#171 build a
+  restore path on. See docs/vivace-graph-v3-doc.org, Chapter 17.
+
+- **`peer-observe-epoch` observes the image clock** (#168). A pulled node
+  carries the *hub's* commit epoch; when the pulling store has a system
+  clock bound, that observation now raises the clock instead of the store's
+  own `tx-id-counter` (which a bound clock leaves dead). Without a clock the
+  original per-store counter path is unchanged. Consequence worth knowing:
+  the image clock is therefore not purely local — a peer sync on one store
+  can advance the whole image's clock, driven by another image's clock.
+
+- **Cross-store read snapshots pin every participating store** (#168).
+  `with-read-snapshot` composes by nesting, and each nested call now takes a
+  read-epoch pin on its own graph's transaction manager for the snapshot's
+  extent, so a cross-store composition ends up pinning every store it
+  touches, not just the innermost or outermost one. Named cost: a long
+  cross-store query delays reaping in every store it touched, for its full
+  duration — the intended price of a shared instant across stores, not a
+  regression.
+
 - **Registration — binding a record's geometry to a registry's regions**
   (#138). `graph-db/spacetime` gains `register-geometry` and `register-node`,
   which turn a source's `:REGISTRATION` facet into one claim per region the
@@ -194,6 +223,29 @@ between releases; cutting a release renames it to the new version and dates it.
     indexes and unique constraints".
 
 ### Fixed
+
+- **`recreate-graph` (restore/replay) minted ids from a per-store scalar,
+  bypassing both the transaction manager and any bound system clock**
+  (#168). Reached via `replay` (snapshot and backup restore) and
+  `migrate-graph`. Under a shared clock this could reissue an epoch some
+  other store had already committed at — exactly the collision a system
+  clock exists to prevent. Restore now allocates through `tm-next-epoch`,
+  which draws from the system clock when the graph has one and otherwise
+  falls back to the store's own counter (unchanged behaviour with no clock
+  bound).
+
+  **Behaviour change, independent of any clock:** the watermark restore
+  persists afterward is now the last id actually used, not one past it —
+  the old code always wasted one epoch on the trailing `+1`, including on
+  an empty snapshot, which bumped the watermark for zero work. This brings
+  `recreate-graph` in line with `apply-transaction` (which persists the id
+  it actually used) and a fresh transaction manager's own `(1+ (max ...))`
+  re-seeding; it closes a gap that was always wasted, it does not shift
+  any restored node's id. Anyone who read a restored store's persisted
+  highest-transaction-id and expected it one past the last restored id
+  will now see it one lower. Separately, under a bound clock, restored ids
+  also stop being dense from a fresh store's own zero — they draw from the
+  clock's shared, current position instead, which is the point of the fix.
 
 - **`GEOSMakeValid` returning a `GEOMETRYCOLLECTION` refused the whole
   subject** (#163). A repair that splits its input across dimensions — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **The image-level system clock** (#168). `open-system-clock` /
+  `close-system-clock` open a durable, crash-safe epoch counter shared by
+  every store attached to it, in place of each store's own per-graph
+  `transaction-id` counter. `*system-clock*` defaults to `nil`; with no
+  clock bound, `make-graph`/`open-graph` and every transaction-allocation
+  path behave exactly as before #168. `make-graph` and `open-graph` gain
+  `:system-clock` (default `*system-clock*`); attaching a store raises the
+  clock above that store's own persisted history (its highest committed
+  transaction id, and for a peer-graph, its pull-cursor too, since those
+  are distinct number spaces) so the clock can never reissue an epoch that
+  store has already used, and refuses while the store has an in-flight
+  transaction. See docs/vivace-graph-v3-doc.org, Chapter 17, "The
+  image-level system clock (optional)".
+
 - **Registration — binding a record's geometry to a registry's regions**
   (#138). `graph-db/spacetime` gains `register-geometry` and `register-node`,
   which turn a source's `:REGISTRATION` facet into one claim per region the

--- a/docs/superpowers/plans/2026-08-20-image-level-clock.md
+++ b/docs/superpowers/plans/2026-08-20-image-level-clock.md
@@ -279,6 +279,10 @@ Add to `graph-db.asd`, in `graph-db/core` components, after `"serialize"`:
                (:file "system-clock" :depends-on ("serialize" "utilities"))
 ```
 
+**⚠ `graph-db/test` does NOT `:use` `#:graph-db`.** It uses only `#:cl #:fiveam` plus an
+explicit `:import-from` list, so a new symbol is invisible in test code until it is added
+there. Export from `package.lisp` **and** import into `tests/package.lisp`.
+
 Export from `package.lisp`:
 
 ```lisp
@@ -291,6 +295,9 @@ Export from `package.lisp`:
            #:clock-observe-epoch
            #:clock-lease-epochs
 ```
+
+Add the same names to the `:import-from #:graph-db` list in `tests/package.lisp`, in a
+block commented `;; image-level epoch clock (GH #168)`.
 
 Register the test file in `graph-db.asd` under `graph-db/test`, after `"mvcc-tests"`:
 
@@ -410,7 +417,8 @@ the journal is data and must never execute."
                 collect r))))))
 ```
 
-Export `#:journal-append` and `#:journal-records` from `package.lisp`.
+Export `#:journal-append` and `#:journal-records` from `package.lisp`, and add both to
+the `:import-from` list in `tests/package.lisp`.
 
 - [ ] **Step 4: Run to verify they pass**
 
@@ -426,12 +434,13 @@ git commit -m "feat(clock): append-only lifecycle journal, read with *read-eval*
 ### Task 3: Route epoch allocation through the clock
 
 **Files:**
-- Modify: `transactions.lisp` (`assign-transaction-id`, and the three counter reads)
+- Modify: `transactions.lisp` (the counter reads and the commit-time assignment)
 - Modify: `graph.lisp` (`make-graph` / `open-graph` gain `:system-clock`)
 - Test: `tests/system-clock-tests.lisp`
 
 **Interfaces:**
-- Consumes: Task 1's clock API.
+- Consumes: Task 1's clock API **and Task 2's `JOURNAL-APPEND`** (used by
+  `ATTACH-TO-SYSTEM-CLOCK` below).
 - Produces:
   - `(tm-next-epoch transaction-manager) => (unsigned-byte 64)`
   - `(tm-current-epoch transaction-manager) => (unsigned-byte 64)`
@@ -534,7 +543,7 @@ In `graph-class.lisp`, add to `defclass graph`:
                  :initform nil)
 ```
 
-In `transactions.lisp`, replace `assign-transaction-id`'s body and add the two helpers:
+In `transactions.lisp`, add the two helpers:
 
 ```lisp
 (defun tm-next-epoch (transaction-manager)
@@ -554,13 +563,11 @@ otherwise from this manager's own counter (pre-#168 behaviour)."
     (if clock
         (clock-current-epoch clock)
         (tx-id-counter transaction-manager))))
-
-(defgeneric assign-transaction-id (transaction transaction-manager)
-  (:method (transaction transaction-manager)
-    (let ((new-id (tm-next-epoch transaction-manager)))
-      (setf (transaction-id transaction) new-id)
-      new-id)))
 ```
+
+**Do NOT touch `assign-transaction-id`.** It has zero callers — the live assignment is
+`transactions.lisp:3075`. Editing a dead generic adds diff noise and implies it is the
+live path; a separate issue tracks removing it.
 
 Replace the three counter reads with `TM-CURRENT-EPOCH`:
 
@@ -603,7 +610,7 @@ git commit -m "feat(clock): route epoch allocation through the image clock (#168
 
 ---
 
-### Task 4: Stop `restore-graph` minting its own ids
+### Task 4: Stop `recreate-graph` minting its own ids
 
 **Files:**
 - Modify: `transaction-restore.lisp:133-152`
@@ -614,54 +621,65 @@ git commit -m "feat(clock): route epoch allocation through the image clock (#168
 **This is the audit finding, and it has no test today** — which is how it survived. Write
 the failing test first.
 
-`restore-graph` currently mints ids with `(incf tx-id)` seeded from
+`recreate-graph` (`transaction-restore.lisp:116`) mints ids with `(incf tx-id)` seeded from
 `(load-highest-transaction-id graph)`, a *per-store* scalar, bypassing the transaction
 manager entirely. Under a shared clock it allocates **below** the global counter, so a
 restore mints epochs another store already committed at.
 
+It is reached by two routes — `replay` (`txn-log.lisp:47`) and the restore-from-backup path
+(`backup.lisp:290`) — so fixing it once covers both. The test drives `SNAPSHOT` + `REPLAY`,
+the real path, rather than calling the internal directly.
+
 - [ ] **Step 1: Write the failing test**
 
 ```lisp
-(test restore-allocates-from-the-image-clock
-  ;; The audit finding (GH #168): RESTORE-GRAPH minted ids from a per-store
+(test recreate-graph-allocates-from-the-image-clock
+  ;; The audit finding (GH #168): RECREATE-GRAPH minted ids from a per-store
   ;; scalar, so under a shared clock it reissued epochs another store had
-  ;; already used.
+  ;; already used.  Drives the real path: SNAPSHOT then REPLAY.
   (with-temp-directory (cdir)
     (let ((clock (open-system-clock (namestring cdir))))
       (unwind-protect
            (with-temp-directory (sdir)
-             (with-temp-directory (ddir)
-               (with-temp-directory (bdir)
-                 ;; Source store: a little history, then a snapshot.
-                 (let ((src (make-graph :sc-src (namestring sdir)
+             (with-temp-directory (odir)
+               ;; Source store: a little history, then a snapshot on disk.
+               (let ((src (make-graph :sc-src (namestring sdir)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock)))
+                 (dotimes (i 3) (with-transaction (:graph src) t))
+                 (graph-db::snapshot src)
+                 (close-graph src))
+               ;; A second store burns epochs, pushing the clock far past
+               ;; anything the restore target's own scalar knows about.
+               (let ((other (make-graph :sc-other (namestring odir)
                                         :buffer-pool-size 1000
-                                        :system-clock clock))
-                       (snap (merge-pathnames "snap.txt" bdir)))
-                   (dotimes (i 3) (with-transaction (:graph src) t))
-                   (backup src :path snap)
-                   (close-graph src))
-                 ;; A second store burns epochs, pushing the clock well past
-                 ;; anything the restore target's own scalar knows about.
-                 (let ((other (make-graph :sc-other (namestring ddir)
-                                          :buffer-pool-size 1000
-                                          :system-clock clock)))
-                   (dotimes (i 50) (with-transaction (:graph other) t))
-                   (let ((floor-epoch (clock-current-epoch clock)))
-                     (with-temp-directory (rdir)
-                       (let ((dst (make-graph :sc-dst (namestring rdir)
-                                              :buffer-pool-size 1000
-                                              :system-clock clock)))
-                         (restore-graph dst
-                                        (merge-pathnames "snap.txt" bdir)
-                                        :package-name "GRAPH-DB/TEST")
-                         ;; Every id the restore issued must sit above the
-                         ;; clock's position when it started.
-                         (is (>= (load-highest-transaction-id dst)
-                                 floor-epoch))
-                         (close-graph dst))))
-                   (close-graph other)))))
+                                        :system-clock clock)))
+                 (dotimes (i 50) (with-transaction (:graph other) t))
+                 (let ((floor-epoch (clock-current-epoch clock)))
+                   (with-temp-directory (rdir)
+                     (let ((dst (make-graph :sc-dst (namestring rdir)
+                                            :buffer-pool-size 1000
+                                            :system-clock clock)))
+                       (graph-db::replay
+                        dst
+                        (graph-db::persistent-transaction-directory
+                         (lookup-graph :sc-src))
+                        "GRAPH-DB/TEST")
+                       ;; Every id the replay issued sits above the clock's
+                       ;; position when it started.
+                       (is (>= (graph-db::load-highest-transaction-id dst)
+                               floor-epoch))
+                       (close-graph dst))))
+                 (close-graph other))))
         (close-system-clock clock)))))
 ```
+
+**Note for the implementer:** `SNAPSHOT`, `REPLAY`, `LOAD-HIGHEST-TRANSACTION-ID` and
+`PERSISTENT-TRANSACTION-DIRECTORY` are internals — reach them with `graph-db::`, matching
+`tests/backup-tests.lisp`. If threading the source graph's txn-log directory to the
+replay proves awkward, copying the `snap-*` file into the destination's txn-log directory
+and replaying from there is an acceptable equivalent; what the test must pin is that the
+ids issued during replay are `>= floor-epoch`.
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -669,7 +687,8 @@ Expected: FAIL — the restored ids start near 0, well below `floor-epoch`.
 
 - [ ] **Step 3: Implement**
 
-In `transaction-restore.lisp`, replace the local `tx-id` allocator:
+In `transaction-restore.lisp`, inside `RECREATE-GRAPH`, replace the local `tx-id`
+allocator:
 
 ```lisp
         (tx-id nil)
@@ -696,14 +715,15 @@ and the trailing persist:
 
 - [ ] **Step 4: Run to verify it passes**
 
-Then the full suites, including the NIL path — `restore-graph` with no clock must still
-produce ascending ids from the store's own counter.
+Then the full suites, including the NIL path — `recreate-graph` with no clock must still
+produce ascending ids from the store's own counter. `backup-tests` and any replay test are
+the existing coverage of that branch.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add transaction-restore.lisp tests/system-clock-tests.lisp
-git commit -m "fix(clock): restore-graph allocates from the manager (#168)"
+git commit -m "fix(clock): recreate-graph allocates from the manager (#168)"
 ```
 
 ---
@@ -865,7 +885,7 @@ that **the clock is not purely local** because `peer-observe-epoch` admits forei
 
 - [ ] **Step 2: CHANGELOG entry**
 
-Note the new exports, the NIL default, and the `restore-graph` fix as a **behaviour
+Note the new exports, the NIL default, and the `recreate-graph` fix as a **behaviour
 change for anyone who was relying on restore's ids being dense from zero**.
 
 - [ ] **Step 3: Mark §6 of the spec implemented**, leaving the epoch-density audit result

--- a/docs/superpowers/plans/2026-08-20-image-level-clock.md
+++ b/docs/superpowers/plans/2026-08-20-image-level-clock.md
@@ -1,0 +1,929 @@
+# Image-Level Clock Implementation Plan (#168)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give an image one snapshot clock, so a query spanning stores resolves at one
+instant, without changing the behaviour of any existing consumer.
+
+**Architecture:** A new `SYSTEM-CLOCK` object owns a durable 64-bit epoch counter and an
+append-only lifecycle journal, both in one directory. `*SYSTEM-CLOCK*` is NIL by default,
+in which case every store keeps its own counter and behaviour is byte-for-byte what it is
+today. When a clock is bound, a store attaching to it raises the clock above that store's
+own history (this *is* the watermark, computed incrementally rather than as a migration
+step) and all epoch allocation routes through the clock.
+
+**Tech Stack:** SBCL 2.6.6, ASDF, FiveAM. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-namespaces-design.md` §6 and §9.1.
+Decision log: `docs/namespace-design-decisions-2026-08-20.md` D9.
+
+## Global Constraints
+
+- **Lisp style: spaces only, never tabs. Hard limit 80 columns** — code, comments,
+  docstrings and strings alike. A 96-column line is a defect.
+- **Comments are terse and point elsewhere.** State the non-obvious fact in a line or
+  two and reference the spec section or issue. Do not narrate reasoning in source.
+- **`*SYSTEM-CLOCK*` NIL must preserve today's behaviour exactly.** This is the
+  backward-compatibility hinge: every existing consumer and all 3684 core checks run with
+  it unbound. Any task that changes behaviour in the NIL case is wrong.
+- **Epochs are 64-bit and never reused.** An id issued must never be issued again, across
+  crashes.
+- **Baseline to preserve:** `graph-db/test` 3684 checks (3674 pass, 10 skip, 0 fail),
+  `graph-db/spacetime-test` 342, `graph-db/geos-test` 185. Verified green on this branch
+  at `6a7623a`.
+- **Run tests from this worktree, not the main checkout.** `graph-db.asd` is symlinked
+  into `~/quicklisp/local-projects` from the main checkout, so a naive load silently tests
+  the wrong tree. Use the runner in `docs/superpowers/plans/` §Testing below, which
+  asserts the resolved source directory.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `system-clock.lisp` (new) | The clock: durable counter, block reservation, leases, journal. No graph dependency. |
+| `graph-db.asd` | Register `system-clock` before `transactions`; register the new test file. |
+| `transactions.lisp` | Route epoch allocation through the clock when one is bound. |
+| `transaction-restore.lisp` | Stop minting ids from a per-store scalar (the audit finding). |
+| `graph.lisp` | `:system-clock` keyword on `make-graph` / `open-graph`; attach on open. |
+| `tests/system-clock-tests.lisp` (new) | The clock in isolation, then wired to graphs. |
+
+`system-clock.lisp` depends only on `utilities` (locks), `serialize` (uint64 codecs) and
+`posix`. It must **not** depend on `graph`, so it can be tested without one.
+
+---
+
+### Task 1: The clock object — durable, monotonic, crash-safe
+
+**Files:**
+- Create: `system-clock.lisp`
+- Modify: `graph-db.asd` (add component after `"serialize"`, before `"graph-class"`)
+- Test: `tests/system-clock-tests.lisp`
+
+**Interfaces:**
+- Produces:
+  - `(open-system-clock location &key (block-size 4096)) => system-clock`
+  - `(close-system-clock clock) => clock`
+  - `(clock-next-epoch clock) => (unsigned-byte 64)` — allocates and returns a fresh epoch
+  - `(clock-current-epoch clock) => (unsigned-byte 64)` — next id that would be issued
+  - `(clock-observe-epoch clock epoch) => (unsigned-byte 64)` — Lamport max, idempotent
+  - `(clock-lease-epochs clock n) => (values start end)` — reserves `[start, end)`
+  - `*system-clock*` — special, initform NIL
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+;;;; The image-level epoch clock (GH #168).  See
+;;;; docs/superpowers/specs/2026-08-20-namespaces-design.md §6.
+(in-package #:graph-db/test)
+
+(def-suite system-clock-suite :in graph-db-suite
+  :description "The image-level epoch clock and its journal.")
+(in-suite system-clock-suite)
+
+(test clock-issues-monotonic-epochs
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((a (clock-next-epoch c))
+                 (b (clock-next-epoch c))
+                 (d (clock-next-epoch c)))
+             (is (< a b d)))
+        (close-system-clock c)))))
+
+(test clock-current-epoch-is-the-next-id
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((seen (clock-current-epoch c)))
+             (is (= seen (clock-next-epoch c)))
+             (is (= (1+ seen) (clock-current-epoch c))))
+        (close-system-clock c)))))
+
+(test clock-observe-epoch-is-a-max
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (clock-observe-epoch c 5000)
+             (is (> (clock-next-epoch c) 5000))
+             ;; A lower observation must not move it backwards.
+             (let ((before (clock-current-epoch c)))
+               (clock-observe-epoch c 10)
+               (is (= before (clock-current-epoch c)))))
+        (close-system-clock c)))))
+
+(test clock-survives-clean-reopen-without-reissuing
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir)))
+           (last (progn (dotimes (i 10) (clock-next-epoch c))
+                        (clock-next-epoch c))))
+      (close-system-clock c)
+      (let ((c2 (open-system-clock (namestring dir))))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) last))
+          (close-system-clock c2))))))
+
+(test clock-survives-crash-without-reissuing
+  ;; No CLOSE-SYSTEM-CLOCK: simulates a crash after ids were handed out.  The
+  ;; block reservation on disk must already dominate every issued id.
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir) :block-size 8))
+           (issued (loop repeat 5 collect (clock-next-epoch c)))
+           (highest (reduce #'max issued)))
+      (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) highest))
+          (close-system-clock c2))))))
+
+(test clock-lease-is-disjoint-and-advances-the-clock
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (multiple-value-bind (start end) (clock-lease-epochs c 1000)
+             (is (= 1000 (- end start)))
+             ;; The clock has skipped the whole lease: nothing it issues now
+             ;; can collide with an id the lease holder allocates.
+             (is (>= (clock-next-epoch c) end)))
+        (close-system-clock c)))))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: see §Testing. Expected: FAIL — `OPEN-SYSTEM-CLOCK` is undefined.
+
+- [ ] **Step 3: Implement the clock**
+
+```lisp
+(in-package :graph-db)
+
+;;; The image-level epoch clock (GH #168).  One clock per *system* -- a
+;;; directory of stores -- rather than one per store, so a query spanning
+;;; stores resolves at one instant.  See
+;;; docs/superpowers/specs/2026-08-20-namespaces-design.md §6.
+
+(defvar *system-clock* nil
+  "The image's SYSTEM-CLOCK, or NIL.  NIL means every store keeps its own
+transaction-id counter, which is the pre-#168 behaviour and the default.")
+
+(defstruct (system-clock (:constructor %make-system-clock))
+  (location nil)
+  ;; Next epoch to hand out.  In memory; CEILING is what disk guarantees.
+  (counter 0 :type (unsigned-byte 64))
+  ;; Disk holds this value; every issued id is strictly below it.  A crash
+  ;; therefore cannot reissue: reopen resumes at the persisted ceiling.
+  (ceiling 0 :type (unsigned-byte 64))
+  (block-size 4096 :type (unsigned-byte 32))
+  (lock (make-recursive-lock "system clock"))
+  (journal nil))
+
+(defun %clock-counter-file (location)
+  (make-pathname :name "system-clock" :type "dat" :defaults location))
+
+(defun %write-clock-ceiling (clock value)
+  "Persist VALUE as the durable ceiling.  Every id issued is < VALUE."
+  (let ((buf (make-byte-vector 8)))
+    (serialize-uint64 buf value 0)
+    (with-open-file (s (%clock-counter-file (system-clock-location clock))
+                       :direction :output
+                       :element-type '(unsigned-byte 8)
+                       :if-does-not-exist :create
+                       :if-exists :supersede)
+      (write-sequence buf s)
+      (finish-output s)))
+  (setf (system-clock-ceiling clock) value))
+
+(defun %read-clock-ceiling (location)
+  (let ((file (%clock-counter-file location))
+        (buf (make-byte-vector 8)))
+    (if (probe-file file)
+        (with-open-file (s file :direction :input
+                                :element-type '(unsigned-byte 8))
+          (unless (= 8 (read-sequence buf s))
+            (error "Short read from ~A" file))
+          (deserialize-uint64 buf 0))
+        0)))
+
+(defun open-system-clock (location &key (block-size 4096))
+  "Open or create the system clock in directory LOCATION.  Ids resume above
+the persisted ceiling, so a crash never reissues one."
+  (ensure-directories-exist location)
+  (let* ((ceiling (%read-clock-ceiling location))
+         (clock (%make-system-clock :location location
+                                    :counter ceiling
+                                    :ceiling ceiling
+                                    :block-size block-size)))
+    (%write-clock-ceiling clock (+ ceiling block-size))
+    (setf (system-clock-counter clock) ceiling)
+    clock))
+
+(defun close-system-clock (clock)
+  "Persist the exact counter so a clean reopen wastes no ids."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (%write-clock-ceiling clock (system-clock-counter clock))
+    (when (system-clock-journal clock)
+      (close (system-clock-journal clock))
+      (setf (system-clock-journal clock) nil)))
+  clock)
+
+(defun %clock-reserve (clock needed)
+  "Raise the durable ceiling so COUNTER + NEEDED stays below it.  Caller
+holds the lock."
+  (let ((target (+ (system-clock-counter clock) needed)))
+    (when (>= target (system-clock-ceiling clock))
+      (%write-clock-ceiling
+       clock (+ target (system-clock-block-size clock))))))
+
+(defun clock-next-epoch (clock)
+  "Allocate and return a fresh epoch."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (%clock-reserve clock 1)
+    (prog1 (system-clock-counter clock)
+      (incf (system-clock-counter clock)))))
+
+(defun clock-current-epoch (clock)
+  "The next epoch CLOCK-NEXT-EPOCH would return."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (system-clock-counter clock)))
+
+(defun clock-observe-epoch (clock epoch)
+  "Raise CLOCK so it strictly exceeds EPOCH.  Monotonic and idempotent; a
+lower EPOCH is a no-op.  Foreign epochs reach here from peer sync, so the
+clock is not purely local -- see spec §6."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (when (and epoch (>= epoch (system-clock-counter clock)))
+      (setf (system-clock-counter clock) (1+ epoch))
+      (%clock-reserve clock 0))
+    (system-clock-counter clock)))
+
+(defun clock-lease-epochs (clock n)
+  "Reserve N epochs for a detached store and skip the clock past them.
+Returns (values START END); the holder allocates in [START, END)."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (%clock-reserve clock n)
+    (let* ((start (system-clock-counter clock))
+           (end (+ start n)))
+      (setf (system-clock-counter clock) end)
+      (%clock-reserve clock 0)
+      (values start end))))
+```
+
+Add to `graph-db.asd`, in `graph-db/core` components, after `"serialize"`:
+
+```lisp
+               ;; The image-level epoch clock (GH #168).  No graph dependency,
+               ;; so it loads early and tests without one.
+               (:file "system-clock" :depends-on ("serialize" "utilities"))
+```
+
+Export from `package.lisp`:
+
+```lisp
+           #:*system-clock*
+           #:system-clock
+           #:open-system-clock
+           #:close-system-clock
+           #:clock-next-epoch
+           #:clock-current-epoch
+           #:clock-observe-epoch
+           #:clock-lease-epochs
+```
+
+Register the test file in `graph-db.asd` under `graph-db/test`, after `"mvcc-tests"`:
+
+```lisp
+               (:file "system-clock-tests")       ; GH #168
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Expected: 6 new checks pass; the three suites stay at their baseline counts plus these.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add system-clock.lisp tests/system-clock-tests.lisp graph-db.asd package.lisp
+git commit -m "feat(clock): durable image-level epoch clock with leases (#168)"
+```
+
+---
+
+### Task 2: The lifecycle journal
+
+**Files:**
+- Modify: `system-clock.lisp`
+- Test: `tests/system-clock-tests.lisp`
+
+**Interfaces:**
+- Consumes: `system-clock` from Task 1.
+- Produces:
+  - `(journal-append clock kind &rest plist) => plist` — appends one record
+  - `(journal-records clock) => list of plists`, oldest first
+
+Records are read with `*READ-EVAL*` NIL. Units 5 and 6 (#170, #171) consume this; it
+lands here because §6 requires the object regardless.
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+(test journal-appends-and-reads-back
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (journal-append c :detach :store :alpha :lease-start 10 :lease-end 20)
+             (journal-append c :attach :store :alpha)
+             (let ((rs (journal-records c)))
+               (is (= 2 (length rs)))
+               (is (eq :detach (getf (first rs) :kind)))
+               (is (eq :alpha (getf (first rs) :store)))
+               (is (eq :attach (getf (second rs) :kind)))))
+        (close-system-clock c)))))
+
+(test journal-survives-reopen
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :beta)
+      (close-system-clock c))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (is (equal '(:create) (mapcar (lambda (r) (getf r :kind))
+                                         (journal-records c2))))
+        (close-system-clock c2)))))
+
+(test journal-refuses-to-evaluate-on-read
+  ;; A journal is data.  Reading it must never evaluate.
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append
+                       :if-does-not-exist :create)
+      (format s "(:kind :bogus :value #.(error \"evaluated\"))~%"))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (signals error (journal-records c2))
+        (close-system-clock c2)))))
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Expected: FAIL — `JOURNAL-APPEND` is undefined.
+
+- [ ] **Step 3: Implement**
+
+```lisp
+(defun %clock-journal-file (location)
+  (make-pathname :name "system-journal" :type "log" :defaults location))
+
+(defun journal-append (clock kind &rest plist)
+  "Append one lifecycle record.  KIND is :CREATE :DETACH :SWAP :ATTACH or
+:RETIRE.  Consumed by #170 and #171."
+  (let ((record (list* :kind kind :epoch (clock-current-epoch clock) plist)))
+    (with-recursive-lock-held ((system-clock-lock clock))
+      (unless (system-clock-journal clock)
+        (setf (system-clock-journal clock)
+              (open (%clock-journal-file (system-clock-location clock))
+                    :direction :output
+                    :if-exists :append
+                    :if-does-not-exist :create)))
+      (let ((s (system-clock-journal clock)))
+        (let ((*print-readably* nil) (*print-pretty* nil))
+          (format s "~S~%" record))
+        (finish-output s)))
+    record))
+
+(defun journal-records (clock)
+  "Every lifecycle record, oldest first.  Read with evaluation disabled --
+the journal is data and must never execute."
+  (let ((file (%clock-journal-file (system-clock-location clock))))
+    (when (system-clock-journal clock)
+      (finish-output (system-clock-journal clock)))
+    (when (probe-file file)
+      (with-open-file (s file :direction :input)
+        (let ((*read-eval* nil))
+          (loop for r = (read s nil :eof)
+                until (eq r :eof)
+                collect r))))))
+```
+
+Export `#:journal-append` and `#:journal-records` from `package.lisp`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add system-clock.lisp tests/system-clock-tests.lisp package.lisp
+git commit -m "feat(clock): append-only lifecycle journal, read with *read-eval* nil (#168)"
+```
+
+---
+
+### Task 3: Route epoch allocation through the clock
+
+**Files:**
+- Modify: `transactions.lisp` (`assign-transaction-id`, and the three counter reads)
+- Modify: `graph.lisp` (`make-graph` / `open-graph` gain `:system-clock`)
+- Test: `tests/system-clock-tests.lisp`
+
+**Interfaces:**
+- Consumes: Task 1's clock API.
+- Produces:
+  - `(tm-next-epoch transaction-manager) => (unsigned-byte 64)`
+  - `(tm-current-epoch transaction-manager) => (unsigned-byte 64)`
+  - `(attach-to-system-clock graph clock)` — raises the clock above this store's
+    persisted highest id. This *is* the watermark of spec §6, applied per store at
+    attach rather than as a separate migration pass.
+  - `graph` gains a `system-clock` slot, initform NIL.
+
+**⚠ The NIL case must not change.** With no clock, `TM-NEXT-EPOCH` must be exactly the
+old `(prog1 counter (incf counter))`.
+
+**Note for the reviewer:** `start-tx-id` and `finish-tx-id` widen numerically under a
+shared clock, because other stores consume epochs inside the window. That is expected and
+harmless: `OVERLAPPING-TRANSACTIONS` filters *this store's* committed set by comparison,
+so a wider numeric window covers the same transactions. It is not a correctness change.
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+(test two-stores-on-one-clock-get-disjoint-ordered-epochs
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let ((ga (make-graph :sc-alpha (namestring da)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock))
+                     (gb (make-graph :sc-beta (namestring db)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock)))
+                 (unwind-protect
+                      (let ((ids '()))
+                        (dotimes (i 3)
+                          (push (transaction-id
+                                 (with-transaction (:graph ga)
+                                   *transaction*))
+                                ids)
+                          (push (transaction-id
+                                 (with-transaction (:graph gb)
+                                   *transaction*))
+                                ids))
+                        (let ((sorted (sort (copy-list ids) #'<)))
+                          ;; No two transactions anywhere share an epoch.
+                          (is (= (length sorted)
+                                 (length (remove-duplicates sorted))))))
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock)))))
+
+(test no-clock-means-per-store-counters-unchanged
+  ;; The backward-compatibility hinge: with *SYSTEM-CLOCK* nil and no
+  ;; :SYSTEM-CLOCK argument, two graphs allocate independently, exactly as
+  ;; before #168 -- so both start low and their ids DO collide.
+  (with-temp-directory (da)
+    (with-temp-directory (db)
+      (let ((ga (make-graph :sc-gamma (namestring da) :buffer-pool-size 1000))
+            (gb (make-graph :sc-delta (namestring db) :buffer-pool-size 1000)))
+        (unwind-protect
+             (let ((ia (transaction-id (with-transaction (:graph ga)
+                                         *transaction*)))
+                   (ib (transaction-id (with-transaction (:graph gb)
+                                         *transaction*))))
+               (is (= ia ib)))
+          (close-graph ga)
+          (close-graph gb))))))
+
+(test attaching-a-store-raises-the-clock-above-its-history
+  ;; The watermark: a store with existing history must not hand the clock a
+  ;; reason to reissue an epoch that store already used.
+  (with-temp-directory (cdir)
+    (with-temp-directory (gdir)
+      (let ((g (make-graph :sc-eps (namestring gdir) :buffer-pool-size 1000)))
+        (dotimes (i 5) (with-transaction (:graph g) t))
+        (let ((highest (load-highest-transaction-id g)))
+          (close-graph g)
+          (let ((clock (open-system-clock (namestring cdir))))
+            (unwind-protect
+                 (let ((g2 (open-graph :sc-eps (namestring gdir)
+                                       :buffer-pool-size 1000
+                                       :system-clock clock)))
+                   (unwind-protect
+                        (is (> (clock-current-epoch clock) highest))
+                     (close-graph g2)))
+              (close-system-clock clock))))))))
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Expected: FAIL — `MAKE-GRAPH` does not accept `:SYSTEM-CLOCK`.
+
+- [ ] **Step 3: Implement**
+
+In `graph-class.lisp`, add to `defclass graph`:
+
+```lisp
+   ;; The image-level epoch clock (GH #168), or NIL for this store's own
+   ;; counter.  NIL is the pre-#168 behaviour and the default.
+   (system-clock :accessor graph-system-clock :initarg :system-clock
+                 :initform nil)
+```
+
+In `transactions.lisp`, replace `assign-transaction-id`'s body and add the two helpers:
+
+```lisp
+(defun tm-next-epoch (transaction-manager)
+  "Allocate a fresh epoch: from the image clock when the graph has one,
+otherwise from this manager's own counter (pre-#168 behaviour)."
+  (let ((clock (and (slot-boundp transaction-manager 'graph)
+                    (graph-system-clock (graph transaction-manager)))))
+    (if clock
+        (clock-next-epoch clock)
+        (prog1 (tx-id-counter transaction-manager)
+          (incf (tx-id-counter transaction-manager))))))
+
+(defun tm-current-epoch (transaction-manager)
+  "The next epoch TM-NEXT-EPOCH would return."
+  (let ((clock (and (slot-boundp transaction-manager 'graph)
+                    (graph-system-clock (graph transaction-manager)))))
+    (if clock
+        (clock-current-epoch clock)
+        (tx-id-counter transaction-manager))))
+
+(defgeneric assign-transaction-id (transaction transaction-manager)
+  (:method (transaction transaction-manager)
+    (let ((new-id (tm-next-epoch transaction-manager)))
+      (setf (transaction-id transaction) new-id)
+      new-id)))
+```
+
+Replace the three counter reads with `TM-CURRENT-EPOCH`:
+
+- `transactions.lisp:644` — `(let ((epoch (tx-id-counter transaction-manager)))`
+- `transactions.lisp:2944` — `:start-tx-id (tx-id-counter transaction-manager)`
+- `transactions.lisp:3049` — `(setf (finish-tx-id tx) (tx-id-counter tm))`
+
+And the commit-time assignment at `transactions.lisp:3075-3076`:
+
+```lisp
+               (setf (transaction-id tx) (tm-next-epoch tm))
+```
+
+Add the attach helper:
+
+```lisp
+(defun attach-to-system-clock (graph clock)
+  "Raise CLOCK above GRAPH's persisted highest id and record the attach.
+This is the spec §6 watermark, applied per store at attach rather than as a
+separate migration pass."
+  (setf (graph-system-clock graph) clock)
+  (clock-observe-epoch clock (load-highest-transaction-id graph))
+  (journal-append clock :attach :store (graph-name graph))
+  graph)
+```
+
+In `graph.lisp`, add `system-clock` to both lambda lists (defaulting to `*system-clock*`)
+and call `attach-to-system-clock` after the transaction manager exists in each.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Also run the full three suites: the NIL path must leave 3684 / 342 / 185 unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add transactions.lisp graph.lisp graph-class.lisp tests/system-clock-tests.lisp
+git commit -m "feat(clock): route epoch allocation through the image clock (#168)"
+```
+
+---
+
+### Task 4: Stop `restore-graph` minting its own ids
+
+**Files:**
+- Modify: `transaction-restore.lisp:133-152`
+- Test: `tests/system-clock-tests.lisp`
+
+**Interfaces:** Consumes `TM-NEXT-EPOCH` from Task 3.
+
+**This is the audit finding, and it has no test today** — which is how it survived. Write
+the failing test first.
+
+`restore-graph` currently mints ids with `(incf tx-id)` seeded from
+`(load-highest-transaction-id graph)`, a *per-store* scalar, bypassing the transaction
+manager entirely. Under a shared clock it allocates **below** the global counter, so a
+restore mints epochs another store already committed at.
+
+- [ ] **Step 1: Write the failing test**
+
+```lisp
+(test restore-allocates-from-the-image-clock
+  ;; The audit finding (GH #168): RESTORE-GRAPH minted ids from a per-store
+  ;; scalar, so under a shared clock it reissued epochs another store had
+  ;; already used.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (sdir)
+             (with-temp-directory (ddir)
+               (with-temp-directory (bdir)
+                 ;; Source store: a little history, then a snapshot.
+                 (let ((src (make-graph :sc-src (namestring sdir)
+                                        :buffer-pool-size 1000
+                                        :system-clock clock))
+                       (snap (merge-pathnames "snap.txt" bdir)))
+                   (dotimes (i 3) (with-transaction (:graph src) t))
+                   (backup src :path snap)
+                   (close-graph src))
+                 ;; A second store burns epochs, pushing the clock well past
+                 ;; anything the restore target's own scalar knows about.
+                 (let ((other (make-graph :sc-other (namestring ddir)
+                                          :buffer-pool-size 1000
+                                          :system-clock clock)))
+                   (dotimes (i 50) (with-transaction (:graph other) t))
+                   (let ((floor-epoch (clock-current-epoch clock)))
+                     (with-temp-directory (rdir)
+                       (let ((dst (make-graph :sc-dst (namestring rdir)
+                                              :buffer-pool-size 1000
+                                              :system-clock clock)))
+                         (restore-graph dst
+                                        (merge-pathnames "snap.txt" bdir)
+                                        :package-name "GRAPH-DB/TEST")
+                         ;; Every id the restore issued must sit above the
+                         ;; clock's position when it started.
+                         (is (>= (load-highest-transaction-id dst)
+                                 floor-epoch))
+                         (close-graph dst))))
+                   (close-graph other)))))
+        (close-system-clock clock)))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — the restored ids start near 0, well below `floor-epoch`.
+
+- [ ] **Step 3: Implement**
+
+In `transaction-restore.lisp`, replace the local `tx-id` allocator:
+
+```lisp
+        (tx-id nil)
+```
+
+and inside `do-snapshot-sexps`:
+
+```lisp
+      ;; Allocate through the transaction manager, not a per-store scalar:
+      ;; under an image clock (GH #168) a local counter reissues epochs
+      ;; another store already used.
+      (let* ((tm (transaction-manager graph))
+             (*transaction* (make-instance 'restore-transaction
+                                           :transaction-id
+                                           (setf tx-id (tm-next-epoch tm)))))
+```
+
+and the trailing persist:
+
+```lisp
+    (when tx-id
+      (persist-highest-transaction-id tx-id graph))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Then the full suites, including the NIL path — `restore-graph` with no clock must still
+produce ascending ids from the store's own counter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add transaction-restore.lisp tests/system-clock-tests.lisp
+git commit -m "fix(clock): restore-graph allocates from the manager (#168)"
+```
+
+---
+
+### Task 5: `peer-observe-epoch` observes the image clock
+
+**Files:**
+- Modify: `transactions.lisp:2413-2429`
+- Test: `tests/system-clock-tests.lisp`
+
+**Interfaces:** Consumes Task 1's `CLOCK-OBSERVE-EPOCH`.
+
+A pulled node carries a *foreign* image's epoch. With a clock bound, the observation must
+raise the clock, not this store's dead counter — otherwise a later local edit opens below
+the pulled node's epoch and MVCC hides it, which is the exact bug the function exists to
+prevent.
+
+- [ ] **Step 1: Write the failing test**
+
+```lisp
+(test peer-observe-epoch-raises-the-image-clock
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (gdir)
+             (let ((g (make-graph :sc-peer (namestring gdir)
+                                  :buffer-pool-size 1000
+                                  :peer-role :device
+                                  :system-clock clock)))
+               (unwind-protect
+                    (progn
+                      (peer-observe-epoch g 999999)
+                      (is (> (clock-current-epoch clock) 999999)))
+                 (close-graph g))))
+        (close-system-clock clock)))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — the clock is untouched; only `tx-id-counter` moved.
+
+- [ ] **Step 3: Implement**
+
+```lisp
+  (when (and epoch (> epoch 0) (typep graph 'peer-graph))
+    (let ((clock (graph-system-clock graph)))
+      (if clock
+          ;; A pulled node carries the HUB's epoch -- a foreign image's clock.
+          ;; So the image clock is not purely local; see spec §6.
+          (clock-observe-epoch clock epoch)
+          (let ((tm (transaction-manager graph)))
+            (with-recursive-lock-held ((lock tm))
+              (when (>= epoch (tx-id-counter tm))
+                (setf (tx-id-counter tm) (1+ epoch))))))))
+  graph)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+The peer suites (`peer-lamport-tests`, `peer-conflict-tests`, `peer-rehome-tests`) must
+stay green — they run with no clock, so they exercise the fallback branch.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add transactions.lisp tests/system-clock-tests.lisp
+git commit -m "feat(clock): peer-observe-epoch raises the image clock when one is bound (#168)"
+```
+
+---
+
+### Task 6: Cross-store read snapshots pin every participating store
+
+**Files:**
+- Modify: `transactions.lisp` (`call-with-read-snapshot`, ~2971-3010)
+- Test: `tests/system-clock-tests.lisp`
+
+**Interfaces:** Consumes Task 3.
+
+`WITH-READ-SNAPSHOT` composes across graphs today, each internally consistent, with
+deliberately no common instant. With a clock there *is* a common instant — but the
+reaper in store B must not free a version store A's snapshot could still dereference. So
+a cross-store snapshot registers a read pin with every participating store.
+
+**Named cost (spec §6):** a long cross-store query delays reaping in every store it
+touched. That is the intended trade, not a regression.
+
+- [ ] **Step 1: Write the failing test**
+
+```lisp
+(test cross-store-snapshot-pins-every-store
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let ((ga (make-graph :sc-pin-a (namestring da)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock))
+                     (gb (make-graph :sc-pin-b (namestring db)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock)))
+                 (unwind-protect
+                      (with-read-snapshot (ga)
+                        (with-read-snapshot (gb)
+                          ;; Both managers hold a pin for this reader.
+                          (is (plusp (hash-table-count
+                                      (read-pins
+                                       (transaction-manager ga)))))
+                          (is (plusp (hash-table-count
+                                      (read-pins
+                                       (transaction-manager gb)))))))
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock)))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — only the innermost graph is pinned.
+
+- [ ] **Step 3: Implement**
+
+In `call-with-read-snapshot`, take a read pin on the graph being snapshotted for the
+dynamic extent of the snapshot, releasing it in the same `unwind-protect` that removes
+the `*read-snapshots*` entry. Keep the existing inheritance short-circuits: an enclosing
+read-write transaction on that graph, or an existing snapshot of it, still returns
+without adding a second pin.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Watch `mvcc-tests` and `multi-graph-tests` particularly — they exercise reaping and
+composed snapshots.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add transactions.lisp tests/system-clock-tests.lisp
+git commit -m "feat(clock): a cross-store snapshot pins every participating store (#168)"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `docs/vivace-graph-v3-doc.org` (new section after "Multiple Graphs in One Image")
+- Modify: `CHANGELOG.md`
+- Modify: `docs/superpowers/specs/2026-08-20-namespaces-design.md` (§6 status)
+
+Docs travel with the code; this task is not optional.
+
+- [ ] **Step 1: Manual section**
+
+Cover: what a system is; `*SYSTEM-CLOCK*` NIL is the default and preserves pre-#168
+behaviour; how to open a clock and attach stores; the watermark and its one stated
+limitation (you cannot snapshot into the pre-migration past across stores); leases; and
+that **the clock is not purely local** because `peer-observe-epoch` admits foreign epochs.
+
+- [ ] **Step 2: CHANGELOG entry**
+
+Note the new exports, the NIL default, and the `restore-graph` fix as a **behaviour
+change for anyone who was relying on restore's ids being dense from zero**.
+
+- [ ] **Step 3: Mark §6 of the spec implemented**, leaving the epoch-density audit result
+in place as the record of why no density work was needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ CHANGELOG.md
+git commit -m "docs(clock): document the image-level clock, leases and the watermark (#168)"
+```
+
+---
+
+## Testing
+
+Every run must assert it loaded the worktree, not the main checkout — `graph-db.asd` is
+symlinked into `~/quicklisp/local-projects` from the main checkout, and a naive load
+silently tests the wrong tree.
+
+```lisp
+(require :asdf)
+(load "~/quicklisp/setup.lisp")
+(asdf:initialize-source-registry
+ '(:source-registry (:directory "<worktree>/") :inherit-configuration))
+(dolist (s '(:graph-db :graph-db/test)) (asdf:clear-system s))
+(let ((dir (namestring (asdf:system-source-directory (asdf:find-system :graph-db)))))
+  (unless (search "168-image-level-clock" dir)
+    (format *error-output* "~&FATAL: ~a is not the worktree~%" dir)
+    (uiop:quit 2)))
+(asdf:test-system :graph-db/test)
+```
+
+Full suite is ~15 minutes and exceeds the default Bash timeout — run it in the
+background and poll the log. **Never run two SBCL builds at once**; they contend on the
+FASL cache.
+
+Single suite while iterating:
+
+```lisp
+(fiveam:run! 'graph-db/test::system-clock-suite)
+```
+
+## Self-Review
+
+**Spec coverage.** §6's five bullets map to Tasks 1 (clock, leases), 2 (journal), 3
+(image-level not store-level, watermark), 5 (foreign epochs), 6 (cross-store pins). §9.1's
+journal is Task 2. The audit finding is Task 4. §6's density audit needs no task — it
+came back clean.
+
+**Not in scope, deliberately:** the shadow swap (#170) and restore retention/manifest
+(#171) consume the journal but are separate units. Two-phase commit (#93) stays deferred.
+
+**Type consistency.** `CLOCK-NEXT-EPOCH` / `CLOCK-CURRENT-EPOCH` / `CLOCK-OBSERVE-EPOCH` /
+`CLOCK-LEASE-EPOCHS` are used with those names in Tasks 3, 4 and 5. `TM-NEXT-EPOCH` and
+`TM-CURRENT-EPOCH` are defined in Task 3 and consumed in Task 4. `GRAPH-SYSTEM-CLOCK` is
+defined in Task 3 and consumed in Task 5.
+
+**Risk to watch.** Task 3 touches the hottest path in the engine. The NIL branch must be
+identical to today's code, and the three suites at their exact baseline counts are the
+evidence. If any count moves, stop rather than adjusting the baseline.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -184,6 +184,14 @@ wrong answer, and the fallback is the full sweep.
 
 ## 6. Time
 
+**Status: implemented (#168).** `system-clock.lisp` (clock, leases,
+journal), `attach-to-system-clock` (watermark), `peer-observe-epoch`
+(foreign epochs), `recreate-graph` (restore no longer bypasses it), and
+the cross-store pin in `call-with-read-snapshot` cover every bullet
+below. User-facing docs: `docs/vivace-graph-v3-doc.org`, Chapter 17,
+starting at "The image-level system clock (optional)". The bullets below
+are kept as the original design record, including the audit finding.
+
 One image-level clock (#94), adopted now rather than deferred: co-locating things that share
 invariants makes cross-store skew rarer, not impossible, and the failure mode is silently
 wrong derived data whose provenance does not record the skew.
@@ -220,6 +228,8 @@ wrong derived data whose provenance does not record the skew.
   this section exists to prevent, arriving through the back door. **Re-pointing it at the
   global clock is in scope for the unit.** This is load-bearing, not incidental — logical
   replay is the proven per-store recovery path and §9 depends on restore semantics.
+  **Done** — `recreate-graph` now allocates through `tm-next-epoch`, same
+  as every other path.
 - **Stated property, not a surprise: the global clock is not purely local.**
   `peer-observe-epoch` advances the counter to strictly exceed a *foreign* epoch carried by
   a pulled node — another image's clock. Under a per-graph counter that was local

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -206,9 +206,30 @@ wrong derived data whose provenance does not record the skew.
 - **Cost:** a cross-store `with-read-snapshot` must register its read pin with every
   participating store, so a long cross-store query delays reaping in each store it touched.
   Per-store reaping must fold in foreign pins.
-- **Required audit:** each WAL will now contain epoch *gaps*. `load-highest-transaction-id`
-  takes a max and is fine; the peer/pull-cursor code compares epochs and takes maxima and
-  appears fine. Anything assuming epoch density must be found **before** this lands.
+- **Epoch-density audit: complete, clean** (2026-08-20, recorded on #168). No code assumes
+  contiguous ids. Consumers either take a max/min over an actual collection, filter an
+  existing collection by comparison, or use `(1+ x)` as an exclusive *lower bound*.
+  `replication-log-ranges` derives log N's end from log N+1's start, which looked dangerous
+  and is not: it over-approximates, and monotonicity still puts log N's ids in
+  `[start_N, start_{N+1})`.
+- **What the audit did find: `restore-graph` is a second id allocator that bypasses the
+  transaction manager.** `transaction-restore.lisp:133-152` mints ids by `(incf tx-id)` from
+  `(load-highest-transaction-id graph)` — a *per-store* scalar — and persists a per-store
+  high-water mark. Under a global clock it would allocate epochs **below** the global
+  counter, putting distinct events in different stores at the same epoch: precisely what
+  this section exists to prevent, arriving through the back door. **Re-pointing it at the
+  global clock is in scope for the unit.** This is load-bearing, not incidental — logical
+  replay is the proven per-store recovery path and §9 depends on restore semantics.
+- **Stated property, not a surprise: the global clock is not purely local.**
+  `peer-observe-epoch` advances the counter to strictly exceed a *foreign* epoch carried by
+  a pulled node — another image's clock. Under a per-graph counter that was local
+  bookkeeping; under an image-level clock a peer sync can advance the whole image's clock.
+  Mechanically sound (Lamport-style max, 64-bit ids, leases allocated ahead of the current
+  clock), but it must be documented rather than discovered.
+- **Three counters exist; one is in scope.** The transaction id (global, this section); the
+  per-graph `lamport` counter for peer conflict resolution, which orders events across
+  *devices* — separate images — and **stays per-graph**; and the per-node 32-bit `revision`,
+  untouched. Stated so nobody globalises the lamport counter by analogy.
 
 **Sequencing:** the debt is monotonic. Every write before the migration lands below the
 watermark permanently. This does not block other units, but its cost accrues daily.
@@ -364,7 +385,6 @@ because its migration debt accrues daily (§6).
 - Whether the shadow swap supersedes logical replay as the per-store restore mechanism. The
   trade is real: logical replay needs no journal and no retention but is not atomic. Since
   unit 5 requires the journal anyway, the marginal cost of consolidating is zero.
-- **WAL epoch-density audit** (§6) — blocking for unit 3.
 - **Identity-slot indexing audit** — external-key slots used for cross-store assertion
   resolution must be `:unique` or at least `:index t`, else assertions resolve by scan.
   Largely answered by the multi-slot index work (#107), which made these keys composite.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -188,7 +188,11 @@ wrong answer, and the fallback is the full sweep.
 journal), `attach-to-system-clock` (watermark), `peer-observe-epoch`
 (foreign epochs), `recreate-graph` (restore no longer bypasses it), and
 the cross-store pin in `call-with-read-snapshot` cover every bullet
-below. User-facing docs: `docs/vivace-graph-v3-doc.org`, Chapter 17,
+below, for explicitly-nested `with-read-snapshot` calls -- `*read-
+snapshots*` is keyed by graph, so a read that walks into another store
+without its own nested snapshot gets only the momentary pin inside
+`lookup-object`, not an extent-length one. User-facing docs:
+`docs/vivace-graph-v3-doc.org`, Chapter 17,
 starting at "The image-level system clock (optional)". The bullets below
 are kept as the original design record, including the audit finding.
 

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -212,7 +212,7 @@ wrong derived data whose provenance does not record the skew.
   `replication-log-ranges` derives log N's end from log N+1's start, which looked dangerous
   and is not: it over-approximates, and monotonicity still puts log N's ids in
   `[start_N, start_{N+1})`.
-- **What the audit did find: `restore-graph` is a second id allocator that bypasses the
+- **What the audit did find: `recreate-graph` is a second id allocator that bypasses the
   transaction manager.** `transaction-restore.lisp:133-152` mints ids by `(incf tx-id)` from
   `(load-highest-transaction-id graph)` — a *per-store* scalar — and persists a per-store
   high-water mark. Under a global clock it would allocate epochs **below** the global

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2718,6 +2718,55 @@ Also note: ~graph~ is now a *reserved* slot name on node classes — it backs th
 home-graph tracking slot described above. A user-defined slot named ~graph~ shadows it and
 silently disables home-graph tracking for that class; do not use it as a slot name.
 
+*** The image-level system clock (optional)
+
+Chapter 17 says a cross-graph instant "would need an epoch shared by every
+transaction manager, which is not implemented." As of GH #168, it can be:
+a ~system-clock~ is one epoch counter shared by every store attached to it,
+in place of each store's own ~transaction-id~ counter.
+
+~*system-clock*~ defaults to ~nil~. With no clock bound and no ~:system-clock~
+argument passed, every store keeps its own counter exactly as before —
+~tm-next-epoch~'s NIL branch is byte-for-byte the pre-#168
+~(prog1 counter (incf counter))~. Nothing about this feature is on by
+default; a production server upgrading past #168 sees no behaviour change
+until it explicitly opens a clock.
+
+To open one and attach stores to it:
+
+#+BEGIN_SRC lisp
+(let ((clock (open-system-clock "/path/to/clock-dir/")))
+  (unwind-protect
+       (let ((a (make-graph :store-a "/path/to/a/" :system-clock clock))
+             (b (make-graph :store-b "/path/to/b/" :system-clock clock)))
+         ;; every transaction on A or B now draws its epoch from CLOCK,
+         ;; so no two transactions anywhere on this clock share one
+         (unwind-protect (progn ...)
+           (close-graph a)
+           (close-graph b)))
+    (close-system-clock clock)))
+#+END_SRC
+
+~make-graph~ and ~open-graph~ both take ~:system-clock~, defaulting to
+~*system-clock*~ — bind that special once per image instead of passing the
+keyword to every call. Attaching (at either ~make-graph~ or ~open-graph~)
+raises the clock above the store's own persisted history — its highest
+committed transaction id, and for a peer-graph, its pull-cursor too, since
+those are distinct number spaces — so the clock can never hand out an
+epoch that store has already used. This is the watermark; it runs under
+the store's transaction-manager lock and refuses (signalling
+~attach-with-active-transactions~) if the store has any in-flight
+transaction, since attaching mid-transaction would poison that
+transaction's overlap window.
+
+**One limitation**: the watermark only ever raises the clock forward. It
+cannot place the clock *below* a store's history, so a store cannot be
+attached to reconstruct what its epoch numbering would have been had the
+clock existed since that store's creation — there is no snapshotting into
+the pre-migration past across stores. A store's own history before attach
+remains ordered correctly by its own counter; only new activity after
+attach shares the image-wide sequence.
+
 ** Chapter 18: Temporal Extents — graph-db/spacetime (optional)
 
 Every timestamp a real system records comes with some story about how sure

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2767,6 +2767,101 @@ the pre-migration past across stores. A store's own history before attach
 remains ordered correctly by its own counter; only new activity after
 attach shares the image-wide sequence.
 
+*** Epoch leases for a detached store
+
+~clock-lease-epochs~ reserves a contiguous range on the clock for a store
+that is about to go offline (a detach, per spec §8 — not yet built; see
+~docs/superpowers/specs/2026-08-20-namespaces-design.md~ §6): the range
+is skipped so the clock never hands the same epochs to anyone else, and
+the detached store can allocate from its own leased range with no further
+coordination while it is disconnected.
+
+#+BEGIN_SRC lisp
+(multiple-value-bind (start end) (clock-lease-epochs clock 100000)
+  ;; the detached store now owns every epoch in [start, end)
+  ...)
+#+END_SRC
+
+Epoch ids are 64-bit, so a lease large enough for any realistic bulk load
+still leaves exhaustion unreachable. As of GH #168, this is a primitive
+with no caller yet — #170's shadow-generation swap is the first thing
+that will call it, to hand a detached bulk load its own private range.
+
+*** The lifecycle journal
+
+Every ~system-clock~ also keeps a small append-only journal of store
+lifecycle events, living beside the clock's own counter file in the same
+directory. ~journal-append~ writes one record — kind ~:create~, ~:detach~
+(with its lease range), ~:swap~, ~:attach~, or ~:retire~, plus whatever
+else the caller supplies — and ~journal-records~ reads every record back,
+oldest first. ~attach-to-system-clock~ already appends an ~:attach~
+record on every attach; the other four kinds are for #170 and #171 to
+write as they build detach, swap and restore on top of this.
+
+**The journal is read with ~*read-eval*~ bound to ~nil~: it is data, and
+is never evaluated.** This is load-bearing, not a stylistic default —
+#170's shadow swap and #171's restore both plan to trust journal contents
+without re-checking them, so a record must never be able to execute code
+just by being read back.
+
+*** Cross-image effects: a peer sync can advance the clock
+
+A pulled node carries the *hub's* commit epoch, and ~peer-observe-epoch~
+raises the pulling store's own epoch source past it so a subsequent local
+edit cannot start before the epoch it just pulled. With no clock bound
+this only ever touches that one store's own counter, as before #168. With
+a clock bound, the store's own ~tx-id-counter~ is dead — every epoch call
+routes through the clock instead — so the observation goes to the clock:
+~clock-observe-epoch~, not the counter.
+
+One consequence worth stating plainly: **the image clock is therefore not
+purely local.** A peer sync on one store can advance the *whole* image's
+clock, driven by another image's clock entirely. This is intentional and
+monotonic — Lamport-style, never moves backward — but it means the clock
+a store observes reflects more than just that image's own activity once
+peer replication and a system clock are both in use.
+
+*** Restore's watermark now matches the rest of the engine
+
+~recreate-graph~ (used by both ~replay~ — snapshot/backup restore — and
+~migrate-graph~) used to mint ids from a per-store scalar,
+~load-highest-transaction-id~, entirely bypassing the transaction
+manager. Under a shared clock that could reissue an epoch some *other*
+store had already committed at — precisely the collision a system clock
+exists to prevent. It now allocates through ~tm-next-epoch~, which draws
+from the image clock when the graph has one, or the store's own counter
+otherwise (unchanged behaviour with no clock bound).
+
+One more change rides along, and it is a *correction*, not a regression:
+the id restore persists as the store's watermark afterward is now the
+last id actually *used*, not one past it. The old ~(incf tx-id)~ before
+the final persist always wasted one epoch — including on an empty
+snapshot, where it bumped the watermark for zero work — and disagreed
+with the convention everywhere else in the engine: ~apply-transaction~
+persists the id it actually used, and a fresh transaction manager's
+~initialize-instance :after~ already re-adds the missing one itself, via
+~(1+ (max ...))~. Restored ids are unchanged; only the trailing watermark
+is one lower than before, closing a gap that was always wasted.
+
+*** Cross-store snapshots pin every store they touch
+
+~with-read-snapshot~ composes by nesting — a query spanning stores looks
+like ~(with-read-snapshot (a) (with-read-snapshot (b) ...))~ — and each
+nested call now takes a read-epoch pin on *its own* graph's transaction
+manager for the snapshot's extent, alongside the snapshot transaction it
+already registered. Because each call only ever pins its own graph, the
+composition covers every participating store for free: nothing about the
+outermost or innermost call is special.
+
+**Name the cost plainly:** for as long as a cross-store snapshot is open,
+every store it touched has its reaper floor held down by that reader —
+not only the store the query happens to be reading from right now. A
+long cross-store query therefore delays reclaiming old versions in every
+store it participated in, for its full duration. This is the intended
+price of giving a cross-store query a genuine shared instant (spec §6);
+without it, one store's reaper could free a version a snapshot on another
+store still depends on.
+
 ** Chapter 18: Temporal Extents — graph-db/spacetime (optional)
 
 Every timestamp a real system records comes with some story about how sure

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2767,6 +2767,13 @@ the pre-migration past across stores. A store's own history before attach
 remains ordered correctly by its own counter; only new activity after
 attach shares the image-wide sequence.
 
+This guarantee does not extend to ~make-graph :replay-txn-dir D
+:system-clock C~: replay runs before the transaction manager and the
+attach exist, so it mints local ids from zero and the later attach's
+watermark observation is then a no-op, leaving the restored store
+holding epochs the clock already issued to other stores. See
+vivace-graph#180.
+
 *** Epoch leases for a detached store
 
 ~clock-lease-epochs~ reserves a contiguous range on the clock for a store

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -129,7 +129,11 @@
                #+ecl (make-hash-table :test 'eq
                                        #+graph-db-ecl-sync-hash :synchronized
                                        #+graph-db-ecl-sync-hash t)
-               #+sbcl (make-hash-table :test 'eq :synchronized t))))
+               #+sbcl (make-hash-table :test 'eq :synchronized t))
+   ;; The image-level epoch clock (GH #168), or NIL for this store's own
+   ;; counter.  NIL is the pre-#168 behaviour and the default.
+   (system-clock :accessor graph-system-clock :initarg :system-clock
+                 :initform nil)))
 
 (defmethod print-object ((graph graph) stream)
   (print-unreadable-object (graph stream :type t :identity t)

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -54,6 +54,9 @@
                (:file "node-id" :depends-on ("package" "posix"))
                (:file "buffer-pool" :depends-on ("pcons" "node-id"))
                (:file "serialize" :depends-on ("conditions" "buffer-pool" "cl-store-ecl"))
+               ;; The image-level epoch clock (GH #168).  No graph dependency,
+               ;; so it loads early and tests without one.
+               (:file "system-clock" :depends-on ("serialize" "utilities"))
                (:file "geometry" :depends-on ("serialize"))
                (:file "geometry-ops" :depends-on ("geometry"))
                (:file "geohash" :depends-on ("package"))
@@ -499,6 +502,7 @@ cl-temporal-extent."
                (:file "reopen-tests")
                (:file "backup-tests")
                (:file "mvcc-tests")
+               (:file "system-clock-tests")       ; GH #168
                (:file "rest-tests")
                (:file "rest-http-tests")
                (:file "prolog-stress-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -89,7 +89,7 @@
                (:file "vertex" :depends-on ("primitive-node"))
                (:file "edge" :depends-on ("vertex"))
                (:file "gc" :depends-on ("edge" "vertex" "views"))
-               (:file "transactions" :depends-on ("graph-class" "type-index" "vev-index" "ve-index" "edge" "vertex" "gc" "spatial-index" "posix"))
+               (:file "transactions" :depends-on ("graph-class" "type-index" "vev-index" "ve-index" "edge" "vertex" "gc" "spatial-index" "posix" "system-clock"))
                (:file "transaction-restore" :depends-on ("transactions"))
                (:file "transaction-log-streaming" :depends-on ("transactions"))
                (:file "backup" :depends-on ("edge"))

--- a/graph.lisp
+++ b/graph.lisp
@@ -358,11 +358,12 @@ Keyword arguments:
                           applies only replicated writes whose node it accepts,
                           so it holds just a subset (e.g. its area of operations).
                           See MAKE-SPATIAL-REPLICATION-FILTER.
-  :SYSTEM-CLOCK           the image-level epoch clock (GH #168) this store's
-                          transactions allocate ids from, or NIL (the default,
-                          via *SYSTEM-CLOCK*) to keep this store's own counter --
-                          the pre-#168 behaviour.  Attaching raises the clock
-                          above this store's persisted highest id.
+  :SYSTEM-CLOCK           the image-level epoch clock (GH #168) this
+                          store's transactions allocate ids from, or NIL
+                          (the default, via *SYSTEM-CLOCK*) to keep this
+                          store's own counter -- the pre-#168 behaviour.
+                          Attaching raises the clock above this store's
+                          persisted highest id.
 
 A .dirty marker file is written on creation; always CLOSE-GRAPH to flush data
 to disk and remove it."

--- a/graph.lisp
+++ b/graph.lisp
@@ -306,7 +306,8 @@ debugging an unexpectedly empty result, check the declaration before the data."
                                    export-predicate device-registry merge-policy
                                    reference-classes (peer-schema-version '(1 0))
                                    (index-backend *index-backend*)
-                                   spatial-index-backend)
+                                   spatial-index-backend
+                                   (system-clock *system-clock*))
   "Create a brand-new graph named NAME with its on-disk files under the
 directory LOCATION, register it (so LOOKUP-GRAPH and *GRAPH* can find it), and
 return it.  The directory is created if necessary and must not already contain
@@ -357,6 +358,11 @@ Keyword arguments:
                           applies only replicated writes whose node it accepts,
                           so it holds just a subset (e.g. its area of operations).
                           See MAKE-SPATIAL-REPLICATION-FILTER.
+  :SYSTEM-CLOCK           the image-level epoch clock (GH #168) this store's
+                          transactions allocate ids from, or NIL (the default,
+                          via *SYSTEM-CLOCK*) to keep this store's own counter --
+                          the pre-#168 behaviour.  Attaching raises the clock
+                          above this store's persisted highest id.
 
 A .dirty marker file is written on creation; always CLOSE-GRAPH to flush data
 to disk and remove it."
@@ -477,6 +483,8 @@ to disk and remove it."
       (setf (transaction-manager graph)
             (make-instance 'transaction-manager
                            :graph graph))
+      (when system-clock
+        (attach-to-system-clock graph system-clock))
       (ensure-directories-exist (persistent-transaction-directory graph))
       (init-replication-log graph)
       (start-replication graph :package package)
@@ -507,10 +515,13 @@ to disk and remove it."
                    ;; so this governs only indexes created after the open -- and,
                    ;; for a pre-v3 graph, the ones its migration re-derives.
                    (spatial-precision 7)
-                   (spatial-max-cells +spatial-insert-max-cells+))
+                   (spatial-max-cells +spatial-insert-max-cells+)
+                   (system-clock *system-clock*))
   "Open the existing graph named NAME whose files live under directory
 LOCATION, register it, and return it.  Use this to reopen a graph created
-earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's.
+earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's, including
+:SYSTEM-CLOCK -- attaching raises the clock above this store's persisted
+highest id (the spec §6 watermark).
 
 Signals an error if LOCATION holds a .dirty marker, which means the graph was
 not closed cleanly and must be recovered first (see RECOVER-TRANSACTIONS and
@@ -703,6 +714,8 @@ Always CLOSE-GRAPH when finished."
       (setf (transaction-manager graph)
             (make-instance 'transaction-manager
                            :graph graph))
+      (when system-clock
+        (attach-to-system-clock graph system-clock))
       (ensure-directories-exist (persistent-transaction-directory graph))
       (init-replication-log graph)
       (start-replication graph :package package)

--- a/package.lisp
+++ b/package.lisp
@@ -33,6 +33,10 @@
            #:clock-lease-epochs
            #:journal-append
            #:journal-records
+           #:graph-system-clock
+           #:attach-to-system-clock
+           #:tm-next-epoch
+           #:tm-current-epoch
            #:make-graph
            #:*default-heap-size*
            #:*default-index-size*

--- a/package.lisp
+++ b/package.lisp
@@ -135,6 +135,7 @@
            #:*read-snapshots*
            #:read-transaction
            #:no-transaction-in-progress
+           #:attach-with-active-transactions
            #:mutating-unregistered-node
            #:copying-uncommitted-node
 

--- a/package.lisp
+++ b/package.lisp
@@ -21,7 +21,17 @@
   #+ccl (:shadowing-import-from "CLOSER-MOP" "COMPUTE-EFFECTIVE-METHOD")
   #+ccl (:shadowing-import-from "CLOSER-MOP" "METHOD-FUNCTION")
   #+ccl (:shadowing-import-from "CLOSER-MOP" "MAKE-METHOD-LAMBDA")
-  (:export #:make-graph
+  (:export
+           ;; image-level epoch clock (GH #168)
+           #:*system-clock*
+           #:system-clock
+           #:open-system-clock
+           #:close-system-clock
+           #:clock-next-epoch
+           #:clock-current-epoch
+           #:clock-observe-epoch
+           #:clock-lease-epochs
+           #:make-graph
            #:*default-heap-size*
            #:*default-index-size*
            #:*index-backend*

--- a/package.lisp
+++ b/package.lisp
@@ -29,6 +29,7 @@
            #:close-system-clock
            #:clock-next-epoch
            #:clock-current-epoch
+           #:clock-peek-epoch
            #:clock-observe-epoch
            #:clock-lease-epochs
            #:journal-append
@@ -37,6 +38,7 @@
            #:attach-to-system-clock
            #:tm-next-epoch
            #:tm-current-epoch
+           #:tm-peek-epoch
            #:make-graph
            #:*default-heap-size*
            #:*default-index-size*

--- a/package.lisp
+++ b/package.lisp
@@ -31,6 +31,8 @@
            #:clock-current-epoch
            #:clock-observe-epoch
            #:clock-lease-epochs
+           #:journal-append
+           #:journal-records
            #:make-graph
            #:*default-heap-size*
            #:*default-index-size*

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -61,7 +61,6 @@ the persisted ceiling, so a crash never reissues one."
                                     :ceiling ceiling
                                     :block-size block-size)))
     (%write-clock-ceiling clock (+ ceiling block-size))
-    (setf (system-clock-counter clock) ceiling)
     clock))
 
 (defun close-system-clock (clock)
@@ -96,7 +95,8 @@ holds the lock."
 (defun clock-observe-epoch (clock epoch)
   "Raise CLOCK so it strictly exceeds EPOCH.  Monotonic and idempotent; a
 lower EPOCH is a no-op.  Foreign epochs reach here from peer sync, so the
-clock is not purely local -- see spec §6."
+clock is not purely local -- see spec §6.  EPOCH may be NIL (a no-op):
+callers like PEER-OBSERVE-EPOCH may not always have one to report."
   (with-recursive-lock-held ((system-clock-lock clock))
     (when (and epoch (>= epoch (system-clock-counter clock)))
       (setf (system-clock-counter clock) (1+ epoch))

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -1,0 +1,115 @@
+(in-package :graph-db)
+
+;;; The image-level epoch clock (GH #168).  One clock per *system* -- a
+;;; directory of stores -- rather than one per store, so a query spanning
+;;; stores resolves at one instant.  See
+;;; docs/superpowers/specs/2026-08-20-namespaces-design.md §6.
+
+(defvar *system-clock* nil
+  "The image's SYSTEM-CLOCK, or NIL.  NIL means every store keeps its own
+transaction-id counter, which is the pre-#168 behaviour and the default.")
+
+(defstruct (system-clock (:constructor %make-system-clock))
+  (location nil)
+  ;; Next epoch to hand out.  In memory; CEILING is what disk guarantees.
+  (counter 0 :type (unsigned-byte 64))
+  ;; Disk holds this value; every issued id is strictly below it.  A crash
+  ;; therefore cannot reissue: reopen resumes at the persisted ceiling.
+  (ceiling 0 :type (unsigned-byte 64))
+  (block-size 4096 :type (unsigned-byte 32))
+  (lock (make-recursive-lock "system clock"))
+  (journal nil))
+
+(defun %clock-counter-file (location)
+  (make-pathname :name "system-clock" :type "dat" :defaults location))
+
+(defun %write-clock-ceiling (clock value)
+  "Persist VALUE as the durable ceiling.  Every id issued is < VALUE.
+:OVERWRITE, not :SUPERSEDE: the file is always 8 bytes, so a crash
+mid-write can't leave it short or absent (cf. transactions.lisp:939)."
+  (let ((buf (make-byte-vector 8)))
+    (serialize-uint64 buf value 0)
+    (with-open-file (s (%clock-counter-file (system-clock-location clock))
+                       :direction :output
+                       :element-type '(unsigned-byte 8)
+                       :if-does-not-exist :create
+                       :if-exists :overwrite)
+      (write-sequence buf s)
+      ;; Flushes to the OS, not FSYNC: survives a process crash, not a
+      ;; power loss -- same limitation as the other counter writers.
+      (finish-output s)))
+  (setf (system-clock-ceiling clock) value))
+
+(defun %read-clock-ceiling (location)
+  (let ((file (%clock-counter-file location))
+        (buf (make-byte-vector 8)))
+    (if (probe-file file)
+        (with-open-file (s file :direction :input
+                                :element-type '(unsigned-byte 8))
+          (unless (= 8 (read-sequence buf s))
+            (error "Short read from ~A" file))
+          (deserialize-uint64 buf 0))
+        0)))
+
+(defun open-system-clock (location &key (block-size 4096))
+  "Open or create the system clock in directory LOCATION.  Ids resume above
+the persisted ceiling, so a crash never reissues one."
+  (ensure-directories-exist location)
+  (let* ((ceiling (%read-clock-ceiling location))
+         (clock (%make-system-clock :location location
+                                    :counter ceiling
+                                    :ceiling ceiling
+                                    :block-size block-size)))
+    (%write-clock-ceiling clock (+ ceiling block-size))
+    (setf (system-clock-counter clock) ceiling)
+    clock))
+
+(defun close-system-clock (clock)
+  "Persist the exact counter so a clean reopen wastes no ids."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (%write-clock-ceiling clock (system-clock-counter clock))
+    (when (system-clock-journal clock)
+      (close (system-clock-journal clock))
+      (setf (system-clock-journal clock) nil)))
+  clock)
+
+(defun %clock-reserve (clock needed)
+  "Raise the durable ceiling so COUNTER + NEEDED stays below it.  Caller
+holds the lock."
+  (let ((target (+ (system-clock-counter clock) needed)))
+    (when (>= target (system-clock-ceiling clock))
+      (%write-clock-ceiling
+       clock (+ target (system-clock-block-size clock))))))
+
+(defun clock-next-epoch (clock)
+  "Allocate and return a fresh epoch."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (%clock-reserve clock 1)
+    (prog1 (system-clock-counter clock)
+      (incf (system-clock-counter clock)))))
+
+(defun clock-current-epoch (clock)
+  "The next epoch CLOCK-NEXT-EPOCH would return."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (system-clock-counter clock)))
+
+(defun clock-observe-epoch (clock epoch)
+  "Raise CLOCK so it strictly exceeds EPOCH.  Monotonic and idempotent; a
+lower EPOCH is a no-op.  Foreign epochs reach here from peer sync, so the
+clock is not purely local -- see spec §6."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (when (and epoch (>= epoch (system-clock-counter clock)))
+      (setf (system-clock-counter clock) (1+ epoch))
+      (%clock-reserve clock 0))
+    (system-clock-counter clock)))
+
+(defun clock-lease-epochs (clock n)
+  "Reserve N epochs for a detached store and skip the clock past them.
+Returns (values START END); the holder allocates in [START, END)."
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (%clock-reserve clock n)
+    (let* ((start (system-clock-counter clock))
+           (end (+ start n)))
+      (setf (system-clock-counter clock) end)
+      (%clock-reserve clock 0)
+      (values start end))))

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -150,5 +150,4 @@ Returns (values START END); the holder allocates in [START, END)."
     (let* ((start (system-clock-counter clock))
            (end (+ start n)))
       (setf (system-clock-counter clock) end)
-      (%clock-reserve clock 0)
       (values start end))))

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -23,6 +23,9 @@ transaction-id counter, which is the pre-#168 behaviour and the default.")
 (defun %clock-counter-file (location)
   (make-pathname :name "system-clock" :type "dat" :defaults location))
 
+(defun %clock-journal-file (location)
+  (make-pathname :name "system-journal" :type "log" :defaults location))
+
 (defun %write-clock-ceiling (clock value)
   "Persist VALUE as the durable ceiling.  Every id issued is < VALUE.
 :OVERWRITE, not :SUPERSEDE: the file is always 8 bytes, so a crash
@@ -71,6 +74,36 @@ the persisted ceiling, so a crash never reissues one."
       (close (system-clock-journal clock))
       (setf (system-clock-journal clock) nil)))
   clock)
+
+(defun journal-append (clock kind &rest plist)
+  "Append one lifecycle record.  KIND is :CREATE :DETACH :SWAP :ATTACH or
+:RETIRE.  Consumed by #170 and #171."
+  (let ((record (list* :kind kind :epoch (clock-current-epoch clock) plist)))
+    (with-recursive-lock-held ((system-clock-lock clock))
+      (unless (system-clock-journal clock)
+        (setf (system-clock-journal clock)
+              (open (%clock-journal-file (system-clock-location clock))
+                    :direction :output
+                    :if-exists :append
+                    :if-does-not-exist :create)))
+      (let ((s (system-clock-journal clock)))
+        (let ((*print-readably* nil) (*print-pretty* nil))
+          (format s "~S~%" record))
+        (finish-output s)))
+    record))
+
+(defun journal-records (clock)
+  "Every lifecycle record, oldest first.  Read with evaluation disabled --
+the journal is data and must never execute."
+  (let ((file (%clock-journal-file (system-clock-location clock))))
+    (when (system-clock-journal clock)
+      (finish-output (system-clock-journal clock)))
+    (when (probe-file file)
+      (with-open-file (s file :direction :input)
+        (let ((*read-eval* nil))
+          (loop for r = (read s nil :eof)
+                until (eq r :eof)
+                collect r))))))
 
 (defun %clock-reserve (clock needed)
   "Raise the durable ceiling so COUNTER + NEEDED stays below it.  Caller

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -125,6 +125,12 @@ holds the lock."
   (with-recursive-lock-held ((system-clock-lock clock))
     (system-clock-counter clock)))
 
+(defun clock-peek-epoch (clock)
+  "The counter without taking the lock.  Monotonic, so a stale (smaller)
+value only makes the reaper more conservative -- never less.  For
+PIN-READ-EPOCH; use CLOCK-CURRENT-EPOCH where exactness matters."
+  (system-clock-counter clock))
+
 (defun clock-observe-epoch (clock epoch)
   "Raise CLOCK so it strictly exceeds EPOCH.  Monotonic and idempotent; a
 lower EPOCH is a no-op.  Foreign epochs reach here from peer sync, so the

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -23,6 +23,8 @@
                 #:clock-current-epoch
                 #:clock-observe-epoch
                 #:clock-lease-epochs
+                #:journal-append
+                #:journal-records
                 ;; serialization
                 #:serialize
                 #:deserialize

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -14,6 +14,15 @@
   ;; so the Prolog compiler recognizes ! in query goals as cut.
   (:shadowing-import-from #:graph-db #:!)
   (:import-from #:graph-db
+                ;; image-level epoch clock (GH #168)
+                #:*system-clock*
+                #:system-clock
+                #:open-system-clock
+                #:close-system-clock
+                #:clock-next-epoch
+                #:clock-current-epoch
+                #:clock-observe-epoch
+                #:clock-lease-epochs
                 ;; serialization
                 #:serialize
                 #:deserialize

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -27,6 +27,7 @@
                 #:journal-records
                 #:graph-system-clock
                 #:attach-to-system-clock
+                #:attach-with-active-transactions
                 #:clock-peek-epoch
                 ;; serialization
                 #:serialize

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -217,6 +217,9 @@
                 #:open-graph
                 #:close-graph
                 #:with-transaction
+                #:*transaction*
+                #:transaction-id
+                #:load-highest-transaction-id
                 #:lookup-vertex
                 #:lookup-edge
                 #:vertex-history

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -25,6 +25,9 @@
                 #:clock-lease-epochs
                 #:journal-append
                 #:journal-records
+                #:graph-system-clock
+                #:attach-to-system-clock
+                #:clock-peek-epoch
                 ;; serialization
                 #:serialize
                 #:deserialize

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -86,3 +86,43 @@
              ;; can collide with an id the lease holder allocates.
              (is (>= (clock-next-epoch c) end)))
         (close-system-clock c)))))
+
+(test journal-appends-and-reads-back
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (journal-append c :detach :store :alpha
+                              :lease-start 10 :lease-end 20)
+             (journal-append c :attach :store :alpha)
+             (let ((rs (journal-records c)))
+               (is (= 2 (length rs)))
+               (is (eq :detach (getf (first rs) :kind)))
+               (is (eq :alpha (getf (first rs) :store)))
+               (is (eq :attach (getf (second rs) :kind)))))
+        (close-system-clock c)))))
+
+(test journal-survives-reopen
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :beta)
+      (close-system-clock c))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (is (equal '(:create) (mapcar (lambda (r) (getf r :kind))
+                                         (journal-records c2))))
+        (close-system-clock c2)))))
+
+(test journal-refuses-to-evaluate-on-read
+  ;; A journal is data.  Reading it must never evaluate.
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append
+                       :if-does-not-exist :create)
+      (format s "(:kind :bogus :value #.(error \"evaluated\"))~%"))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (signals error (journal-records c2))
+        (close-system-clock c2)))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -114,7 +114,10 @@
         (close-system-clock c2)))))
 
 (test journal-refuses-to-evaluate-on-read
-  ;; A journal is data.  Reading it must never evaluate.
+  ;; A journal is data.  Reading it must never evaluate.  Must assert the
+  ;; condition TYPE: bare `signals error' passes under *READ-EVAL* T too
+  ;; (the crafted form's own ERROR call also signals an ERROR), so it
+  ;; proves nothing.  READER-ERROR only comes from the reader refusing.
   (with-temp-directory (dir)
     (let ((c (open-system-clock (namestring dir))))
       (close-system-clock c))
@@ -124,5 +127,5 @@
       (format s "(:kind :bogus :value #.(error \"evaluated\"))~%"))
     (let ((c2 (open-system-clock (namestring dir))))
       (unwind-protect
-           (signals error (journal-records c2))
+           (signals reader-error (journal-records c2))
         (close-system-clock c2)))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -462,3 +462,117 @@
                       (is (> (clock-current-epoch clock) 999999)))
                  (close-graph g :snapshot-p nil))))
         (close-system-clock clock)))))
+
+;;; Cross-store read snapshots pin every participating store (GH #168 task 6).
+;;; See spec sec.6: a long cross-store query delays reaping in EVERY store it
+;;; touched -- the intended trade, not a regression.
+
+(test cross-store-snapshot-pins-every-store
+  ;; Identity, not just presence (review round 2): a hypothetical swapped
+  ;; implementation -- GA's snapshot pinning TM-B, GB's pinning TM-A --
+  ;; would still pass a count-only check, since both tables end up with
+  ;; one entry each.  Under a SHARED clock the two managers' epochs are
+  ;; usually the same number, so a value comparison alone can't tell them
+  ;; apart -- unless something advances the clock between the two
+  ;; snapshots' establishment.  A real write on GB before GB's own
+  ;; snapshot does exactly that, so GA's and GB's own pin-time epochs
+  ;; diverge and a swap becomes visible as a value mismatch.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let* ((ga (make-graph :sc-pin-a (namestring da)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock))
+                      (gb (make-graph :sc-pin-b (namestring db)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock))
+                      (tm-a (graph-db::transaction-manager ga))
+                      (tm-b (graph-db::transaction-manager gb)))
+                 (flet ((pin-values (tm)
+                          (loop for v being the hash-values
+                                  of (graph-db::read-pins tm)
+                                collect v)))
+                   (unwind-protect
+                        (graph-db:with-read-snapshot (ga)
+                          (let ((epoch-a (graph-db::tm-peek-epoch tm-a)))
+                            ;; Bumps the shared clock before GB pins.
+                            (with-transaction (tm-b) t)
+                            (graph-db:with-read-snapshot (gb)
+                              (let ((epoch-b
+                                      (graph-db::tm-peek-epoch tm-b)))
+                                ;; Both managers hold a pin.
+                                (is (plusp (hash-table-count
+                                            (graph-db::read-pins tm-a))))
+                                (is (plusp (hash-table-count
+                                            (graph-db::read-pins tm-b))))
+                                ;; Each table's value is its OWN
+                                ;; manager's pin-time epoch -- not the
+                                ;; other store's.
+                                (is (equal (list epoch-a)
+                                           (pin-values tm-a)))
+                                (is (equal (list epoch-b)
+                                           (pin-values tm-b)))))))
+                     (close-graph ga)
+                     (close-graph gb))))))
+        (close-system-clock clock)))))
+
+(test cross-store-snapshot-releases-pins-after-normal-return
+  ;; A pin taken and never released wedges the reaper forever in the store it
+  ;; leaked on -- worse than the visibility bug this unit fixes.  Assert both
+  ;; stores' pins are gone once the composed snapshot exits normally.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let* ((ga (make-graph :sc-pin-c (namestring da)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock))
+                      (gb (make-graph :sc-pin-d (namestring db)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock))
+                      (tm-a (graph-db::transaction-manager ga))
+                      (tm-b (graph-db::transaction-manager gb)))
+                 (unwind-protect
+                      (progn
+                        (graph-db:with-read-snapshot (ga)
+                          (graph-db:with-read-snapshot (gb) t))
+                        (is (zerop (hash-table-count
+                                    (graph-db::read-pins tm-a))))
+                        (is (zerop (hash-table-count
+                                    (graph-db::read-pins tm-b)))))
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock)))))
+
+(test cross-store-snapshot-releases-pins-on-non-local-exit
+  ;; Same property, but the body THROWs out instead of returning -- this is
+  ;; the whole point of putting the release in UNWIND-PROTECT.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let* ((ga (make-graph :sc-pin-e (namestring da)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock))
+                      (gb (make-graph :sc-pin-f (namestring db)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock))
+                      (tm-a (graph-db::transaction-manager ga))
+                      (tm-b (graph-db::transaction-manager gb)))
+                 (unwind-protect
+                      (progn
+                        (catch 'bail-out
+                          (graph-db:with-read-snapshot (ga)
+                            (graph-db:with-read-snapshot (gb)
+                              (throw 'bail-out nil))))
+                        (is (zerop (hash-table-count
+                                    (graph-db::read-pins tm-a))))
+                        (is (zerop (hash-table-count
+                                    (graph-db::read-pins tm-b)))))
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock)))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -389,3 +389,76 @@
                        (close-graph dst :snapshot-p nil))))
                  (close-graph other :snapshot-p nil))))
         (close-system-clock clock)))))
+
+(defparameter *observe-epoch-origin*
+  (make-array 16 :element-type '(unsigned-byte 8) :initial-element 9)
+  "A fixed device origin id for the PEER-OBSERVE-EPOCH tests.")
+
+(test peer-observe-epoch-raises-the-image-clock
+  ;; PEER-OBSERVE-EPOCH exists so a pulled node's HUB epoch can't outrun this
+  ;; store's next start-tx-id (see PEER-OBSERVE-EPOCH's docstring).  With a
+  ;; clock bound, TX-ID-COUNTER is dead -- TM-NEXT-EPOCH/TM-CURRENT-EPOCH
+  ;; route to the clock (GH #168) -- so the observation must land there too.
+  ;; Also pins monotonicity in both directions: a high epoch raises the
+  ;; clock, and a later LOWER epoch is a no-op, not a regression.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (gdir)
+             (let ((g (make-graph :sc-peer (namestring gdir)
+                                  :buffer-pool-size 1000
+                                  :peer-role :device
+                                  :origin-id *observe-epoch-origin*
+                                  :system-clock clock)))
+               (unwind-protect
+                    (progn
+                      (graph-db::peer-observe-epoch g 999999)
+                      (is (> (clock-current-epoch clock) 999999)))
+                 (close-graph g :snapshot-p nil))))
+        (close-system-clock clock)))))
+
+(test peer-observe-epoch-does-not-drag-the-clock-backwards
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (gdir)
+             (let ((g (make-graph :sc-peer-lo (namestring gdir)
+                                  :buffer-pool-size 1000
+                                  :peer-role :device
+                                  :origin-id *observe-epoch-origin*
+                                  :system-clock clock)))
+               (unwind-protect
+                    (progn
+                      (graph-db::peer-observe-epoch g 999999)
+                      (let ((raised (clock-current-epoch clock)))
+                        (graph-db::peer-observe-epoch g 5)
+                        (is (= raised (clock-current-epoch clock)))))
+                 (close-graph g :snapshot-p nil))))
+        (close-system-clock clock)))))
+
+(test peer-observe-epoch-ignores-the-dead-counter
+  ;; The nearest wrong implementation: route to the clock but keep the old
+  ;; `(>= epoch (tx-id-counter tm))' guard.  Under a clock TX-ID-COUNTER is
+  ;; dead -- nothing ever advances it -- so gating on it either always
+  ;; passes (masking the bug for a fresh store, where the guard is
+  ;; vacuously true) or, once something has left a stale high value in the
+  ;; slot, wrongly SKIPS the clock observation.  Force that stale value
+  ;; directly and confirm the clock still raises regardless.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (gdir)
+             (let ((g (make-graph :sc-peer-stale (namestring gdir)
+                                  :buffer-pool-size 1000
+                                  :peer-role :device
+                                  :origin-id *observe-epoch-origin*
+                                  :system-clock clock)))
+               (unwind-protect
+                    (progn
+                      (setf (graph-db::tx-id-counter
+                             (graph-db::transaction-manager g))
+                            5000000)
+                      (graph-db::peer-observe-epoch g 999999)
+                      (is (> (clock-current-epoch clock) 999999)))
+                 (close-graph g :snapshot-p nil))))
+        (close-system-clock clock)))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -319,3 +319,73 @@
                       (is (null (graph-system-clock g))))
                  (close-system-clock clock)))
           (close-graph g :snapshot-p nil))))))
+
+(test recreate-graph-allocates-from-the-image-clock
+  ;; The audit finding (GH #168): RECREATE-GRAPH minted ids from a per-store
+  ;; scalar, so under a shared clock it reissued epochs another store had
+  ;; already used.  Drives the real path: SNAPSHOT then REPLAY.  (The plan's
+  ;; sketch reached the source graph via LOOKUP-GRAPH post-close and via
+  ;; PERSISTENT-TRANSACTION-DIRECTORY, neither of which line up with how
+  ;; CLOSE-GRAPH deregisters or where SNAPSHOT actually writes; and empty
+  ;; transaction bodies leave nothing in the snapshot for REPLAY to
+  ;; allocate ids against.  Fixed by reusing backup-tests.lisp's txn-log/
+  ;; convention and g-person schema, both already loaded by graph-tests.lisp.
+  ;; The source and destination graphs share *INTEGRATION-GRAPH-NAME* -- as
+  ;; many other tests do sequentially -- because that is the schema key
+  ;; G-PERSON is registered under; they never overlap while open.
+  ;;
+  ;; RECORD-COUNT exceeds *RESTORE-OBJECTS-PER-TRANSACTION* (10) so REPLAY
+  ;; spans several batches -- several allocator calls, not one -- and the
+  ;; clock's ADVANCE (not just a floor on the persisted id) is asserted:
+  ;; a TM-CURRENT-EPOCH-for-TM-NEXT-EPOCH substitution peeks the same
+  ;; floor without moving the clock, which a floor-only check cannot see
+  ;; but an exact advance-by-BATCHES check does.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir)))
+          (record-count 25))
+      (unwind-protect
+           (with-temp-directory (sdir)
+             (with-temp-directory (odir)
+               ;; Source store: enough real history to span several REPLAY
+               ;; batches, then a snapshot on disk.
+               (let ((src (make-graph *integration-graph-name* (namestring sdir)
+                                      :buffer-pool-size 1000
+                                      :system-clock clock)))
+                 (let ((*graph* src))
+                   (dotimes (i record-count)
+                     (with-transaction ((graph-db::transaction-manager src))
+                       (make-g-person :name "restore-probe" :age i)))
+                   (graph-db::snapshot src))
+                 (close-graph src :snapshot-p nil))
+               ;; A second store burns epochs, pushing the clock far past
+               ;; anything the restore target's own scalar knows about.
+               (let ((other (make-graph :sc-other (namestring odir)
+                                        :buffer-pool-size 1000
+                                        :system-clock clock)))
+                 (dotimes (i 50)
+                   (with-transaction ((graph-db::transaction-manager other))
+                     t))
+                 (let* ((per graph-db::*restore-objects-per-transaction*)
+                        (floor-epoch (clock-current-epoch clock))
+                        (batches (ceiling record-count per)))
+                   (with-temp-directory (rdir)
+                     (let ((dst (make-graph *integration-graph-name*
+                                            (namestring rdir)
+                                            :buffer-pool-size 1000
+                                            :system-clock clock)))
+                       (graph-db::replay
+                        dst
+                        (merge-pathnames "txn-log/" sdir)
+                        :graph-db/test)
+                       ;; Every id the replay issued sits above the clock's
+                       ;; position when it started ...
+                       (is (>= (graph-db::load-highest-transaction-id dst)
+                               floor-epoch))
+                       ;; ... and the clock advanced by exactly one epoch
+                       ;; per batch -- the property TM-NEXT-EPOCH provides
+                       ;; and a peek-only TM-CURRENT-EPOCH does not.
+                       (is (= batches
+                              (- (clock-current-epoch clock) floor-epoch)))
+                       (close-graph dst :snapshot-p nil))))
+                 (close-graph other :snapshot-p nil))))
+        (close-system-clock clock)))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -61,6 +61,21 @@
              (is (> (clock-next-epoch c2) highest))
           (close-system-clock c2))))))
 
+(test clock-survives-crash-after-refilling-its-block
+  ;; The above stays below BLOCK-SIZE, so it never exercises the
+  ;; incremental refill in %CLOCK-RESERVE -- OPEN-SYSTEM-CLOCK's one-time
+  ;; upfront reservation alone would satisfy it.  This one issues past
+  ;; the block boundary (block-size 8, 20 ids) so refill's own disk write
+  ;; is what has to be durable, not just the initial one.
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir) :block-size 8))
+           (issued (loop repeat 20 collect (clock-next-epoch c)))
+           (highest (reduce #'max issued)))
+      (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) highest))
+          (close-system-clock c2))))))
+
 (test clock-lease-is-disjoint-and-advances-the-clock
   (with-temp-directory (dir)
     (let ((c (open-system-clock (namestring dir))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -1,0 +1,73 @@
+;;;; The image-level epoch clock (GH #168).  See
+;;;; docs/superpowers/specs/2026-08-20-namespaces-design.md §6.
+(in-package #:graph-db/test)
+
+(def-suite system-clock-suite :in graph-db-suite
+  :description "The image-level epoch clock and its journal.")
+(in-suite system-clock-suite)
+
+(test clock-issues-monotonic-epochs
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((a (clock-next-epoch c))
+                 (b (clock-next-epoch c))
+                 (d (clock-next-epoch c)))
+             (is (< a b d)))
+        (close-system-clock c)))))
+
+(test clock-current-epoch-is-the-next-id
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((seen (clock-current-epoch c)))
+             (is (= seen (clock-next-epoch c)))
+             (is (= (1+ seen) (clock-current-epoch c))))
+        (close-system-clock c)))))
+
+(test clock-observe-epoch-is-a-max
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (clock-observe-epoch c 5000)
+             (is (> (clock-next-epoch c) 5000))
+             ;; A lower observation must not move it backwards.
+             (let ((before (clock-current-epoch c)))
+               (clock-observe-epoch c 10)
+               (is (= before (clock-current-epoch c)))))
+        (close-system-clock c)))))
+
+(test clock-survives-clean-reopen-without-reissuing
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir)))
+           (last (progn (dotimes (i 10) (clock-next-epoch c))
+                        (clock-next-epoch c))))
+      (close-system-clock c)
+      (let ((c2 (open-system-clock (namestring dir))))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) last))
+          (close-system-clock c2))))))
+
+(test clock-survives-crash-without-reissuing
+  ;; No CLOSE-SYSTEM-CLOCK: simulates a crash after ids were handed out.  The
+  ;; block reservation on disk must already dominate every issued id.
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir) :block-size 8))
+           (issued (loop repeat 5 collect (clock-next-epoch c)))
+           (highest (reduce #'max issued)))
+      (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) highest))
+          (close-system-clock c2))))))
+
+(test clock-lease-is-disjoint-and-advances-the-clock
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (multiple-value-bind (start end) (clock-lease-epochs c 1000)
+             (is (= 1000 (- end start)))
+             ;; The clock has skipped the whole lease: nothing it issues now
+             ;; can collide with an id the lease holder allocates.
+             (is (>= (clock-next-epoch c) end)))
+        (close-system-clock c)))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -145,15 +145,15 @@
                                      :buffer-pool-size 1000
                                      :system-clock clock)))
                  (unwind-protect
-                      (let ((ids '()))
+                      (let ((tm-a (graph-db::transaction-manager ga))
+                            (tm-b (graph-db::transaction-manager gb))
+                            (ids '()))
                         (dotimes (i 3)
-                          (push (transaction-id
-                                 (with-transaction ((graph-db::transaction-manager ga))
-                                   *transaction*))
+                          (push (transaction-id (with-transaction (tm-a)
+                                                  *transaction*))
                                 ids)
-                          (push (transaction-id
-                                 (with-transaction ((graph-db::transaction-manager gb))
-                                   *transaction*))
+                          (push (transaction-id (with-transaction (tm-b)
+                                                  *transaction*))
                                 ids))
                         (let ((sorted (sort (copy-list ids) #'<)))
                           ;; No two transactions anywhere share an epoch.
@@ -166,19 +166,32 @@
 (test no-clock-means-per-store-counters-unchanged
   ;; The backward-compatibility hinge: with *SYSTEM-CLOCK* nil and no
   ;; :SYSTEM-CLOCK argument, two graphs allocate independently, exactly as
-  ;; before #168 -- so both start low and their ids DO collide.
-  (with-temp-directory (da)
-    (with-temp-directory (db)
-      (let ((ga (make-graph :sc-gamma (namestring da) :buffer-pool-size 1000))
-            (gb (make-graph :sc-delta (namestring db) :buffer-pool-size 1000)))
-        (unwind-protect
-             (let ((ia (transaction-id (with-transaction ((graph-db::transaction-manager ga))
-                                         *transaction*)))
-                   (ib (transaction-id (with-transaction ((graph-db::transaction-manager gb))
-                                         *transaction*))))
-               (is (= ia ib)))
-          (close-graph ga)
-          (close-graph gb))))))
+  ;; before #168 -- so both start low and their ids DO collide.  Assert the
+  ;; actual pre-#168 values, not just their equality: an off-by-one NIL
+  ;; branch (e.g. a bare INCF instead of PROG1-then-INCF) would still
+  ;; satisfy (= IA IB) without this.  *SYSTEM-CLOCK* is bound explicitly
+  ;; rather than relied on as a lambda-list default, so this test's premise
+  ;; does not depend on run order against any test that SETFs the global.
+  (let ((*system-clock* nil))
+    (with-temp-directory (da)
+      (with-temp-directory (db)
+        (let ((ga (make-graph :sc-gamma (namestring da)
+                              :buffer-pool-size 1000))
+              (gb (make-graph :sc-delta (namestring db)
+                              :buffer-pool-size 1000)))
+          (unwind-protect
+               (let* ((tm-a (graph-db::transaction-manager ga))
+                      (tm-b (graph-db::transaction-manager gb))
+                      (ia (transaction-id (with-transaction (tm-a)
+                                            *transaction*)))
+                      (ib (transaction-id (with-transaction (tm-b)
+                                            *transaction*)))
+                      (ia2 (transaction-id (with-transaction (tm-a)
+                                             *transaction*))))
+                 (is (= 1 ia ib))
+                 (is (= 2 ia2)))
+            (close-graph ga)
+            (close-graph gb)))))))
 
 (test attaching-a-store-raises-the-clock-above-its-history
   ;; The watermark: a store with existing history must not hand the clock a
@@ -186,7 +199,8 @@
   (with-temp-directory (cdir)
     (with-temp-directory (gdir)
       (let ((g (make-graph :sc-eps (namestring gdir) :buffer-pool-size 1000)))
-        (dotimes (i 5) (with-transaction ((graph-db::transaction-manager g)) t))
+        (dotimes (i 5)
+          (with-transaction ((graph-db::transaction-manager g)) t))
         (let ((highest (load-highest-transaction-id g)))
           (close-graph g)
           (let ((clock (open-system-clock (namestring cdir))))
@@ -195,6 +209,113 @@
                                        :buffer-pool-size 1000
                                        :system-clock clock)))
                    (unwind-protect
-                        (is (> (clock-current-epoch clock) highest))
+                        (progn
+                          (is (> (clock-current-epoch clock) highest))
+                          ;; The property the watermark exists for: the
+                          ;; NEXT id this store actually allocates must
+                          ;; exceed its own history, not just leave the
+                          ;; clock's internal counter above it (which
+                          ;; would also catch an attach that raced ahead
+                          ;; of its own watermark -- fix 2 in the review).
+                          (let ((tm-2 (graph-db::transaction-manager g2)))
+                            (is (> (transaction-id (with-transaction (tm-2)
+                                                     *transaction*))
+                                   highest))))
                      (close-graph g2)))
               (close-system-clock clock))))))))
+
+(test start-and-finish-tx-id-bracket-the-shared-epoch
+  ;; The gap that matters most (reviewer finding): an implementation that
+  ;; drew only the COMMIT id from the clock while leaving start-tx-id and
+  ;; finish-tx-id on the local counter would pass every test above and
+  ;; still corrupt this store's overlap window (OVERLAPPING-TRANSACTIONS
+  ;; filters committed transactions by (<= START (TRANSACTION-ID TX)
+  ;; FINISH)).  Interleave commits across two stores sharing one clock and
+  ;; check each transaction's own start/finish bracket its own
+  ;; transaction-id -- proving all three come from the same sequence.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let ((ga (make-graph :sc-theta (namestring da)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock))
+                     (gb (make-graph :sc-iota (namestring db)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock)))
+                 (unwind-protect
+                      (let ((tm-a (graph-db::transaction-manager ga))
+                            (tm-b (graph-db::transaction-manager gb))
+                            (txs '()))
+                        (dotimes (i 3)
+                          (push (with-transaction (tm-a) *transaction*) txs)
+                          (push (with-transaction (tm-b) *transaction*) txs))
+                        (dolist (tx txs)
+                          (is (<= (graph-db::start-tx-id tx)
+                                  (transaction-id tx)
+                                  (graph-db::finish-tx-id tx)))))
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock)))))
+
+(test attach-watermarks-a-peer-graphs-pull-cursor-too
+  ;; Correctness (reviewer fix 1): a peer-graph's pull-cursor and its local
+  ;; highest-transaction-id are DISTINCT number spaces (see
+  ;; PEER-OBSERVE-EPOCH's docstring; tests/peer-lamport-tests.lisp confirms
+  ;; they diverge).  ATTACH-TO-SYSTEM-CLOCK must watermark past whichever
+  ;; is higher, or a node this device pulled at the hub's epoch becomes
+  ;; MVCC-invisible to a subsequent local edit once the clock takes over.
+  (with-temp-directory (cdir)
+    (with-temp-directory (gdir)
+      (let ((origin (make-array 16 :element-type '(unsigned-byte 8)
+                                :initial-element 7)))
+        (let ((g (make-graph :sc-lambda (namestring gdir)
+                             :peer-role :device :origin-id origin
+                             :peer-host "localhost" :replication-port 0
+                             :buffer-pool-size 1000)))
+          (let ((*graph* g))
+            ;; Local feed-seq advances to 3 ...
+            (dotimes (i 3)
+              (with-transaction ((graph-db::transaction-manager g)) t)))
+          ;; ... while the pull-cursor (a hub frontier) is far above it.
+          (graph-db::persist-peer-pull-cursor 42 g)
+          (close-graph g :snapshot-p nil))
+        (let ((clock (open-system-clock (namestring cdir))))
+          (unwind-protect
+               (let ((g2 (open-graph :sc-lambda (namestring gdir)
+                                     :peer-role :device :origin-id origin
+                                     :peer-host "localhost" :replication-port 0
+                                     :buffer-pool-size 1000
+                                     :system-clock clock)))
+                 (unwind-protect
+                      (is (> (clock-current-epoch clock) 42))
+                   (close-graph g2 :snapshot-p nil)))
+            (close-system-clock clock)))))))
+
+(test attach-does-not-half-apply-when-watermark-computation-fails
+  ;; Ordering (reviewer fix 2): ATTACH-TO-SYSTEM-CLOCK must compute and
+  ;; raise the watermark BEFORE it sets GRAPH-SYSTEM-CLOCK, so a failure
+  ;; mid-attach leaves the graph un-attached rather than attached-but-
+  ;; un-watermarked (a store whose epoch source is a clock not yet raised
+  ;; above its own history -- and already findable via *GRAPHS* by any
+  ;; other thread).  Corrupt the persisted highest-id file so
+  ;; LOAD-HIGHEST-TRANSACTION-ID signals, and assert the slot never moved.
+  (with-temp-directory (cdir)
+    (with-temp-directory (gdir)
+      (let ((g (make-graph :sc-kappa (namestring gdir) :buffer-pool-size 1000)))
+        (with-transaction ((graph-db::transaction-manager g)) t)
+        (unwind-protect
+             (let ((clock (open-system-clock (namestring cdir))))
+               (unwind-protect
+                    (progn
+                      (with-open-file
+                          (s (graph-db::highest-transaction-id-file g)
+                             :direction :output
+                             :element-type '(unsigned-byte 8)
+                             :if-exists :supersede)
+                        (write-byte 0 s))
+                      (signals error (attach-to-system-clock g clock))
+                      (is (null (graph-system-clock g))))
+                 (close-system-clock clock)))
+          (close-graph g :snapshot-p nil))))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -76,6 +76,21 @@
              (is (> (clock-next-epoch c2) highest))
           (close-system-clock c2))))))
 
+(test clock-observe-epoch-persists-its-jump-across-a-crash
+  ;; No coverage before this (GH #168 review): both crash tests above
+  ;; exercise CLOCK-NEXT-EPOCH only, never an OBSERVE.  CLOCK-OBSERVE-
+  ;; EPOCH's trailing %CLOCK-RESERVE forces the ceiling write that makes
+  ;; a large foreign jump durable; without it a crash right after an
+  ;; observe loses the jump and reopen resumes below it.
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir) :block-size 8))
+           (observed 999999))
+      (clock-observe-epoch c observed)
+      (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) observed))
+          (close-system-clock c2))))))
+
 (test clock-lease-is-disjoint-and-advances-the-clock
   (with-temp-directory (dir)
     (let ((c (open-system-clock (namestring dir))))
@@ -319,6 +334,26 @@
                       (is (null (graph-system-clock g))))
                  (close-system-clock clock)))
           (close-graph g :snapshot-p nil))))))
+
+(test attach-refuses-a-store-with-an-active-transaction
+  ;; No coverage before this (GH #168 review): the quiescence guard in
+  ;; ATTACH-TO-SYSTEM-CLOCK exists to prevent the FINISH-TX-ID skew
+  ;; described in its docstring.  Attach from inside an open transaction
+  ;; and confirm both the signal and that the graph is left un-attached.
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (gdir)
+             (let ((g (make-graph :sc-quiescence (namestring gdir)
+                                  :buffer-pool-size 1000)))
+               (unwind-protect
+                    (progn
+                      (with-transaction ((graph-db::transaction-manager g))
+                        (signals attach-with-active-transactions
+                          (attach-to-system-clock g clock)))
+                      (is (null (graph-system-clock g))))
+                 (close-graph g :snapshot-p nil))))
+        (close-system-clock clock)))))
 
 (test recreate-graph-allocates-from-the-image-clock
   ;; The audit finding (GH #168): RECREATE-GRAPH minted ids from a per-store

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -129,3 +129,72 @@
       (unwind-protect
            (signals reader-error (journal-records c2))
         (close-system-clock c2)))))
+
+;;; Routing epoch allocation through the clock (GH #168 task 3).
+
+(test two-stores-on-one-clock-get-disjoint-ordered-epochs
+  (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let ((ga (make-graph :sc-alpha (namestring da)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock))
+                     (gb (make-graph :sc-beta (namestring db)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock)))
+                 (unwind-protect
+                      (let ((ids '()))
+                        (dotimes (i 3)
+                          (push (transaction-id
+                                 (with-transaction ((graph-db::transaction-manager ga))
+                                   *transaction*))
+                                ids)
+                          (push (transaction-id
+                                 (with-transaction ((graph-db::transaction-manager gb))
+                                   *transaction*))
+                                ids))
+                        (let ((sorted (sort (copy-list ids) #'<)))
+                          ;; No two transactions anywhere share an epoch.
+                          (is (= (length sorted)
+                                 (length (remove-duplicates sorted))))))
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock)))))
+
+(test no-clock-means-per-store-counters-unchanged
+  ;; The backward-compatibility hinge: with *SYSTEM-CLOCK* nil and no
+  ;; :SYSTEM-CLOCK argument, two graphs allocate independently, exactly as
+  ;; before #168 -- so both start low and their ids DO collide.
+  (with-temp-directory (da)
+    (with-temp-directory (db)
+      (let ((ga (make-graph :sc-gamma (namestring da) :buffer-pool-size 1000))
+            (gb (make-graph :sc-delta (namestring db) :buffer-pool-size 1000)))
+        (unwind-protect
+             (let ((ia (transaction-id (with-transaction ((graph-db::transaction-manager ga))
+                                         *transaction*)))
+                   (ib (transaction-id (with-transaction ((graph-db::transaction-manager gb))
+                                         *transaction*))))
+               (is (= ia ib)))
+          (close-graph ga)
+          (close-graph gb))))))
+
+(test attaching-a-store-raises-the-clock-above-its-history
+  ;; The watermark: a store with existing history must not hand the clock a
+  ;; reason to reissue an epoch that store already used.
+  (with-temp-directory (cdir)
+    (with-temp-directory (gdir)
+      (let ((g (make-graph :sc-eps (namestring gdir) :buffer-pool-size 1000)))
+        (dotimes (i 5) (with-transaction ((graph-db::transaction-manager g)) t))
+        (let ((highest (load-highest-transaction-id g)))
+          (close-graph g)
+          (let ((clock (open-system-clock (namestring cdir))))
+            (unwind-protect
+                 (let ((g2 (open-graph :sc-eps (namestring gdir)
+                                       :buffer-pool-size 1000
+                                       :system-clock clock)))
+                   (unwind-protect
+                        (is (> (clock-current-epoch clock) highest))
+                     (close-graph g2)))
+              (close-system-clock clock))))))))

--- a/transaction-restore.lisp
+++ b/transaction-restore.lisp
@@ -126,15 +126,24 @@ as bare #(...): their ids, and an edge's FROM / TO, are repaired here by
 ENSURE-ID-ARRAY, but the element type of a node's own vector-valued SLOTS was
 never recorded in those files and cannot be recovered -- such a slot restores as
 a plain SIMPLE-VECTOR.  Re-snapshot after restoring to get the types back."
-  (let ((*package* (find-package package-name))
-        (*readtable* *restore-readtable*)
-        (*graph* graph)
-        (count 0)
-        (tx-id (load-highest-transaction-id graph))
-        (start-time (get-universal-time)))
+  (let* ((*package* (find-package package-name))
+         (*readtable* *restore-readtable*)
+         (*graph* graph)
+         (count 0)
+         ;; GH #168; slot-boundp mirrors WITH-READ-PIN (graph-class.lisp):
+         ;; the manager is unbound on the :replay-txn-dir path, and no
+         ;; clock can be attached before it either.
+         (tm (and (slot-boundp graph 'transaction-manager)
+                  (transaction-manager graph)))
+         (local-tx-id (unless tm (load-highest-transaction-id graph)))
+         (tx-id nil)
+         (start-time (get-universal-time)))
     (do-snapshot-sexps (plists snapshot-file *restore-objects-per-transaction*)
-      (let ((*transaction* (make-instance 'restore-transaction
-                                          :transaction-id (incf tx-id))))
+      (let ((*transaction*
+              (make-instance
+               'restore-transaction
+               :transaction-id
+               (setf tx-id (if tm (tm-next-epoch tm) (incf local-tx-id))))))
         (dolist (plist plists)
           (when (zerop (mod (incf count) 1000))
             (log:info "~A RESTORED ~A NODES" (current-thread) count))
@@ -149,7 +158,8 @@ a plain SIMPLE-VECTOR.  Re-snapshot after restoring to get the types back."
             (otherwise
              (log:error "RESTORE: Unknown input: ~S" plist))))
         (apply-transaction *transaction* graph)))
-    (persist-highest-transaction-id (incf tx-id) graph)
+    (when tx-id
+      (persist-highest-transaction-id tx-id graph))
     (let ((elapsed-time (- (get-universal-time) start-time)))
       (log:info "RESTORE TOOK ~A SECONDS" elapsed-time)
       (values graph :count count :elapsed-time elapsed-time))))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -3058,7 +3058,15 @@ The snapshot is recorded in *READ-SNAPSHOTS* under GRAPH rather than bound to
 one snapshot per participating graph, each internally consistent, with
 deliberately no single instant across them (GH #53).  An enclosing snapshot of
 the SAME graph is inherited, as is a read-write transaction on it.  A no-op
-(THUNK runs directly) when GRAPH has no transaction manager yet."
+(THUNK runs directly) when GRAPH has no transaction manager yet.
+
+Also takes a read-epoch pin on GRAPH's own manager for the extent (GH #168):
+under a shared image clock, a cross-store composition holds one such pin per
+participating store, so store B's reaper cannot free a version store A's
+snapshot could still dereference.  Nesting composes this for free -- each
+graph's own CALL-WITH-READ-SNAPSHOT pins only its own manager, and the named
+cost (spec sec.6) is that a long cross-store query delays reaping in every
+store it touched."
   (let ((tm (and graph
                  (slot-boundp graph 'transaction-manager)
                  (transaction-manager graph))))
@@ -3071,7 +3079,8 @@ the SAME graph is inherited, as is a read-write transaction on it.  A no-op
       ((and *read-snapshots* (gethash graph *read-snapshots*)) (funcall thunk))
       (t
        (let ((txn (create-transaction tm))
-             (table (or *read-snapshots* (make-hash-table :test 'eq))))
+             (table (or *read-snapshots* (make-hash-table :test 'eq)))
+             (pin (pin-read-epoch tm)))
          (unwind-protect
               (let ((*read-snapshots* table))
                 (setf (gethash graph table) txn)
@@ -3079,7 +3088,8 @@ the SAME graph is inherited, as is a read-write transaction on it.  A no-op
            ;; the entry must not outlive the extent: a stale snapshot pins the
            ;; reaper's floor and retains versions forever (GH #53)
            (remhash graph table)
-           (remove-transaction txn tm)))))))
+           (remove-transaction txn tm)
+           (unpin-read-epoch tm pin)))))))
 
 (defmacro with-read-snapshot ((&optional (graph '*graph*)) &body body)
   "Evaluate BODY with reads of GRAPH pinned to a single consistent MVCC snapshot.

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -129,6 +129,18 @@ per graph and may compose; read-write transactions are not (GH #53).")
 
 (define-condition no-transaction-in-progress (error) ())
 
+(define-condition attach-with-active-transactions (error)
+  ;; Attaching mid-transaction poisons the overlap window (GH #168 review):
+  ;; a transaction already holding a low START-TX-ID would get a raised
+  ;; FINISH-TX-ID, so OVERLAPPING-TRANSACTIONS spuriously returns every
+  ;; committed transaction and VALIDATE conflicts on all of them.
+  ((graph :initarg :graph :reader attach-with-active-transactions-graph))
+  (:report (lambda (condition stream)
+             (format stream "Cannot attach ~A to a system clock: it has ~
+in-flight transactions. Attach only a quiescent store."
+                     (graph-name (attach-with-active-transactions-graph
+                                  condition))))))
+
 (define-condition no-transaction-in-progress-warning (warning) ()
   (:report
    (lambda (condition stream)
@@ -641,7 +653,7 @@ vertices (the normal case for ingested source records) are unaffected."
   "Register a read pin at the current epoch; return its token (for UNPIN)."
   ;; Racy read of the epoch is fine: it is monotonic, and a slightly stale
   ;; (smaller) value only makes the reaper MORE conservative, never less.
-  (let ((epoch (tm-current-epoch transaction-manager)))
+  (let ((epoch (tm-peek-epoch transaction-manager)))
     (with-recursive-lock-held ((read-pins-lock transaction-manager))
       (let ((token (incf (read-pin-counter transaction-manager))))
         (setf (gethash token (read-pins transaction-manager)) epoch)
@@ -2925,11 +2937,16 @@ stops appearing in queries.  MARK-DELETED is the usual entry point.")
         (when (< (transaction-id tx) min-id)
           (remove-transaction tx transaction-manager))))))
 
+(defun tm-clock (transaction-manager)
+  "TRANSACTION-MANAGER's image clock, or NIL for its own counter (GH #168).
+A transaction-manager always has a graph -- INITIALIZE-INSTANCE :AFTER
+dereferences it immediately, so a NIL graph dies there first."
+  (graph-system-clock (graph transaction-manager)))
+
 (defun tm-next-epoch (transaction-manager)
   "Allocate a fresh epoch: from the image clock when the graph has one,
 otherwise from this manager's own counter (pre-#168 behaviour)."
-  (let ((clock (and (slot-boundp transaction-manager 'graph)
-                    (graph-system-clock (graph transaction-manager)))))
+  (let ((clock (tm-clock transaction-manager)))
     (if clock
         (clock-next-epoch clock)
         (prog1 (tx-id-counter transaction-manager)
@@ -2937,19 +2954,39 @@ otherwise from this manager's own counter (pre-#168 behaviour)."
 
 (defun tm-current-epoch (transaction-manager)
   "The next epoch TM-NEXT-EPOCH would return."
-  (let ((clock (and (slot-boundp transaction-manager 'graph)
-                    (graph-system-clock (graph transaction-manager)))))
+  (let ((clock (tm-clock transaction-manager)))
     (if clock
         (clock-current-epoch clock)
         (tx-id-counter transaction-manager))))
 
+(defun tm-peek-epoch (transaction-manager)
+  "Like TM-CURRENT-EPOCH but lock-free under a clock -- see
+CLOCK-PEEK-EPOCH.  For PIN-READ-EPOCH, where a racy read is fine."
+  (let ((clock (tm-clock transaction-manager)))
+    (if clock
+        (clock-peek-epoch clock)
+        (tx-id-counter transaction-manager))))
+
 (defun attach-to-system-clock (graph clock)
-  "Raise CLOCK above GRAPH's persisted highest id and record the attach.
-This is the spec §6 watermark, applied per store at attach rather than as a
-separate migration pass."
-  (setf (graph-system-clock graph) clock)
-  (clock-observe-epoch clock (load-highest-transaction-id graph))
-  (journal-append clock :attach :store (graph-name graph))
+  "Raise CLOCK above GRAPH's persisted history and record the attach --
+the spec §6 watermark, applied per store at attach rather than as a
+separate migration pass.  Mirrors TRANSACTION-MANAGER's own counter-
+seeding rule: a peer-graph's pull cursor is a distinct number space from
+its local highest id (see PEER-OBSERVE-EPOCH's docstring), so both are
+watermarked, not just the local one.  Refuses -- signals
+ATTACH-WITH-ACTIVE-TRANSACTIONS -- while GRAPH has any in-flight
+transaction; see that condition for why."
+  (let ((tm (transaction-manager graph)))
+    (with-transaction-manager-lock (tm)
+      (when (minimum-start-transaction-id tm)
+        (error 'attach-with-active-transactions :graph graph))
+      (let ((watermark (max (load-highest-transaction-id graph)
+                            (if (peer-graph-p graph)
+                                (load-peer-pull-cursor graph)
+                                0))))
+        (clock-observe-epoch clock watermark)
+        (journal-append clock :attach :store (graph-name graph))
+        (setf (graph-system-clock graph) clock))))
   graph)
 
 (defgeneric remove-transaction (transaction transaction-manager)
@@ -2966,9 +3003,10 @@ separate migration pass."
     (let* ((sequence-number (next-sequence-number transaction-manager))
            (graph (graph transaction-manager))
            (cache (cache graph))
+           (start-tx-id (tm-current-epoch transaction-manager))
            (tx (make-instance 'tx
                               :sequence-number sequence-number
-                              :start-tx-id (tm-current-epoch transaction-manager)
+                              :start-tx-id start-tx-id
                               :finish-tx-id nil
                               :tx-id nil
                               :transaction-manager transaction-manager
@@ -3068,12 +3106,9 @@ See CALL-WITH-READ-SNAPSHOT."
              ;; non-replicated graph).
              (setf tmp (prepare-tx-persistence tx))
              (with-transaction-manager-lock (tm)
-               ;; finish-tx-id must be set inside the manager lock so the overlap
-               ;; window computed by validate is consistent with the epoch source
-               ;; (this store's counter, or the shared clock -- GH #168).  Setting
-               ;; it outside would let concurrent commits advance the epoch
-               ;; between the read and the lock acquisition, making lost updates
-               ;; invisible.
+               ;; finish-tx-id is read under the manager lock so no commit of
+               ;; THIS store can allocate an epoch between the read and VALIDATE
+               ;; (GH #168 for the shared-clock case).
                (setf (finish-tx-id tx) (tm-current-epoch tm))
                (unless (validate tx)
                  (error 'validation-conflict :transaction tx))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -2423,20 +2423,32 @@ mint).  Persists if it moved.  A NIL/zero RECEIVED is a no-op."
   graph)
 
 (defun peer-observe-epoch (graph epoch)
-  "Advance GRAPH's TX-ID-COUNTER so it STRICTLY EXCEEDS EPOCH -- the MVCC commit
-epoch of an op this peer just APPLIED from a remote origin (a pulled node carries the
-HUB's epoch).  A device seeds its counter from its OWN feed-seq; without this the
-counter can sit at or below the epochs it applied, so a subsequent LOCAL edit
-transaction starts at a START-TX-ID that MVCC-hides the very node it means to edit
-(the node is invisible until the counter passes its epoch).  Under the tm lock, so it
-composes with CREATE-TRANSACTION; idempotent + monotonic; a NIL/zero EPOCH is a no-op.
-The durable side is the pull-cursor, which the barrier advances to the pull frontier T
-(>= every applied epoch) and which TX-ID-COUNTER is re-seeded from on open."
+  "Advance GRAPH's epoch source so it STRICTLY EXCEEDS EPOCH -- the MVCC
+commit epoch of an op this peer just APPLIED from a remote origin (a pulled
+node carries the HUB's epoch).  A device seeds its counter from its OWN
+feed-seq; without this the counter can sit at or below the epochs it
+applied, so a subsequent LOCAL edit transaction starts at a START-TX-ID that
+MVCC-hides the very node it means to edit (the node is invisible until the
+counter passes its epoch).  With an image clock bound (GH #168), TX-ID-
+COUNTER is dead -- TM-NEXT-EPOCH/TM-CURRENT-EPOCH/TM-PEEK-EPOCH all route
+around it -- so the observation goes to CLOCK-OBSERVE-EPOCH instead,
+taking only the clock's lock, not the tm lock.  That is safe only because
+this function runs solely on the device's peer-writer thread -- WP-8 funnels
+every local write through the same thread (see PEER-WRITER-LOOP and
+PEER-ENQUEUE-WRITE, peer-streaming.lisp) -- so it can never interleave with
+a local CREATE-TRANSACTION on this store.  Without a clock it falls back to
+the manager's own counter under its lock.  Idempotent + monotonic; a
+NIL/zero EPOCH is a no-op.  The durable side is the pull-cursor, which the
+barrier advances to the pull frontier T (>= every applied epoch) and which
+TX-ID-COUNTER is re-seeded from on open."
   (when (and epoch (> epoch 0) (typep graph 'peer-graph))
-    (let ((tm (transaction-manager graph)))
-      (with-recursive-lock-held ((lock tm))
-        (when (>= epoch (tx-id-counter tm))
-          (setf (tx-id-counter tm) (1+ epoch))))))
+    (let* ((tm (transaction-manager graph))
+           (clock (tm-clock tm)))
+      (if clock
+          (clock-observe-epoch clock epoch)
+          (with-recursive-lock-held ((lock tm))
+            (when (>= epoch (tx-id-counter tm))
+              (setf (tx-id-counter tm) (1+ epoch)))))))
   graph)
 
 (defun serialize-peer-meta (origin-id op-id lamport op-class)

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -639,9 +639,9 @@ vertices (the normal case for ingested source records) are unaffected."
 
 (defun pin-read-epoch (transaction-manager)
   "Register a read pin at the current epoch; return its token (for UNPIN)."
-  ;; Racy read of tx-id-counter is fine: it is monotonic, and a slightly stale
+  ;; Racy read of the epoch is fine: it is monotonic, and a slightly stale
   ;; (smaller) value only makes the reaper MORE conservative, never less.
-  (let ((epoch (tx-id-counter transaction-manager)))
+  (let ((epoch (tm-current-epoch transaction-manager)))
     (with-recursive-lock-held ((read-pins-lock transaction-manager))
       (let ((token (incf (read-pin-counter transaction-manager))))
         (setf (gethash token (read-pins transaction-manager)) epoch)
@@ -2925,6 +2925,33 @@ stops appearing in queries.  MARK-DELETED is the usual entry point.")
         (when (< (transaction-id tx) min-id)
           (remove-transaction tx transaction-manager))))))
 
+(defun tm-next-epoch (transaction-manager)
+  "Allocate a fresh epoch: from the image clock when the graph has one,
+otherwise from this manager's own counter (pre-#168 behaviour)."
+  (let ((clock (and (slot-boundp transaction-manager 'graph)
+                    (graph-system-clock (graph transaction-manager)))))
+    (if clock
+        (clock-next-epoch clock)
+        (prog1 (tx-id-counter transaction-manager)
+          (incf (tx-id-counter transaction-manager))))))
+
+(defun tm-current-epoch (transaction-manager)
+  "The next epoch TM-NEXT-EPOCH would return."
+  (let ((clock (and (slot-boundp transaction-manager 'graph)
+                    (graph-system-clock (graph transaction-manager)))))
+    (if clock
+        (clock-current-epoch clock)
+        (tx-id-counter transaction-manager))))
+
+(defun attach-to-system-clock (graph clock)
+  "Raise CLOCK above GRAPH's persisted highest id and record the attach.
+This is the spec §6 watermark, applied per store at attach rather than as a
+separate migration pass."
+  (setf (graph-system-clock graph) clock)
+  (clock-observe-epoch clock (load-highest-transaction-id graph))
+  (journal-append clock :attach :store (graph-name graph))
+  graph)
+
 (defgeneric remove-transaction (transaction transaction-manager)
   (:method (transaction transaction-manager)
     (remhash (sequence-number transaction)
@@ -2941,7 +2968,7 @@ stops appearing in queries.  MARK-DELETED is the usual entry point.")
            (cache (cache graph))
            (tx (make-instance 'tx
                               :sequence-number sequence-number
-                              :start-tx-id (tx-id-counter transaction-manager)
+                              :start-tx-id (tm-current-epoch transaction-manager)
                               :finish-tx-id nil
                               :tx-id nil
                               :transaction-manager transaction-manager
@@ -3042,11 +3069,12 @@ See CALL-WITH-READ-SNAPSHOT."
              (setf tmp (prepare-tx-persistence tx))
              (with-transaction-manager-lock (tm)
                ;; finish-tx-id must be set inside the manager lock so the overlap
-               ;; window computed by validate is consistent with tx-id-counter.
-               ;; Setting it outside would let concurrent commits advance the
-               ;; counter between the read and the lock acquisition, making lost
-               ;; updates invisible.
-               (setf (finish-tx-id tx) (tx-id-counter tm))
+               ;; window computed by validate is consistent with the epoch source
+               ;; (this store's counter, or the shared clock -- GH #168).  Setting
+               ;; it outside would let concurrent commits advance the epoch
+               ;; between the read and the lock acquisition, making lost updates
+               ;; invisible.
+               (setf (finish-tx-id tx) (tm-current-epoch tm))
                (unless (validate tx)
                  (error 'validation-conflict :transaction tx))
                ;; Unique constraints (issue #6): a pre-durability check under the same
@@ -3072,8 +3100,7 @@ See CALL-WITH-READ-SNAPSHOT."
                ;; exactly what that leaves reachable and why it is benign while
                ;; relocation is on.
                (ensure-vector-segment-capacity tx (graph tx))
-               (setf (transaction-id tx) (tx-id-counter tm))
-               (incf (tx-id-counter tm))
+               (setf (transaction-id tx) (tm-next-epoch tm))
                (prune-committed-transactions tm)
                ;; Cheap under the lock: rename temp to its final id-keyed name
                ;; (+ append replication log in commit order for masters).  Must


### PR DESCRIPTION
Gives a Lisp image **one shared epoch clock**, so a query spanning several stores resolves
at one consistent instant. Previously each store had its own transaction-id counter and
there was deliberately no common instant across them.

Closes #94. Implements §6 and §9.1 of `docs/superpowers/specs/2026-08-20-namespaces-design.md`
(unit 3 of the namespaces epic, #110).

## The binding constraint

`*system-clock*` defaults to `nil`, and **with no clock bound every path behaves exactly as
before this branch.** Nothing here is on by default; a deployment upgrading past this sees no
behaviour change until it explicitly opens a clock. The whole-branch review verified that
site by site against pre-branch text:

| site | pre-branch | NIL branch now |
|---|---|---|
| `create-transaction` `:start-tx-id` | `(tx-id-counter tm)` | `tm-current-epoch` → same |
| `finish-tx-id` | `(tx-id-counter tm)` | `tm-current-epoch` → same |
| commit assignment | `setf` then `incf` | `tm-next-epoch` → `(prog1 counter (incf counter))` |
| `pin-read-epoch` | `(tx-id-counter tm)` | `tm-peek-epoch` → same |
| `peer-observe-epoch` | body under tm lock | same body verbatim in the else arm |

`recreate-graph` is the one genuine change on that path, and it is a fix — see below.

## What landed

- **`system-clock.lisp`** — a durable epoch counter with a crash-safe block reservation
  (every issued id is strictly below the persisted ceiling, so a reopen never reissues),
  **epoch leases** carving a range out for a store being detached, and an **append-only
  lifecycle journal**. The journal is read with `*read-eval*` bound to `nil`: it is data and
  is never evaluated.
- **Epoch allocation routed through the clock** at every site, behind the NIL default above.
- **`attach-to-system-clock`** applies the watermark per store at attach rather than as a
  separate migration pass, and refuses a store with in-flight transactions. For a peer graph
  it maxes the local highest id against the **pull-cursor** — a different number space;
  omitting it reintroduced the MVCC-invisibility bug `peer-observe-epoch` exists to prevent.
- **`recreate-graph` allocates through the transaction manager** instead of a per-store
  scalar. This was the audit finding the unit was scoped around: under a shared clock the old
  code minted epochs *below* the global counter, so a restore could reissue epochs another
  store had already committed at. Issued ids are byte-identical for an ordinary disk graph;
  the trailing persisted watermark is now the last id used rather than one past it, matching
  `apply-transaction`.
- **`peer-observe-epoch`** raises the clock rather than a counter nothing reads once a clock
  is attached. Consequence worth knowing: the image clock is therefore **not purely local** —
  a peer sync can advance it, driven by another image's clock.
- **A cross-store snapshot pins every participating store**, so store B's reaper cannot free
  a version store A's snapshot could dereference. Named cost: a long cross-store query delays
  reaping in every store it touched.
- Manual chapter, CHANGELOG, spec §6 marked implemented.

## Tests

`graph-db/test` **3730 / 3720 pass / 10 skip / 0 fail** · `graph-db/spacetime-test` 342/342 ·
`graph-db/geos-test` 185/185. Baseline before the branch: 3684 / 3674 / 10 / 0.

⚠ **The baseline is load-order dependent.** "10 skips" identifies the GEOS-**unloaded**
population. A runner that loads `graph-db/geos-test` before the main suite pulls in
`graph-db/geos`, flips `*geos-available-p*`, and ~9 GEOS-gated tests inside the main suite
execute rather than skip — giving ~3837 with 1 skip. That is *more* coverage, not a
regression, but the two are **not comparable**. Run `graph-db/test` alone in its own image.

`POINT-IN-RING-PACKED-CONSES-NOTHING` is a known pre-existing flake (#174) —
`sb-ext:get-bytes-consed` is process-wide, so other threads contaminate its measurement.

## Follow-ups filed rather than fixed

#173, #176, #177, #178, #179, #180, #181, #182, #183, #184 — each with the analysis that
produced it.

**#182 should land before #170.** There is no cross-process exclusion on the clock directory,
so two images pointed at it both reserve blocks and issue overlapping epochs — silently
destroying the one property the clock provides. This branch built the *lease* that makes a
correct multi-process story possible, but nothing yet stops a second process bypassing it,
and #170's detached bulk load is exactly that scenario.

#93 (cross-store two-phase commit) remains deliberately out of scope: the clock is in,
cross-store atomicity is not. Store placement is the tool for deciding what gets
transactional consistency — two namespaces in one store are already in one transaction domain.

## Review notes

17 defects were found during development. 11 originated in the implementation plan, none in
the implementations; 8 of those 11 were tests that passed while proving nothing. Two guards
shipped in intermediate commits with zero coverage and were caught only because the
whole-branch review checked whether deleting them broke anything — it didn't, until tests
were added.

The technique that found them, for anyone reviewing this: **ablate the implementation a test
guards, confirm the test fails, restore, confirm it passes — then ask what the nearest wrong
implementation is and ablate that too.** The second half matters; a correct ablation against
the one bug you had in mind gave false confidence twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o9cANB4ycNnbr4zjduxyA
