### PR TITLE
Cross-process exclusion on the system clock directory (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,29 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **`open-system-clock` let two processes both allocate epochs for the same
+  system directory, silently** (#182). The image-level clock (#168) had no
+  cross-process exclusion: two images opening one clock directory both read
+  the persisted ceiling, both reserved a block, and both started issuing
+  epochs from overlapping ranges — destroying the one property the clock
+  exists to provide, that no two transactions in the system share an epoch.
+  `open-system-clock` now takes an exclusive, non-blocking `flock(2)` on
+  `system-clock.lock` (a sibling of `system-clock.dat` and
+  `system-journal.log`) before touching the ceiling file, and signals
+  `system-clock-in-use` (with a `system-clock-in-use-location` reader) when
+  the lock is already held. Non-blocking is deliberate: a blocking wait
+  would present as a startup hang with no diagnostic. `close-system-clock`
+  releases by closing the fd — there is no `LOCK_UN` path — and the kernel
+  releases the lock automatically if the holder dies, so a crashed process
+  leaves no residue for the next opener to clean up.
+
+  **No recovery step, deliberately.** The counter is already crash-safe:
+  `%write-clock-ceiling` persists `ceiling + block-size` before any id in
+  that block is issued, so a crashed process's successor simply resumes
+  above the persisted ceiling and never reissues. A `.dirty`-style marker
+  or other recovery path would force manual intervention for a condition
+  the ceiling protocol already handles correctly, so none was added.
+
 - **The memory-graph native image (`VGMI`) packed `type-id` at 2 bytes and
   truncated silently; format bumped to v8** (#187). `ni-uint` writes with
   `ldb`, so a `type-id` above 65535 lost its high bits with no signal — 70000

--- a/docs/superpowers/plans/2026-08-21-system-clock-exclusion.md
+++ b/docs/superpowers/plans/2026-08-21-system-clock-exclusion.md
@@ -1,0 +1,392 @@
+# System Clock Cross-Process Exclusion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `open-system-clock` refuses, immediately and by name, when another live process
+holds the clock directory — instead of silently issuing a second stream of epochs.
+
+**Architecture:** An advisory `flock(2)` lock on a file in the clock directory, taken
+`LOCK_EX | LOCK_NB` at open and held for the clock's lifetime via an fd on the
+`system-clock` struct. The kernel releases it on process death, so a stale lock is
+impossible by construction and no recovery step is needed. Two tasks: the FFI wrapper, then
+the clock change that uses it.
+
+**Tech Stack:** Common Lisp (SBCL 2.6.6 primary, ECL conditionally supported), CFFI,
+FiveAM, ASDF.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md`
+
+## Global Constraints
+
+- **Lisp: spaces only, never tabs. Hard 80-column limit** — code, comments, docstrings and
+  strings alike. A 96-column line is a defect.
+- **Comments are terse and point elsewhere.** State the non-obvious fact in a line or two
+  and reference an issue or a doc. Do not narrate reasoning in source.
+- **Scope is exclusion only.** The clock counter is already crash-safe (`%write-clock-ceiling`
+  persists `ceiling + block-size` ahead of issuing). Do **not** add a clean/unclean flag, a
+  recovery path, or a `.dirty`-style marker.
+- **No new arguments or modes on any public entry point.** No `:read-only`, no `LOCK_SH`.
+- **Do not touch** `clock-next-epoch`, `clock-lease-epochs`, `clock-observe-epoch`,
+  `journal-append`, `journal-records`, or `attach-to-system-clock`.
+- **#191 (torn journal tail) is out of scope.** Same file, unrelated failure.
+- Every push that changes source changes docs too; a `PreToolUse` hook enforces it.
+- Run tests in the **foreground**. Never two SBCL builds at once — they share one FASL cache
+  and concurrent builds corrupt it.
+
+---
+
+### Task 1: `%posix-flock`
+
+**Files:**
+- Modify: `posix.lisp` (constants near the existing `+o-*+` block ~line 33-48; wrapper in
+  the syscall-wrapper section after `%posix-open`, ~line 100)
+- Create: `tests/posix-tests.lisp`
+- Modify: `graph-db.asd` (register the new test file)
+
+**Interfaces:**
+- Produces: `%posix-flock (fd operation)` → `T` when taken, `NIL` when held elsewhere,
+  signals otherwise. Constants `+lock-ex+`, `+lock-nb+`. Helper `%errno`.
+- Consumes: `%posix-open`, `%posix-close`, `+o-creat+`, `+o-rdwr+` (all existing).
+
+**Context the brief cannot give you:** nothing in this tree reads `errno` today, and
+`graph-db.asd` still carries `#+ecl` conditionals, so ECL is not hypothetical. The `#+ecl`
+branch below is a starting point, not a verified one — **verify it or replace it**, and if
+ECL cannot report `errno`, make `%errno` return `NIL` there and say so in the docstring
+rather than guessing a value.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/posix-tests.lisp`:
+
+```lisp
+;;;; POSIX syscall wrappers.
+(in-package #:graph-db/test)
+
+(def-suite posix-suite :in graph-db-suite
+  :description "Thin syscall wrappers over CFFI.")
+(in-suite posix-suite)
+
+(defun %open-rw (path)
+  (graph-db::%posix-open path (logior graph-db::+o-creat+
+                                      graph-db::+o-rdwr+)))
+
+(test flock-denies-a-second-open-file-description
+  "flock locks attach to the open file description, not the process, so two
+OPEN(2) calls in one image contend exactly as two processes would.  That is
+what makes GH #182's guard testable without spawning a child."
+  (with-temp-directory (dir)
+    (let* ((path (namestring (merge-pathnames "lockme" dir)))
+           (a (%open-rw path))
+           (b (%open-rw path))
+           (op (logior graph-db::+lock-ex+ graph-db::+lock-nb+)))
+      (unwind-protect
+           (progn
+             (is-true (graph-db::%posix-flock a op)
+                      "the first descriptor takes the lock")
+             (is (null (graph-db::%posix-flock b op))
+                 "the second is denied, and denial is NIL, not an error"))
+        (graph-db::%posix-close a)
+        (graph-db::%posix-close b)))))
+
+(test flock-signals-rather-than-reporting-held-on-a-real-error
+  "Acceptance criterion: a genuine failure must stay distinguishable from a
+held lock.  EBADF on an invalid descriptor is the cheapest way to reach the
+signalling branch -- if %ERRNO cannot report on this implementation, this test
+is what catches the resulting misreport."
+  (signals error (graph-db::%posix-flock -1 (logior graph-db::+lock-ex+
+                                                    graph-db::+lock-nb+))))
+
+(test flock-releases-on-close
+  "Close is the only release path the clock uses -- CLOSE-SYSTEM-CLOCK closes
+the fd rather than calling LOCK_UN -- so this is the release semantics that
+matter."
+  (with-temp-directory (dir)
+    (let* ((path (namestring (merge-pathnames "lockme" dir)))
+           (a (%open-rw path))
+           (op (logior graph-db::+lock-ex+ graph-db::+lock-nb+)))
+      (is-true (graph-db::%posix-flock a op))
+      (graph-db::%posix-close a)
+      (let ((b (%open-rw path)))
+        (unwind-protect
+             (is-true (graph-db::%posix-flock b op)
+                      "closing the holder frees the lock")
+          (graph-db::%posix-close b))))))
+```
+
+Register it in `graph-db.asd` beside `system-clock-tests`:
+
+```lisp
+               (:file "posix-tests")             ; GH #182
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run the `posix-suite` only. Expected: failure naming `%POSIX-FLOCK` as undefined. If you
+see a *reader* error instead, you have a paren or package problem — fix that first; an
+undefined-function failure is the one that means "feature missing".
+
+- [ ] **Step 3: Add the constants**
+
+In `posix.lisp`, with the other flag constants:
+
+```lisp
+;;; flock(2).  Same values on Linux and Darwin, so unlike the mmap and open
+;;; flags above these need no platform conditional.  No +LOCK-UN+: the clock
+;;; releases by closing the fd (GH #182).
+(defconstant +lock-ex+ 2)
+(defconstant +lock-nb+ 4)
+
+;;; EWOULDBLOCK == EAGAIN on both targets, but the value differs.
+(defconstant +eagain+ #+graph-db-posix-linux 11 #-graph-db-posix-linux 35)
+```
+
+- [ ] **Step 4: Add `%errno` and `%posix-flock`**
+
+```lisp
+(defun %errno ()
+  "The current errno, or NIL where this implementation cannot report one.
+NIL is honest: a caller must not mistake an unknown failure for a held lock."
+  #+sbcl (sb-alien:get-errno)
+  #+ecl  (ffi:c-inline () () :int "errno" :one-liner t)
+  #-(or sbcl ecl) nil)
+
+(defun %posix-flock (fd operation)
+  "flock(2).  Returns T when the lock was taken, NIL when OPERATION included
++LOCK-NB+ and the lock is held elsewhere.  Signals on any other failure: a
+caller must not report 'another process holds this' for EBADF or ENOLCK."
+  (let* ((r (cffi:foreign-funcall "flock" :int fd :int operation :int))
+         (e (unless (zerop r) (%errno))))
+    (cond ((zerop r) t)
+          ((eql e +eagain+) nil)
+          (t (error "posix flock failed for fd ~D (operation ~D, errno ~A)"
+                    fd operation e)))))
+```
+
+`e` is captured on the line after the call, before anything else can clobber `errno`.
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+Both green, output pristine. Then run the **whole** suite once to confirm the new ASDF
+component did not disturb load order.
+
+- [ ] **Step 6: Ablation**
+
+Change `%posix-flock` to `(declare (ignore operation)) t` — always claim success. Confirm
+`flock-denies-a-second-open-file-description` **fails**. Restore, confirm it passes. Record
+both numbers in the report. A guard test that passes with the guard removed proves nothing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add posix.lisp tests/posix-tests.lisp graph-db.asd
+git commit -m "feat(posix): flock(2) wrapper distinguishing held from failed (#182)"
+```
+
+---
+
+### Task 2: Exclusion in `open-system-clock`
+
+**Files:**
+- Modify: `system-clock.lisp` (struct ~line 12; `open-system-clock` ~line 57;
+  `close-system-clock` ~line 69; new condition and lock-file helper)
+- Modify: `package.lisp` (export the condition, beside `#:open-system-clock` ~line 28)
+- Modify: `tests/system-clock-tests.lisp` (append)
+- Modify: `CHANGELOG.md`, `docs/vivace-graph-v3-doc.org`
+
+**Interfaces:**
+- Consumes: `%posix-flock`, `%posix-open`, `%posix-close`, `+lock-ex+`, `+lock-nb+`,
+  `+o-creat+`, `+o-rdwr+` from Task 1.
+- Produces: condition `system-clock-in-use` with reader
+  `system-clock-in-use-location`; new struct slot `lock-fd`.
+
+**Context the brief cannot give you:** the lock file is
+`system-clock.lock`, named to match its siblings `system-clock.dat` and
+`system-journal.log`. The spec writes it illustratively as `.lock`; the sibling naming
+wins. No ASDF change is needed for load order — `system-clock` depends on `utilities`,
+which already depends on `posix`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/system-clock-tests.lisp`:
+
+```lisp
+;;; GH #182: two images on one clock directory both issued epochs, silently.
+
+(test second-open-of-a-held-clock-signals
+  "The whole point: a second allocator on one system directory destroys the
+single property the clock provides."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (signals graph-db:system-clock-in-use
+             (open-system-clock (namestring dir)))
+        (close-system-clock c)))))
+
+(test a-held-clock-refuses-without-blocking
+  "LOCK_NB is deliberate: blocking would present as a startup hang with no
+diagnostic.  Proven by the refusal returning at all -- a blocking flock here
+would never reach the assertion."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((loc (handler-case
+                          (progn (open-system-clock (namestring dir)) nil)
+                        (graph-db:system-clock-in-use (e)
+                          (graph-db:system-clock-in-use-location e)))))
+             (is-true loc "the refusal names the directory it refused"))
+        (close-system-clock c)))))
+
+(test a-closed-clock-can-be-reopened
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (close-system-clock c))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect (is-true c2 "the lock was released by the clean close")
+        (close-system-clock c2)))))
+
+(test leasing-works-while-the-lock-is-held
+  "A lease-holder is inside the owning image (spec §8.1), so the guard must not
+break the #170 path."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (multiple-value-bind (start end) (clock-lease-epochs c 100)
+             (is (= 100 (- end start)))
+             (is (>= (clock-current-epoch c) end)
+                 "the clock skipped past the leased range"))
+        (close-system-clock c)))))
+
+(test epochs-stay-monotonic-across-a-close-and-reopen
+  "The lock must not disturb the ceiling protocol."
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir)))
+           (a (clock-next-epoch c)))
+      (close-system-clock c)
+      (let ((c2 (open-system-clock (namestring dir))))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) a)
+                 "a reopened clock never reissues")
+          (close-system-clock c2))))))
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run `system-clock-suite` only. Expected: `SYSTEM-CLOCK-IN-USE` undefined, and
+`second-open-of-a-held-clock-signals` failing because the second open **succeeds**. That
+second failure is the defect itself — confirm you see it before fixing anything.
+
+- [ ] **Step 3: Add the condition and the lock-file helper**
+
+In `system-clock.lisp`, after the struct:
+
+```lisp
+(define-condition system-clock-in-use (error)
+  ((location :initarg :location :reader system-clock-in-use-location))
+  (:report
+   (lambda (c s)
+     (format s "The system clock at ~A is held by another process.  Only one ~
+image may allocate epochs for a system; a second would issue epochs colliding ~
+with the holder's (GH #182).  A lease-holding process must not open the clock ~
+directory -- see the design's §8.1."
+             (system-clock-in-use-location c)))))
+
+(defun %clock-lock-file (location)
+  (make-pathname :name "system-clock" :type "lock" :defaults location))
+```
+
+Add the slot to `system-clock`, after `journal`:
+
+```lisp
+  ;; Held open for the clock's lifetime; the kernel releases it on process
+  ;; death, so a stale lock cannot happen (GH #182).
+  (lock-fd nil))
+```
+
+Export from `package.lisp`, beside `#:open-system-clock`:
+
+```lisp
+           #:system-clock-in-use
+           #:system-clock-in-use-location
+```
+
+- [ ] **Step 4: Take the lock in `open-system-clock`**
+
+Replace the body. The `unwind-protect` matters: without it a failure in
+`%write-clock-ceiling` leaks the fd, and the leaked fd holds the lock for the life of the
+process — turning a transient error into a permanently unopenable clock.
+
+```lisp
+(defun open-system-clock (location &key (block-size 4096))
+  "Open or create the system clock in directory LOCATION.  Ids resume above
+the persisted ceiling, so a crash never reissues one.  Signals
+SYSTEM-CLOCK-IN-USE if another live process holds LOCATION (GH #182)."
+  (ensure-directories-exist location)
+  (let ((fd (%posix-open (%clock-lock-file location)
+                         (logior +o-creat+ +o-rdwr+)))
+        (opened nil))
+    (unwind-protect
+         (progn
+           (unless (%posix-flock fd (logior +lock-ex+ +lock-nb+))
+             (error 'system-clock-in-use :location location))
+           (let* ((ceiling (%read-clock-ceiling location))
+                  (clock (%make-system-clock :location location
+                                             :counter ceiling
+                                             :ceiling ceiling
+                                             :block-size block-size
+                                             :lock-fd fd)))
+             (%write-clock-ceiling clock (+ ceiling block-size))
+             (setf opened t)
+             clock))
+      (unless opened (%posix-close fd)))))
+```
+
+- [ ] **Step 5: Release it in `close-system-clock`**
+
+Add to the existing `with-recursive-lock-held` body, after the journal clause:
+
+```lisp
+    (when (system-clock-lock-fd clock)
+      ;; Closing the fd is the release; there is no LOCK_UN path.
+      (%posix-close (system-clock-lock-fd clock))
+      (setf (system-clock-lock-fd clock) nil))
+```
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+`system-clock-suite` green, then the **full** suite. Report both counts. The full suite is
+~15 minutes and exceeds the default Bash timeout — run it in the background and poll, or
+raise the timeout. Do not skip it: `open-system-clock` is called from graph open paths.
+
+**Known coverage gap, stated deliberately.** The spec's acceptance criterion *"a holder
+that dies leaves no residue"* is **not** covered by a test. It is a kernel guarantee of
+`flock`, and reaching it needs a child process that dies holding the lock — machinery worth
+more than it buys here, since `flock-releases-on-close` already pins the release path the
+clock actually uses. Do not add a subprocess test for it; do not claim it is covered.
+
+- [ ] **Step 7: Ablation**
+
+Delete the `unless (%posix-flock ...)` form from `open-system-clock` — leaving the fd open
+so only the *refusal* is gone. Confirm `second-open-of-a-held-clock-signals` **fails**.
+Restore, confirm it passes. Record both numbers; state explicitly that you verified the
+edit landed before running.
+
+- [ ] **Step 8: Docs**
+
+`CHANGELOG.md`, under `## [Unreleased]` → `### Fixed`: what the hole was (two images both
+issuing), the mechanism (`flock`, kernel-released), and **why there is no recovery step** —
+the counter is already crash-safe, so a `.dirty`-style marker was rejected.
+
+`docs/vivace-graph-v3-doc.org`, Chapter 17's clock section: one image per system directory;
+the refusal is immediate and names the directory; a crashed holder needs no operator action;
+`flock` over NFS is unreliable and the design assumes one host; the guard is advisory, so a
+process bypassing `open-system-clock` is not stopped.
+
+Wrap Org prose at 79 columns.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add system-clock.lisp package.lisp tests/system-clock-tests.lisp \
+        CHANGELOG.md docs/vivace-graph-v3-doc.org
+git commit -m "fix(clock): refuse a second process on the clock directory (#182)"
+```

--- a/docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md
+++ b/docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md
@@ -92,6 +92,8 @@ taking `LOCK_SH` would add a second code path plus a mode check on every mutatin
 point, to serve a consumer that does not exist. Anything wanting to inspect a live system
 reads the files directly, outside the API and at its own risk.
 
+The obvious objection — that this strands #170's lease-holder — does not hold. See §8.1.
+
 ### 5.2 errno must be read
 
 `flock` returning −1 must distinguish `EWOULDBLOCK`/`EAGAIN` — held, the expected case —
@@ -133,13 +135,51 @@ guard test that passes with the guard removed proves nothing.
 - **#191, the torn journal tail.** Same file, unrelated failure: #182 is two live
   processes, #191 is one process losing power. Folding them together would put an
   exclusion bug and a durability bug in one diff.
-- **The lease escape hatch for #170.** The contract is that a lease-holding process never
-  opens the clock directory at all. That is #170's to honour; this unit makes violating it
-  loud. **Open question flagged for #170:** if a lease-holder ever needs to read the
-  lifecycle journal, this design blocks it, and #170 must then either take the journal
-  through the owning image or revisit §5.1.
+- **#170's detach protocol.** This unit makes a violation of its contract loud; it does not
+  implement it. See §8.1 — the contract is not merely compatible with exclusive-only
+  locking, it is forced by it.
 - **Global type registry placement (#186).** The registry lands in this directory and
   inherits this protection; it is not designed here.
+
+### 8.1 Why exclusive-only does not constrain #170
+
+Recorded because it looks like a conflict and is not, and the reasoning is otherwise
+re-derived every time someone reads §5.1.
+
+A lease-holder does **not** need the clock directory, and cannot be given it. What
+`clock-lease-epochs` hands out is a range `[start, end)` that the owning clock has
+**already skipped past** — so no coordination with the clock is possible or required for
+the lifetime of the lease. That is the whole mechanism. The holder needs a number range and
+a directory to write a shadow generation into; both are handed to it at detach.
+
+Journal access is already gated on holding the directory, by construction rather than by
+convention: `journal-append` takes a `clock` as its first argument, and a `system-clock`
+struct is produced only by `open-system-clock`. The sole in-tree caller
+(`transactions.lisp:3000`) sits inside `attach-to-system-clock`, in the owning image.
+
+The case that appears to break this is **who records `:SWAP`**. The holder cannot: §8 of
+the namespaces design defines reattach as an atomic swap *plus a brief quiesce*, and
+quiescing means refusing new pins and draining in-flight ones against live node objects,
+buffer-pool pages and mmap handles held **by the owning image**. Only the owner can do
+that, so the swap is necessarily an owning-image operation and records its own journal
+entry. The holder signals "shadow ready" out of band.
+
+Two adjacent cases, for completeness:
+
+- **The holder crashes mid-load.** Nobody needs to know how many epochs it consumed: the
+  owning clock skipped the entire range at lease time. Unused epochs are wasted, which at
+  64 bits is free. No journal read is required to reconcile.
+- **The holder outlives an owning-image restart.** The restarted image must learn a lease
+  is outstanding, so it reads the journal *while holding the lock*. Sequential access, not
+  concurrent.
+
+Note also that the namespaces design's §8 makes **in-process** detach the primary case —
+*"In-process detach becomes viable for the first time... The epoch lease still accommodates
+out-of-process later without redesign."* In-process, the holder **is** the owning image and
+no exclusion question arises at all.
+
+**Left to #170:** an out-of-process holder should persist its lease range in its own shadow
+directory, so the range survives the holder's own restart without consulting the clock.
 
 ## 9. Acceptance
 

--- a/docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md
+++ b/docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md
@@ -1,0 +1,151 @@
+# Cross-process exclusion on the system clock — design
+
+**Issue:** kraison/vivace-graph#182
+**Depends on:** nothing. #168 (the clock) is merged.
+**Blocks:** #186 (global type registry), #170 (detach quiescence)
+**Related:** #191 (torn journal tail — same file, different failure, out of scope here)
+
+## 1. Goal
+
+`open-system-clock` must refuse when another live process holds the clock directory,
+loudly and immediately, instead of silently issuing a second stream of epochs.
+
+Everything else about the clock stays as #168 built it.
+
+## 2. The defect
+
+`open-system-clock` (`system-clock.lisp:57`) calls `ensure-directories-exist`, reads the
+persisted ceiling, reserves a block, and returns. There is no marker, no lock, and no
+refusal. The clock's only lock is a single `bordeaux-threads` recursive lock, held at six
+sites, and the file contains zero OS-level exclusion primitives — so all existing mutual
+exclusion is **intra-image**.
+
+Two images pointed at one clock directory therefore both read the same ceiling, both
+reserve from it, and both begin issuing. That destroys the single property the clock
+exists to provide: that no two transactions in the system share an epoch. There is no
+error, nothing in the logs, and no way to detect it afterward except by finding two
+records with the same epoch and different provenance.
+
+Stores do not have this hole: `open-graph` signals when `.dirty` is present
+(`graph.lisp:546`).
+
+## 3. Scope: exclusion only, not crash recovery
+
+**The clock counter is already crash-safe, and this design does not add recovery to it.**
+
+`%write-clock-ceiling` persists `ceiling + block-size` *before* any id in that block is
+issued, into a fixed 8-byte file opened `:if-exists :overwrite` — chosen over `:supersede`
+precisely so a crash cannot leave it short or absent. A crashed process's successor reads
+the *higher* persisted ceiling and resumes above it: at most `block-size` ids are wasted,
+and none is ever reissued. #168 pins this with `clock-survives-crash-without-reissuing`
+and `clock-survives-crash-after-refilling-its-block`.
+
+So a clean/unclean flag for the counter would force a manual recovery step for a condition
+already handled correctly and automatically. It is rejected on those grounds.
+
+This is the substantive difference from the store convention. `.dirty` answers two
+questions at once — *is someone holding this?* and *did the last holder exit cleanly?* —
+and can, because a store's blast radius is one store. For the clock the second question has
+no consequence, and a stale marker would block **every image in the system**.
+
+## 4. Mechanism
+
+An advisory `flock(2)` lock on `<clock-dir>/.lock`, acquired `LOCK_EX | LOCK_NB` during
+`open-system-clock` and held for the clock's lifetime by retaining the fd in the
+`system-clock` struct. `close-system-clock` closes the fd, which releases the lock.
+
+**The kernel releases the lock when the holding process dies.** That is the property being
+bought, and it is why the design is a lock rather than a marker file: staleness becomes
+impossible by construction rather than something to detect.
+
+`LOCK_EX` = 2, `LOCK_NB` = 4, `LOCK_UN` = 8 on both Linux and Darwin, so unlike several
+existing constants in `posix.lisp` these need no platform conditional.
+
+### 4.1 Rejected mechanisms
+
+| Mechanism | Why not |
+|---|---|
+| `O_EXCL` lock file | The file outlives the process, reintroducing stale-marker detection — the problem this design exists to avoid. `posix.lisp` lacks `+o-excl+`, but adding it is not the obstacle; the semantics are. |
+| `fcntl(F_SETLK)` | Better over NFS, but **any** `close()` on that file anywhere in the process drops every lock the process holds on it. Too easy to trip from unrelated code. |
+| A `.dirty`-shaped marker | Conflates exclusion with crash recovery (§3), and cannot distinguish a live holder from a dead one. |
+| Liveness probe (pid + boot-id) | Self-healing without new FFI, but pid reuse can make a dead holder look alive, and the probe is platform-specific. Strictly worse than letting the kernel answer. |
+
+### 4.2 Non-blocking is deliberate
+
+`LOCK_NB` is not an optimization. Without it a second image blocks indefinitely inside
+startup, which presents as a hang with no diagnostic. An immediate, named refusal is
+diagnosable; a hang is not.
+
+## 5. Surface
+
+- `open-system-clock` gains one failure mode and signals `system-clock-in-use`, naming the
+  directory. **No new arguments and no mode flag.**
+- `close-system-clock` additionally closes the lock fd.
+- No other entry point changes. `clock-next-epoch`, `clock-lease-epochs`,
+  `clock-observe-epoch`, `journal-append` and `journal-records` are untouched.
+
+### 5.1 Exclusive only
+
+There is no shared/read-only mode. Nothing in the tree wants concurrent read access:
+#170 and #171 consume the journal from **inside** the owning image. A `:read-only` mode
+taking `LOCK_SH` would add a second code path plus a mode check on every mutating entry
+point, to serve a consumer that does not exist. Anything wanting to inspect a live system
+reads the files directly, outside the API and at its own risk.
+
+### 5.2 errno must be read
+
+`flock` returning −1 must distinguish `EWOULDBLOCK`/`EAGAIN` — held, the expected case —
+from a genuine failure such as `EBADF` or `ENOLCK`. Nothing in the tree reads `errno`
+today, so this is new. Conflating the two would report "another image holds this
+directory" when the real fault is unrelated, which is a worse diagnostic than the silence
+being fixed.
+
+## 6. Testing
+
+**Exclusion is honestly testable in-process.** `flock` locks attach to the *open file
+description*, not the process: Linux's `flock(2)` states that file descriptors obtained
+from separate `open()` calls are treated independently, and one may be denied by a lock the
+same process holds via another. So opening the clock twice in one image and asserting the
+second signals is a real test of the mechanism, not a simulation of it.
+
+This matters because the subprocess alternative is slow, and slow tests get skipped.
+
+| Test | Pins |
+|---|---|
+| Second `open-system-clock` on a held directory signals `system-clock-in-use` | The refusal itself |
+| Reopen after `close-system-clock` succeeds | Release on clean close |
+| `clock-lease-epochs` still works while the lock is held | The #170 path is not broken by the guard — a lease-holder is inside the owning image |
+| Epochs stay monotonic across a close/reopen cycle | The lock did not disturb the ceiling protocol |
+
+**Required ablation:** remove the `flock` call and confirm the second-open test fails. A
+guard test that passes with the guard removed proves nothing.
+
+## 7. Stated limitations
+
+- **NFS.** `flock` over NFS is unreliable on older configurations. This design assumes one
+  image per system directory on one host, which the surrounding design already assumes;
+  the limitation is stated rather than engineered around.
+- **Advisory, not mandatory.** A process that never calls `open-system-clock` — reading or
+  writing the files directly — is not stopped. The guard binds users of the API.
+
+## 8. Out of scope
+
+- **#191, the torn journal tail.** Same file, unrelated failure: #182 is two live
+  processes, #191 is one process losing power. Folding them together would put an
+  exclusion bug and a durability bug in one diff.
+- **The lease escape hatch for #170.** The contract is that a lease-holding process never
+  opens the clock directory at all. That is #170's to honour; this unit makes violating it
+  loud. **Open question flagged for #170:** if a lease-holder ever needs to read the
+  lifecycle journal, this design blocks it, and #170 must then either take the journal
+  through the owning image or revisit §5.1.
+- **Global type registry placement (#186).** The registry lands in this directory and
+  inherits this protection; it is not designed here.
+
+## 9. Acceptance
+
+- A second `open-system-clock` on a held directory signals, naming the directory, without
+  blocking.
+- A holder that dies leaves no residue: the next open succeeds with no operator action.
+- An unclean shutdown still requires no manual recovery of the counter, exactly as today.
+- `clock-lease-epochs` and every other clock entry point behave as before.
+- The refusal is distinguishable from an unrelated `flock` failure.

--- a/docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md
+++ b/docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md
@@ -50,7 +50,8 @@ no consequence, and a stale marker would block **every image in the system**.
 
 ## 4. Mechanism
 
-An advisory `flock(2)` lock on `<clock-dir>/.lock`, acquired `LOCK_EX | LOCK_NB` during
+An advisory `flock(2)` lock on `<clock-dir>/system-clock.lock`, named as a
+visible sibling of `system-clock.dat`, acquired `LOCK_EX | LOCK_NB` during
 `open-system-clock` and held for the clock's lifetime by retaining the fd in the
 `system-clock` struct. `close-system-clock` closes the fd, which releases the lock.
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2912,6 +2912,39 @@ watermark observation is then a no-op, leaving the restored store
 holding epochs the clock already issued to other stores. See
 vivace-graph#180.
 
+*** Cross-process exclusion
+
+Only one image may hold a given clock directory open at a time. A second
+process opening a directory another process already holds gets an
+immediate refusal, not a hang: ~open-system-clock~ signals
+~system-clock-in-use~, whose ~system-clock-in-use-location~ reader names
+the directory that was refused. This exists because #168's watermark
+protects against a *store* being attached twice, but not against a
+second *image* independently opening the same clock directory and
+issuing its own overlapping epochs — silently violating the one
+guarantee the clock exists to provide (GH #182).
+
+The lock is a plain, non-blocking ~flock(2)~ on ~system-clock.lock~, a
+sibling of ~system-clock.dat~ and ~system-journal.log~ in the clock
+directory, held open for the lifetime of the ~system-clock~ struct and
+released by ~close-system-clock~ closing the descriptor — there is no
+~LOCK_UN~ call. A process that dies while holding the clock needs no
+operator action: the kernel releases ~flock~ locks automatically when
+the holding process exits, so the next opener simply succeeds. No
+"unclean shutdown" marker is written or checked, because none is
+needed — see "Restore's watermark now matches the rest of the engine"
+above for why the ceiling protocol already makes a crashed clock safe
+to reopen without recovery.
+
+Two caveats worth stating plainly. First, ~flock~ semantics are
+unreliable over NFS on many kernels; this design assumes the clock
+directory lives on local storage, one host at a time, matching how
+every other file this engine memory-maps is treated. Second, the guard
+is advisory, not mandatory: it only stops a second call to
+~open-system-clock~ on the same directory. A process that reads or
+writes ~system-clock.dat~ directly, bypassing this API, is not stopped
+by the lock.
+
 *** Epoch leases for a detached store
 
 ~clock-lease-epochs~ reserves a contiguous range on the clock for a store

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -511,6 +511,7 @@ cl-temporal-extent."
                (:file "backup-tests")
                (:file "mvcc-tests")
                (:file "system-clock-tests")       ; GH #168
+               (:file "posix-tests")               ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")
                (:file "prolog-stress-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -511,7 +511,7 @@ cl-temporal-extent."
                (:file "backup-tests")
                (:file "mvcc-tests")
                (:file "system-clock-tests")       ; GH #168
-               (:file "posix-tests")               ; GH #182
+               (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")
                (:file "prolog-stress-tests")

--- a/package.lisp
+++ b/package.lisp
@@ -27,6 +27,8 @@
            #:system-clock
            #:open-system-clock
            #:close-system-clock
+           #:system-clock-in-use
+           #:system-clock-in-use-location
            #:clock-next-epoch
            #:clock-current-epoch
            #:clock-peek-epoch

--- a/posix.lisp
+++ b/posix.lisp
@@ -117,8 +117,10 @@
   "The current errno, or NIL where this implementation cannot report one.
 NIL is honest: a caller must not mistake an unknown failure for a held lock."
   #+sbcl (sb-alien:get-errno)
+  ;; CCL returns it negated.
+  #+ccl  (- (ccl::%get-errno))
   #+ecl  (ffi:c-inline () () :int "errno" :one-liner t)
-  #-(or sbcl ecl) nil)
+  #-(or sbcl ecl ccl) nil)
 
 (defun %posix-flock (fd operation)
   "flock(2).  Returns T when the lock was taken, NIL when OPERATION included

--- a/posix.lisp
+++ b/posix.lisp
@@ -37,6 +37,15 @@
 (defconstant +seek-set+ 0)
 (defconstant +seek-end+ 2)
 
+;;; flock(2).  Same values on Linux and Darwin, so unlike the mmap and open
+;;; flags above these need no platform conditional.  No +LOCK-UN+: the clock
+;;; releases by closing the fd (GH #182).
+(defconstant +lock-ex+ 2)
+(defconstant +lock-nb+ 4)
+
+;;; EWOULDBLOCK == EAGAIN on both targets, but the value differs.
+(defconstant +eagain+ #+graph-db-posix-linux 11 #-graph-db-posix-linux 35)
+
 (defconstant +prot-none+  0)
 (defconstant +prot-read+  1)
 (defconstant +prot-write+ 2)
@@ -97,6 +106,30 @@
     (when (minusp fd)
       (error "posix open failed for ~A (flags ~D)" path flags))
     fd))
+
+;; ECL's C output has no implicit <errno.h>; without this CLINES, the bare
+;; `errno` reference in %ERRNO below fails to compile ("errno undeclared"),
+;; not merely misreports -- verified against ECL 26.5.5.
+#+ecl
+(ffi:clines "#include <errno.h>")
+
+(defun %errno ()
+  "The current errno, or NIL where this implementation cannot report one.
+NIL is honest: a caller must not mistake an unknown failure for a held lock."
+  #+sbcl (sb-alien:get-errno)
+  #+ecl  (ffi:c-inline () () :int "errno" :one-liner t)
+  #-(or sbcl ecl) nil)
+
+(defun %posix-flock (fd operation)
+  "flock(2).  Returns T when the lock was taken, NIL when OPERATION included
++LOCK-NB+ and the lock is held elsewhere.  Signals on any other failure: a
+caller must not report 'another process holds this' for EBADF or ENOLCK."
+  (let* ((r (cffi:foreign-funcall "flock" :int fd :int operation :int))
+         (e (unless (zerop r) (%errno))))
+    (cond ((zerop r) t)
+          ((eql e +eagain+) nil)
+          (t (error "posix flock failed for fd ~D (operation ~D, errno ~A)"
+                    fd operation e)))))
 
 (defun %posix-close (fd)
   (cffi:foreign-funcall "close" :int fd :int))

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -80,7 +80,13 @@ SYSTEM-CLOCK-IN-USE if another live process holds LOCATION (GH #182)."
         (opened nil))
     (unwind-protect
          (progn
-           (unless (%posix-flock fd (logior +lock-ex+ +lock-nb+))
+           (unless (handler-case
+                       (%posix-flock fd (logior +lock-ex+ +lock-nb+))
+                     ;; A real failure (EBADF, ENOLCK) reports an fd number and
+                     ;; a raw errno; name the directory it was for.
+                     (error (e)
+                       (error "Cannot lock the system clock at ~A: ~A"
+                              location e)))
              (error 'system-clock-in-use :location location))
            (let* ((ceiling (%read-clock-ceiling location))
                   (clock (%make-system-clock :location location
@@ -94,16 +100,20 @@ SYSTEM-CLOCK-IN-USE if another live process holds LOCATION (GH #182)."
       (unless opened (%posix-close fd)))))
 
 (defun close-system-clock (clock)
-  "Persist the exact counter so a clean reopen wastes no ids."
+  "Persist the exact counter so a clean reopen wastes no ids.  Releases the
+directory lock even if that persist fails: a stranded lock would refuse every
+later open in this image, for the life of the process (GH #182)."
   (with-recursive-lock-held ((system-clock-lock clock))
-    (%write-clock-ceiling clock (system-clock-counter clock))
-    (when (system-clock-journal clock)
-      (close (system-clock-journal clock))
-      (setf (system-clock-journal clock) nil))
-    (when (system-clock-lock-fd clock)
-      ;; Closing the fd is the release; there is no LOCK_UN path.
-      (%posix-close (system-clock-lock-fd clock))
-      (setf (system-clock-lock-fd clock) nil)))
+    (unwind-protect
+         (progn
+           (%write-clock-ceiling clock (system-clock-counter clock))
+           (when (system-clock-journal clock)
+             (close (system-clock-journal clock))
+             (setf (system-clock-journal clock) nil)))
+      (when (system-clock-lock-fd clock)
+        ;; Closing the fd is the release; there is no LOCK_UN path.
+        (%posix-close (system-clock-lock-fd clock))
+        (setf (system-clock-lock-fd clock) nil))))
   clock)
 
 (defun journal-append (clock kind &rest plist)

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -18,7 +18,23 @@ transaction-id counter, which is the pre-#168 behaviour and the default.")
   (ceiling 0 :type (unsigned-byte 64))
   (block-size 4096 :type (unsigned-byte 32))
   (lock (make-recursive-lock "system clock"))
-  (journal nil))
+  (journal nil)
+  ;; Held open for the clock's lifetime; the kernel releases it on process
+  ;; death, so a stale lock cannot happen (GH #182).
+  (lock-fd nil))
+
+(define-condition system-clock-in-use (error)
+  ((location :initarg :location :reader system-clock-in-use-location))
+  (:report
+   (lambda (c s)
+     (format s "The system clock at ~A is held by another process.  Only one ~
+image may allocate epochs for a system; a second would issue epochs colliding ~
+with the holder's (GH #182).  A lease-holding process must not open the clock ~
+directory -- see the design's §8.1."
+             (system-clock-in-use-location c)))))
+
+(defun %clock-lock-file (location)
+  (make-pathname :name "system-clock" :type "lock" :defaults location))
 
 (defun %clock-counter-file (location)
   (make-pathname :name "system-clock" :type "dat" :defaults location))
@@ -56,15 +72,26 @@ mid-write can't leave it short or absent (cf. transactions.lisp:939)."
 
 (defun open-system-clock (location &key (block-size 4096))
   "Open or create the system clock in directory LOCATION.  Ids resume above
-the persisted ceiling, so a crash never reissues one."
+the persisted ceiling, so a crash never reissues one.  Signals
+SYSTEM-CLOCK-IN-USE if another live process holds LOCATION (GH #182)."
   (ensure-directories-exist location)
-  (let* ((ceiling (%read-clock-ceiling location))
-         (clock (%make-system-clock :location location
-                                    :counter ceiling
-                                    :ceiling ceiling
-                                    :block-size block-size)))
-    (%write-clock-ceiling clock (+ ceiling block-size))
-    clock))
+  (let ((fd (%posix-open (%clock-lock-file location)
+                         (logior +o-creat+ +o-rdwr+)))
+        (opened nil))
+    (unwind-protect
+         (progn
+           (unless (%posix-flock fd (logior +lock-ex+ +lock-nb+))
+             (error 'system-clock-in-use :location location))
+           (let* ((ceiling (%read-clock-ceiling location))
+                  (clock (%make-system-clock :location location
+                                             :counter ceiling
+                                             :ceiling ceiling
+                                             :block-size block-size
+                                             :lock-fd fd)))
+             (%write-clock-ceiling clock (+ ceiling block-size))
+             (setf opened t)
+             clock))
+      (unless opened (%posix-close fd)))))
 
 (defun close-system-clock (clock)
   "Persist the exact counter so a clean reopen wastes no ids."
@@ -72,7 +99,11 @@ the persisted ceiling, so a crash never reissues one."
     (%write-clock-ceiling clock (system-clock-counter clock))
     (when (system-clock-journal clock)
       (close (system-clock-journal clock))
-      (setf (system-clock-journal clock) nil)))
+      (setf (system-clock-journal clock) nil))
+    (when (system-clock-lock-fd clock)
+      ;; Closing the fd is the release; there is no LOCK_UN path.
+      (%posix-close (system-clock-lock-fd clock))
+      (setf (system-clock-lock-fd clock) nil)))
   clock)
 
 (defun journal-append (clock kind &rest plist)

--- a/tests/posix-tests.lisp
+++ b/tests/posix-tests.lisp
@@ -1,0 +1,52 @@
+;;;; POSIX syscall wrappers.
+(in-package #:graph-db/test)
+
+(def-suite posix-suite :in graph-db-suite
+  :description "Thin syscall wrappers over CFFI.")
+(in-suite posix-suite)
+
+(defun %open-rw (path)
+  (graph-db::%posix-open path (logior graph-db::+o-creat+
+                                      graph-db::+o-rdwr+)))
+
+(test flock-denies-a-second-open-file-description
+  "flock locks attach to the open file description, not the process, so two
+OPEN(2) calls in one image contend exactly as two processes would.  That is
+what makes GH #182's guard testable without spawning a child."
+  (with-temp-directory (dir)
+    (let* ((path (namestring (merge-pathnames "lockme" dir)))
+           (a (%open-rw path))
+           (b (%open-rw path))
+           (op (logior graph-db::+lock-ex+ graph-db::+lock-nb+)))
+      (unwind-protect
+           (progn
+             (is-true (graph-db::%posix-flock a op)
+                      "the first descriptor takes the lock")
+             (is (null (graph-db::%posix-flock b op))
+                 "the second is denied, and denial is NIL, not an error"))
+        (graph-db::%posix-close a)
+        (graph-db::%posix-close b)))))
+
+(test flock-signals-rather-than-reporting-held-on-a-real-error
+  "Acceptance criterion: a genuine failure must stay distinguishable from a
+held lock.  EBADF on an invalid descriptor is the cheapest way to reach the
+signalling branch -- if %ERRNO cannot report on this implementation, this test
+is what catches the resulting misreport."
+  (signals error (graph-db::%posix-flock -1 (logior graph-db::+lock-ex+
+                                                    graph-db::+lock-nb+))))
+
+(test flock-releases-on-close
+  "Close is the only release path the clock uses -- CLOSE-SYSTEM-CLOCK closes
+the fd rather than calling LOCK_UN -- so this is the release semantics that
+matter."
+  (with-temp-directory (dir)
+    (let* ((path (namestring (merge-pathnames "lockme" dir)))
+           (a (%open-rw path))
+           (op (logior graph-db::+lock-ex+ graph-db::+lock-nb+)))
+      (is-true (graph-db::%posix-flock a op))
+      (graph-db::%posix-close a)
+      (let ((b (%open-rw path)))
+        (unwind-protect
+             (is-true (graph-db::%posix-flock b op)
+                      "closing the holder frees the lock")
+          (graph-db::%posix-close b))))))

--- a/tests/posix-tests.lisp
+++ b/tests/posix-tests.lisp
@@ -43,10 +43,19 @@ matter."
     (let* ((path (namestring (merge-pathnames "lockme" dir)))
            (a (%open-rw path))
            (op (logior graph-db::+lock-ex+ graph-db::+lock-nb+)))
-      (is-true (graph-db::%posix-flock a op))
-      (graph-db::%posix-close a)
-      (let ((b (%open-rw path)))
-        (unwind-protect
-             (is-true (graph-db::%posix-flock b op)
-                      "closing the holder frees the lock")
-          (graph-db::%posix-close b))))))
+      ;; A is closed mid-test -- that close IS the release under test -- so
+      ;; the cleanup is conditional rather than unconditional, or a clean run
+      ;; would double-close.  Without the guard, a real error from
+      ;; %POSIX-FLOCK exits non-locally past the close and leaks a held lock
+      ;; into the rest of the run.
+      (unwind-protect
+           (progn
+             (is-true (graph-db::%posix-flock a op))
+             (graph-db::%posix-close a)
+             (setf a nil)
+             (let ((b (%open-rw path)))
+               (unwind-protect
+                    (is-true (graph-db::%posix-flock b op)
+                             "closing the holder frees the lock")
+                 (graph-db::%posix-close b))))
+        (when a (graph-db::%posix-close a))))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -49,6 +49,13 @@
              (is (> (clock-next-epoch c2) last))
           (close-system-clock c2))))))
 
+(defun %simulate-crash (clock)
+  "Release CLOCK's flock without persisting anything, mirroring what the
+kernel does when a process dies mid-flight (GH #182).  Lets crash tests
+open a second clock on the same directory without CLOSE-SYSTEM-CLOCK's
+clean write masking what's actually durable."
+  (graph-db::%posix-close (graph-db::system-clock-lock-fd clock)))
+
 (test clock-survives-crash-without-reissuing
   ;; No CLOSE-SYSTEM-CLOCK: simulates a crash after ids were handed out.  The
   ;; block reservation on disk must already dominate every issued id.
@@ -56,6 +63,7 @@
     (let* ((c (open-system-clock (namestring dir) :block-size 8))
            (issued (loop repeat 5 collect (clock-next-epoch c)))
            (highest (reduce #'max issued)))
+      (%simulate-crash c)
       (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
         (unwind-protect
              (is (> (clock-next-epoch c2) highest))
@@ -71,6 +79,7 @@
     (let* ((c (open-system-clock (namestring dir) :block-size 8))
            (issued (loop repeat 20 collect (clock-next-epoch c)))
            (highest (reduce #'max issued)))
+      (%simulate-crash c)
       (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
         (unwind-protect
              (is (> (clock-next-epoch c2) highest))
@@ -86,6 +95,7 @@
     (let* ((c (open-system-clock (namestring dir) :block-size 8))
            (observed 999999))
       (clock-observe-epoch c observed)
+      (%simulate-crash c)
       (let ((c2 (open-system-clock (namestring dir) :block-size 8)))
         (unwind-protect
              (is (> (clock-next-epoch c2) observed))
@@ -611,3 +621,61 @@
                    (close-graph ga)
                    (close-graph gb)))))
         (close-system-clock clock)))))
+
+;;; GH #182: two images on one clock directory both issued epochs, silently.
+
+(test second-open-of-a-held-clock-signals
+  "The whole point: a second allocator on one system directory destroys the
+single property the clock provides."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (signals graph-db:system-clock-in-use
+             (open-system-clock (namestring dir)))
+        (close-system-clock c)))))
+
+(test a-held-clock-refuses-without-blocking
+  "LOCK_NB is deliberate: blocking would present as a startup hang with no
+diagnostic.  Proven by the refusal returning at all -- a blocking flock here
+would never reach the assertion."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((loc (handler-case
+                          (progn (open-system-clock (namestring dir)) nil)
+                        (graph-db:system-clock-in-use (e)
+                          (graph-db:system-clock-in-use-location e)))))
+             (is-true loc "the refusal names the directory it refused"))
+        (close-system-clock c)))))
+
+(test a-closed-clock-can-be-reopened
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (close-system-clock c))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect (is-true c2 "the lock was released by the clean close")
+        (close-system-clock c2)))))
+
+(test leasing-works-while-the-lock-is-held
+  "A lease-holder is inside the owning image (spec §8.1), so the guard must not
+break the #170 path."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (multiple-value-bind (start end) (clock-lease-epochs c 100)
+             (is (= 100 (- end start)))
+             (is (>= (clock-current-epoch c) end)
+                 "the clock skipped past the leased range"))
+        (close-system-clock c)))))
+
+(test epochs-stay-monotonic-across-a-close-and-reopen
+  "The lock must not disturb the ceiling protocol."
+  (with-temp-directory (dir)
+    (let* ((c (open-system-clock (namestring dir)))
+           (a (clock-next-epoch c)))
+      (close-system-clock c)
+      (let ((c2 (open-system-clock (namestring dir))))
+        (unwind-protect
+             (is (> (clock-next-epoch c2) a)
+                 "a reopened clock never reissues")
+          (close-system-clock c2))))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -54,7 +54,11 @@
 kernel does when a process dies mid-flight (GH #182).  Lets crash tests
 open a second clock on the same directory without CLOSE-SYSTEM-CLOCK's
 clean write masking what's actually durable."
-  (graph-db::%posix-close (graph-db::system-clock-lock-fd clock)))
+  (graph-db::%posix-close (graph-db::system-clock-lock-fd clock))
+  ;; Clear the slot: CLOSE-SYSTEM-CLOCK guards on it, so a later close of
+  ;; this struct would otherwise double-close -- and close a reused
+  ;; descriptor belonging to something else.
+  (setf (graph-db::system-clock-lock-fd clock) nil))
 
 (test clock-survives-crash-without-reissuing
   ;; No CLOSE-SYSTEM-CLOCK: simulates a crash after ids were handed out.  The

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -638,10 +638,15 @@ single property the clock provides."
              (open-system-clock (namestring dir)))
         (close-system-clock c)))))
 
-(test a-held-clock-refuses-without-blocking
-  "LOCK_NB is deliberate: blocking would present as a startup hang with no
-diagnostic.  Proven by the refusal returning at all -- a blocking flock here
-would never reach the assertion."
+(test a-refusal-names-the-directory-it-refused
+  "The operator needs to know WHICH system directory is held.
+
+Named for what it asserts.  It does not measure timing: LOCK_NB is what stops
+a second open blocking forever, and that is proven by this suite terminating
+at all -- a blocking flock would hang here rather than fail.  What is NOT
+test-enforced is *immediate* versus merely bounded: a short retry loop would
+still pass.  Catching that needs a bound tight enough to be flaky on a loaded
+machine, which costs more than it buys (GH #182)."
   (with-temp-directory (dir)
     (let ((c (open-system-clock (namestring dir))))
       (unwind-protect

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -654,7 +654,8 @@ machine, which costs more than it buys (GH #182)."
                           (progn (open-system-clock (namestring dir)) nil)
                         (graph-db:system-clock-in-use (e)
                           (graph-db:system-clock-in-use-location e)))))
-             (is-true loc "the refusal names the directory it refused"))
+             (is (equal (namestring dir) loc)
+                 "the refusal names the directory it refused"))
         (close-system-clock c)))))
 
 (test a-closed-clock-can-be-reopened


### PR DESCRIPTION
`open-system-clock` had no cross-process exclusion. Two images pointed at one clock
directory both read the persisted ceiling, both reserved a block, and both began issuing
epochs — silently destroying the single property the clock exists to provide, that no two
transactions in a system share an epoch. No error, nothing in the logs, and no way to detect
it afterward except by finding two records with the same epoch and different provenance.

Stores never had this hole: `open-graph` signals when `.dirty` is present.

Closes #182. Unblocks #186, whose global type registry lands in this same directory.

Spec: `docs/superpowers/specs/2026-08-21-system-clock-exclusion-design.md`

## Mechanism

An advisory `flock(2)` on `system-clock.lock`, taken `LOCK_EX | LOCK_NB` and held for the
clock's lifetime via an fd on the `system-clock` struct.

**The kernel releases it on process death**, which is the property being bought and the
reason this is a lock rather than a marker file: staleness becomes impossible by
construction rather than something to detect. `O_EXCL` was rejected for outliving the
process; `fcntl` for dropping every lock in the process on any `close()` of that file.

`LOCK_NB` is not an optimization. Without it a second image blocks indefinitely inside
startup, which presents as a hang with no diagnostic.

## Scope: exclusion only, no recovery path

**Deliberately no `.dirty`-style marker**, and this is the decision most likely to read as
an omission.

The counter is *already* crash-safe: `%write-clock-ceiling` persists `ceiling + block-size`
**before** any id in that block is issued, into a fixed 8-byte file opened `:overwrite` so a
crash cannot leave it short. A crashed process's successor reads the higher ceiling and
resumes above it — at most `block-size` ids wasted, none reissued. #168 pins this with
`clock-survives-crash-without-reissuing` and `…-after-refilling-its-block`.

A clean/unclean flag would therefore force manual recovery for a condition already handled
automatically — and a stale one would block **every image in the system**, where a stale
`.dirty` blocks one store. `.dirty` can conflate "someone holds this" with "the last holder
crashed" precisely because a store's blast radius is one store.

Taking the lock *before* the ceiling read **narrows** the crash window rather than widening
it: the read-modify-write is now inside the lock.

## Portability

`%errno` covers SBCL, CCL and ECL, and returns `NIL` elsewhere. `NIL` is never `eql` to
`+eagain+`, so an implementation that cannot report errno falls to the **signalling** branch,
never to "held" — the safe direction.

Two portability defects were found by *executing* against the real implementations rather
than by reading:

- **ECL** — a bare `errno` in `ffi:c-inline` does not compile; ECL's generated C has no
  implicit `<errno.h>`. Fixed with `ffi:clines`. Verified under ECL 26.5.5.
- **CCL** — `ccl::%get-errno` returns errno **negated**, so the SBCL line copied across
  would silently never match `+eagain+` and every held lock would signal. Verified under
  CCL 1.13.

## Testing

Full suite **3829 checks, 3819 pass, 10 skip, 0 fail** (parent baseline 3818/3808/10 — the
+11 is exactly the new tests). `system-clock-suite` 52/52, `posix-suite` 5/5.

Written test-first, with ablations on both halves: stubbing `%posix-flock` to always succeed
drops posix 5→3; deleting only the refusal drops the clock suite 52→50, failing exactly the
two refusal tests.

**Exclusion is tested in-process.** `flock` locks attach to the *open file description*, not
the process, so two `open()` calls in one image contend exactly as two processes would — no
subprocess machinery, and slow tests are the ones that get skipped.

Three pre-existing #168 crash tests were modified. They previously opened a second clock
while the first was still held, which exclusion now forbids, so the change is **forced by
the feature**. A new `%simulate-crash` helper closes only the raw lock fd — what the kernel
does on process death — and writes nothing, so the durable state a reopen observes is still
exactly what was written ahead of issuance. The assertions are unchanged, and an
always-succeeds `flock` would not be masked by it.

**Stated coverage gap:** "a holder that dies leaves no residue" is *not* tested. It is a
kernel guarantee needing a child process to reach, and `flock-releases-on-close` already
pins the release path the clock actually uses.

**Also not test-enforced:** *immediate* versus *merely bounded* refusal. `LOCK_NB` is proven
by the suite terminating at all, but a short retry loop would pass. Catching that needs a
bound tight enough to be flaky on a loaded machine. Named in the test's docstring rather
than papered over.

## Limitations

- `flock` over NFS is unreliable on older configurations. The surrounding design already
  assumes one image per system directory on one host.
- Advisory, not mandatory: a process that never calls `open-system-clock` is not stopped.
- No in-tree production caller of `open-system-clock` exists — `*system-clock*` defaults to
  `NIL` and `attach-to-system-clock` receives an already-open clock. The refusal surfaces
  only to the embedding application.

## Related, not included

- **#191** — a torn final record makes the entire lifecycle journal unreadable. Same file,
  unrelated failure: this PR is two live processes, #191 is one process losing power.
  Blocks #170 and #171.
- **#170's lease contract.** A lease-holder never opens the clock directory, and cannot: the
  lease range is already skipped past by the owning clock, `journal-append` requires a clock
  object obtainable only from `open-system-clock`, and the swap needs a quiesce only the
  owning image can perform. See §8.1 of the spec.
- **#193** — whether `flock` should replace `.dirty` for stores generally, if this works
  out. Explicitly gated on operational evidence from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o9cANB4ycNnbr4zjduxyA

