### PR TITLE
Widen the memory image's type-id to 32 bits, format v8 (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,33 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **The memory-graph native image (`VGMI`) packed `type-id` at 2 bytes and
+  truncated silently; format bumped to v8** (#187). `ni-uint` writes with
+  `ldb`, so a `type-id` above 65535 lost its high bits with no signal — 70000
+  was restored as 4464, yielding either a node built against the **wrong
+  class** or a `NIL` type lookup. Six sites were affected: the node record
+  (both the live-node and `LZNODE` arms, plus its reader) and all three index
+  key codecs (`type`, `ve`, `vev`).
+
+  Unreachable while type-ids were per-graph and handed out from 1, but #166
+  widened the on-disk field to 32 bits and #186 makes ids global, so this was
+  the last 16-bit narrowing on the path. It mattered more than the equivalent
+  assumption on the replication wire (`peer-streaming.lisp`), which validates
+  and **signals**: this one failed silently, and a memory graph's image is its
+  **only** durable copy — the journal is cleared on every checkpoint.
+
+  **v5, v6 and v7 images still open.** Record and key layouts are parsed
+  positionally, so `%read-memory-image` selects the type-id width from the
+  version and threads it through the record reader and all three key readers;
+  reading a v7 image at v8's width would shift every field after the type-id.
+  Writers always emit 4 bytes. The width is a defaulted parameter on each
+  codec rather than a duplicated set of `*-v7` functions.
+
+  `ni-type-id` replaces the bare `ni-uint` on every type-id write and
+  **signals `memory-image-type-id-too-wide`** rather than truncating, so the
+  silent-narrowing class of bug is gone and not merely this instance of it.
+
+
 - **`recreate-graph` (restore/replay) minted ids from a per-store scalar,
   bypassing both the transaction manager and any bound system clock**
   (#168). Reached via `replay` (snapshot and backup restore) and

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2631,6 +2631,28 @@ A lazy graph loads each node as a compact *blob* (its parsed head plus its still
 
 Caveats: a *full* scan (e.g. ~map-vertices~ over everything) still materializes everything — lazy wins for *partial* working sets, which is the field case. A lazy graph uses the VG-native image format (written automatically on checkpoint/close), so run one checkpoint on it before relying on the fast open. ~:lazy~ composes with the peer device — it is purely a storage-mode flag.
 
+**The native image's format version.** The VG-native image (magic ~VGMI~)
+carries its own format version, independent of ~+storage-version+~ — they
+version different things, and a graph can be current on one and stale on the
+other. This build writes **v8** and reads v5 through v8.
+
+Backward compatibility is not optional here. A memory graph's image is the
+*only* durable record of a cleanly-closed graph: the retained journal is
+cleared on every checkpoint, so an image the build cannot read is a graph that
+is gone. An unknown version is therefore refused with a message naming the
+remedy (open with a build that reads it, or migrate), never by deleting and
+"recovering" onto an empty graph.
+
+v8 widened ~type-id~ from 2 to 4 bytes (GH #187), matching the 32-bit on-disk
+field #166 introduced. Before it, ~ni-uint~ — which writes with ~ldb~ — dropped
+the high bits of any id above 65535 without signalling, so a ~type-id~ of 70000
+came back as 4464. Records and index keys are parsed *positionally*, so
+~%read-memory-image~ picks the width from the version and threads it through
+the record reader and the three index-key readers; reading a v7 image at v8's
+width would shift every field after the type-id. Writers always emit 4 bytes,
+and ~ni-type-id~ signals ~memory-image-type-id-too-wide~ rather than
+truncating.
+
 | | Eager (default) | Lazy (~:lazy t~) |
 |---|---|---|
 | Open latency | Builds every node (~O(nodes)~) | Near-instant (~O(1)~) |

--- a/globals.lisp
+++ b/globals.lisp
@@ -89,6 +89,13 @@ application's own config; graph-db does not read an ini file itself.")
 ;; MIGRATE-GRAPH (snapshot + replay); a v1 or v2 graph is refused at
 ;; OPEN-GRAPH, not silently misread.
 (alexandria:define-constant +storage-version+     #x03)
+
+;; The memory-graph native image ("VGMI") carries its own format version,
+;; independent of +STORAGE-VERSION+.  v8 (#187) widens type-id from 2 to 4
+;; bytes; v5/v6/v7 stay readable, because a cleanly-closed memory graph's
+;; image is its ONLY durable copy -- the journal is cleared on checkpoint.
+(alexandria:define-constant +native-image-version+ 8)
+(alexandria:define-constant +image-type-id-bytes+  4)
 (alexandria:define-constant +fixed-integer-64+    #x01)
 (alexandria:define-constant +data-magic-byte+     #x17)
 (alexandria:define-constant +lhash-magic-byte+    #x18)

--- a/memory-graph.lisp
+++ b/memory-graph.lisp
@@ -420,6 +420,22 @@ cells loaded straight from PAIRS -- no node scan, no geohash recompute."
 ;;; ===========================================================================
 
 ;;; ---- write: growable little-endian byte buffer ----
+(define-condition memory-image-type-id-too-wide (error)
+  ((type-id :initarg :type-id :reader mitw-type-id)
+   (nbytes  :initarg :nbytes  :reader mitw-nbytes))
+  (:report
+   (lambda (c s)
+     (format s "type-id ~D does not fit the ~D-byte field this memory-image ~
+version uses.  Refusing rather than truncating (GH #187)."
+             (mitw-type-id c) (mitw-nbytes c)))))
+
+(defun ni-type-id (buf type-id nbytes)
+  "Write TYPE-ID as NBYTES.  NI-UINT truncates via LDB, which is how #187 --
+a type-id of 70000 restored as 4464 -- stayed invisible; refuse instead."
+  (unless (< type-id (ash 1 (* 8 nbytes)))
+    (error 'memory-image-type-id-too-wide :type-id type-id :nbytes nbytes))
+  (ni-uint buf type-id nbytes))
+
 (defun ni-mkbuf () (make-array 65536 :element-type '(unsigned-byte 8)
                                :adjustable t :fill-pointer 0))
 (declaim (inline ni-u8 ni-uint ni-bytes ni-blob ni-lisp))
@@ -456,25 +472,25 @@ cells loaded straight from PAIRS -- no node scan, no geohash recompute."
 ;;; node record = raw head fields + length-prefixed data blob (edges add from/to/
 ;;; weight before data).  Writer handles a live node OR an LZNODE (untouched nodes
 ;;; pass their blob straight through -- no re-serialize on checkpoint).
-(defun ni-node (buf id x edge-p)
+(defun ni-node (buf id x edge-p &optional (w +image-type-id-bytes+))
   (if (lznode-p x)
       (progn
-        (ni-uint buf (lznode-type-id x) 2) (ni-blob buf id)
+        (ni-type-id buf (lznode-type-id x) w) (ni-blob buf id)
         (ni-u8 buf (if (lznode-deleted-p x) 1 0))
         (ni-uint buf (lznode-revision x) 4) (ni-uint buf (lznode-commit-epoch x) 8)
         (when edge-p (ni-blob buf (lznode-from x)) (ni-blob buf (lznode-to x))
               (ni-lisp buf (lznode-weight x)))
         (ni-blob buf (lznode-data-blob x)))
       (progn
-        (ni-uint buf (type-id x) 2) (ni-blob buf id)
+        (ni-type-id buf (type-id x) w) (ni-blob buf id)
         (ni-u8 buf (if (deleted-p x) 1 0))
         (ni-uint buf (revision x) 4) (ni-uint buf (commit-epoch x) 8)
         (when edge-p (ni-blob buf (from x)) (ni-blob buf (to x)) (ni-lisp buf (weight x)))
         (ni-blob buf (serialize (data x))))))
 
-(defun ri-node (rc edge-p)
+(defun ri-node (rc edge-p &optional (w +image-type-id-bytes+))
   "Read one record into (values ID LZNODE) -- head parsed, data blob deferred."
-  (let* ((type-id (ri-uint rc 2)) (id (ri-blob rc)) (del (= 1 (ri-u8 rc)))
+  (let* ((type-id (ri-uint rc w)) (id (ri-blob rc)) (del (= 1 (ri-u8 rc)))
          (rev (ri-uint rc 4)) (ce (ri-uint rc 8))
          (from (when edge-p (ri-blob rc))) (to (when edge-p (ri-blob rc)))
          (weight (if edge-p (ri-lisp rc) 1.0))
@@ -527,14 +543,19 @@ lookups return the live object).  Returns the node."
         (dotimes (j m) (push (ri-blob rc) ids))
         (push (cons key (nreverse ids)) acc)))
     (nreverse acc)))
-(defun ni-key-type (buf k) (ni-uint buf k 2))
-(defun ri-key-type (rc) (ri-uint rc 2))
-(defun ni-key-ve (buf k) (ni-blob buf (ve-key-id k)) (ni-uint buf (ve-key-type-id k) 2))
-(defun ri-key-ve (rc) (let ((id (ri-blob rc)) (ti (ri-uint rc 2))) (make-ve-key :id id :type-id ti)))
-(defun ni-key-vev (buf k)
-  (ni-blob buf (vev-key-out-id k)) (ni-blob buf (vev-key-in-id k)) (ni-uint buf (vev-key-type-id k) 2))
-(defun ri-key-vev (rc)
-  (let ((o (ri-blob rc)) (in (ri-blob rc)) (ti (ri-uint rc 2)))
+(defun ni-key-type (buf k &optional (w +image-type-id-bytes+))
+  (ni-type-id buf k w))
+(defun ri-key-type (rc &optional (w +image-type-id-bytes+)) (ri-uint rc w))
+(defun ni-key-ve (buf k &optional (w +image-type-id-bytes+))
+  (ni-blob buf (ve-key-id k)) (ni-type-id buf (ve-key-type-id k) w))
+(defun ri-key-ve (rc &optional (w +image-type-id-bytes+))
+  (let ((id (ri-blob rc)) (ti (ri-uint rc w)))
+    (make-ve-key :id id :type-id ti)))
+(defun ni-key-vev (buf k &optional (w +image-type-id-bytes+))
+  (ni-blob buf (vev-key-out-id k)) (ni-blob buf (vev-key-in-id k))
+  (ni-type-id buf (vev-key-type-id k) w))
+(defun ri-key-vev (rc &optional (w +image-type-id-bytes+))
+  (let ((o (ri-blob rc)) (in (ri-blob rc)) (ti (ri-uint rc w)))
     (make-vev-key :out-id o :in-id in :type-id ti)))
 ;; Tagged value codec for spatial values / view keys: VG's SERIALIZE cannot
 ;; round-trip a bare (unsigned-byte 8) array (ids/uuids -- the on-disk path always
@@ -616,7 +637,7 @@ lookups return the live object).  Returns the node."
     (nreverse acc)))
 
 (defun write-memory-image-native (graph)
-  "Write GRAPH's full state in the VG-native (v7) format: per-node blob records
+  "Write GRAPH's full state in the VG-native (v8) format: per-node blob records
 plus the same structural derived dumps.  Untouched LZNODEs pass their blob
 through."
   (let ((buf (ni-mkbuf)))
@@ -625,8 +646,10 @@ through."
     ;; v6's LAYOUT exactly (the pair codec always round-tripped values); it
     ;; bumps because a spatial entry's value now carries its type tag, and a v6
     ;; image's NIL values would restore an index no scoped query can filter on
-    ;; (GH #104).
-    (ni-bytes buf *native-image-magic*) (ni-uint buf 7 4)
+    ;; (GH #104).  v8 is v7's layout with type-id widened 2 -> 4 bytes (#187);
+    ;; v5-v7 are still read, so an older image is never orphaned.
+    (ni-bytes buf *native-image-magic*)
+    (ni-uint buf +native-image-version+ 4)
     (ni-uint buf (load-highest-transaction-id graph) 8)
     (let ((vt (mem-table-data (vertex-table graph)))
           (et (mem-table-data (edge-table graph))))
@@ -654,11 +677,11 @@ through."
 journal is cleared on checkpoint (GH #65) -- so the old advice to delete it and
 recover from the journal was actively wrong (it discards the graph and 'succeeds'
 onto an empty one).  Say what remedies actually exist instead."
-  (error "Unsupported memory-image format v~D at ~A (this build reads v5, v6 ~
-and v7, writing v7).  This image is the ONLY durable record of a cleanly-~
+  (error "Unsupported memory-image format v~D at ~A (this build reads v5, v6, ~
+v7 and v8, writing v8).  This image is the ONLY durable record of a cleanly-~
 closed memory graph -- the journal is cleared after every checkpoint, so ~
 deleting the image discards the graph, it does not recover it.  Open it with a ~
-build that reads v~D, or migrate it to v7 first."
+build that reads v~D, or migrate it to v8 first."
          ver file ver))
 
 (defun %custom-node-geometry-classes ()
@@ -753,22 +776,37 @@ was filed for).  Returns :STRUCTURAL and stashes the view dump in
     ;; the spatial section per-(owner . slot); v7 shares v6's layout exactly
     ;; and differs only in what a spatial entry's value holds (GH #104).  Both
     ;; v5 and v6 are migrated below.
-    (unless (member ver '(5 6 7))
+    (unless (member ver '(5 6 7 8))
       (%signal-unsupported-memory-image-version ver file))
     (ri-uint rc 8)                                 ; highest-tx-id
-    (let ((nv (ri-uint rc 4)))
-      (dotimes (i nv)
-        (multiple-value-bind (id lz) (ri-node rc nil)
-          (mem-table-put vtable id (if lazy lz (%lznode->node vtable id lz))))))
-    (let ((ne (ri-uint rc 4)))
-      (dotimes (i ne)
-        (multiple-value-bind (id lz) (ri-node rc t)
-          (mem-table-put etable id (if lazy lz (%lznode->node etable id lz))))))
-    (%load-mem-index (mem-type-index-data (vertex-index graph)) (ri-index rc #'ri-key-type))
-    (%load-mem-index (mem-type-index-data (edge-index graph))   (ri-index rc #'ri-key-type))
-    (%load-mem-index (mem-ve-index-data (ve-index-in graph))    (ri-index rc #'ri-key-ve))
-    (%load-mem-index (mem-ve-index-data (ve-index-out graph))   (ri-index rc #'ri-key-ve))
-    (%load-mem-index (mem-vev-index-data (vev-index graph))     (ri-index rc #'ri-key-vev))
+    ;; v8 widened type-id 2 -> 4 bytes (#187).  Every record and index key
+    ;; before it is parsed POSITIONALLY, so the width has to be selected per
+    ;; version and threaded through -- reading a v7 image at 4 bytes shifts
+    ;; every field after the type-id.
+    (let ((w (if (< ver 8) 2 +image-type-id-bytes+)))
+      (let ((nv (ri-uint rc 4)))
+        (dotimes (i nv)
+          (multiple-value-bind (id lz) (ri-node rc nil w)
+            (mem-table-put vtable id
+                           (if lazy lz (%lznode->node vtable id lz))))))
+      (let ((ne (ri-uint rc 4)))
+        (dotimes (i ne)
+          (multiple-value-bind (id lz) (ri-node rc t w)
+            (mem-table-put etable id
+                           (if lazy lz (%lznode->node etable id lz))))))
+      (flet ((rd-type (rc) (ri-key-type rc w))
+             (rd-ve   (rc) (ri-key-ve rc w))
+             (rd-vev  (rc) (ri-key-vev rc w)))
+        (%load-mem-index (mem-type-index-data (vertex-index graph))
+                         (ri-index rc #'rd-type))
+        (%load-mem-index (mem-type-index-data (edge-index graph))
+                         (ri-index rc #'rd-type))
+        (%load-mem-index (mem-ve-index-data (ve-index-in graph))
+                         (ri-index rc #'rd-ve))
+        (%load-mem-index (mem-ve-index-data (ve-index-out graph))
+                         (ri-index rc #'rd-ve))
+        (%load-mem-index (mem-vev-index-data (vev-index graph))
+                         (ri-index rc #'rd-vev))))
     (if (= ver 5)
         (ri-pairs rc)         ; v5's flat spatial pairs: always empty, discard (GH #65)
         (dolist (rec (ri-spatial rc))

--- a/tests/memory-graph-tests.lisp
+++ b/tests/memory-graph-tests.lisp
@@ -756,24 +756,24 @@ is the same call sequence as today's writer."
     (let ((vt (graph-db::mem-table-data (graph-db::vertex-table graph)))
           (et (graph-db::mem-table-data (graph-db::edge-table graph))))
       (graph-db::ni-uint buf (hash-table-count vt) 4)
-      (maphash (lambda (id x) (graph-db::ni-node buf id x nil)) vt)
+      (maphash (lambda (id x) (graph-db::ni-node buf id x nil 2)) vt)
       (graph-db::ni-uint buf (hash-table-count et) 4)
-      (maphash (lambda (id x) (graph-db::ni-node buf id x t)) et))
+      (maphash (lambda (id x) (graph-db::ni-node buf id x t 2)) et))
     (graph-db::ni-index buf (graph-db::%dump-mem-index
                               (graph-db::mem-type-index-data (graph-db::vertex-index graph)))
-                         #'graph-db::ni-key-type)
+                         (lambda (b k) (graph-db::ni-key-type b k 2)))
     (graph-db::ni-index buf (graph-db::%dump-mem-index
                               (graph-db::mem-type-index-data (graph-db::edge-index graph)))
-                         #'graph-db::ni-key-type)
+                         (lambda (b k) (graph-db::ni-key-type b k 2)))
     (graph-db::ni-index buf (graph-db::%dump-mem-index
                               (graph-db::mem-ve-index-data (graph-db::ve-index-in graph)))
-                         #'graph-db::ni-key-ve)
+                         (lambda (b k) (graph-db::ni-key-ve b k 2)))
     (graph-db::ni-index buf (graph-db::%dump-mem-index
                               (graph-db::mem-ve-index-data (graph-db::ve-index-out graph)))
-                         #'graph-db::ni-key-ve)
+                         (lambda (b k) (graph-db::ni-key-ve b k 2)))
     (graph-db::ni-index buf (graph-db::%dump-mem-index
                               (graph-db::mem-vev-index-data (graph-db::vev-index graph)))
-                         #'graph-db::ni-key-vev)
+                         (lambda (b k) (graph-db::ni-key-vev b k 2)))
     (graph-db::ni-pairs buf '())          ; v5's flat spatial section: always empty
     (graph-db::ni-views buf graph)
     (graph-db::ni-val buf (graph-db::%dump-unique-indexes graph))
@@ -924,5 +924,195 @@ empty, and deleting the image discards the ONLY durable copy of the graph
         (when msg
           (is (search "v5" msg))
           (is (search "v6" msg))
+          (is (search "v8" msg)
+              "the message names the version this build writes")
           (is (not (search "Delete" msg)))
           (is (not (search "delete" msg))))))))
+
+;;; ---------------------------------------------------------------------------
+;;; GH #187: the native image packed type-id at 2 bytes and truncated silently.
+;;;
+;;; NI-UINT writes with LDB, so a type-id above 65535 lost its high bits with no
+;;; signal -- 70000 (#x11170) came back as 4464 (#x1170).  Unreachable while
+;;; type-ids were per-graph and handed out from 1, but #166 widened the on-disk
+;;; field to 32 bits and #186 makes ids global, so the image is now the only
+;;; 16-bit narrowing left.  v8 widens it; v5/v6/v7 stay readable, because the
+;;; image is the ONLY durable copy of a cleanly-closed memory graph.
+;;; ---------------------------------------------------------------------------
+
+(defun %mem-image-big-type-id-lznode ()
+  (graph-db::make-lznode :type-id 70000 :revision 3 :commit-epoch 9
+                         :data-blob (graph-db::serialize '(:a 1))))
+
+(test memory-image-node-record-round-trips-a-type-id-above-16-bits
+  "A vertex record's type-id survives NI-NODE -> RI-NODE.  At 2 bytes it did
+not: 70000 restored as 4464, silently."
+  (let ((buf (graph-db::ni-mkbuf))
+        (id (graph-db::gen-vertex-id)))
+    (graph-db::ni-node buf id (%mem-image-big-type-id-lznode) nil)
+    (multiple-value-bind (rid lz)
+        (graph-db::ri-node (graph-db::ni-ric buf) nil)
+      (is (equalp id rid) "id round-trips")
+      (is (= 70000 (graph-db::lznode-type-id lz))
+          "type-id round-trips; 4464 means it was truncated to 2 bytes")
+      (is (= 3 (graph-db::lznode-revision lz)) "revision still lands")
+      (is (= 9 (graph-db::lznode-commit-epoch lz))
+          "commit-epoch still lands -- a mis-sized type-id shifts every
+field after it, so these pin the whole record layout, not just the type-id"))))
+
+(test memory-image-edge-record-round-trips-a-type-id-above-16-bits
+  "The edge arm writes its own type-id and carries from/to/weight after the
+head, so a mis-sized type-id corrupts those too."
+  (let* ((buf (graph-db::ni-mkbuf))
+         (id (graph-db::gen-edge-id))
+         (from (graph-db::gen-vertex-id))
+         (to (graph-db::gen-vertex-id))
+         (lz (%mem-image-big-type-id-lznode)))
+    (setf (graph-db::lznode-from lz) from
+          (graph-db::lznode-to lz) to
+          (graph-db::lznode-weight lz) 2.5)
+    (graph-db::ni-node buf id lz t)
+    (multiple-value-bind (rid rlz)
+        (graph-db::ri-node (graph-db::ni-ric buf) t)
+      (is (equalp id rid))
+      (is (= 70000 (graph-db::lznode-type-id rlz)))
+      (is (equalp from (graph-db::lznode-from rlz)))
+      (is (equalp to (graph-db::lznode-to rlz)))
+      (is (= 2.5 (graph-db::lznode-weight rlz))))))
+
+(test memory-image-type-key-round-trips-a-type-id-above-16-bits
+  "The type index's key IS a bare type-id."
+  (let ((buf (graph-db::ni-mkbuf)))
+    (graph-db::ni-key-type buf 70000)
+    (is (= 70000 (graph-db::ri-key-type (graph-db::ni-ric buf))))))
+
+(test memory-image-ve-key-round-trips-a-type-id-above-16-bits
+  (let ((buf (graph-db::ni-mkbuf))
+        (k (graph-db::make-ve-key :id (graph-db::gen-vertex-id)
+                                  :type-id 70000)))
+    (graph-db::ni-key-ve buf k)
+    (let ((back (graph-db::ri-key-ve (graph-db::ni-ric buf))))
+      (is (equalp (graph-db::ve-key-id k) (graph-db::ve-key-id back)))
+      (is (= 70000 (graph-db::ve-key-type-id back))))))
+
+(test memory-image-vev-key-round-trips-a-type-id-above-16-bits
+  (let ((buf (graph-db::ni-mkbuf))
+        (k (graph-db::make-vev-key :out-id (graph-db::gen-vertex-id)
+                                   :in-id (graph-db::gen-vertex-id)
+                                   :type-id 70000)))
+    (graph-db::ni-key-vev buf k)
+    (let ((back (graph-db::ri-key-vev (graph-db::ni-ric buf))))
+      (is (equalp (graph-db::vev-key-out-id k) (graph-db::vev-key-out-id back)))
+      (is (equalp (graph-db::vev-key-in-id k) (graph-db::vev-key-in-id back)))
+      (is (= 70000 (graph-db::vev-key-type-id back))))))
+
+(test memory-image-writer-refuses-a-type-id-it-cannot-represent
+  "The v5/v6/v7 writers are still reachable (the old-image test helpers use
+them).  Handing one a type-id too wide for its field must SIGNAL rather than
+drop the high bits -- silence is what made #187 invisible.  A dedicated
+condition, so an arity or type error cannot satisfy this by accident."
+  (let ((buf (graph-db::ni-mkbuf)))
+    (signals graph-db::memory-image-type-id-too-wide
+      (graph-db::ni-node buf (graph-db::gen-vertex-id)
+                         (%mem-image-big-type-id-lznode) nil 2))
+    (signals graph-db::memory-image-type-id-too-wide
+      (graph-db::ni-key-type buf 70000 2))
+    (signals graph-db::memory-image-type-id-too-wide
+      (graph-db::ni-key-ve buf (graph-db::make-ve-key
+                                :id (graph-db::gen-vertex-id) :type-id 70000)
+                           2))
+    (signals graph-db::memory-image-type-id-too-wide
+      (graph-db::ni-key-vev buf (graph-db::make-vev-key
+                                 :out-id (graph-db::gen-vertex-id)
+                                 :in-id (graph-db::gen-vertex-id)
+                                 :type-id 70000)
+                            2))))
+
+(defun %write-v7-test-image (graph)
+  "Write GRAPH as a v7 native image: byte-identical to today's v8 writer except
+the version stamp and the 2-byte type-id fields.  Clears the journal afterward,
+like a real checkpoint, so the reopen exercises the image and not a replay."
+  (let ((buf (graph-db::ni-mkbuf)))
+    (graph-db::ni-bytes buf graph-db::*native-image-magic*)
+    (graph-db::ni-uint buf 7 4)
+    (graph-db::ni-uint buf (graph-db::load-highest-transaction-id graph) 8)
+    (let ((vt (graph-db::mem-table-data (graph-db::vertex-table graph)))
+          (et (graph-db::mem-table-data (graph-db::edge-table graph))))
+      (graph-db::ni-uint buf (hash-table-count vt) 4)
+      (maphash (lambda (id x) (graph-db::ni-node buf id x nil 2)) vt)
+      (graph-db::ni-uint buf (hash-table-count et) 4)
+      (maphash (lambda (id x) (graph-db::ni-node buf id x t 2)) et))
+    (graph-db::ni-index buf (graph-db::%dump-mem-index
+                             (graph-db::mem-type-index-data
+                              (graph-db::vertex-index graph)))
+                        (lambda (b k) (graph-db::ni-key-type b k 2)))
+    (graph-db::ni-index buf (graph-db::%dump-mem-index
+                             (graph-db::mem-type-index-data
+                              (graph-db::edge-index graph)))
+                        (lambda (b k) (graph-db::ni-key-type b k 2)))
+    (graph-db::ni-index buf (graph-db::%dump-mem-index
+                             (graph-db::mem-ve-index-data
+                              (graph-db::ve-index-in graph)))
+                        (lambda (b k) (graph-db::ni-key-ve b k 2)))
+    (graph-db::ni-index buf (graph-db::%dump-mem-index
+                             (graph-db::mem-ve-index-data
+                              (graph-db::ve-index-out graph)))
+                        (lambda (b k) (graph-db::ni-key-ve b k 2)))
+    (graph-db::ni-index buf (graph-db::%dump-mem-index
+                             (graph-db::mem-vev-index-data
+                              (graph-db::vev-index graph)))
+                        (lambda (b k) (graph-db::ni-key-vev b k 2)))
+    (graph-db::ni-spatial buf graph)
+    (graph-db::ni-views buf graph)
+    (graph-db::ni-val buf (graph-db::%dump-unique-indexes graph))
+    (with-open-file (s (graph-db::memory-image-file
+                        (graph-db::location graph))
+                       :direction :output :element-type '(unsigned-byte 8)
+                       :if-exists :supersede :if-does-not-exist :create)
+      (write-sequence buf s))
+    (graph-db::clear-memory-journal graph)))
+
+(test v7-memory-image-still-opens-on-the-v8-build
+  "The image is the ONLY durable copy of a cleanly-closed memory graph, so
+widening type-id must not orphan images written before #187.  A real v7 image
+-- 2-byte type-ids throughout, including every index key -- restores whole.
+
+This is the half of #187 that a writer-only fix would break: reading a v7
+image with v8's 4-byte parse shifts every field after the type-id, so the
+version fork in %READ-MEMORY-IMAGE is what this pins."
+  (reset-mem-view-registry)
+  (with-temp-directory (dir)
+    (let ((loc (namestring dir))
+          person-id place-id knows-id)
+      (let ((g (graph-db::make-memory-graph *mem-test-graph-name* loc)))
+        (let ((*graph* g))
+          (with-transaction ()
+            (let ((a (make-m-person :name "alice" :age 30))
+                  (b (make-m-person :name "bob" :age 40)))
+              (setq person-id (id a))
+              (setq knows-id (id (make-m-knows :from (id a) :to (id b))))
+              (setq place-id
+                    (id (make-m-place
+                         :label "kharkiv"
+                         :geom (graph-db::make-point 36.3d0 50.0d0)))))))
+        (%write-v7-test-image g)
+        (close-graph g :snapshot-p nil))
+      (let ((g2 (graph-db::open-memory-graph *mem-test-graph-name* loc)))
+        (unwind-protect
+             (let ((*graph* g2))
+               (is (= 3 (graph-db::mem-table-count
+                         (graph-db::vertex-table g2)))
+                   "all three vertices survived the v7 read")
+               (is (string= "alice" (slot-value (lookup-vertex person-id)
+                                                'name))
+                   "a v7 node's data blob is still found at the right offset")
+               (is (string= "kharkiv" (slot-value (lookup-vertex place-id)
+                                                  'label)))
+               ;; The ve/vev index keys carry their own type-id, so a
+               ;; mis-parsed key silently loses adjacency rather than erroring.
+               (is-true (lookup-edge knows-id) "the edge record survived")
+               (is (= 1 (length (graph-db::map-edges #'identity g2
+                                                    :collect-p t)))
+                   "exactly one edge, so no key was dropped or duplicated"))
+          (ignore-errors (close-graph g2 :snapshot-p nil))
+          (collect-garbage))))))


### PR DESCRIPTION
The memory-graph native image (`VGMI`) packed `type-id` at **2 bytes** and truncated
**silently**. `ni-uint` writes with `ldb`, so a type-id above 65535 lost its high bits with
no signal — 70000 (`#x11170`) restored as **4464** (`#x1170`), yielding either a node built
against the wrong class or a `NIL` type lookup.

Closes #187. Unblocks #186.

## Why this mattered enough to fix now

Unreachable while type-ids were per-graph and handed out from 1. But #166 widened the
on-disk field to 32 bits and raised `+max-node-types+` to 2³², and #186 makes ids global —
this was the last 16-bit narrowing on the path.

It was also worse than the *same* assumption on the replication wire.
`peer-streaming.lisp:261` validates with `(typep id '(unsigned-byte 16))` and **signals**;
that fails loud, so deferring it is safe. This one failed silent — and a memory graph's
image is its **only** durable copy, because the retained journal is cleared on every
checkpoint. A truncated type-id here is not a recoverable read error, it is the graph.

## The six sites

Node record (`ni-node` live-node arm, `ni-node` LZNODE arm, `ri-node`) and all three index
key codecs (`ni-key-type`/`ri-key-type`, `ni-key-ve`/`ri-key-ve`, `ni-key-vev`/`ri-key-vev`).

## Approach

**Format v8; v5, v6 and v7 still open.** Records and index keys are parsed *positionally*,
so `%read-memory-image` selects the type-id width from the version and threads it through
the record reader and all three key readers. Reading a v7 image at v8's width shifts every
field after the type-id. Writers always emit 4 bytes.

The width is a **defaulted parameter** on each codec rather than a duplicated set of `*-v7`
functions — the fork is one number in one place, and an old-format caller's explicit `2`
documents its own intent.

**`ni-type-id` replaces the bare `ni-uint` on every type-id write** and signals
`memory-image-type-id-too-wide` rather than truncating. Widening alone fixes today's
instance; this closes the class.

`+native-image-version+` and `+image-type-id-bytes+` replace a magic `7` that was
duplicated between the writer and its own error message.

## The hazard this change contained

`%write-v5-test-image` (`tests/memory-graph-tests.lisp:739`) synthesizes an old image using
the **production** writers. Widening them without touching it would have made it emit
4-byte type-ids into a file stamped v5 — and the v5 tests would have gone on **passing
while guarding a format that never existed**. It is pinned to `2`.

## Testing

Full suite: **3818 checks, 3808 pass, 10 skip, 0 fail** (baseline 3793/3783/10 — +25
checks, no regressions). `memory-graph-suite` 119/119.

Written test-first. RED reproduced the defect exactly: `ri-key-type` returned **4464** for a
written 70000.

New coverage: vertex and edge record round-trips above 16 bits (asserting `revision`,
`commit-epoch`, `from`/`to`/`weight` too, since a mis-sized type-id shifts every field after
it), all three index key round-trips, the writer's refusal on an unrepresentable id, and
`v7-memory-image-still-opens-on-the-v8-build` — a real v7 image, 2-byte type-ids
throughout, restoring whole.

The refusal test asserts a **dedicated condition**, so an arity or type error cannot satisfy
it by accident.

**Ablation.** Removing the reader's version fork fails
`V7-MEMORY-IMAGE-STILL-OPENS-ON-THE-V8-BUILD` **and both pre-existing V5 tests** —
confirming the new test discriminates and that pinning the v5 helper was load-bearing. The
writer half was ablated by the RED run itself.

## Note for review

Verified statically plus by full-suite run in a clean worktree; not exercised against a
running instance (`cl-mcp-server` SBCLs and the mine-action dev server were live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o9cANB4ycNnbr4zjduxyA
