### PR TITLE
Global type-ids: image registry, mandatory system directory, adoption and distribution (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -479,6 +479,45 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Changed
 
+- **BREAKING: type-ids are assigned system-wide, and a system directory is
+  now mandatory** (#186). `graph-db:*system-directory*` names the directory
+  holding this system's shared state; type-ids are assigned there, in an
+  append-only registry (`type-registry.log`) keyed on the package-qualified
+  type name, in place of each graph's own counter. One type name therefore
+  means one id in every store of the system, and no two names share an id.
+  Vertices and edges remain separate id spaces.
+
+  **The special has no default and is required.** `make-graph` and
+  `open-graph` signal the new `graph-db:system-directory-required` when it is
+  `nil`. There is deliberately no per-graph fallback: two id regimes drifting
+  apart unnoticed is the failure the registry exists to prevent, and a
+  fallback would make the divergence invisible. Set it once, from your
+  application's configuration, before opening anything:
+  `(setf graph-db:*system-directory* "/var/lib/my-system/")`.
+
+  Existing stores keep the ids already written into their nodes — reopening
+  one replays its persisted schema and does not renumber. Adopting the
+  registry for a system whose stores were numbered independently is a
+  separate migration (still #186) and is not done by this change.
+
+  A store's type-ids are now **sparse**: it holds the ids of its own types,
+  wherever those landed in the system's numbering, not a dense run from 1.
+  Code that enumerated types by counting from 0 to the schema's `next-*-id`
+  must enumerate the schema's actual ids instead; `gc.lisp`'s mark phase did
+  exactly that and now uses `list-vertex-types`/`list-edge-types`. The type
+  index is sized by the highest id a store holds rather than by how many
+  types it has.
+
+- **BREAKING: a node class may now be defined for more than one graph**
+  (#186). The cross-graph name check existed only because type-ids were
+  per-graph; with a system-wide id space it has no job, so it and its call
+  are gone. `duplicate-node-class-error` is no longer signalled by anything.
+  The condition remains exported so existing handlers still compile. Note
+  that both definitions define the *same* CLOS class, so the last one loaded
+  determines its slots — keep them identical, or use different type names.
+  See the manual, Chapter 17, "Class names are global, and one class may
+  serve several stores".
+
 - **The temporal algebra now lives in its own library**,
   [cl-temporal-extent](https://github.com/kraison/cl-temporal-extent) (#159).
   Bounds, extents, the Allen relations and the standing vocabulary never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **A store's persisted type-ids are reconciled with the registry at open,
+  or the open is refused** (#186). This is the invariant the rest of the unit
+  assumed and nothing established. `instantiate-node-type` keeps a persisted
+  id without telling the registry and mints a new one from a counter that has
+  never seen that store's ids, so the ordinary upgrade — open an existing
+  store under a fresh system directory, then ship one more `def-vertex` —
+  minted an id the store already used and `update-node-type` overwrote it:
+  every persisted node of the first type then materialised as the second,
+  silently. `reconcile-schema-with-registry` now runs before the schema
+  replay on every open. A type the registry has never seen, at an id nothing
+  else claims, is **adopted** (a single-store deployment therefore needs no
+  operator action at all); a type the registry gives a different id, or an id
+  it gives to a different type, signals the new
+  `graph-db:store-registry-conflict`, naming both sides and pointing at
+  `registry-seed-from-stores`. It is also what makes the peer type table
+  honest — the table is the registry while the wire carries store ids.
+
+- **`graph-db:with-schema-frozen`** (#186) opens a store exactly as it stands
+  on disk, replaying no schema and checking no ids. The supported way to
+  *read* a store the registry contradicts — a class census, a backup, the
+  before-and-after of an adoption run — which an ordinary open now refuses.
+  Writes made through a frozen open go out under the store's own ids.
+
 - **A replication handshake refuses a peer whose type registry disagrees**
   (#186). After `:auth-ok`, a device compares the hub's type table against
   this image's registry and signals
@@ -544,6 +567,30 @@ between releases; cutting a release renames it to the new version and dates it.
   so explicitly.
 
 ### Changed
+
+- **The hub resolves its type registry on the thread that starts
+  replication** (#186). A hub serves each device connection on a new thread,
+  and a new thread does not inherit dynamic bindings, so a session calling
+  `ensure-type-registry` read the *global* `*system-directory*` — `nil`, so
+  auth-ok failed on every connection and the device saw a closed socket, or
+  worse, another system's directory. `start-replication` now captures it on
+  the caller's thread (`peer-type-registry` on the graph).
+
+- **Seeding breaks a size tie on the store location** (#186).
+  `registry-seed-from-stores` ranked stores by heap high-water mark with a
+  `sort` that is not required to be stable, and equal marks are ordinary
+  (fresh or empty stores), so two images could rank one store set differently
+  and seed two different registries.
+
+- **The out-of-process harnesses set a system directory** (#186). Every
+  script under `tests/replication/`, `tests/peer-replication*/`, the
+  profiling modules and the `example.lisp` / `test.lisp` / `test-mop.lisp`
+  scratch files called `make-graph` without one and had been failing
+  outright since a system directory became mandatory; none of them is in the
+  FiveAM suite, so its green hid this. Each peer harness process now takes
+  its *own* system directory under `REPL_WORK`, which is what makes them
+  faithful: hub and device are separate images with separate registries that
+  agree because both evaluate one `schema.lisp`.
 
 - **The peer type table is the image's type registry, not one graph's
   schema** (#186). The `:type-table` string the hub ships in its `:auth-ok`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **A replication handshake refuses a peer whose type registry disagrees**
+  (#186). After `:auth-ok`, a device compares the hub's type table against
+  this image's registry and signals
+  `graph-db::peer-type-registry-conflict-error`, closing the session and
+  naming every conflicting symbol package-qualified. Both directions are
+  checked, because neither subsumes the other: *one name at two ids* (a node
+  arriving under the hub's id would materialise as some other class here) and
+  *one id at two names* (the hub's type is unknown in this image and its id
+  already means a local type). This is deliberately not a reconciliation —
+  agreeing at a handshake would mean rewriting every node of the losing type
+  because a network event said so. A hub too old to ship a table sends no
+  `:type-table` key and cannot be compared, so it is still trusted; that path
+  is kept for pre-#186 hubs. See docs/vivace-graph-v3-doc.org, Chapter 16,
+  "Type-ids on the wire, and the handshake that refuses a disagreeing peer".
+
+- **The peer type-table encoder refuses a type-id the wire cannot carry**
+  (#186). The registry assigns 32-bit type-ids while the table's `id` field
+  is frozen at `(unsigned-byte 16)`. Previously only the reference *parser*
+  enforced that, so a hub emitted a row its own parser could not read and the
+  failure landed on the device. The encoder now signals at the hub, naming
+  the type and the id. Widening the field is a change to a frozen external
+  contract and is tracked separately as #199.
+
 - **Adopting global type-ids on an existing system** (#186).
   `registry-seed-from-stores` seeds the type registry from stores that were
   each numbered from 1, and reports which of them must now be rewritten. It
@@ -521,6 +544,39 @@ between releases; cutting a release renames it to the new version and dates it.
   so explicitly.
 
 ### Changed
+
+- **The peer type table is the image's type registry, not one graph's
+  schema** (#186). The `:type-table` string the hub ships in its `:auth-ok`
+  plist now names every type this system has assigned an id, because type-ids
+  are image-level and a device may be sent an id belonging to any store.
+  `peer-type-table-string` takes a registry (defaulting to this image's)
+  rather than a graph. The wire *grammar* is unchanged — it is a frozen
+  external contract parsed by non-Lisp peers — only what fills it. Two
+  consequences, both intended: a type the hub's own graph does not
+  instantiate still appears in the table, and a type name that cannot be
+  encoded now fails every device connection in the image rather than only
+  sessions for the store that declared it. A third consequence is not
+  intended and is tracked as #200: a registry entry whose class this image
+  never loaded emits an empty `supers` field, which the wire cannot tell
+  apart from a type that genuinely roots at `vertex`/`edge`.
+
+- **The downcased-name collision error names the packages, and no longer
+  advises a rename** (#186). Pooling every store's types into one table
+  widened that collision surface: two types that never shared a schema now
+  share one namespace, and same-named symbols from two packages are no longer
+  exotic. The error prints both symbols package-qualified — the package is
+  the only thing that distinguishes them — and says the fix is a retirement
+  or rename, which for a type with nodes on disk is a store migration rather
+  than an edit.
+
+- **The renumbering migration mints in a deterministic order** (#186).
+  `renumber-schema` iterated survivors with `maphash`, so two images
+  renumbering one store into two empty registries could assign different ids
+  — a disagreement the new handshake guard would then refuse, though nothing
+  about the two systems actually differed. It now mints in package-name then
+  symbol-name order. This makes a single migration reproducible (and so
+  verifiable by re-running it); it is *not* a substitute for distributing the
+  registry, and images that opened different stores still disagree.
 
 - **BREAKING: type-ids are assigned system-wide, and a system directory is
   now mandatory** (#186). `graph-db:*system-directory*` names the directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -695,7 +695,8 @@ between releases; cutting a release renames it to the new version and dates it.
   shared index — separated at query time by the required type filter, not by
   storage — which is narrower than "per class"; a class that overrides
   `node-geometry` is indexed under `(owner . NIL)` and is still scopeable by name.
-  Motivated by the mine-action team's spatial-index change request (CR-1).
+  Motivated by a downstream application team's spatial-index change request
+  (CR-1).
 - **`:spatial-precision` slot option — per-index geohash precision.** A geometry
   slot may declare `(slot :type geometry :index t :spatial-precision N)`; that
   index is built on an `N`-level geohash grid instead of the graph default (7).
@@ -990,7 +991,8 @@ between releases; cutting a release renames it to the new version and dates it.
   filter is what makes a scoped query correct when sibling subclasses share a
   mixin-owned index. A required positional argument makes every stale call site a
   compile-time warning on SBCL and ECL, which is the safest way to land a
-  deliberate break. Requested by the mine-action team (CR-1): they needed to
+  deliberate break. Requested by a downstream application team (CR-1): they
+  needed to
   query one class's geometry without dredging up another's.
   *Known limitation:* a scope resolves the named class's own geometry slots, so
   scoping to a parent does not reach an index a *subclass* declares on an extra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **Adopting global type-ids on an existing system** (#186).
+  `registry-seed-from-stores` seeds the type registry from stores that were
+  each numbered from 1, and reports which of them must now be rewritten. It
+  opens no graph: each store is read from its `schema.dat` and the allocation
+  high-water mark in its `heap.dat` header. Stores are offered their ids
+  **largest on disk first**, and each keeps every id it can, so the store
+  that costs most to rewrite wins every contest — the cost of adoption is
+  bytes replayed, not types moved. (Measured on a five-store system: 66
+  vertex type names competing for 36 ids, and the store holding 59 of the 95
+  types was among the smallest, so seeding by type count would have replayed
+  ~4.9 GB instead of ~1.1 GB.) The returned `seeding-report` names the seed
+  store, every id that moves, the stores to migrate, and any name a single
+  store's history left holding **two** ids — a case no seeding policy
+  exempts, since those must unify whichever store wins. See
+  docs/vivace-graph-v3-doc.org, Chapter 17, "Adopting global type-ids on an
+  existing system".
+
+- **`migrate-graph` gains `:renumber-p`** (#186), default `nil`. `nil`
+  preserves the source's type-ids exactly as #166 built it. `t` takes every
+  type-id from the system registry instead, so a renumbered store's ids mean
+  the same thing in every other store of the system; this is the migration
+  half of the adoption procedure above. `migrate-graph` now returns
+  `(values new-graph unified)`, where `unified` names each type whose several
+  ids collapsed into one. #166's migration tests were renamed to say which
+  mode they pin (`migrate-v1-graph-to-v3-without-renumbering`,
+  `migrate-v2-graph-to-v3-without-renumbering`) — the type-id guarantee is
+  mode-dependent now, and the renumbering path is the exact reverse of what
+  they assert.
+
 - **The image-level system clock** (#168). `open-system-clock` /
   `close-system-clock` open a durable, crash-safe epoch counter shared by
   every store attached to it, in place of each store's own per-graph
@@ -223,6 +252,20 @@ between releases; cutting a release renames it to the new version and dates it.
     indexes and unique constraints".
 
 ### Fixed
+
+- **`migrate-graph` no longer pollutes the type registry** (#186). Creating
+  the destination graph ran `update-schema`, which interned every one of the
+  graph's types and assigned them real ids; `migrate-graph` then installed
+  the source's schema over the top, discarding those ids and leaving the
+  registry permanently holding entries at ids no store uses. Opening the
+  *source* had the same effect for any type declared in the image but absent
+  from that store — and wrote a registry id into a store whose every other id
+  was per-graph. The schema replay is now suppressed for both of
+  `migrate-graph`'s opens, since it installs the schema it wants by hand in
+  either mode; a `:renumber-p nil` migration therefore leaves the registry
+  untouched, which is the only answer consistent with preserving the source's
+  own ids. One consequence for the record: `migrate-graph` no longer rewrites
+  the source's `schema.dat` at all.
 
 - **`open-system-clock` let two processes both allocate epochs for the same
   system directory, silently** (#182). The image-level clock (#168) had no
@@ -497,8 +540,8 @@ between releases; cutting a release renames it to the new version and dates it.
 
   Existing stores keep the ids already written into their nodes — reopening
   one replays its persisted schema and does not renumber. Adopting the
-  registry for a system whose stores were numbered independently is a
-  separate migration (still #186) and is not done by this change.
+  registry for a system whose stores were numbered independently is the
+  seeding-plus-renumbering procedure added below.
 
   A store's type-ids are now **sparse**: it holds the ids of its own types,
   wherever those landed in the system's numbering, not a dense run from 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ between releases; cutting a release renames it to the new version and dates it.
   before-and-after of an adoption run — which an ordinary open now refuses.
   Writes made through a frozen open go out under the store's own ids.
 
+  **It may read such a store; it may not serve one.** `start-replication`
+  signals the new `graph-db:frozen-graph-cannot-replicate` for a master,
+  slave or peer graph opened frozen. Every transport puts raw type-ids on the
+  wire, so a frozen hub would ship a type table built from the *registry*
+  while its node heads carried the store's contradicted ids — and the damage
+  would land on a remote peer, where no local guard can see it.
+
 - **A replication handshake refuses a peer whose type registry disagrees**
   (#186). After `:auth-ok`, a device compares the hub's type table against
   this image's registry and signals
@@ -575,6 +582,15 @@ between releases; cutting a release renames it to the new version and dates it.
   auth-ok failed on every connection and the device saw a closed socket, or
   worse, another system's directory. `start-replication` now captures it on
   the caller's thread (`peer-type-registry` on the graph).
+
+- **A store that owes a renumbering says so at open** (#186). An id the
+  store occupies but its own name lookup no longer returns — orphaned
+  metadata, with nodes still on disk under it — is tolerated when it sits at
+  or below the registry's high-water mark, and now emits a `log:warn` naming
+  the type and both ids instead of passing silently. Above the mark it is
+  still refused: the registry would hand that id to another type and there is
+  no way to reserve it. The tolerance is a policy choice about
+  already-orphaned metadata rather than a proof of safety — see #202.
 
 - **Seeding breaks a size tie on the store location** (#186).
   `registry-seed-from-stores` ranked stores by heap high-water mark with a

--- a/backup.lisp
+++ b/backup.lisp
@@ -260,26 +260,44 @@ failure mode this function exists to prevent.  See GH #100."
 
 (defun migrate-graph (name old-location new-location
                       &key (package :graph-db) include-deleted-p
-                           (delete-snapshot-p t)
+                           (delete-snapshot-p t) renumber-p
                            (snapshot-file (%migration-snapshot-file name)))
   "Migrate a pre-current (v1 or v2) graph at OLD-LOCATION to the current (v3)
-on-disk format at NEW-LOCATION, returning the new, open graph.
+on-disk format at NEW-LOCATION, returning (values NEW-GRAPH UNIFIED) -- the
+new, open graph, and (under :RENUMBER-P T) the types whose several ids were
+unified into one.
 
 Migration is a logical snapshot + replay: OLD-LOCATION's own stamped storage
 version is read first, so the old graph is opened read-only with the head
 shim that matches IT (15-byte v1, 31-byte v2), every live node is written to a
 format-independent snapshot file, then a fresh v3 graph is created and the
-snapshot replayed through the normal MAKE-VERTEX / MAKE-EDGE path.  The old
-graph's schema (its type-id registry) is copied to the new graph, so type-ids
-are preserved -- this does not renumber (#186).
+snapshot replayed through the normal MAKE-VERTEX / MAKE-EDGE path.
+
+:RENUMBER-P decides which type-ids the new graph gets, and it is the one
+guarantee here that is mode-dependent (GH #186, spec §10.1):
+
+  NIL (default) -- the old graph's schema is copied across verbatim, so
+    every type-id survives unchanged.  This is #166's format migration.  The
+    new store's ids are then the SOURCE's per-graph ids and NOT this
+    system's registry ids, so the migration deliberately leaves the registry
+    untouched rather than claim ids for names it did not renumber.
+  T -- every type-id is taken from the system registry instead, so the new
+    store's ids mean the same thing in every other store of the system.
+    This is how a populated system adopts global ids; seed the registry
+    first with REGISTRY-SEED-FROM-STORES, which also says which stores need
+    this.  A symbol the source's history left holding two ids unifies under
+    one here, and is named in the second return value.
 
 OLD-LOCATION's DATA -- its heap and its vertex/edge/index tables -- is left
 untouched; it remains fully openable by an engine of its own (pre-migration)
 version afterward, which is the rollback story: repoint at OLD-LOCATION rather
 than restore from a snapshot.  It is NOT byte-for-byte identical, though:
-snapshotting requires OPENing it, and that OPEN unconditionally rewrites
-schema.dat (via UPDATE-SCHEMA/SAVE-SCHEMA -- same content, re-serialized, so
-type-ids are unaffected) and creates one new, empty tx/replication-*.log file.
+snapshotting requires OPENing it, and that OPEN creates one new, empty
+tx/replication-*.log file.  (schema.dat is no longer rewritten at all: the
+schema replay is suppressed for both of this function's opens, so a type
+declared in this image but absent from the source is not added to the source
+either -- it would carry a registry id in a store whose every other id is
+per-graph.  GH #186.)
 This assumes OLD-LOCATION was closed cleanly and still has its index
 sidecars: OPEN-GRAPH rebuilds a spatial, unique, or secondary index from a
 live-node scan whenever its sidecar is absent (graph.lisp's
@@ -312,7 +330,13 @@ an explicit path if you want a predictable one."
            ;;    it logically.  The reader shim applies only to this read; the
            ;;    replay below always writes the current (v3) format.
            (let* ((found (%migration-source-version old-location))
-                  (*node-head-reader* (%migration-source-version-reader found)))
+                  (*node-head-reader* (%migration-source-version-reader found))
+                  ;; Both opens: this function decides both schemas itself
+                  ;; (see :RENUMBER-P above), and UPDATE-SCHEMA running first
+                  ;; would mint registry ids for a schema thrown away on the
+                  ;; next form -- and, on the source, write one into a store
+                  ;; whose every other id is per-graph (GH #186).
+                  (*schema-update-suppressed* t))
              (let ((old (open-graph name old-location
                                     ;; tolerate FOUND so a re-run is harmless
                                     :accept-versions
@@ -325,19 +349,30 @@ an explicit path if you want a predictable one."
                                 found old-location snapshot-file)
                       (backup old snapshot-file :include-deleted-p include-deleted-p))
                  (close-graph old :snapshot-p nil))))
-           ;; 2. Create the v3 graph, adopt the old schema (preserves
-           ;;    type-ids), replay.
-           (let ((new (make-graph name new-location)))
+           ;; 2. Create the v3 graph, install the schema (verbatim, or
+           ;;    renumbered from the registry), replay.
+           (let ((new (let ((*schema-update-suppressed* t))
+                        (make-graph name new-location))))
              (handler-case
-                 (progn
-                   (setf (schema new) old-schema)
+                 (multiple-value-bind (schema unified)
+                     (if renumber-p
+                         (renumber-schema old-schema (ensure-type-registry))
+                         (values old-schema nil))
+                   (setf (schema new) schema)
                    (restore-schema-locks (schema new))
                    (setf (schema-lock (schema new)) (make-recursive-lock))
                    (save-schema (schema new) new)
+                   (when unified
+                     (log:warn "MIGRATE-GRAPH: ~D type~:P in ~A held more ~
+than one type-id; unified: ~S" (length unified) old-location unified))
+                   (unless renumber-p
+                     (log:warn "MIGRATE-GRAPH: ~A keeps ~A's per-graph ~
+type-ids, which are NOT this system's registry ids (:RENUMBER-P NIL, #186)."
+                               new-location old-location))
                    (log:info "MIGRATE-GRAPH: replaying snapshot ~
 into v~D graph ~A" +storage-version+ new-location)
                    (recreate-graph new snapshot-file :package-name package)
-                   new)
+                   (values new unified))
                (error (c)
                  (close-graph new)
                  (error c)))))

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -101,17 +101,39 @@ says ~D."
 registry gives it to ~S."
                   parent store-id type-name holder))
          (:stale-id
-          (format stream "~(~A~) id ~D is held by metadata this store's own ~
-name lookup no longer reaches, and it is above every id the registry has ~
-assigned -- so the registry would hand that id to some other type while ~
-nodes on disk still carry it."
-                  parent store-id)))
+          (format stream "~(~A~) id ~D is held by orphaned metadata~@[ for ~
+~S~] -- the store's own name lookup no longer returns it -- and it is above ~
+every id the registry has assigned, so the registry would hand that id to ~
+another type while nodes on disk still carry it."
+                  parent store-id type-name)))
        (format stream "  Neither side may be changed here: the losing id is ~
 already written into every node of its type.  Reconcile out of band -- ~
 GRAPH-DB::REGISTRY-SEED-FROM-STORES to adopt a store's ids, then ~
 GRAPH-DB::MIGRATE-GRAPH with :RENUMBER-P T for the stores it lists.  To ~
 READ this store meanwhile, open it inside GRAPH-DB:WITH-SCHEMA-FROZEN ~
 (GH #186).")))))
+
+(define-condition frozen-graph-cannot-replicate (error)
+  ;; A graph opened inside WITH-SCHEMA-FROZEN never had its persisted
+  ;; type-ids checked against the registry, so it must not serve or stream
+  ;; them: the peer type table describes the REGISTRY while node heads carry
+  ;; the STORE's ids, and a contradicted store would corrupt a remote peer
+  ;; (GH #186).
+  ((graph-name :initarg :graph-name :initform nil
+               :reader frozen-graph-cannot-replicate-graph-name)
+   (location :initarg :location :initform nil
+             :reader frozen-graph-cannot-replicate-location))
+  (:report
+   (lambda (error stream)
+     (format stream "Graph ~S~@[ at ~A~] was opened inside ~
+WITH-SCHEMA-FROZEN, so its type-ids were never reconciled with this system's ~
+registry, and replication may not be started for it.  A frozen open is for ~
+READING a store the registry contradicts; serving one would describe the ~
+registry's ids on the wire while shipping the store's.  Reconcile it first ~
+-- GRAPH-DB::REGISTRY-SEED-FROM-STORES, then GRAPH-DB::MIGRATE-GRAPH with ~
+:RENUMBER-P T -- and open it normally (GH #186)."
+             (frozen-graph-cannot-replicate-graph-name error)
+             (frozen-graph-cannot-replicate-location error)))))
 
 (define-condition stale-revision-error (error)
   ((instance :initarg :instance)

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -68,6 +68,51 @@ store cannot be created or opened without it.  Bind or SETF ~
 *SYSTEM-DIRECTORY* to your system's directory (GH #186)."
                      (system-directory-required-operation error)))))
 
+(define-condition store-registry-conflict (error)
+  ;; A store's persisted type-ids and the image registry disagree, and no
+  ;; open, write or handshake may paper over it: the losing id is already in
+  ;; every node head of its type (GH #186, spec §10.1).
+  ((location :initarg :location :initform nil
+             :reader store-registry-conflict-location)
+   ;; :NAME-AT-TWO-IDS, :ID-AT-TWO-NAMES or :STALE-ID -- see the report.
+   (reason :initarg :reason :reader store-registry-conflict-reason)
+   (type-name :initarg :type-name :initform nil
+              :reader store-registry-conflict-type-name)
+   (parent :initarg :parent :reader store-registry-conflict-parent)
+   (store-id :initarg :store-id :reader store-registry-conflict-store-id)
+   (registry-id :initarg :registry-id :initform nil
+                :reader store-registry-conflict-registry-id)
+   (holder :initarg :holder :initform nil
+           :reader store-registry-conflict-holder))
+  (:report
+   (lambda (error stream)
+     (with-slots (location reason type-name parent store-id registry-id
+                  holder)
+         error
+       (format stream "The store~@[ at ~A~] disagrees with this system's ~
+type registry.  " location)
+       (ecase reason
+         (:name-at-two-ids
+          (format stream "~(~A~) type ~S: the store uses id ~D, the registry ~
+says ~D."
+                  parent type-name store-id registry-id))
+         (:id-at-two-names
+          (format stream "~(~A~) id ~D: the store uses it for ~S, the ~
+registry gives it to ~S."
+                  parent store-id type-name holder))
+         (:stale-id
+          (format stream "~(~A~) id ~D is held by metadata this store's own ~
+name lookup no longer reaches, and it is above every id the registry has ~
+assigned -- so the registry would hand that id to some other type while ~
+nodes on disk still carry it."
+                  parent store-id)))
+       (format stream "  Neither side may be changed here: the losing id is ~
+already written into every node of its type.  Reconcile out of band -- ~
+GRAPH-DB::REGISTRY-SEED-FROM-STORES to adopt a store's ids, then ~
+GRAPH-DB::MIGRATE-GRAPH with :RENUMBER-P T for the stores it lists.  To ~
+READ this store meanwhile, open it inside GRAPH-DB:WITH-SCHEMA-FROZEN ~
+(GH #186).")))))
+
 (define-condition stale-revision-error (error)
   ((instance :initarg :instance)
    (current-revision :initarg :current-revision))

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -55,6 +55,19 @@ is single-graph; use one transaction per graph."
 cannot redefine it for ~A. Class names are global; remove the old definition ~
 to re-home it." name existing-graph new-graph)))))
 
+(define-condition system-directory-required (error)
+  ;; *SYSTEM-DIRECTORY* is where the type-id registry lives; a store opened
+  ;; without one would mint ids no other store in the system agrees with
+  ;; (GH #186).
+  ((operation :initarg :operation :initform nil
+              :reader system-directory-required-operation))
+  (:report (lambda (error stream)
+             (format stream "~@[~A: ~]GRAPH-DB:*SYSTEM-DIRECTORY* is NIL. ~
+Type-ids are assigned from the system-wide registry that lives there, so a ~
+store cannot be created or opened without it.  Bind or SETF ~
+*SYSTEM-DIRECTORY* to your system's directory (GH #186)."
+                     (system-directory-required-operation error)))))
+
 (define-condition stale-revision-error (error)
   ((instance :initarg :instance)
    (current-revision :initarg :current-revision))

--- a/docs/superpowers/plans/2026-08-21-global-type-ids.md
+++ b/docs/superpowers/plans/2026-08-21-global-type-ids.md
@@ -61,7 +61,9 @@ may read the registry concurrently; only assignment serialises.
   - `(registry-intern registry symbol parent)` → integer; **assigns if absent**, under lock.
   - `(registry-entries registry)` → list of `(symbol parent id)`, oldest first.
   - `(close-type-registry registry)`.
-  - Condition `type-registry-conflict` with reader `type-registry-conflict-entries`.
+  - Condition `type-registry-busy` with reader `type-registry-busy-location`,
+    signalled when the append lock is held elsewhere. (The *disagreement*
+    condition D15 needs is Task 4's, not this one's — do not add it here.)
 - Consumes: `%posix-flock`, `%posix-open`, `%posix-close`, `+lock-ex+`, `+lock-nb+` (#182).
 
 **Context the brief cannot give you:** the file is `type-registry.log`, a sibling of
@@ -283,29 +285,52 @@ is already a blocker on #167.
 
 - [ ] **Step 1: Write the failing tests**
 
+`with-test-graph` (`tests/suite.lisp:137`) takes only `(g)` and hardcodes
+`*integration-graph-name*`, so it **cannot** open the two graphs these tests need.
+Write a two-graph helper first:
+
 ```lisp
+(defmacro with-two-test-graphs ((g1 g2 sysdir) &body body)
+  "Two stores in ONE image, sharing SYSDIR as their system directory.  The
+existing WITH-TEST-GRAPH binds a single hardcoded graph name and cannot express
+this, which is why #186 needs its own helper."
+  (let ((d1 (gensym)) (d2 (gensym)))
+    `(with-temp-directory (,sysdir)
+       (with-temp-directory (,d1)
+         (with-temp-directory (,d2)
+           (let ((graph-db::*system-directory* (namestring ,sysdir)))
+             (let ((,g1 (make-graph :reg-store-1 (namestring ,d1)
+                                    :buffer-pool-size 1000))
+                   (,g2 (make-graph :reg-store-2 (namestring ,d2)
+                                    :buffer-pool-size 1000)))
+               (unwind-protect (progn ,@body)
+                 (ignore-errors (close-graph ,g1))
+                 (ignore-errors (close-graph ,g2))))))))))
+```
+
+There is no `lookup-node-type-id`; the id comes from the metadata:
+
+```lisp
+(defun %type-id-of (sym parent graph)
+  (graph-db::node-type-id
+   (graph-db::lookup-node-type-by-name sym parent :graph graph)))
+
 (test two-graphs-in-one-image-share-a-symbol-s-type-id
   "The unit's entire purpose.  Before #186 each graph counted from 1, so the
 same symbol got different ids in different stores and different symbols
 collided on one id."
-  (with-temp-directory (dir)
-    (let ((graph-db::*system-directory* (namestring dir)))
-      (with-test-graph (g1 :name :reg-share-1)
-        (with-test-graph (g2 :name :reg-share-2)
-          (is (= (graph-db::lookup-node-type-id 'shared-type :vertex :graph g1)
-                 (graph-db::lookup-node-type-id 'shared-type :vertex :graph g2))
-              "one symbol, one id, both stores"))))))
+  (with-two-test-graphs (g1 g2 sysdir)
+    (declare (ignore sysdir))
+    (is (= (%type-id-of 'shared-type :vertex g1)
+           (%type-id-of 'shared-type :vertex g2))
+        "one symbol, one id, both stores")))
 
 (test distinct-symbols-never-collide-across-graphs
-  (with-temp-directory (dir)
-    (let ((graph-db::*system-directory* (namestring dir)))
-      (with-test-graph (g1 :name :reg-coll-1)
-        (with-test-graph (g2 :name :reg-coll-2)
-          (is (/= (graph-db::lookup-node-type-id
-                   'type-in-one :vertex :graph g1)
-                  (graph-db::lookup-node-type-id
-                   'type-in-two :vertex :graph g2))
-              "two symbols never share an id, even in different stores"))))))
+  (with-two-test-graphs (g1 g2 sysdir)
+    (declare (ignore sysdir))
+    (is (/= (%type-id-of 'type-in-one :vertex g1)
+            (%type-id-of 'type-in-two :vertex g2))
+        "two symbols never share an id, even in different stores")))
 
 (test opening-a-graph-without-a-system-directory-signals
   "The directory is mandatory as of #186: the registry has nowhere to live
@@ -321,13 +346,13 @@ counters -- a silent fallback is how two id regimes diverge unnoticed."
   "Closes cl-llm#20.  %CHECK-NODE-CLASS-GRAPH-UNIQUE refused this and existed
 only because ids were per-graph."
   (with-temp-directory (dir)
-    (let ((graph-db::*system-directory* (namestring dir)))
-      (with-test-graph (g1 :name :reg-dual-1)
-        (with-test-graph (g2 :name :reg-dual-2)
-          (is-true (graph-db::lookup-node-type-by-name
-                    'dual-type :vertex :graph g1))
-          (is-true (graph-db::lookup-node-type-by-name
-                    'dual-type :vertex :graph g2)))))))
+    (declare (ignore dir))
+    (with-two-test-graphs (g1 g2 sysdir)
+      (declare (ignore sysdir))
+      (is-true (graph-db::lookup-node-type-by-name
+                'dual-type :vertex :graph g1))
+      (is-true (graph-db::lookup-node-type-by-name
+                'dual-type :vertex :graph g2)))))
 ```
 
 - [ ] **Step 2: Run and watch them fail.** The first two must fail because the ids

--- a/docs/superpowers/plans/2026-08-21-global-type-ids.md
+++ b/docs/superpowers/plans/2026-08-21-global-type-ids.md
@@ -1,0 +1,422 @@
+# Global Type-IDs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `type-id` means the same thing in every store of a system, backed by a
+persisted image-level registry keyed on package-qualified symbol.
+
+**Architecture:** A single append-only registry file in the **system directory**, which
+this unit makes **mandatory**. Assignment moves out of the per-graph `schema-next-*-id`
+counters and into the registry, under a short exclusive `flock` held across
+read-decide-append. Existing systems adopt via a renumbering replay seeded from the
+largest store. The hub's frozen type-table wire format becomes the normal distribution
+path, and a handshake refuses a peer whose registry disagrees.
+
+**Tech Stack:** Common Lisp (SBCL primary, CCL/ECL conditionally), CFFI, FiveAM, ASDF.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-namespaces-design.md` — §3.4 (registry, D14,
+D15), §10.1 (migration), §12 (acceptance).
+
+## Global Constraints
+
+- **Lisp: spaces only, never tabs. Hard 80-column limit** — code, comments, docstrings and
+  strings alike; Org prose at 79. A 96-column line is a defect.
+- Comments terse: state the non-obvious fact, reference an issue, do not narrate.
+- **This repo is PUBLIC.** No domain specifics in code, comments, docs or commit messages.
+  Describe shapes ("a five-store system"), never a deployment's class or store names.
+- **The system directory is now mandatory.** `*system-clock*` stays optional; its
+  *directory* does not. Decided 2026-08-21; see the "Directory vs clock" note below.
+- **Do not reuse the clock's lifetime lock for the registry.** #182 holds `LOCK_EX` for the
+  clock's whole life. The registry must NOT do that — see Task 1.
+- `peer-type-table-string`'s wire format is a **frozen external contract** parsed by a
+  non-Lisp peer. Do not change its grammar.
+- Every push that changes source changes docs too; a `PreToolUse` hook enforces it.
+- Run tests in the **foreground**. Never two SBCL builds at once — shared FASL cache.
+- Assert ASDF resolved to this worktree before trusting any test result.
+
+### Directory vs clock — the distinction that must not blur
+
+#182 gave the *clock* an exclusive `flock` held for its whole lifetime, so only one image
+may **allocate epochs**. If the registry reused that lock, making the directory mandatory
+would mean only one image could open **any graph at all** — a far larger restriction than
+#182 argued for, arriving as a side effect rather than a decision.
+
+So the registry takes its **own** lock, held only across a read-decide-append. Many images
+may read the registry concurrently; only assignment serialises.
+
+---
+
+### Task 1: The registry object
+
+**Files:**
+- Create: `type-registry.lisp`
+- Modify: `graph-db.asd` (component after `system-clock`; `:depends-on ("serialize" "utilities")`)
+- Modify: `package.lisp` (exports)
+- Create: `tests/type-registry-tests.lisp`, register it in `graph-db.asd`
+
+**Interfaces:**
+- Produces:
+  - `(open-type-registry location)` → `type-registry`; creates the file if absent.
+  - `(registry-id-for registry symbol parent)` → integer or `NIL` (pure read).
+  - `(registry-intern registry symbol parent)` → integer; **assigns if absent**, under lock.
+  - `(registry-entries registry)` → list of `(symbol parent id)`, oldest first.
+  - `(close-type-registry registry)`.
+  - Condition `type-registry-conflict` with reader `type-registry-conflict-entries`.
+- Consumes: `%posix-flock`, `%posix-open`, `%posix-close`, `+lock-ex+`, `+lock-nb+` (#182).
+
+**Context the brief cannot give you:** the file is `type-registry.log`, a sibling of
+`system-clock.dat` and `system-journal.log`. Records are one per line, `~S`-printed and
+read back with `*read-eval*` **NIL** — the journal in `system-clock.lisp` is the pattern to
+follow, including that it is data and must never execute. Note #191: a torn final record
+there makes the whole file unreadable. **Do not repeat that defect** — this reader must
+tolerate a truncated *final* record (log it, stop) while still signalling on a malformed
+record anywhere earlier.
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+;;;; The image-level type-id registry (GH #186).
+(in-package #:graph-db/test)
+
+(def-suite type-registry-suite :in graph-db-suite
+  :description "The persisted, image-level type-id registry.")
+(in-suite type-registry-suite)
+
+(test registry-assigns-distinct-ids-to-distinct-symbols
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (let ((a (graph-db::registry-intern r 'reg-alpha :vertex))
+                 (b (graph-db::registry-intern r 'reg-beta :vertex)))
+             (is (integerp a))
+             (is (/= a b) "two symbols never share an id"))
+        (graph-db::close-type-registry r)))))
+
+(test registry-is-idempotent-for-one-symbol
+  "The whole point of a registry: asking twice gives the same answer, and
+asking in another image after a reopen still does."
+  (with-temp-directory (dir)
+    (let* ((r (graph-db::open-type-registry (namestring dir)))
+           (first (graph-db::registry-intern r 'reg-gamma :vertex)))
+      (is (= first (graph-db::registry-intern r 'reg-gamma :vertex)))
+      (graph-db::close-type-registry r)
+      (let ((r2 (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (= first (graph-db::registry-intern r2 'reg-gamma :vertex))
+                 "the assignment is durable, not in-memory")
+          (graph-db::close-type-registry r2))))))
+
+(test registry-separates-vertex-and-edge-spaces
+  "Vertices and edges are distinct spaces, as they are per-graph today; the
+same symbol may hold a different id in each."
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (let ((v (graph-db::registry-intern r 'reg-delta :vertex))
+                 (e (graph-db::registry-intern r 'reg-delta :edge)))
+             (is (integerp v)) (is (integerp e))
+             (is (= v (graph-db::registry-id-for r 'reg-delta :vertex)))
+             (is (= e (graph-db::registry-id-for r 'reg-delta :edge))))
+        (graph-db::close-type-registry r)))))
+
+(test registry-distinguishes-same-name-in-two-packages
+  "The registry is keyed on the PACKAGE-QUALIFIED symbol.  Keying on the name
+would collide two packages' types -- the defect #190 records in the per-graph
+keyword alias, which this must not reproduce."
+  (with-temp-directory (dir)
+    (flet ((pkg (n) (or (find-package n) (make-package n :use '()))))
+      (let* ((s1 (intern "SPECIES" (pkg "REG-TEST-1")))
+             (s2 (intern "SPECIES" (pkg "REG-TEST-2")))
+             (r (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (/= (graph-db::registry-intern r s1 :vertex)
+                     (graph-db::registry-intern r s2 :vertex))
+                 "same name, different packages, different ids")
+          (graph-db::close-type-registry r))))))
+
+(test registry-tolerates-a-torn-final-record
+  "GH #191: the lifecycle journal signals on a truncated tail and loses the
+whole file.  The registry is the ONLY record of what a type-id means -- losing
+it is worse -- so a torn FINAL record is dropped with a log, while a malformed
+record earlier still signals."
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (graph-db::registry-intern r 'reg-keep-1 :vertex)
+      (graph-db::registry-intern r 'reg-keep-2 :vertex)
+      (graph-db::close-type-registry r))
+    (let ((f (merge-pathnames "type-registry.log" dir)))
+      (with-open-file (s f :direction :output :if-exists :append)
+        (format s "(:SYMBOL REG-TORN :PARENT :VERT"))   ; truncated, no newline
+      (let ((r2 (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (= 2 (length (graph-db::registry-entries r2)))
+                 "the two intact records survive a torn tail")
+          (graph-db::close-type-registry r2))))))
+
+(test registry-assignment-is-serialised-across-open-file-descriptions
+  "Two images assigning concurrently must not hand the same id to different
+symbols.  flock attaches to the open file description, so two registries on one
+directory in this image contend exactly as two processes would."
+  (with-temp-directory (dir)
+    (let ((r1 (graph-db::open-type-registry (namestring dir)))
+          (r2 (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (let ((a (graph-db::registry-intern r1 'reg-race-a :vertex))
+                 (b (graph-db::registry-intern r2 'reg-race-b :vertex)))
+             (is (/= a b)
+                 "the second assigner re-read the tail under the lock and did
+not reuse the first's id"))
+        (graph-db::close-type-registry r1)
+        (graph-db::close-type-registry r2)))))
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run `type-registry-suite` only. Expected: `OPEN-TYPE-REGISTRY` undefined. A reader error
+instead means a paren or package problem — fix that first.
+
+- [ ] **Step 3: Implement the registry**
+
+```lisp
+(in-package :graph-db)
+
+;;; The image-level type-id registry (GH #186).  Append-only; hosts read it,
+;;; none recompute it (D14).  Keyed on the PACKAGE-QUALIFIED symbol, so two
+;;; packages' same-named types never collide (cf. #190).
+
+(defstruct (type-registry (:constructor %make-type-registry))
+  (location nil)
+  ;; symbol -> id, per parent.  Rebuilt from the file at open.
+  (vertex (make-hash-table :test 'eq))
+  (edge   (make-hash-table :test 'eq))
+  (next-vertex 1 :type (unsigned-byte 32))
+  (next-edge   1 :type (unsigned-byte 32))
+  (lock (make-recursive-lock "type registry")))
+
+(defun %registry-file (location)
+  (make-pathname :name "type-registry" :type "log" :defaults location))
+
+(defun %registry-table (registry parent)
+  (ecase parent
+    ((:vertex vertex) (type-registry-vertex registry))
+    ((:edge edge)     (type-registry-edge registry))))
+```
+
+Then `%registry-load` (read records, tolerate a torn **final** record only),
+`%registry-append` (one `~S` line + `finish-output`), and the three entry points. The
+assignment path is:
+
+```lisp
+(defun registry-intern (registry symbol parent)
+  "The id for SYMBOL under PARENT, assigning one if absent.  The read-decide-
+append runs under an exclusive flock: two images that both find SYMBOL absent
+would otherwise assign it different ids, or one id to two symbols (#186)."
+  (with-recursive-lock-held ((type-registry-lock registry))
+    (or (registry-id-for registry symbol parent)
+        (let* ((file (%registry-file (type-registry-location registry)))
+               (fd (%posix-open file (logior +o-creat+ +o-rdwr+))))
+          (unwind-protect
+               (progn
+                 (unless (%posix-flock fd (logior +lock-ex+ +lock-nb+))
+                   (error 'type-registry-busy
+                          :location (type-registry-location registry)))
+                 ;; Re-read under the lock: another image may have assigned
+                 ;; SYMBOL between our miss above and taking the lock.
+                 (%registry-load registry)
+                 (or (registry-id-for registry symbol parent)
+                     (%registry-assign registry symbol parent)))
+            (%posix-close fd))))))
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+Then the **full** suite once, to confirm the new ASDF component did not disturb load order.
+
+- [ ] **Step 5: Ablation**
+
+Remove the re-read under the lock (the `%registry-load` call inside `registry-intern`) and
+confirm `registry-assignment-is-serialised-across-open-file-descriptions` **fails**.
+Restore; confirm it passes. Report both counts and confirm you re-read the file to verify
+the restore landed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add type-registry.lisp tests/type-registry-tests.lisp graph-db.asd package.lisp
+git commit -m "feat(registry): persisted image-level type-id registry (#186)"
+```
+
+---
+
+### Task 2: Assignment moves to the registry; the system directory becomes mandatory
+
+**Files:**
+- Modify: `schema.lisp` (`get-next-type-id` ~`:149`; `update-node-type` ~`:218`;
+  delete `%check-node-class-graph-unique` ~`:234` and its caller)
+- Modify: `globals.lisp` (`*system-directory*`)
+- Modify: `graph.lisp` (`make-graph` ~`:310`, `open-graph` ~`:520` — require the directory)
+- Modify: `package.lisp`, `tests/schema-tests.lisp` (or nearest), `CHANGELOG.md`,
+  `docs/vivace-graph-v3-doc.org`
+
+**Interfaces:**
+- Consumes: `open-type-registry`, `registry-intern`, `registry-id-for` (Task 1).
+- Produces: `*system-directory*` (special, no default); `*type-registry*` (the open
+  registry for this image).
+
+**Context the brief cannot give you:**
+
+`get-next-type-id` currently takes `(schema parent)` and bumps a per-graph counter. It must
+now consult the registry, which is keyed on **symbol** — so the *symbol* has to reach it.
+`update-node-type` (`schema.lisp:218`) is where the type's name is known. Restructure so
+assignment happens there, not in a counter bump that never sees the name.
+
+**Delete `%check-node-class-graph-unique` in this task.** It exists only because type-ids
+were per-graph; once ids are global it has no job. Its call site is in `def-node-type`.
+Removing it is *why* a class may be instantiated in more than one store (D4, and the
+acceptance criterion that closes cl-llm#20).
+
+**The keyword alias at `schema.lisp:227` is #190 and is NOT in scope.** Do not fix it here
+and do not extend it. If your change makes it more reachable, say so in your report — #190
+is already a blocker on #167.
+
+`+max-node-types+` stays `(expt 2 32)`; nothing about the ceiling changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+(test two-graphs-in-one-image-share-a-symbol-s-type-id
+  "The unit's entire purpose.  Before #186 each graph counted from 1, so the
+same symbol got different ids in different stores and different symbols
+collided on one id."
+  (with-temp-directory (dir)
+    (let ((graph-db::*system-directory* (namestring dir)))
+      (with-test-graph (g1 :name :reg-share-1)
+        (with-test-graph (g2 :name :reg-share-2)
+          (is (= (graph-db::lookup-node-type-id 'shared-type :vertex :graph g1)
+                 (graph-db::lookup-node-type-id 'shared-type :vertex :graph g2))
+              "one symbol, one id, both stores"))))))
+
+(test distinct-symbols-never-collide-across-graphs
+  (with-temp-directory (dir)
+    (let ((graph-db::*system-directory* (namestring dir)))
+      (with-test-graph (g1 :name :reg-coll-1)
+        (with-test-graph (g2 :name :reg-coll-2)
+          (is (/= (graph-db::lookup-node-type-id
+                   'type-in-one :vertex :graph g1)
+                  (graph-db::lookup-node-type-id
+                   'type-in-two :vertex :graph g2))
+              "two symbols never share an id, even in different stores"))))))
+
+(test opening-a-graph-without-a-system-directory-signals
+  "The directory is mandatory as of #186: the registry has nowhere to live
+without one, and a graph opened outside a system would mint ids that mean
+nothing to anyone else.  Refuse rather than silently fall back to per-graph
+counters -- a silent fallback is how two id regimes diverge unnoticed."
+  (with-temp-directory (dir)
+    (let ((graph-db::*system-directory* nil))
+      (signals graph-db:system-directory-required
+        (make-graph :reg-nodir (namestring dir))))))
+
+(test a-class-may-be-instantiated-in-more-than-one-store
+  "Closes cl-llm#20.  %CHECK-NODE-CLASS-GRAPH-UNIQUE refused this and existed
+only because ids were per-graph."
+  (with-temp-directory (dir)
+    (let ((graph-db::*system-directory* (namestring dir)))
+      (with-test-graph (g1 :name :reg-dual-1)
+        (with-test-graph (g2 :name :reg-dual-2)
+          (is-true (graph-db::lookup-node-type-by-name
+                    'dual-type :vertex :graph g1))
+          (is-true (graph-db::lookup-node-type-by-name
+                    'dual-type :vertex :graph g2)))))))
+```
+
+- [ ] **Step 2: Run and watch them fail.** The first two must fail because the ids
+      *differ* — confirm you see that, not merely an undefined symbol.
+
+- [ ] **Step 3: Implement.** Assignment consults the registry; `make-graph`/`open-graph`
+      signal `system-directory-required` when `*system-directory*` is `NIL`; delete
+      `%check-node-class-graph-unique` and its call.
+
+- [ ] **Step 4: Run tests, then the full suite.** This task changes a core path — expect
+      fallout in existing schema and multi-graph suites and fix it properly rather than
+      relaxing assertions. Report the count.
+
+- [ ] **Step 5: Ablation.** Make `registry-intern` fall back to the per-graph counter when
+      the registry lacks the symbol; confirm `two-graphs-in-one-image-share-a-symbol-s-type-id`
+      fails. Restore and verify.
+
+- [ ] **Step 6: Docs + commit** — CHANGELOG (breaking: the directory is now required) and
+      the manual's schema chapter.
+
+---
+
+### Task 3: Seeding and the renumbering migration
+
+**Files:**
+- Modify: `backup.lisp` (`migrate-graph` ~`:271`), `type-registry.lisp` (seeding)
+- Modify: `tests/type-id-width-tests.lisp` (make #166's mode explicit), new tests
+- Modify: `CHANGELOG.md`, `docs/vivace-graph-v3-doc.org`
+
+**Interfaces:**
+- Produces: `(registry-seed-from-stores registry locations)`;
+  `migrate-graph` gains `:renumber-p` (default `NIL`).
+
+**Context the brief cannot give you:** read **§10.1** of the spec before starting; it
+carries the measurement this task exists because of.
+
+**Seed from the largest store on disk, not the one with the most types.** All but one store
+renumbers whichever is favoured, so the cost is bytes. On the measured system, seeding by
+type count would have picked a store holding 59 of 95 types and among the *smallest*,
+forcing a rewrite of the largest — roughly 4.9 GB of replay instead of 1.1 GB.
+
+**A symbol may already hold two different ids within one store's history.** Those unify
+whichever store wins, so such a store is always in the migration set. Seeding must detect
+this and report it, not pick arbitrarily.
+
+**#166's guarantee becomes mode-dependent.** `migrate-v1-graph-to-v3` and
+`migrate-v2-graph-to-v3` assert type-ids "must survive migration unchanged"
+(`tests/type-id-width-tests.lisp:441`). That stays true for `:renumber-p nil`. **Rename or
+re-docstring them so they name the mode they pin**, and add the renumbering counterparts —
+otherwise the renumbering path inherits tests asserting the reverse of its behaviour.
+
+Required tests: a two-store fixture with colliding ids migrates to distinct global ids with
+every node's *class* preserved; a symbol holding two ids unifies and the migration says so;
+`:renumber-p nil` still preserves ids exactly as #166 asserts.
+
+Ablation: make the renumbering pass reuse the source id; confirm the collision test fails.
+
+---
+
+### Task 4: Distribution, the handshake guard, and the fixed-width audit
+
+**Files:**
+- Modify: `peer-streaming.lisp` (`%peer-type-table-rows` ~`:144`, handshake)
+- Modify: `tests/peer-*-tests.lisp`, `CHANGELOG.md`, `docs/vivace-graph-v3-doc.org`
+
+**Context the brief cannot give you:**
+
+**`peer-type-table-string`'s grammar is a FROZEN EXTERNAL CONTRACT** parsed by a non-Lisp
+peer. Do not change the grammar. What changes is *what fills it*: the table becomes the
+image's registry rather than one graph's schema.
+
+`%peer-type-table-rows` takes a `graph` and reads that graph's `schema-type-table`. Under a
+global registry the rows are image-level. **`%peer-validate-type-table-rows` matters more
+now, not less** — it refuses two types that `string-downcase` to one name, and pooling every
+store's types into one table widens that collision surface. Its error message currently
+advises renaming; check that advice still makes sense when the two types come from
+different stores.
+
+**D15, the handshake guard.** Compare registries at the handshake and **refuse, naming the
+conflicting symbols**. An image with no hub is its own authority — the common case, since
+`*peer-hub-enabled*` defaults to `NIL` — so two such images can independently assign the
+same symbol different ids. Reconciling would mean a data migration triggered by a network
+handshake; a disagreement between two populated stores is an operator event.
+
+**The fixed-width audit (§3.4).** #187 existed because the original analysis asked "what
+scales with `+max-node-types+`?" and never asked "**where else is a type-id serialised at a
+fixed width?**". Ask that second question of every remaining wire and file format and report
+the answer as a list, even if empty. Known: `memory-graph.lisp` fixed by #187;
+`peer-streaming.lisp:261` validates and signals. Anything else you find gets an issue, not a
+silent fix — a widening outside this unit's scope needs its own review.
+
+Ablation: make the handshake accept a disagreeing registry; confirm the refusal test fails.

--- a/docs/superpowers/plans/2026-08-21-global-type-ids.md
+++ b/docs/superpowers/plans/2026-08-21-global-type-ids.md
@@ -389,6 +389,33 @@ only because ids were per-graph."
 **Context the brief cannot give you:** read **§10.1** of the spec before starting; it
 carries the measurement this task exists because of.
 
+**The registry is already dirty when you arrive, and `migrate-graph` is why.** Found by the
+Task 2 review, deferred here because this task owns the function.
+
+`migrate-graph` (`backup.lisp:330-338`) calls `(make-graph name new-location)`. As of Task 2
+that path runs `update-schema`, which interns **every** one of the graph's types into the
+registry and assigns them real ids. `migrate-graph` then immediately does
+`(setf (schema new) old-schema)` — discarding those ids and installing the legacy per-graph
+ones.
+
+Two consequences you must handle rather than discover:
+
+1. **The migrated store's ids are not the registry's.** That is precisely the two-regime
+   divergence this whole unit exists to prevent, arriving through the migration path.
+2. **The registry permanently holds entries for those names at ids no store uses.** So
+   `registry-seed-from-stores` cannot assume it is seeding into an empty registry, and a
+   naive seed will collide with junk its own migration created.
+
+**This is currently invisible in the suite.** `migrate-v2-graph-to-v3`
+(`tests/type-id-width-tests.lisp:365`) passes *because* the schema swap wins — nothing
+notices that the registry was consulted and overruled. A test that fails for this reason is
+part of this task.
+
+Decide deliberately whether `:renumber-p nil` should still intern into the registry at all.
+Preserving legacy ids and *also* polluting the registry is the worst of both; either the
+non-renumbering path stays out of the registry entirely, or it seeds it consistently with
+what it preserved.
+
 **Seed from the largest store on disk, not the one with the most types.** All but one store
 renumbers whichever is favoured, so the cost is bytes. On the measured system, seeding by
 type count would have picked a store holding 59 of 95 types and among the *smallest*,

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -391,6 +391,7 @@ Three migrations, each chosen for a reversible failure mode.
 | What | Mechanism | Rewrites data? | Status |
 |---|---|---|---|
 | 32-bit `type-id` | new head-codec version; `migrate-graph` reads the old and replays | logical replay | **Implemented** (#166, unit 1a) |
+| **Global type-ids** | **renumbering replay against the seeded registry — see §10.1** | **logical replay** | **not built (unit 1b)** |
 | Global epoch | watermark above every store's counter | no | not built |
 | Tagged store id | v8 for new ids, v5 fallback for old | no | not built |
 
@@ -410,6 +411,45 @@ and `migrate-graph` carries a v1 *or* v2 source to v3 through one version-detect
 (it reads the source's own stamped version rather than being told). This row is done; the
 other two rows in this table, and §3.4's global type registry, are not — those are unit
 1b (#186) and later units, unaffected by this change.
+
+### 10.1 Adopting global ids on an existing system
+
+**This row was missing from the table above until unit 1b measured it.** The design
+described the steady state — registry, distribution, handshake refusal — and never said how
+a populated system reaches it.
+
+**Why a migration is unavoidable.** `schema-next-vertex-id` and `schema-next-edge-id` both
+start at **1** in every store. So in any system with more than one store, low type-ids name
+different classes in different stores. Under one space at most one store keeps a contested
+id and the rest must be renumbered — and `type-id` is written into the node head, `ve-key`,
+`vev-key` and the type-index, so renumbering a store means rewriting it.
+
+**Measured, not assumed.** On a five-store system read directly from `schema.dat` (no store
+opened): **66 vertex symbols competing for 36 distinct ids**, 11 of those ids claimed by
+more than one symbol — the lowest ids contested by nearly every store. Edges: 29 symbols,
+23 ids, 3 contested. The collision is close to total at the low end, which is what
+"every schema counts from 1" predicts.
+
+**The cost is bounded by bytes, not by type count.** Since the low ids are contested
+system-wide, all but one store is renumbered whichever store is favoured. Favour the store
+that is **largest on disk**, not the one with the most types: on the measured system that
+was the difference between replaying ~1.1 GB and replaying ~4.9 GB, and the store with the
+most types (59 of the 95) was one of the smallest. Seeding policy is therefore: **the
+registry adopts the assignment of the largest store, and every other store renumbers.**
+
+**One case no seeding policy exempts.** A symbol may already hold *two different ids* in one
+store's history — the measured system had three. Those must unify regardless of which store
+wins, so a store containing one is always in the migration set.
+
+**Mechanism.** A renumbering mode on `migrate-graph`, which already performs the logical
+snapshot-and-replay #166 built. It satisfies §12's requirement that no record be rewritten
+except by logical replay.
+
+**Consequence for #166's guarantee.** `migrate-graph` currently *preserves* `type-id` and
+its tests assert so ("must survive migration unchanged"). That was correct when the field
+widened but ids stayed per-graph. Under 1b the guarantee becomes **mode-dependent**, and
+those tests must say which mode they pin — otherwise the renumbering path silently inherits
+tests asserting the opposite of what it does.
 
 **Deployment gate.** A type-id migration lands on hosts that may be behind the current
 engine. Every consumer's version floor and each deployed engine version must be checked

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -95,6 +95,23 @@ unique, unlike today's enforced-by-convention global class name.
 keyed structure. This also retires the `(make-array +max-node-types+)` of **65,536 mutexes**
 allocated per index per store today regardless of type count.
 
+**As built (#166), this is a growable array rather than a keyed structure.** It starts at
+4,096 types and doubles in place via `extend-mapped-file`, which never relocates the base
+address, so a concurrent reader is never left holding a moved pointer. That satisfies the
+requirement above — nothing is allocated for type-ids not in use — by a different mechanism
+than the text anticipated. Two consequences the design did not state: growth is bounded by
+the 1 GiB mmap reservation, so the first type-id at or above 2²⁵ signals rather than growing
+(loud, and unreachable while ids are per-graph); and locking became **256 fixed stripes** by
+`(mod type-id 256)`, so two type-ids sharing a stripe now serialize against each other.
+
+**The consequence analysis above missed one narrowing, and the omission is instructive.** It
+enumerated the type-index and stopped at structures whose *size* scales with
+`+max-node-types+`. It did not ask the different question — *where else is a type-id
+serialised at a fixed width?* — which would have found `memory-graph.lisp`'s VG-native image
+packing it at 2 bytes with no range check (#187, fixed: format v8, readers fork on version,
+`ni-type-id` signals rather than truncating). Unit 1b should ask that second question
+explicitly of every remaining wire and file format before assuming this class is closed.
+
 **Known residual:** widening moves the hard ceiling out of reach and leaves a soft one at
 CLOS class count — 100k runtime types means 100k finalized classes with interned accessors.
 If genuinely high-cardinality runtime types are ever wanted, the alternative (types sharing
@@ -222,7 +239,12 @@ wrong derived data whose provenance does not record the skew.
 
 - **The clock is image-level, not store-level.** A *system* — a directory of N stores —
   owns one clock. Opening any subset opens the system, so a store opened alone still
-  allocates from the shared counter. A store's WAL remains self-contained.
+  allocates from the shared counter. A store's WAL remains self-contained. **This holds
+  only while one process owns the directory, which #168 did not enforce** — two images both
+  read the ceiling, both reserved, and both issued, silently. Closed by #182: an advisory
+  `flock` held for the clock's lifetime, kernel-released on process death, refusing
+  immediately and by name. Scope there is exclusion only; the counter needed no recovery
+  path, because the ceiling is persisted a block ahead of issuance.
 - **Detach takes an epoch lease.** A detaching store is granted `[E1, E2)` and allocates
   inside it while offline; the global clock skips past `E2`. One handshake at detach, one at
   reattach, no coordination in between — which is what keeps a separate-process bulk load
@@ -372,8 +394,10 @@ Three migrations, each chosen for a reversible failure mode.
 | Global epoch | watermark above every store's counter | no | not built |
 | Tagged store id | v8 for new ids, v5 fallback for old | no | not built |
 
-The type-id widening is the **only on-disk format change** in this design, and it has a
-proven precedent: `*node-head-reader*` is already a dispatch variable and
+The type-id widening is the only change to the **graph's** on-disk format in this design.
+It is no longer the only durable-format change: #187 bumped the memory-graph native image
+(`VGMI`) to v8 for the same widening, reading v5-v8 so no image is orphaned. That was not
+foreseen here — see §3.4. The widening has a proven precedent: `*node-head-reader*` is already a dispatch variable and
 `deserialize-node-head-v1` already reads the pre-MVCC 15-byte head so `migrate-graph` can
 back up and replay a v1 graph. Widening adds a v3 reader the same way. The head goes 31 → 33
 bytes (flags 1, type-id 2→**4**, revision 4, data-pointer 8, commit-epoch 8, prev-pointer 8)
@@ -393,16 +417,22 @@ before this ships. That is a release gate, not a design gate.
 
 ## 11. Units
 
-| # | Unit | Depends on |
-|---|---|---|
-| 1a | Widen `type-id` to 32 bits, sparse type-index, v3 head codec, migration — **ids stay per-graph** | — |
-| 1b | Global type-ids: canonical registry (D14), distribution, handshake guard (D15), delete the uniqueness check | 1a |
-| 2 | Packages as namespaces; store/namespace decoupling; placement defaults | **1b** |
-| 3 | Image-level clock, system journal, epoch leases | — |
-| 4 | Tagged UUIDv8 store field, resolver, detached-read marker | 3 |
-| 5 | Detach quiescence protocol and shadow bulk load | 3, 4 |
-| 6 | Restore: retention policy, algorithm, manifest, cascade | 5 |
-| 7 | Runtime schema from persisted metadata | 1b, 2 |
+| # | Unit | Issue | Depends on | Status |
+|---|---|---|---|---|
+| 1a | Widen `type-id` to 32 bits, sparse type-index, v3 head codec, migration — **ids stay per-graph** | #166 | — | **Done** |
+| 1b | Global type-ids: canonical registry (D14), distribution, handshake guard (D15), delete the uniqueness check | #186 | 1a | In progress |
+| 2 | Packages as namespaces; store/namespace decoupling; placement defaults | #167 | **1b**, #190 | Blocked |
+| 3 | Image-level clock, system journal, epoch leases | #168 | — | **Done** |
+| 4 | Tagged UUIDv8 store field, resolver, detached-read marker | #169 | 3 | Not started |
+| 5 | Detach quiescence protocol and shadow bulk load | #170 | 3, 4, #191 | Blocked |
+| 6 | Restore: retention policy, algorithm, manifest, cascade | #171 | 5, #191 | Blocked |
+| 7 | Runtime schema from persisted metadata | #172 | 1b, 2 | Blocked |
+
+Defects found while building the units above, which gate later ones: #187 (memory-image
+narrowing, **done**), #182 (clock had no cross-process exclusion, **done**), #190
+(package-blind type alias, gates unit 2), #191 (a torn record makes the whole lifecycle
+journal unreadable, gates units 5 and 6), #193 (whether `flock` should replace `.dirty`
+generally — exploration, not scheduled).
 
 Units 1a and 3 have no dependencies and may start in parallel. Unit 1 was split:
 1a is the only on-disk format change in this design, and a migration failure should be
@@ -453,3 +483,5 @@ because its migration debt accrues daily (§6).
 | D11 32-bit type-id | 3.4, 10 |
 | D12 shadow bulk load | 8 |
 | D13 restore interaction | 9 |
+| D14 registry persisted and distributed | 3.4 |
+| D15 handshake refuses on registry disagreement | 3.4 |

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3011,13 +3011,51 @@ nodes.
 
 *** Adopting global type-ids on an existing system
 
-A system whose stores predate the registry has a problem the registry cannot
-solve on its own: every store's schema counted type-ids from 1, so in any
-system with more than one store the low ids name *different* classes in
-different stores. Under one shared id space at most one store can keep a
-contested id, and the rest must be renumbered — and since ~type-id~ is
-written into the node head, the ~ve-key~, the ~vev-key~ and the type-index,
-renumbering a store means rewriting it.
+**One store, and nothing to do.** Opening a store reconciles its persisted
+type-ids with the registry before anything else happens. A type the registry
+has never seen, at an id no other type has claimed, is **adopted**: the
+registry records the id the store already uses. So a single-store deployment
+upgrading past #186 — set ~*system-directory*~ to a fresh directory, open —
+adopts its own ids on the first open and needs none of the procedure below.
+
+That reconciliation is not a nicety. Without it the registry would stay empty
+while the store kept its persisted ids, and the next release that adds one
+~def-vertex~ would mint an id the store already uses — silently overwriting
+one type's schema entry with another's, so every persisted node of the first
+type materialises as the second. It is also what makes the peer type table
+honest: the table is the registry while the wire carries store ids, and they
+agree only because this runs.
+
+**When the two cannot be reconciled, the open is refused.** If the registry
+gives the type a *different* id, or gives that id to a *different* type,
+~open-graph~ signals ~graph-db:store-registry-conflict~, naming both sides.
+That is not a retryable error and there is nothing an open may do about it:
+the losing id is already written into every node of its type. It means this
+store must be adopted deliberately, which is what the rest of this section is
+for.
+
+To *read* such a store meanwhile — a class census, a backup, the
+before-and-after of an adoption run — wrap the open in
+~graph-db:with-schema-frozen~, which opens the store exactly as it stands on
+disk, replaying no schema and checking no ids. Writes made through a frozen
+open go out under the *store's* ids, which is right for a legacy store and
+wrong for one you intend to keep in this system.
+
+#+BEGIN_SRC lisp
+  (let ((g (graph-db:with-schema-frozen ()
+             (graph-db:open-graph :my-app "/var/db/store-b/"))))
+    (unwind-protect (census g)
+      (graph-db:close-graph g :snapshot-p nil)))
+#+END_SRC
+
+**Several stores is the case that needs a decision.** A system whose stores
+predate the registry has a problem the registry cannot solve on its own: every
+store's schema counted type-ids from 1, so in any system with more than one
+store the low ids name *different* classes in different stores.
+Under one shared id space at most one store can keep a contested id, and the
+rest must be renumbered — and since ~type-id~ is written into the node head,
+the ~ve-key~, the ~vev-key~ and the type-index, renumbering a store means
+rewriting it.
 
 This is measured, not assumed. On a five-store system read straight off disk:
 66 vertex type names competing for 36 distinct ids, 11 of those ids claimed
@@ -3065,6 +3103,11 @@ Plan the run: each renumbering is a ~migrate-graph~, so the transient disk
 and the deployment gate described in Chapter 12 apply to every store in the
 list, and each store is written to a *new* location, leaving the source
 rollback-able.
+
+Until a store in the renumber list has been migrated, opening it under the
+seeded registry is refused — deliberately: its ids no longer mean what the
+system says they mean. Read it with ~with-schema-frozen~ if you need to, and
+migrate it when you are ready.
 
 **Renumber once, then distribute — do not renumber twice and hope.** The
 registry is persisted and *distributed*, not recomputed: hosts read it, none
@@ -4206,6 +4249,12 @@ This chapter provides a categorized reference for the most important exported sy
 
 - ~migrate-graph (name old-location new-location &key package include-deleted-p renumber-p)~ ::
   Migrates a v1 or v2 graph at ~old-location~ to the current (v3) format at ~new-location~, returning ~(values new-graph unified)~. A logical snapshot-and-replay; the original is left untouched. ~:renumber-p nil~ (default) preserves the source's type-ids; ~:renumber-p t~ takes them from the system registry instead and returns the names whose several ids it unified. See Chapter 12.
+
+- ~with-schema-frozen (() &body body)~ ::
+  Run BODY with schema replay and type-id reconciliation suppressed, so a store opens exactly as it stands on disk. The supported way to READ a store whose ids the registry contradicts — a census, a backup, the before-and-after of an adoption run. Writes made through a frozen open go out under the store's own ids. See Chapter 17.
+
+- ~store-registry-conflict~ (condition) ::
+  Signalled by ~open-graph~/~make-graph~ when a store's persisted type-id for a type is not the one the registry holds, or when the registry gives that id to another type. Not retryable: the losing id is already in every node head of its type. Readers: ~store-registry-conflict-location~, ~-type-name~, ~-parent~, ~-store-id~, ~-registry-id~, ~-holder~. The remedy is ~registry-seed-from-stores~ plus ~migrate-graph :renumber-p t~.
 
 - ~registry-seed-from-stores (registry locations)~ ::
   Seeds ~registry~ from the stores at ~locations~ (no graph is opened), adopting the largest store's type-ids and returning a ~seeding-report~ naming the stores that must now be migrated with ~:renumber-p t~. See Chapter 17, "Adopting global type-ids on an existing system".

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2328,7 +2328,7 @@ Every query takes a *scope* as its first argument: a node-class name, a list of 
 
 *** Subset replication (field devices)
 
-A replication *slave* can hold only a subset of the master's data — useful for a field device that needs just its area of operations, not the whole dataset. Give the slave a ~:replication-filter~: a predicate ~(node) -> boolean~ that decides, per replicated write, whether the slave applies it. Each transaction still advances the slave's high-water mark, so filtered transactions are not re-requested.
+A replication *slave* can hold only a subset of the master's data — useful for a field device that needs just its own region, not the whole dataset. Give the slave a ~:replication-filter~: a predicate ~(node) -> boolean~ that decides, per replicated write, whether the slave applies it. Each transaction still advances the slave's high-water mark, so filtered transactions are not re-requested.
 
 ~make-spatial-replication-filter~ builds a filter from an area geometry. It accepts a node when it has /no/ geometry (so schema and reference data replicate in full) or when its geometry lies in the area:
 
@@ -4128,7 +4128,7 @@ This chapter provides a categorized reference for the most important exported sy
 - ~make-spatial-replication-filter (area)~ ::
   Build a slave-graph ~:replication-filter~ predicate from ~area~ (a ~:polygon~ /
   ~:multipolygon~): the slave applies non-spatial nodes plus spatial nodes inside
-  ~area~, so it holds only its area of operations. See "Subset replication" above.
+  ~area~, so it holds only its own region. See "Subset replication" above.
 
 **** REST API
 - ~start-rest ( &optional port)~ ::

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2785,6 +2785,83 @@ A device is constructed with a hub-minted ~:origin-id~ (an opaque 16-byte id) an
 
 As with master/slave, a *minor* schema drift (same major version) still syncs, degraded-safe; a *major* mismatch is rejected before any data moves.
 
+*** Type-ids on the wire, and the handshake that refuses a disagreeing peer
+
+A ~type-id~ crosses the peer wire as an opaque integer; no type *name* ever
+does. A Lisp device gets away with that because it evaluates the same
+~schema.lisp~ the hub does. A non-Lisp peer (a Kotlin/SQLite field device)
+cannot, so after authenticating, the hub ships a *type table* in its
+~:auth-ok~ control plist: one delimited string of ~kind,id,name,supers~
+records, sorted by id.
+
+That string's grammar is a *frozen external contract*. It is parsed by
+implementations this repository does not build,
+~graph-db::peer-parse-type-table~ is the reference parser, and its strictness
+is part of the specification — an ~id~ is decimal digits only in 0..65535, a
+record has exactly four fields, ~kind~ is exactly ~"v"~ or ~"e"~, and a
+consumer must read *all* rows before resolving superclass names, because the
+table is sorted by id and may carry forward references.
+
+**What the table contains changed with GH #186: it is the IMAGE's type
+registry, not the hub graph's schema.** Type-ids are image-level now
+(Chapter 17), so a device may be sent an id belonging to any store in the
+system, and the hub therefore ships the whole mapping. Two consequences
+follow, both intended:
+
+- a type the hub's own graph does not instantiate still appears in the table;
+- a type name that cannot be encoded fails *every* device connection in the
+  image, not only sessions for the store that declared it.
+
+The encoder refuses rather than emit something a device cannot recover from.
+It signals, naming the offending type package-qualified, when a name is empty
+or carries a delimiter (a comma splits the record into two fields; a
+semicolon splits it into two *records*, the first of which parses silently as
+a bogus type), when two types' names collide once downcased, or when a
+type-id will not fit the wire's 16-bit ~id~ field (issue #199 tracks widening
+it; the registry itself assigns 32-bit ids).
+
+One thing the encoder cannot refuse, because it cannot see it: a row's
+~supers~ field is derived from CLOS, so a registry entry whose ~def-vertex~
+this image never loaded emits an *empty* field — indistinguishable on the
+wire from a type that really does root at ~vertex~/~edge~. A consumer places
+it at the root and drops it from its parent's closure. This became ordinary
+when the table became image-wide (an image holding store A's schema but not
+store B's still ships B's names); it is tracked as issue #200, with #195 as
+the same absence one level down.
+
+The downcased-name collision deserves a note, because pooling every store's
+types into one table *widened* it: two types that never shared a schema now
+share this namespace, and same-named symbols from two packages are no longer
+exotic. The error prints both symbols with their packages, since the package
+is the only thing that tells them apart. Resolving it is a *retirement or a
+rename*, and for a type with nodes on disk that is a store migration, not an
+edit.
+
+**The device refuses a hub whose registry disagrees with its own.** An image
+with no hub is its own authority — the ordinary case, since peer replication
+is off by default — so two such images can independently give one symbol two
+ids, or one id two symbols. Comparing the hub's table against the local
+registry at the handshake, the device signals
+~graph-db::peer-type-registry-conflict-error~ and closes the session, naming
+every conflicting symbol package-qualified. Both directions are checked and
+reported:
+
+- *one name, two ids* — a node arriving under the hub's id would materialise
+  as some other class here;
+- *one id, two names* — the hub's type is unknown in this image and its id
+  already means a local type, which is the same corruption with no shared
+  name to key on.
+
+This is deliberately *not* a reconciliation. Agreeing at a handshake would
+mean rewriting every node of the losing type because a network event said so.
+A disagreement between two populated stores is an operator event: reconcile
+the registries out of band (Chapter 17, "Adopting global type-ids on an
+existing system"), then reconnect.
+
+One gap is kept on purpose: a hub too old to ship a type table at all sends
+no ~:type-table~ key, and such a hub cannot be compared, so it is trusted.
+Removing that path would break every pre-#186 hub.
+
 *** Peer replication over the in-memory backend
 
 The storage backend is orthogonal to the replication role: ~make-memory-graph~ accepts the very same peer arguments, yielding an *in-memory peer device* — the intended mobile/ECL configuration. Combined with ~:lazy t~ and a post-sync ~checkpoint-memory-graph~, such a device gets a near-instant open plus fault-on-access reads of its synced subgraph (Chapter 15).
@@ -2988,6 +3065,17 @@ Plan the run: each renumbering is a ~migrate-graph~, so the transient disk
 and the deployment gate described in Chapter 12 apply to every store in the
 list, and each store is written to a *new* location, leaving the source
 rollback-able.
+
+**Renumber once, then distribute — do not renumber twice and hope.** The
+registry is persisted and *distributed*, not recomputed: hosts read it, none
+rebuild it. Within a single migration the ids are reproducible (the
+renumbering mints in package-then-symbol-name order, so re-running it on the
+same input gives the same answer), but that is a debugging aid, not a
+synchronisation mechanism. Two images that opened different stores, or the
+same stores in a different order, will still disagree — and a replication
+handshake between them is *refused*, naming the conflicting symbols, rather
+than silently reconciled. See Chapter 16, "Type-ids on the wire, and the
+handshake that refuses a disagreeing peer".
 
 *** The image-level system clock (optional)
 
@@ -4121,6 +4209,15 @@ This chapter provides a categorized reference for the most important exported sy
 
 - ~registry-seed-from-stores (registry locations)~ ::
   Seeds ~registry~ from the stores at ~locations~ (no graph is opened), adopting the largest store's type-ids and returning a ~seeding-report~ naming the stores that must now be migrated with ~:renumber-p t~. See Chapter 17, "Adopting global type-ids on an existing system".
+
+- ~peer-type-table-string (&optional registry)~ ::
+  Encodes the image's type registry as the delimited ~kind,id,name,supers~ string the hub ships in its ~:auth-ok~ plist. Signals, naming the type, rather than emit a table a device cannot recover from. The grammar is a frozen external contract — see Chapter 16, "Type-ids on the wire".
+
+- ~peer-parse-type-table (string)~ ::
+  The reference parser for that contract, and part of the specification: strict by design, since every laxness here is a place a non-Lisp implementation will silently diverge. ~nil~ or ~""~ (an old hub that ships no table) parses to ~nil~.
+
+- ~peer-check-type-registry-agreement (table &optional registry)~ ::
+  Signals ~peer-type-registry-conflict-error~, naming every conflicting symbol, unless the hub's ~table~ agrees with this image's registry about every type-id the two share. Run by ~peer-sync~ at the handshake; a disagreement is an operator event, not something a handshake may reconcile.
 
 **** MVCC / Versioning
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2156,11 +2156,27 @@ Internally it is a *logical* snapshot-and-replay, the same format-independent
 mechanism used for backups: the old graph is opened read-only through the
 head shim matching *its own* stamped version, every live node is written to
 a pointer-free snapshot, and a fresh v3 graph is created and the snapshot
-replayed through the normal ~make-vertex~ / ~make-edge~ path. The old
-graph's schema (its type-id registry) is copied across unchanged, so
-type-ids are preserved, not renumbered. (This mirrors the migration advice
-given for the 2016 hashing change — snapshot and replay — now packaged as a
-single call, and extended here to detect its own source version.)
+replayed through the normal ~make-vertex~ / ~make-edge~ path. (This mirrors
+the migration advice given for the 2016 hashing change — snapshot and replay
+— now packaged as a single call, and extended here to detect its own source
+version.)
+
+*Which type-ids the new graph gets is the one mode-dependent thing here*, and
+~:renumber-p~ chooses:
+
+- ~:renumber-p nil~ (the default) copies the old graph's schema across
+  unchanged, so every type-id is preserved. This is the #166 format
+  migration and nothing else. The new store's ids are the *source's*
+  per-graph ids, not the system registry's, so the migration deliberately
+  leaves the registry alone rather than claim ids for names it did not
+  renumber.
+- ~:renumber-p t~ takes every type-id from the system registry instead, so
+  the new store's ids mean the same thing in every other store of the
+  system. This is how a populated system adopts global ids; see "Adopting
+  global type-ids on an existing system" in Chapter 17 for the procedure,
+  which starts with seeding the registry rather than with this call. A
+  symbol the source's history left holding two ids unifies under one here,
+  and ~migrate-graph~ names it in its *second return value*.
 
 *The rollback guarantee, precisely.* The source graph's *data* — its heap
 and every vertex/edge/index table — is untouched, and it remains fully
@@ -2168,12 +2184,14 @@ usable: a pre-#166 engine can reopen it directly and read every node with
 its type-ids intact. Rollback is therefore *repointing at the old
 directory*, not restoring from a snapshot. It is not, however, byte-for-byte
 identical: producing the snapshot requires *opening* the source, and that
-open unconditionally rewrites ~schema.dat~ (the same content, re-serialized
-— type-ids are unaffected) and creates one new, empty
-~tx/replication-*.log~ file. Those are the only two files that change. This
-was verified by building a real, unmodified old-version engine (no shim) and
-reopening a post-migration source directory with it: every vertex and edge
-present, every type-id identical to before the migration.
+open creates one new, empty ~tx/replication-*.log~ file. That is the only
+file that changes. (It also rewrote ~schema.dat~ before #186 — same content,
+re-serialized. ~migrate-graph~ now suppresses the schema replay for both of
+its opens, so a type declared in your image but absent from the source is no
+longer written into the source at all.) This was verified by building a
+real, unmodified old-version engine (no shim) and reopening a
+post-migration source directory with it: every vertex and edge present,
+every type-id identical to before the migration.
 
 This guarantee assumes the source was *closed cleanly and still has its
 index sidecars*. ~open-graph~ rebuilds a spatial, unique, or secondary index
@@ -2913,6 +2931,63 @@ ids of the types it defines, wherever those landed in the system's numbering,
 not a dense run from 1. And ids are never reused or renumbered — the registry
 is append-only, and reopening a store keeps the ids already written into its
 nodes.
+
+*** Adopting global type-ids on an existing system
+
+A system whose stores predate the registry has a problem the registry cannot
+solve on its own: every store's schema counted type-ids from 1, so in any
+system with more than one store the low ids name *different* classes in
+different stores. Under one shared id space at most one store can keep a
+contested id, and the rest must be renumbered — and since ~type-id~ is
+written into the node head, the ~ve-key~, the ~vev-key~ and the type-index,
+renumbering a store means rewriting it.
+
+This is measured, not assumed. On a five-store system read straight off disk:
+66 vertex type names competing for 36 distinct ids, 11 of those ids claimed
+by more than one name, and the lowest ids contested by nearly every store.
+
+**Seed from the largest store on disk, not the one with the most types.**
+Every store but one is renumbered whichever store is favoured, so the cost is
+*bytes replayed*. On that same system the store holding 59 of the 95 types
+was among the smallest: seeding from it would have replayed roughly 4.9 GB
+instead of 1.1 GB.
+
+~registry-seed-from-stores~ applies that policy for you. It opens no graph —
+it reads each store's ~schema.dat~ and the allocation high-water mark in its
+~heap.dat~ header — and it tells you which stores must now be renumbered:
+
+#+BEGIN_SRC lisp
+  (let* ((registry (graph-db::ensure-type-registry))
+         (report (graph-db::registry-seed-from-stores
+                  registry '("/var/db/store-a/" "/var/db/store-b/"
+                             "/var/db/store-c/"))))
+    (graph-db::seeding-report-seed report)        ; the store adopted verbatim
+    (graph-db::seeding-report-sizes report)       ; ((location . bytes) ...)
+    (graph-db::seeding-report-changes report)     ; every id that moves
+    (graph-db::seeding-report-duplicates report)  ; see below
+    (dolist (location (graph-db::seeding-report-renumber report))
+      (graph-db::migrate-graph :my-app location (new-location-for location)
+                               :renumber-p t)))
+#+END_SRC
+
+Stores are offered their ids largest first, and each keeps every id it can: a
+name the registry has not seen, at an id no other name has claimed, is
+adopted verbatim. So the store that costs most to rewrite wins every contest.
+The registry need not be empty — entries already in it outrank every store,
+including the largest, because the registry is the authority and may already
+have been distributed to peers.
+
+**One case no seeding policy exempts.** A single store's history may already
+hold *two different ids for one name* (the measured system had three). Those
+must unify whichever store wins, so such a store is always in the migration
+set even if nothing else contests it. Seeding reports it in
+~seeding-report-duplicates~, and the renumbering migration reports the
+unification in its second return value rather than picking one id silently.
+
+Plan the run: each renumbering is a ~migrate-graph~, so the transient disk
+and the deployment gate described in Chapter 12 apply to every store in the
+list, and each store is written to a *new* location, leaving the source
+rollback-able.
 
 *** The image-level system clock (optional)
 
@@ -4041,8 +4116,11 @@ This chapter provides a categorized reference for the most important exported sy
 - ~replay (graph snapshot-dir &key package-name)~ ::
   Restores a graph from snapshot files located in ~snapshot-dir~ into a new, empty graph. Automatically finds the latest snapshot and rebuilds all views.
 
-- ~migrate-graph (name old-location new-location &key package include-deleted-p)~ ::
-  Migrates a pre-MVCC (storage v1) graph at ~old-location~ to the current (v2) format at ~new-location~, returning the new open graph. A logical snapshot-and-replay; the original is left untouched. See Chapter 12.
+- ~migrate-graph (name old-location new-location &key package include-deleted-p renumber-p)~ ::
+  Migrates a v1 or v2 graph at ~old-location~ to the current (v3) format at ~new-location~, returning ~(values new-graph unified)~. A logical snapshot-and-replay; the original is left untouched. ~:renumber-p nil~ (default) preserves the source's type-ids; ~:renumber-p t~ takes them from the system registry instead and returns the names whose several ids it unified. See Chapter 12.
+
+- ~registry-seed-from-stores (registry locations)~ ::
+  Seeds ~registry~ from the stores at ~locations~ (no graph is opened), adopting the largest store's type-ids and returning a ~seeding-report~ naming the stores that must now be migrated with ~:renumber-p t~. See Chapter 17, "Adopting global type-ids on an existing system".
 
 **** MVCC / Versioning
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -211,8 +211,14 @@ With our schema defined, we can connect to the database. We will store our graph
 
 The global special variable ~*graph*~ must be bound to the active graph instance. A common pattern is to check if the database exists and either create a new one or open the existing one.
 
+Before opening any graph, point ~*system-directory*~ at the directory holding
+this system's shared state — the type-id registry lives there, and graph-db
+refuses to create or open a store without it (see Chapter 17, "The system
+directory is mandatory").
+
 #+BEGIN_SRC lisp
   (defvar *my-graph-path* "/var/tmp/social-app/")
+  (setf graph-db:*system-directory* "/var/tmp/social-app-system/")
   
   (defun connect-to-database ()
     "Creates a new graph or opens an existing one."
@@ -425,14 +431,16 @@ For these primary node tables, the *key* is the node's 16-byte UUID, and the *va
 
 ~type-id~ widened from 2 to 4 bytes in v3, which breaks the byte-for-byte prefix the v1 and v2 heads used to share (both had ~flags(1) type-id(2) ...~); a v2 head must be read with ~deserialize-node-head-v2~, not reinterpreted against the v3 layout in place. ~data-pointer~ is the all-important offset to the node's data in the heap file; ~commit-epoch~ and ~prev-pointer~ drive the versioning machinery described in Chapter 12, "MVCC: Immutable Versioned Nodes". The on-disk storage version is recorded in each memory-mapped region; opening a v1 *or v2* graph with a v3 build signals an error directing you to ~migrate-graph~ (see "Migrating an older graph to v3" in Chapter 12).
 
-*A wider ceiling, still per graph.* The 4-byte field raises the number of
-distinct node types one graph can register from 65,536 to 4,294,967,295 — in
-practice unreachable, since each registered type is also a finalized CLOS
-class. This is *not* a global type-id space: ids are still assigned
-independently by each graph's own schema, starting from 1, so the same
-numeric type-id can (and typically does) mean a different class in two
-different graphs. A future change to make type-ids global and distributed is
-tracked separately (GH #186) and has not landed.
+*A wider ceiling, and now a system-wide one.* The 4-byte field raises the
+number of distinct node types a system can register from 65,536 to
+4,294,967,295 — in practice unreachable, since each registered type is also a
+finalized CLOS class. As of GH #186 the id space is *system-wide*, not per
+graph: ids are assigned by the registry in ~*system-directory*~, keyed on the
+package-qualified type name, so one name means one id in every store of the
+system and no two names ever share an id. Vertices and edges remain separate
+id spaces, as they were per graph. Before #186 each graph counted from 1
+independently, so the same integer typically named a different class in two
+graphs; see Chapter 17, "The system directory is mandatory".
 
 *** The Type Index (~type-index.lisp~): finding nodes by type
 
@@ -454,16 +462,20 @@ and grows by doubling, in place, the first time a type-id past its current
 capacity is touched. "In place" is the operative property — growth extends
 the memory-mapped file and never relocates its base address, so a concurrent
 reader is never at risk of dereferencing a pointer the grow just moved out
-from under it. Because type-ids are assigned sequentially from 1, ordinary
-schemas never grow the index more than once or twice, if at all.
+from under it. Since #186 a store's type-ids are *sparse* — they come from
+the system-wide registry, so a store holds the ids of its own types, not a
+dense run from 1 — and the index is sized by the highest id it holds rather
+than by how many types it has. The initial 4,096 slots therefore cover a
+*system* of that many types; a store in a larger system grows its index once
+or twice, which costs one in-place extension each.
 
 Growth is not unbounded: the index's mmap reserves address space at the 1 GiB
 floor (~*mmap-min-reservation*~), and doubling from 4,096 types reaches 2^25
 (33,554,432) types cleanly but the next doubling would exceed that
 reservation, so ~extend-mapped-file~ signals ("mmap reservation exhausted")
 rather than growing past it. That is a loud failure, not silent corruption,
-and it is unreachable in practice while type-ids stay per-graph and are
-handed out sequentially from 1.
+and it is unreachable in practice: reaching it needs a system that has
+registered 2^25 distinct type names.
 
 *Lock striping.* Every push/remove against a type's index-list is serialized
 by a lock. Before #166 that was one mutex *per type-id* — 65,536 of them per
@@ -2829,32 +2841,78 @@ One consequence worth knowing: a node retained past its graph's ~close-graph~ no
 dereferences an unmapped heap rather than silently decoding whatever lies at that offset
 in another graph's file. Do not hold nodes across a close.
 
-*** Class names are global
+*** Class names are global, and one class may serve several stores
 
-Common Lisp has one class namespace, so a node class name must be unique across *all*
-graph schemas. Defining the same name for a second graph signals
-~duplicate-node-class-error~. Redefining a type under the *same* graph name remains
-legal — that is ordinary schema evolution and works at runtime.
+Common Lisp has one class namespace, so a node class name names one class
+across *all* graph schemas. Since GH #186 that class may be defined for more
+than one graph — ~(def-vertex user () (...) :store-a)~ and ~(def-vertex user ()
+(...) :store-b)~ — and both stores hold the same type-id for it, because the id
+comes from the system registry rather than each store's own counter. Redefining
+a type under the same graph name remains legal: ordinary schema evolution, at
+runtime.
 
-Previously a second definition silently replaced the first class's slots, leaving the
-first graph's stored data unreachable through the API while still on disk.
+Both definitions define the *same CLOS class*, so the last one loaded
+determines its slots; declaring different slot sets for the two stores is how
+you get a class whose accessors return ~NIL~ against one of them. Keep the
+definitions identical, or give the two stores different type names.
+
+Before #186 the second definition signalled ~duplicate-node-class-error~,
+because the two stores would otherwise have disagreed about what their type-ids
+meant. That check is gone and the condition is no longer signalled (the symbol
+remains exported, so existing handlers still compile). Before that check
+existed, the second definition silently replaced the first class's slots,
+leaving the first graph's stored data unreachable through the API while still
+on disk.
 
 *** ~*transaction*~ is NIL inside a read-only snapshot
 
-~with-read-snapshot~ (and ~select~/~do-query~ with ~:snapshot t~) records its snapshot per
-graph in ~*read-snapshots*~ rather than binding ~*transaction*~, so code that reads
-~*transaction*~ to tell whether it is inside a query sees ~NIL~ there. Call
-~(read-transaction &optional graph)~ instead: it returns the read-write ~*transaction*~ when
-one is active and covers ~graph~, else ~graph~'s read snapshot from ~*read-snapshots*~, else
-~NIL~. This has second-order effects inside a snapshot: ~copy~ now signals
+~with-read-snapshot~ (and ~select~/~do-query~ with ~:snapshot t~) records its
+snapshot per graph in ~*read-snapshots*~ rather than binding ~*transaction*~,
+so code that reads ~*transaction*~ to tell whether it is inside a query sees
+~NIL~ there. Call ~(read-transaction &optional graph)~ instead: it returns the
+read-write ~*transaction*~ when one is active and covers ~graph~, else
+~graph~'s read snapshot from ~*read-snapshots*~, else ~NIL~. This has
+second-order effects inside a snapshot: ~copy~ now signals
 ~no-transaction-in-progress-warning~, ~commit~/~rollback~ now signal
-~no-transaction-in-progress~, and ~make-<type>~/~mark-deleted~ now auto-wrap their own real,
-committing transaction instead of silently joining a snapshot that was never going to
-commit.
+~no-transaction-in-progress~, and ~make-<type>~/~mark-deleted~ now auto-wrap
+their own real, committing transaction instead of silently joining a snapshot
+that was never going to commit.
 
-Also note: ~graph~ is now a *reserved* slot name on node classes — it backs the ~:META~
-home-graph tracking slot described above. A user-defined slot named ~graph~ shadows it and
-silently disables home-graph tracking for that class; do not use it as a slot name.
+Also note: ~graph~ is now a *reserved* slot name on node classes — it backs the
+~:META~ home-graph tracking slot described above. A user-defined slot named
+~graph~ shadows it and silently disables home-graph tracking for that class; do
+not use it as a slot name.
+
+*** The system directory is mandatory
+
+Type-ids are assigned from an append-only *registry* shared by every store in a
+system, so that one type name means one id everywhere (GH #186). The registry
+lives in ~type-registry.log~ under the directory named by
+~graph-db:*system-directory*~, beside the optional system clock's files.
+
+That special has *no default*, and ~make-graph~/~open-graph~ signal
+~graph-db:system-directory-required~ when it is ~NIL~. This is deliberate: a
+store opened outside a system would have to mint ids from a private counter,
+and two id regimes drifting apart unnoticed is exactly what the registry exists
+to prevent. Set it from your application's own configuration, once, before
+opening anything:
+
+#+BEGIN_SRC lisp
+  (setf graph-db:*system-directory* "/var/lib/my-system/")
+#+END_SRC
+
+The registry is opened lazily on first use and reopened if you change the
+special. Assignment takes a short exclusive ~flock~ across its
+read-decide-append — only *assignment* serialises, so any number of images may
+read the registry concurrently, and ~type-registry-busy~ is signalled if
+another image holds the append lock. Reads of an already-assigned id take no
+lock at all.
+
+Two consequences worth knowing. A store's type-ids are *sparse*: it holds the
+ids of the types it defines, wherever those landed in the system's numbering,
+not a dense run from 1. And ids are never reused or renumbered — the registry
+is append-only, and reopening a store keeps the ids already written into its
+nodes.
 
 *** The image-level system clock (optional)
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3048,6 +3048,19 @@ wrong for one you intend to keep in this system.
       (graph-db:close-graph g :snapshot-p nil)))
 #+END_SRC
 
+**A frozen open may read such a store; it may not serve one.** Starting
+replication on a graph opened this way signals
+~graph-db:frozen-graph-cannot-replicate~ — for a master, a slave or a peer.
+The hatch skips the id check, and every replication transport puts a store's
+raw type-ids on the wire: a hub would ship a type table built from the
+*registry* while its node heads carried the store's contradicted ids, and the
+damage would land on a remote peer where no local guard can see it. Reconcile
+the store and open it normally before replicating it.
+
+Note also what a frozen open leaves behind in the registry: **nothing**. It
+adopts no ids, so a store read this way is exactly as unreconciled afterwards
+as before.
+
 **Several stores is the case that needs a decision.** A system whose stores
 predate the registry has a problem the registry cannot solve on its own: every
 store's schema counted type-ids from 1, so in any system with more than one
@@ -4251,7 +4264,10 @@ This chapter provides a categorized reference for the most important exported sy
   Migrates a v1 or v2 graph at ~old-location~ to the current (v3) format at ~new-location~, returning ~(values new-graph unified)~. A logical snapshot-and-replay; the original is left untouched. ~:renumber-p nil~ (default) preserves the source's type-ids; ~:renumber-p t~ takes them from the system registry instead and returns the names whose several ids it unified. See Chapter 12.
 
 - ~with-schema-frozen (() &body body)~ ::
-  Run BODY with schema replay and type-id reconciliation suppressed, so a store opens exactly as it stands on disk. The supported way to READ a store whose ids the registry contradicts — a census, a backup, the before-and-after of an adoption run. Writes made through a frozen open go out under the store's own ids. See Chapter 17.
+  Run BODY with schema replay and type-id reconciliation suppressed, so a store opens exactly as it stands on disk. The supported way to READ a store whose ids the registry contradicts — a census, a backup, the before-and-after of an adoption run. Writes made through a frozen open go out under the store's own ids, and starting replication on one signals ~frozen-graph-cannot-replicate~. See Chapter 17.
+
+- ~frozen-graph-cannot-replicate~ (condition) ::
+  Signalled by ~start-replication~ for a master, slave or peer graph opened inside ~with-schema-frozen~. Its type-ids were never checked against the registry, and every transport puts raw type-ids on the wire, so serving it would corrupt a remote peer. Readers: ~frozen-graph-cannot-replicate-graph-name~, ~-location~.
 
 - ~store-registry-conflict~ (condition) ::
   Signalled by ~open-graph~/~make-graph~ when a store's persisted type-id for a type is not the one the registry holds, or when the registry gives that id to another type. Not retryable: the losing id is already in every node head of its type. Readers: ~store-registry-conflict-location~, ~-type-name~, ~-parent~, ~-store-id~, ~-registry-id~, ~-holder~. The remedy is ~registry-seed-from-stores~ plus ~migrate-graph :renumber-p t~.

--- a/example.lisp
+++ b/example.lisp
@@ -3,6 +3,10 @@
 
 (defvar *graph-name* :test-graph)
 (defvar *graph-path* "/var/tmp/test-graph/")
+;; Type-ids come from the registry in *SYSTEM-DIRECTORY*; a store cannot be
+;; opened without one (GH #186).
+(setf *system-directory*
+      (namestring (ensure-directories-exist "/var/tmp/test-graph-system/")))
 (log:config :all :sane :d :nopretty :thread :daily "/var/tmp/graph.log")
 
 ;;; Types

--- a/gc.lisp
+++ b/gc.lisp
@@ -50,16 +50,21 @@ by +MAX-NODE-TYPES+).  MAPHASHing the cache directly would therefore miss the
 index-lists of any type not yet touched THIS session -- e.g. right after
 OPEN-GRAPH, before any scan -- and this function feeds GC-HEAP's mark phase:
 missing a live type here means GC-HEAP reclaims that type's still-live nodes
-as garbage.  Enumerate every ASSIGNED type-id instead -- ids are dense from 0
-(0 = generic) up to the schema's next-*-id -- materializing each via
-GET-TYPE-INDEX-LIST, which lazily deserializes-and-caches on first touch."
-  (let ((schema (schema graph)))
-    (flet ((map-idx (idx next-id)
-             (dotimes (tid next-id)
-               (let ((il (get-type-index-list idx tid)))
-                 (when il (map-index-list-addresses fn il))))))
-      (map-idx (edge-index graph) (schema-next-edge-id schema))
-      (map-idx (vertex-index graph) (schema-next-vertex-id schema)))))
+as garbage.  Enumerate every ASSIGNED type-id instead, materializing each via
+GET-TYPE-INDEX-LIST, which lazily deserializes-and-caches on first touch.
+
+The ids the SCHEMA actually holds, not a range: type-ids come from the
+system-wide registry as of #186, so a store's are sparse and a DOTIMES up to
+a counter would skip live types -- and skipping one here marks its nodes
+garbage."
+  (flet ((map-idx (idx type-ids)
+           (dolist (tid type-ids)
+             (let ((il (get-type-index-list idx tid)))
+               (when il (map-index-list-addresses fn il))))))
+    ;; LIST-*-TYPES already prepends 0, the generic type-id, which is never a
+    ;; key in the type-table.
+    (map-idx (edge-index graph) (list-edge-types graph))
+    (map-idx (vertex-index graph) (list-vertex-types graph))))
 
 (defun map-all-index-list-addresses (fn graph)
   "Call FN with the heap address of the elements of all index lists

--- a/globals.lisp
+++ b/globals.lisp
@@ -88,6 +88,14 @@ what #186 exists to prevent.  Set it from your application's own config.")
   "The open TYPE-REGISTRY for this image, opened from *SYSTEM-DIRECTORY* on
 first use by ENSURE-TYPE-REGISTRY and reopened whenever that changes.  Bind
 *SYSTEM-DIRECTORY*, not this.")
+
+(defvar *schema-update-suppressed* nil
+  "When true, UPDATE-SCHEMA is a no-op.  Bound by MIGRATE-GRAPH only, around
+the opens whose schema it then installs by hand: minting registry type-ids
+for a schema discarded on the next form leaves the registry holding ids no
+store uses (GH #186).  Nothing else should bind it -- a store opened with the
+schema replay skipped does not learn the types declared since it was closed.")
+
 ;; The type-id READ-PATH ceiling (schema.lisp's LOOKUP-NODE-TYPE-BY-ID
 ;; assert), not an allocation size -- TYPE-INDEX no longer preallocates by
 ;; this (#166; see +TYPE-INDEX-INITIAL-TYPES+ below).  Matches the type-id

--- a/globals.lisp
+++ b/globals.lisp
@@ -75,11 +75,24 @@ application's own config; graph-db does not read an ini file itself.")
 (alexandria:define-constant +data-file+ "data.dat" :test 'equal)
 
 (defvar *schema-node-metadata* (make-hash-table :test 'equal))
+
+(defvar *system-directory* nil
+  "Directory holding this SYSTEM's image-level state: the type-id registry
+(GH #186), a sibling of the optional system clock's files (#182).  It has no
+default and is MANDATORY -- MAKE-GRAPH and OPEN-GRAPH signal
+SYSTEM-DIRECTORY-REQUIRED when it is NIL rather than fall back to per-graph
+type-id counters, because two id regimes that diverge unnoticed is exactly
+what #186 exists to prevent.  Set it from your application's own config.")
+
+(defvar *type-registry* nil
+  "The open TYPE-REGISTRY for this image, opened from *SYSTEM-DIRECTORY* on
+first use by ENSURE-TYPE-REGISTRY and reopened whenever that changes.  Bind
+*SYSTEM-DIRECTORY*, not this.")
 ;; The type-id READ-PATH ceiling (schema.lisp's LOOKUP-NODE-TYPE-BY-ID
 ;; assert), not an allocation size -- TYPE-INDEX no longer preallocates by
 ;; this (#166; see +TYPE-INDEX-INITIAL-TYPES+ below).  Matches the type-id
 ;; field's full width: (UNSIGNED-BYTE 32), widened by #166's Task 1, so the
-;; counter (GET-NEXT-TYPE-ID) can never issue an id the read path then
+;; registry (ASSIGN-TYPE-ID, #186) can never issue an id the read path then
 ;; refuses.
 (alexandria:define-constant +max-node-types+ (expt 2 32))
 

--- a/globals.lisp
+++ b/globals.lisp
@@ -160,7 +160,7 @@ first use by ENSURE-TYPE-REGISTRY and reopened whenever that changes.  Bind
 ;; reservation is PROT_NONE + MAP_NORESERVE anonymous address space, and on
 ;; 64-bit the address space it consumes is irrelevant.  Exception: RLIMIT_AS /
 ;; `ulimit -v` counts reserved address space regardless of MAP_NORESERVE, so a
-;; process capped by one (e.g. a systemd unit's LimitAS=, as on odm) can fail
+;; process capped by one (e.g. a systemd unit's LimitAS=) can fail
 ;; to open a graph outright even though nothing here is actually resident.
 ;;
 ;; At dimension 1024 (4,112 bytes per slot), capacity only ever advances by

--- a/globals.lisp
+++ b/globals.lisp
@@ -90,11 +90,17 @@ first use by ENSURE-TYPE-REGISTRY and reopened whenever that changes.  Bind
 *SYSTEM-DIRECTORY*, not this.")
 
 (defvar *schema-update-suppressed* nil
-  "When true, UPDATE-SCHEMA is a no-op.  Bound by MIGRATE-GRAPH only, around
-the opens whose schema it then installs by hand: minting registry type-ids
-for a schema discarded on the next form leaves the registry holding ids no
-store uses (GH #186).  Nothing else should bind it -- a store opened with the
-schema replay skipped does not learn the types declared since it was closed.")
+  "When true, UPDATE-SCHEMA is a no-op -- including its
+RECONCILE-SCHEMA-WITH-REGISTRY pass.  Bound by MIGRATE-GRAPH around the opens
+whose schema it then installs by hand: minting registry type-ids for a schema
+discarded on the next form leaves the registry holding ids no store uses
+(GH #186), and adopting them would be the same mistake in the other
+direction.
+
+Bind it elsewhere only for a store deliberately held inconsistent with its
+own registry -- a fixture, or a rescue open.  A store opened with the replay
+skipped does not learn the types declared since it was closed, and its ids
+are not checked against the registry.")
 
 ;; The type-id READ-PATH ceiling (schema.lisp's LOOKUP-NODE-TYPE-BY-ID
 ;; assert), not an allocation size -- TYPE-INDEX no longer preallocates by

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -14,6 +14,11 @@
 (defclass graph ()
   ((graph-name :accessor graph-name :initarg :graph-name)
    (graph-open-p :accessor graph-open-p :initarg :graph-open-p :initform nil)
+   ;; T when this graph was opened inside WITH-SCHEMA-FROZEN, so its
+   ;; persisted type-ids were never checked against the registry.  Set by
+   ;; UPDATE-SCHEMA, read by START-REPLICATION, which refuses (GH #186).
+   (schema-frozen-p :accessor schema-frozen-p :initarg :schema-frozen-p
+                    :initform nil)
    (location :accessor location :initarg :location)
    (txn-log :accessor txn-log :initarg :txn-log)
    (txn-file :accessor txn-file :initarg :txn-file)
@@ -253,15 +258,17 @@
                    :documentation "Branch B: surfaced field conflicts retained for the
                    app review surface (a list of PEER-CONFLICT for now; B3 makes it a
                    durable enumeration API + MVCC loser retention).")
-   (peer-type-registry :accessor peer-type-registry :initarg :peer-type-registry
-                       :initform nil
-                       :documentation "The image type registry, resolved on the thread
-                       that started replication.  A hub serves each connection on a NEW
-                       thread, which does not inherit dynamic bindings, so a session
-                       calling ENSURE-TYPE-REGISTRY would read the GLOBAL
-                       *SYSTEM-DIRECTORY* -- NIL (auth-ok then fails on every
-                       connection) or, worse, another system's directory.  Resolved once
-                       in START-REPLICATION instead (GH #186).  NIL falls back to
+   (peer-type-registry :accessor peer-type-registry
+                       :initarg :peer-type-registry :initform nil
+                       :documentation "The image type registry, resolved on
+                       the thread that started replication.  A hub serves
+                       each connection on a NEW thread, which does not
+                       inherit dynamic bindings, so a session calling
+                       ENSURE-TYPE-REGISTRY would read the GLOBAL
+                       *SYSTEM-DIRECTORY* -- NIL (auth-ok then fails on
+                       every connection) or, worse, another system's
+                       directory.  Resolved once in START-REPLICATION
+                       instead (GH #186).  NIL falls back to
                        ENSURE-TYPE-REGISTRY.")
    (peer-conflicts-lock :accessor peer-conflicts-lock :initform (make-recursive-lock "peer-conflicts"))
    (applied-op-ids :accessor applied-op-ids :initarg :applied-op-ids :initform nil
@@ -349,6 +356,15 @@ peer journal its writes (peer-replication WP-2).")
 ;; embeddable engine (graph-db/core) can open a graph without the network
 ;; replication transport.  The real master-graph/slave-graph methods (usocket
 ;; listener/slave threads) are in transaction-streaming.lisp (full graph-db).
+(defun check-replicable (graph)
+  "Signal FROZEN-GRAPH-CANNOT-REPLICATE if GRAPH was opened frozen.  Called
+by every START-REPLICATION method that actually starts a transport; the base
+method below is a no-op, and a plain store has nothing to serve (GH #186)."
+  (when (schema-frozen-p graph)
+    (error 'frozen-graph-cannot-replicate
+           :graph-name (graph-name graph)
+           :location (ignore-errors (location graph)))))
+
 (defmethod start-replication ((graph graph) &key package)
   (declare (ignore package))
   ;; noop

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -253,6 +253,16 @@
                    :documentation "Branch B: surfaced field conflicts retained for the
                    app review surface (a list of PEER-CONFLICT for now; B3 makes it a
                    durable enumeration API + MVCC loser retention).")
+   (peer-type-registry :accessor peer-type-registry :initarg :peer-type-registry
+                       :initform nil
+                       :documentation "The image type registry, resolved on the thread
+                       that started replication.  A hub serves each connection on a NEW
+                       thread, which does not inherit dynamic bindings, so a session
+                       calling ENSURE-TYPE-REGISTRY would read the GLOBAL
+                       *SYSTEM-DIRECTORY* -- NIL (auth-ok then fails on every
+                       connection) or, worse, another system's directory.  Resolved once
+                       in START-REPLICATION instead (GH #186).  NIL falls back to
+                       ENSURE-TYPE-REGISTRY.")
    (peer-conflicts-lock :accessor peer-conflicts-lock :initform (make-recursive-lock "peer-conflicts"))
    (applied-op-ids :accessor applied-op-ids :initarg :applied-op-ids :initform nil
                    :documentation "Durable OP-ID -> lamport dedup index (WP-3), checked

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -515,6 +515,7 @@ cl-temporal-extent."
                (:file "mvcc-tests")
                (:file "system-clock-tests")       ; GH #168
                (:file "type-registry-tests")      ; GH #186
+               (:file "global-type-id-tests")     ; GH #186
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -89,6 +89,10 @@
                ;; (#186); it only built before because that component happens
                ;; to precede this one in the list.
                (:file "schema" :depends-on ("stats" "type-registry"))
+               ;; Reads a store's schema.dat and heap header, so it cannot
+               ;; live in "type-registry" -- "schema" depends on THAT (#186).
+               (:file "type-seeding"
+                :depends-on ("schema" "allocator" "mmap"))
                (:file "node-class" :depends-on ("schema"))
                (:file "views" :depends-on ("node-class"))
                (:file "primitive-node" :depends-on ("views"))
@@ -98,7 +102,7 @@
                (:file "transactions" :depends-on ("graph-class" "type-index" "vev-index" "ve-index" "edge" "vertex" "gc" "spatial-index" "posix" "system-clock"))
                (:file "transaction-restore" :depends-on ("transactions"))
                (:file "transaction-log-streaming" :depends-on ("transactions"))
-               (:file "backup" :depends-on ("edge"))
+               (:file "backup" :depends-on ("edge" "type-seeding"))
                (:file "replication" :depends-on ("backup"))
                (:file "txn-log" :depends-on ("replication"))
                (:file "functor" :depends-on ("vertex" "edge" "views" "schema"))
@@ -519,6 +523,7 @@ cl-temporal-extent."
                (:file "system-clock-tests")       ; GH #168
                (:file "type-registry-tests")      ; GH #186
                (:file "global-type-id-tests")     ; GH #186
+               (:file "type-id-seeding-tests")    ; GH #186
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -9,7 +9,7 @@
 ;; This is the target for the offline Android field app (cross-compiled under
 ;; ECL); the app calls in-process, not over HTTP.  The full :graph-db system
 ;; below is core + the two network leaves and stays behaviour-identical for
-;; existing consumers (mine-action, odm).
+;; existing consumers.
 (defsystem graph-db/core
   :name "VivaceGraph (embeddable core)"
   :maintainer "Kevin Raison"
@@ -85,7 +85,10 @@
                       ("ve-index" "vev-index" "type-index" "linear-hash" "allocator"
                        "spatial-index" "posix"))
                (:file "stats" :depends-on ("graph"))
-               (:file "schema" :depends-on ("stats"))
+               ;; "type-registry" for ASSIGN-TYPE-ID / ENSURE-TYPE-REGISTRY
+               ;; (#186); it only built before because that component happens
+               ;; to precede this one in the list.
+               (:file "schema" :depends-on ("stats" "type-registry"))
                (:file "node-class" :depends-on ("schema"))
                (:file "views" :depends-on ("node-class"))
                (:file "primitive-node" :depends-on ("views"))
@@ -145,8 +148,8 @@
 ;; FULL: replication + the HTTP API leaf (rest, clack/ningle).  graph-db/replication
 ;; (and transitively graph-db/core) has already compiled+loaded the engine + transport,
 ;; so rest needs no intra-file :depends-on -- the system-level dependency guarantees
-;; order.  Stays behaviour-identical for existing consumers (mine-action, odm), which
-;; keep depending on :graph-db.
+;; order.  Stays behaviour-identical for existing consumers, which keep
+;; depending on :graph-db.
 (defsystem graph-db
   :name "VivaceGraph"
   :maintainer "Kevin Raison"

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -57,6 +57,9 @@
                ;; The image-level epoch clock (GH #168).  No graph dependency,
                ;; so it loads early and tests without one.
                (:file "system-clock" :depends-on ("serialize" "utilities"))
+               ;; The image-level type-id registry (GH #186).  Same shape as
+               ;; system-clock: no graph dependency, loads early.
+               (:file "type-registry" :depends-on ("serialize" "utilities"))
                (:file "geometry" :depends-on ("serialize"))
                (:file "geometry-ops" :depends-on ("geometry"))
                (:file "geohash" :depends-on ("package"))
@@ -511,6 +514,7 @@ cl-temporal-extent."
                (:file "backup-tests")
                (:file "mvcc-tests")
                (:file "system-clock-tests")       ; GH #168
+               (:file "type-registry-tests")      ; GH #186
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph.lisp
+++ b/graph.lisp
@@ -365,8 +365,18 @@ Keyword arguments:
                           Attaching raises the clock above this store's
                           persisted highest id.
 
+GRAPH-DB:*SYSTEM-DIRECTORY* must be set before calling this: type-ids are
+assigned from the registry that lives there, so that one symbol names one id
+in every store of the system (GH #186).  SYSTEM-DIRECTORY-REQUIRED is
+signalled when it is NIL -- there is deliberately no per-graph fallback.
+
 A .dirty marker file is written on creation; always CLOSE-GRAPH to flush data
 to disk and remove it."
+  ;; Type-ids come from the system's registry, which lives in
+  ;; *SYSTEM-DIRECTORY*; refuse rather than mint ids no peer agrees with
+  ;; (GH #186).
+  (unless *system-directory*
+    (error 'system-directory-required :operation 'make-graph))
   (when (and replay-txn-dir (not slave-p))
     (error ":REPLAY-TXN-DIR is only for slave graphs"))
   (when (and (or slave-p master-p) (not replication-port))
@@ -530,7 +540,12 @@ the backup/recovery chapter).  By default the heap is garbage-collected
 (:GC-HEAP-P) and outstanding transactions are recovered on open.  Views are
 reconciled against their declarative definitions and kept as-is unless changed
 (see DEF-VIEW); pass :REGENERATE-VIEWS T to force-rebuild every view on open.
-Always CLOSE-GRAPH when finished."
+Always CLOSE-GRAPH when finished.
+
+*SYSTEM-DIRECTORY* must be set: reopening replays the schema and may assign
+ids to types added since (GH #186)."
+  (unless *system-directory*
+    (error 'system-directory-required :operation 'open-graph))
   (when (and peer-role (or master-p slave-p))
     (error ":PEER-ROLE is mutually exclusive with :MASTER-P / :SLAVE-P"))
   (when (and peer-role (not (member peer-role '(:hub :device))))

--- a/graph.lisp
+++ b/graph.lisp
@@ -356,7 +356,7 @@ Keyword arguments:
                           indexes; existing ones reopen on their persisted tag.
   :REPLICATION-FILTER     (slaves only) a predicate (NODE) -> boolean; the slave
                           applies only replicated writes whose node it accepts,
-                          so it holds just a subset (e.g. its area of operations).
+                          so it holds just a subset (e.g. its own region).
                           See MAKE-SPATIAL-REPLICATION-FILTER.
   :SYSTEM-CLOCK           the image-level epoch clock (GH #168) this
                           store's transactions allocate ids from, or NIL

--- a/package.lisp
+++ b/package.lisp
@@ -51,6 +51,18 @@
            #:*type-registry*
            #:system-directory-required
            #:system-directory-required-operation
+           ;; GH #186: a store's persisted type-ids disagree with the
+           ;; image registry.  Operator-facing -- the remedy is a seeding
+           ;; run plus a renumbering migration, not a retry.
+           #:store-registry-conflict
+           #:store-registry-conflict-location
+           #:store-registry-conflict-type-name
+           #:store-registry-conflict-parent
+           #:store-registry-conflict-store-id
+           #:store-registry-conflict-registry-id
+           #:store-registry-conflict-holder
+           ;; Open a store the registry disagrees with, to read it.
+           #:with-schema-frozen
            #:tm-next-epoch
            #:tm-current-epoch
            #:tm-peek-epoch

--- a/package.lisp
+++ b/package.lisp
@@ -47,6 +47,10 @@
            #:registry-id-for
            #:registry-intern
            #:registry-entries
+           #:*system-directory*
+           #:*type-registry*
+           #:system-directory-required
+           #:system-directory-required-operation
            #:tm-next-epoch
            #:tm-current-epoch
            #:tm-peek-epoch

--- a/package.lisp
+++ b/package.lisp
@@ -38,6 +38,15 @@
            #:journal-records
            #:graph-system-clock
            #:attach-to-system-clock
+           ;; image-level type-id registry (GH #186)
+           #:type-registry
+           #:open-type-registry
+           #:close-type-registry
+           #:type-registry-busy
+           #:type-registry-busy-location
+           #:registry-id-for
+           #:registry-intern
+           #:registry-entries
            #:tm-next-epoch
            #:tm-current-epoch
            #:tm-peek-epoch

--- a/package.lisp
+++ b/package.lisp
@@ -60,7 +60,12 @@
            #:store-registry-conflict-parent
            #:store-registry-conflict-store-id
            #:store-registry-conflict-registry-id
+           #:store-registry-conflict-reason
            #:store-registry-conflict-holder
+           ;; GH #186: replication refuses a graph opened frozen.
+           #:frozen-graph-cannot-replicate
+           #:frozen-graph-cannot-replicate-graph-name
+           #:frozen-graph-cannot-replicate-location
            ;; Open a store the registry disagrees with, to read it.
            #:with-schema-frozen
            #:tm-next-epoch

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -1479,6 +1479,10 @@ re-ship.  Returns the ack result plist (:created / :purged id lists)."
 
 (defmethod start-replication ((graph peer-graph) &key package)
   (declare (ignore package))
+  ;; A frozen open never checked this store's ids against the registry, and
+  ;; the type table a hub ships describes the REGISTRY while its node heads
+  ;; carry the STORE's ids: serving one would corrupt a remote peer (#186).
+  (check-replicable graph)
   (setf (stop-replication-p graph) nil)
   ;; On THIS thread, while the caller's *SYSTEM-DIRECTORY* binding is still
   ;; visible: the hub's session threads cannot see it (GH #186).

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -714,6 +714,15 @@ MAX."
 ;;; Hub: handshake + authority-scoped pull.
 ;;; ---------------------------------------------------------------------------
 
+(defun %peer-registry (graph)
+  "GRAPH's captured type registry, or this image's.  A hub session runs on a
+thread START-REPLICATION spawned, and a new thread does NOT inherit dynamic
+bindings, so ENSURE-TYPE-REGISTRY there reads the GLOBAL *SYSTEM-DIRECTORY* --
+NIL, or another system's.  START-REPLICATION captures it on the caller's
+thread; the fallback covers a graph made before that (GH #186)."
+  (or (and (typep graph 'peer-graph) (peer-type-registry graph))
+      (ensure-type-registry)))
+
 (defun peer-hub-handshake-plist (graph)
   "What the hub announces on a new connection (schema-version split into plist-
 safe integers; schema-digest carried as a within-major integrity signal)."
@@ -836,9 +845,11 @@ DEF-VERTEX/DEF-EDGE evaluation order and no name crosses the wire."
                    ;; schema.  Additive and back-compatible -- every peer-path plist
                    ;; read on both sides is a bare GETF, so an old device simply never
                    ;; asks for this key, and a new device against an old hub gets NIL.
-                   (peer-write-plist (list :peer-control :auth-ok
-                                           :type-table (peer-type-table-string))
-                                     socket)
+                   (peer-write-plist
+                    (list :peer-control :auth-ok
+                          :type-table (peer-type-table-string
+                                       (%peer-registry graph)))
+                    socket)
                    (peer-pull-phase graph socket device
                                     :full-resync-p (and (getf auth :full-resync) t)
                                     :min-cursor (or (getf auth :pull-cursor) 0))
@@ -1433,7 +1444,8 @@ re-ship.  Returns the ack result plist (:created / :purged id lists)."
                  (error 'peer-schema-incompatible-error
                         :hub-version hub-version :device-version my-version))))
            (peer-write-plist (peer-device-auth-plist graph :full-resync full-resync) socket)
-           (peer-device-accept-auth-ok (read-plist-packet socket))
+           (peer-device-accept-auth-ok (read-plist-packet socket)
+                                       (%peer-registry graph))
            (let* ((mailbox (peer-writer-mailbox graph))
                   ;; Drain the pull until the pull-end control plist (carries T).
                   (end (loop for r = (peer-read-and-enqueue socket graph mailbox)
@@ -1468,6 +1480,9 @@ re-ship.  Returns the ack result plist (:created / :purged id lists)."
 (defmethod start-replication ((graph peer-graph) &key package)
   (declare (ignore package))
   (setf (stop-replication-p graph) nil)
+  ;; On THIS thread, while the caller's *SYSTEM-DIRECTORY* binding is still
+  ;; visible: the hub's session threads cannot see it (GH #186).
+  (setf (peer-type-registry graph) (ensure-type-registry))
   (ecase (peer-role graph)
     (:hub
      (setf (peer-thread graph)

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -120,6 +120,15 @@ want only the direct parents so the consumer can rebuild the closure itself."
                            '(vertex edge primitive-node node standard-object t))
               collect (string-downcase (symbol-name (class-name super)))))))
 
+(defun %peer-type-label (type)
+  "TYPE printed package-qualified, for an error an operator has to act on.  ~S
+alone omits the package whenever the symbol is accessible in the ambient
+*PACKAGE*, and under the image-level registry the types named in one of these
+errors routinely come from different packages and different stores -- the
+package is the whole discriminator (GH #186)."
+  (let ((*package* (%registry-print-package)))
+    (format nil "~S" type)))
+
 (defun %peer-check-wire-name (name type what)
   "Signal unless NAME -- a name about to be emitted into the type table -- is
 representable on the peer wire.  TYPE is the node-type SYMBOL whose row it came from and
@@ -130,69 +139,111 @@ The encoder is the ONLY possible defense.  A #\\, in a name splits it into two F
 SILENTLY as a bogus type.  Either way the table reaching a Kotlin/SQLite device is
 corrupt and unrecoverable there, so a loud error on the hub is strictly better."
   (when (zerop (length name))
-    (error "Node type ~S is UNREPRESENTABLE on the peer wire: its ~A is the empty string.  ~
-The peer type table cannot encode it; rename the type."
-           type what))
+    (error "Node type ~A is UNREPRESENTABLE on the peer wire: its ~A is the ~
+empty string.  The peer type table cannot encode it; rename the type."
+           (%peer-type-label type) what))
   (let ((bad (find-if (lambda (c) (member c *peer-type-name-reserved-chars*)) name)))
     (when bad
-      (error "Node type ~S is UNREPRESENTABLE on the peer wire: its ~A ~S contains the ~
-reserved character ~S.  The peer type table is a delimited external contract (see ~
-PEER-TYPE-TABLE-STRING); a name may not contain a comma, a semicolon, a space, a double ~
-quote, a backslash, a newline or a tab.  Rename the type."
-             type what name bad))))
+      (error "Node type ~A is UNREPRESENTABLE on the peer wire: its ~A ~S ~
+contains the reserved character ~S.  The peer type table is a delimited ~
+external contract (see PEER-TYPE-TABLE-STRING); a name may not contain a ~
+comma, a semicolon, a space, a double quote, a backslash, a newline or a ~
+tab.  Rename the type."
+             (%peer-type-label type) what name bad))))
 
-(defun %peer-type-table-rows (graph)
-  "GRAPH's node types as a list of (KIND-STRING ID NAME SUPERS TYPE): vertex types then
-edge types, each sorted by type-id.  SUPERS is a list of downcased names; TYPE is the
-node-type symbol, carried only so a validation error can name the type the developer
-actually wrote (the emitted NAME is downcased and may be the very thing at fault).
+(defun %peer-check-wire-id (id type)
+  "Signal unless ID fits the type table's ID field.  The registry assigns
+(UNSIGNED-BYTE 32) type-ids; the wire's ID field is (UNSIGNED-BYTE 16) and its
+grammar is frozen (PEER-TYPE-TABLE-STRING), so this is the one place a
+type-id is still narrowed.  The ENCODER must refuse -- emitting a row the
+reference parser cannot read puts the failure on the device rather than on
+the hub that produced it.  Widening the field is GH #199."
+  (unless (typep id '(unsigned-byte 16))
+    (error "Node type ~A is UNREPRESENTABLE on the peer wire: its type-id ~D ~
+is outside 0..65535.  The peer type table's ID field is a frozen external ~
+contract (see PEER-TYPE-TABLE-STRING) while the image registry assigns ~
+32-bit ids, so a system with more than 65536 types of one parent kind cannot ~
+replicate until the field is widened (GH #199)."
+           (%peer-type-label type) id)))
 
-The schema sub-tables are triple-keyed (id -> meta, symbol -> id, keyword -> id; see
-UPDATE-NODE-TYPE in schema.lisp), hence the (INTEGERP K) filter -- without it every type
-appears three times."
-  (loop for kind in '(:vertex :edge)
-        for kind-string in '("v" "e")
-        append (let ((sub (gethash kind (schema-type-table (schema graph)))))
-                 (when sub
-                   (loop for id in (sort (loop for k being the hash-keys in sub
-                                               when (integerp k) collect k)
-                                         #'<)
-                         for meta = (gethash id sub)
-                         when (node-type-p meta)
-                           collect (let ((type (node-type-name meta)))
-                                     (list kind-string
-                                           id
-                                           (string-downcase (symbol-name type))
-                                           (%peer-type-direct-supers type)
-                                           type)))))))
+(defun %peer-type-table-rows (registry)
+  "REGISTRY's types as a list of (KIND-STRING ID NAME SUPERS TYPE): vertex
+types then edge types, each sorted by type-id.  SUPERS is a list of downcased
+names; TYPE is the node-type symbol, carried only so a validation error can
+name the type the developer actually wrote (the emitted NAME is downcased and
+may be the very thing at fault).
+
+The rows are the IMAGE's type registry, not one graph's schema (D14, GH #186).
+A type-id means one thing across every store in the system, so the hub ships
+the whole mapping and a device can resolve any id it may ever be sent.  Two
+consequences, both intended: a type the hub's own graph does not hold is still
+emitted, and ONE unrepresentable type name anywhere in the image fails every
+device connection rather than only the store holding it -- see
+%PEER-VALIDATE-TYPE-TABLE-ROWS.
+
+SUPERS comes from CLOS, so a registered symbol whose class this image has not
+loaded emits an EMPTY supers field -- indistinguishable on the wire from a
+type that really does root at VERTEX/EDGE, so the device places it at the root
+and drops it from its parent's closure.  GH #200; GH #195 is the same absence
+one level down."
+  (flet ((rows-for (parent kind-string)
+           ;; LOOP COLLECT, not REMOVE-IF-NOT: the latter may return the
+           ;; registry's own list, which SORT would then destroy.
+           (let ((entries (loop for e in (registry-entries registry)
+                                when (eq parent (second e)) collect e)))
+             (loop for (type nil id) in (sort entries #'< :key #'third)
+                   collect (list kind-string
+                                 id
+                                 (string-downcase (symbol-name type))
+                                 (%peer-type-direct-supers type)
+                                 type)))))
+    (append (rows-for :vertex "v") (rows-for :edge "e"))))
 
 (defun %peer-validate-type-table-rows (rows)
-  "Signal if ROWS cannot be encoded unambiguously: a name carrying a reserved character
-or empty, or two types emitting the SAME name.  Returns ROWS.
+  "Signal if ROWS cannot be encoded unambiguously: an id outside the wire's
+range, a name carrying a reserved character or empty, or two types emitting
+the SAME name.  Returns ROWS.
 
-Names are otherwise globally unique (each is a CLOS class name), but STRING-DOWNCASE is
-NOT injective -- P-PERSON and |P-Person| are distinct classes that emit one name, as can
-same-named symbols from different packages.  A device would then resolve one type-id's
-name to the other type's row."
+STRING-DOWNCASE is NOT injective -- P-PERSON and |P-Person| are distinct
+classes that emit one name, as are same-named symbols from different
+packages.  A device would then resolve one type-id's name to the other
+type's row.
+
+This matters MORE under the image-level registry, not less (GH #186).  ROWS
+pool every store's types into one table, so two types that never shared a
+schema now share this namespace, and the same-named-symbols-in-two-packages
+case stops being exotic.  Hence %PEER-TYPE-LABEL: the error has to print the
+package or an operator cannot tell the two apart, let alone find them."
   (let ((seen (make-hash-table :test 'equal)))
     (dolist (row rows rows)
       (destructuring-bind (kind id name supers type) row
-        (declare (ignore kind id))
+        (declare (ignore kind))
+        (%peer-check-wire-id id type)
         (%peer-check-wire-name name type "name")
         (dolist (super supers)
           (%peer-check-wire-name super type "superclass name"))
         (let ((other (gethash name seen)))
           (when other
-            (error "Node types ~S and ~S are UNREPRESENTABLE together on the peer wire: ~
-both emit the name ~S (STRING-DOWNCASE is not injective).  The peer type table maps ~
-type-id -> name and a device cannot tell them apart; rename one."
-                   other type name))
+            (error "Node types ~A and ~A are UNREPRESENTABLE together on the ~
+peer wire: both emit the name ~S (STRING-DOWNCASE is not injective).  The peer ~
+type table maps type-id -> name and a device cannot tell them apart.  The ~
+table is the IMAGE's registry (GH #186), so these two need not share a schema ~
+or even a store -- the packages above are what tells them apart.  Retire or ~
+rename one; for a type with nodes on disk that is a store migration, not an ~
+edit."
+                   (%peer-type-label other) (%peer-type-label type) name))
           (setf (gethash name seen) type))))))
 
-(defun peer-type-table-string (&optional (graph *graph*))
-  "Encode GRAPH's node-type registry as ONE delimited string, for the plist control
-channel.  A nested list would trip PLIST-TOO-FANCY-ERROR, so the table rides as a
-single string -- the same dodge as PEER-IDS->STRING.
+(defun peer-type-table-string (&optional (registry (ensure-type-registry)))
+  "Encode this IMAGE's type registry as ONE delimited string, for the plist
+control channel.  A nested list would trip PLIST-TOO-FANCY-ERROR, so the table
+rides as a single string -- the same dodge as PEER-IDS->STRING.
+
+REGISTRY, not a graph (D14, GH #186): type-ids are image-level, so the table
+names every type this system has assigned, not the subset one store happens to
+instantiate.  Signals SYSTEM-DIRECTORY-REQUIRED when *SYSTEM-DIRECTORY* is
+NIL, which no graph-owning image can be -- MAKE-GRAPH and OPEN-GRAPH both
+refuse without one.
 
 *** THIS FORMAT IS A FROZEN EXTERNAL CONTRACT. *** It is parsed by non-Lisp peers (the
 Kotlin/SQLite device).  PEER-PARSE-TYPE-TABLE is the reference implementation and its
@@ -232,17 +283,22 @@ STRICT PARSE RULES (the contract; PEER-PARSE-TYPE-TABLE enforces all of them):
   - no record is empty -- no leading, trailing or doubled #\\; -- and no super is empty;
   - the WHOLE table may be empty (\"\", or the key absent): an old hub sends no table.
 
-Both KIND and ID are required: NEXT-VERTEX-ID and NEXT-EDGE-ID are separate counters
-that BOTH start at 1 (schema.lisp), so a vertex type and an edge type routinely share a
-numeric id.  A consumer must key on (KIND . ID), never ID alone.
+Both KIND and ID are required: the registry's vertex and edge counters are
+separate and BOTH start at 1 (type-registry.lisp; before GH #186, schema.lisp's
+per-graph pair), so a vertex type and an edge type routinely share a numeric
+id.  A consumer must key on (KIND . ID), never ID alone.
 
-Signals an error if the schema cannot be represented -- see
-%PEER-VALIDATE-TYPE-TABLE-ROWS.  That is deliberate: a corrupt table is undebuggable on
-the device, so the failure belongs at the hub.  Note WHERE it lands: this runs on the
-auth-ok path, so an unrepresentable schema fails every device CONNECTION, not the
-offending DEF-VERTEX.  Loud and hub-side either way, but the traceback points at a
-session, not at the schema form that caused it."
-  (let ((rows (%peer-validate-type-table-rows (%peer-type-table-rows graph))))
+Signals an error if the registry cannot be represented -- see
+%PEER-VALIDATE-TYPE-TABLE-ROWS.  That is deliberate: a corrupt table is
+undebuggable on the device, so the failure belongs at the hub.  Note WHERE it
+lands: this runs on the auth-ok path, so an unrepresentable type fails every
+device CONNECTION, not the offending DEF-VERTEX.  Since GH #186 the table is
+the IMAGE's registry, so that one type need not even be in the store being
+replicated -- the blast radius is every peer session in the image.  Loud and
+hub-side either way, but the traceback points at a session, not at the schema
+form that caused it."
+  (let ((rows (%peer-validate-type-table-rows
+               (%peer-type-table-rows registry))))
     (with-output-to-string (s)
       (loop for row in rows
             for firstp = t then nil
@@ -318,6 +374,116 @@ names), because the table is sorted by id and may carry forward references."
   (unless (or (null string) (string= string ""))
     (loop for record in (%peer-split #\; string)
           collect (%peer-parse-type-record record))))
+
+;;; ---------------------------------------------------------------------------
+;;; D15: the handshake refuses a peer whose type registry disagrees.
+;;;
+;;; An image with no hub is its own authority -- the common case, since peer
+;;; replication is off by default -- so two images can independently give one
+;;; symbol two ids, or one id two symbols.  Reconciling here would mean a data
+;;; migration triggered by a network handshake, on stores that may hold millions
+;;; of nodes stamped with the losing id.  Refuse instead, and NAME the symbols:
+;;; a disagreement between two populated stores is an operator event
+;;; (spec §3.4).
+;;; ---------------------------------------------------------------------------
+
+(define-condition peer-type-registry-conflict-error (error)
+  ((conflicts :initarg :conflicts :reader peer-type-registry-conflicts))
+  (:report
+   (lambda (c s)
+     (let ((conflicts (peer-type-registry-conflicts c)))
+       (format s "The hub's type registry disagrees with this image's, so a ~
+type-id on the wire would materialise the WRONG class here.  Refusing the ~
+session (D15, GH #186) -- reconcile the registries out of band; a handshake ~
+may not do it, because the losing id is already written into every node of ~
+its type.  ~D conflict~:P:~{~%  ~A~}"
+               (length conflicts)
+               (mapcar #'%peer-conflict-description conflicts))))))
+
+(defun %peer-conflict-description (conflict)
+  "One line naming CONFLICT's two sides, package-qualified."
+  (destructuring-bind (reason parent key hub local symbol) conflict
+    (ecase reason
+      (:same-name-two-ids
+       (format nil "~(~A~) ~A (~S): hub says id ~D, this image says ~D"
+               parent (%peer-type-label symbol) key hub local))
+      (:same-id-two-names
+       (format nil "~(~A~) id ~D: hub says ~S, this image says ~S (~A)"
+               parent key hub local (%peer-type-label symbol))))))
+
+(defun %peer-registry-conflicts (hub-rows registry)
+  "Every disagreement between HUB-ROWS (PEER-PARSE-TYPE-TABLE output) and
+REGISTRY, as a list of conflict descriptors
+(REASON PARENT KEY HUB-SIDE LOCAL-SIDE LOCAL-SYMBOL).
+
+Compared by DOWNCASED NAME, because that is all the wire carries -- which is
+exactly why %PEER-VALIDATE-TYPE-TABLE-ROWS must go on refusing two types that
+downcase alike.  It is applied to the LOCAL rows here too: if this image's own
+registry is ambiguous the comparison below is unsound, so that has to signal
+rather than silently check one of the two.
+
+BOTH directions are reported and neither subsumes the other.  One name at two
+ids is the case where a node arrives under an id this image reads as some
+other type.  One id at two names is the case where the hub's type is unknown
+here and its id already means a local type -- the same corruption, with no
+shared name to key on."
+  (let ((conflicts nil)
+        (local (%peer-validate-type-table-rows
+                (%peer-type-table-rows registry))))
+    (dolist (parent '(:vertex :edge) (nreverse conflicts))
+      (let ((kind-string (ecase parent (:vertex "v") (:edge "e")))
+            (by-name (make-hash-table :test 'equal))
+            (by-id (make-hash-table :test 'eql)))
+        (dolist (row local)
+          (destructuring-bind (kind id name supers type) row
+            (declare (ignore supers))
+            (when (string= kind kind-string)
+              (setf (gethash name by-name) (cons id type))
+              (setf (gethash id by-id) (cons name type)))))
+        (dolist (row hub-rows)
+          (destructuring-bind (hub-parent hub-id hub-name hub-supers) row
+            (declare (ignore hub-supers))
+            (when (eq hub-parent parent)
+              (let ((named (gethash hub-name by-name))
+                    (numbered (gethash hub-id by-id)))
+                (when (and named (/= hub-id (car named)))
+                  (push (list :same-name-two-ids parent hub-name
+                              hub-id (car named) (cdr named))
+                        conflicts))
+                (when (and numbered (not (string= hub-name (car numbered))))
+                  (push (list :same-id-two-names parent hub-id
+                              hub-name (car numbered) (cdr numbered))
+                        conflicts))))))))))
+
+(defun peer-check-type-registry-agreement (table &optional
+                                                 (registry
+                                                  (ensure-type-registry)))
+  "Signal PEER-TYPE-REGISTRY-CONFLICT-ERROR unless the hub's TABLE -- the
+auth-ok :TYPE-TABLE string -- agrees with REGISTRY about every type-id the two
+share.  Returns the parsed table (PEER-PARSE-TYPE-TABLE).
+
+NIL or \"\" checks nothing and returns NIL.  That is the back-compat path for a
+hub too old to ship a table, and it is the one hole in this guard: such a hub
+cannot be compared at all, so it is trusted."
+  (let ((rows (peer-parse-type-table table)))
+    (when rows
+      (let ((conflicts (%peer-registry-conflicts rows registry)))
+        (when conflicts
+          (error 'peer-type-registry-conflict-error :conflicts conflicts))))
+    rows))
+
+(defun peer-device-accept-auth-ok (ctrl &optional
+                                        (registry (ensure-type-registry)))
+  "The device's half of the auth-ok step: refuse a rejection, then refuse a hub
+whose type registry disagrees with this image's (D15).  Returns the parsed hub
+type table.
+
+Factored out of PEER-SYNC so the refusal is reachable without a socket; the
+socket plumbing around this call is NOT covered by the tests that drive it
+directly."
+  (unless (eq (getf ctrl :peer-control) :auth-ok)
+    (error "peer auth rejected by hub: ~S" ctrl))
+  (peer-check-type-registry-agreement (getf ctrl :type-table) registry))
 
 (defun peer-portable-string (value)
   "Coerce a STRING VALUE to a general (CHARACTER) string; pass non-strings through.
@@ -671,7 +837,7 @@ DEF-VERTEX/DEF-EDGE evaluation order and no name crosses the wire."
                    ;; read on both sides is a bare GETF, so an old device simply never
                    ;; asks for this key, and a new device against an old hub gets NIL.
                    (peer-write-plist (list :peer-control :auth-ok
-                                           :type-table (peer-type-table-string graph))
+                                           :type-table (peer-type-table-string))
                                      socket)
                    (peer-pull-phase graph socket device
                                     :full-resync-p (and (getf auth :full-resync) t)
@@ -1267,9 +1433,7 @@ re-ship.  Returns the ack result plist (:created / :purged id lists)."
                  (error 'peer-schema-incompatible-error
                         :hub-version hub-version :device-version my-version))))
            (peer-write-plist (peer-device-auth-plist graph :full-resync full-resync) socket)
-           (let ((ctrl (read-plist-packet socket)))
-             (unless (eq (getf ctrl :peer-control) :auth-ok)
-               (error "peer auth rejected by hub: ~S" ctrl)))
+           (peer-device-accept-auth-ok (read-plist-packet socket))
            (let* ((mailbox (peer-writer-mailbox graph))
                   ;; Drain the pull until the pull-end control plist (carries T).
                   (end (loop for r = (peer-read-and-enqueue socket graph mailbox)

--- a/profiling/harness.lisp
+++ b/profiling/harness.lisp
@@ -1,6 +1,15 @@
 ;;;; Combined Profiling Harness for VivaceGraph Profiler
 (in-package #:graph-db/profiler)
 
+;;; Every module here opens its own throwaway store, and since GH #186 a store
+;;; cannot be opened without a system directory to take type-ids from.  One for
+;;; the whole profiler image, which is the shape a real system has: many
+;;; stores, one registry.  SETF at load time, so a module run from any thread
+;;; sees it.
+(setf graph-db:*system-directory*
+      (namestring
+       (ensure-directories-exist #p"/tmp/vg-profiler-system/")))
+
 (defstruct profiler-run-result
   (name "Profile Run" :type string)
   (subsystems '() :type list)

--- a/schema.lisp
+++ b/schema.lisp
@@ -551,9 +551,15 @@ Example:
         (error "Cannot update schema for graph ~A: graph not open!" graph-name))))
 
 (defmethod update-schema ((graph graph))
-  (with-recursive-lock-held ((schema-lock (schema graph)))
-    (let ((node-metadata (gethash (graph-name graph) *schema-node-metadata*)))
-      ;; The list is maintained oldest-first (GH #53); apply in order.
-      (dolist (meta node-metadata)
-        (instantiate-node-type meta graph)))
-    (save-schema (schema graph) graph)))
+  ;; *SCHEMA-UPDATE-SUPPRESSED* is bound by MIGRATE-GRAPH alone, which
+  ;; installs by hand the schema each of its two opens is to have: minting
+  ;; registry ids here for a schema discarded on the next form is how the
+  ;; registry ends up holding ids no store uses (GH #186).
+  (unless *schema-update-suppressed*
+    (with-recursive-lock-held ((schema-lock (schema graph)))
+      (let ((node-metadata (gethash (graph-name graph)
+                                    *schema-node-metadata*)))
+        ;; The list is maintained oldest-first (GH #53); apply in order.
+        (dolist (meta node-metadata)
+          (instantiate-node-type meta graph)))
+      (save-schema (schema graph) graph))))

--- a/schema.lisp
+++ b/schema.lisp
@@ -437,10 +437,11 @@ be defined before or after the graph is created."
                                          *graph*
                                          :edge-type ',name)))))
                   )
-           ;; Replace in place, preserving position: UPDATE-SCHEMA applies the
-           ;; list oldest-to-newest and INSTANTIATE-NODE-TYPE assigns type-ids in
-           ;; that order, so moving a redefined type would change its type-id on
-           ;; a fresh graph (GH #53).
+           ;; Replace in place, preserving position.  The type-id reason is
+           ;; historical: ids came from this list's order until #186 moved
+           ;; assignment to the registry, which keys on the name.  Position
+           ;; still governs the order UPDATE-SCHEMA instantiates types in, so
+           ;; a moved entry reorders schema replay (GH #53).
            (let* ((,metas (gethash ',graph-name *schema-node-metadata*))
                   (,pos (position ',name ,metas :key #'node-type-name)))
              (if ,pos
@@ -528,9 +529,11 @@ Example:
           ;; not in UPDATE-NODE-TYPE because only this branch knows the store
           ;; has no id of its own yet -- the redefinition branch above must
           ;; keep the one already written into every node of that type.
-          ;; Unconditional: META is the object in *SCHEMA-NODE-METADATA*,
-          ;; shared by every store that defines this type, so any id already
-          ;; on it belongs to whichever store instantiated it first.
+          ;; Unconditional, not guarded on (NULL (NODE-TYPE-ID META)):
+          ;; *SCHEMA-NODE-METADATA* holds one META per graph-name, and it
+          ;; outlives the store, so a second, fresh store opened under that
+          ;; name would find the first store's id still on it and adopt it
+          ;; instead of asking the registry.
           (progn
             (setf (gethash (node-type-name meta)
                            (schema-class-locks (schema graph)))

--- a/schema.lisp
+++ b/schema.lisp
@@ -500,30 +500,36 @@ Example:
   "(values CLAIMS HIGHEST) for SCHEMA's persisted type table.
 
 CLAIMS is (SYMBOL PARENT ID) for every type the store answers to BY NAME.
-HIGHEST is an alist (PARENT . ID) over EVERY integer key in the table, which
-is not the same set: a store's history can leave old metadata at an id its
-name lookup no longer resolves to, and nodes on disk still carry it (spec
-§10.1).  Both are needed -- the first says what must agree, the second says
-which ids must stay out of the registry's reach.
+STALE is the same shape for every id the table OCCUPIES that its own name
+lookup no longer returns: a store's history can leave old metadata behind,
+and nodes on disk still carry that id (spec §10.1).  The first says what must
+agree with the registry; the second says which ids must stay out of the
+registry's reach.
 
 The sub-tables are triple-keyed (id -> meta, symbol -> id, keyword -> id;
 see UPDATE-NODE-TYPE), which is what the key discrimination below is for."
   (let ((claims nil)
-        (highest (list (cons :vertex 0) (cons :edge 0))))
-    (dolist (parent '(:vertex :edge) (values (nreverse claims) highest))
-      (let ((sub (gethash parent (schema-type-table schema))))
+        (stale nil))
+    (dolist (parent '(:vertex :edge) (values (nreverse claims)
+                                             (nreverse stale)))
+      (let ((sub (gethash parent (schema-type-table schema)))
+            (occupied nil))
         (when sub
           (maphash
            (lambda (key value)
              (cond ((and (integerp key) (node-type-p value))
-                    (let ((cell (assoc parent highest)))
-                      (setf (cdr cell) (max (cdr cell) key))))
+                    (push (cons key (node-type-name value)) occupied))
                    ((and (symbolp key) (not (keywordp key))
                          (integerp value))
                     (push (list key parent value) claims))))
-           sub))))))
+           sub)
+          ;; An occupied id the NAME lookup no longer returns is stale: the
+          ;; metadata is unreachable but node heads still carry the id.
+          (dolist (cell occupied)
+            (unless (eql (car cell) (gethash (cdr cell) sub))
+              (push (list (cdr cell) parent (car cell)) stale))))))))
 
-(defun %reconcile-claims (registry claims highest location)
+(defun %reconcile-claims (registry claims stale location)
   "Adopt or refuse, under REGISTRY's append lock.  See
 RECONCILE-SCHEMA-WITH-REGISTRY for the policy; this is the half that writes."
   (let ((tables (list (cons :vertex (registry-ids-table registry :vertex))
@@ -547,17 +553,26 @@ RECONCILE-SCHEMA-WITH-REGISTRY for the policy; this is the half that writes."
                  (%registry-adopt registry symbol parent id)
                  (setf (gethash id (cdr (assoc parent tables))) symbol))))))
     ;; Stale ids: metadata the name lookup no longer reaches, but node heads
-    ;; still do.  One at or below the registry's high-water mark can never be
-    ;; minted, so it is merely a store that owes a renumbering (§10.1) and is
-    ;; logged.  One ABOVE it is next in line to be handed to some other type,
-    ;; and there is no honest way to reserve it -- the registry records
-    ;; symbols, not holes -- so refuse.
-    (dolist (cell highest)
-      (let ((parent (car cell)) (top (cdr cell)))
-        (when (> top (registry-highest-id registry parent))
-          (error 'store-registry-conflict
-                 :reason :stale-id :location location
-                 :parent parent :store-id top))))))
+    ;; still do.  One ABOVE the registry's high-water mark is next in line to
+    ;; be handed to another type and there is no honest way to reserve it --
+    ;; the registry records symbols, not holes -- so refuse.
+    ;;
+    ;; One at or below the mark is TOLERATED, and that is a policy choice
+    ;; about already-orphaned metadata rather than a proof of safety:
+    ;; %REGISTRY-ASSIGN never reaches it, but %REGISTRY-ADOPT takes an
+    ;; arbitrary id and this very function calls it, so a later adopt still
+    ;; can (GH #202).  Such a store owes a renumbering (§10.1); say so.
+    (dolist (entry stale)
+      (destructuring-bind (symbol parent id) entry
+        (if (> id (registry-highest-id registry parent))
+            (error 'store-registry-conflict
+                   :reason :stale-id :location location
+                   :type-name symbol :parent parent :store-id id)
+            (log:warn "~A holds ~(~A~) type ~S at id ~D as well as ~D; ~
+nodes at the older id are only carried across by a renumbering migration ~
+(:RENUMBER-P T, spec §10.1, GH #186)."
+                      location parent symbol id
+                      (registry-id-for registry symbol parent)))))))
 
 (defmacro with-schema-frozen (() &body body)
   "Run BODY with schema replay AND type-id reconciliation suppressed, so a
@@ -601,23 +616,23 @@ Adoption raises the registry's counters past every id it takes, so a later
 mint cannot collide.  Runs before UPDATE-SCHEMA instantiates anything, which
 is the only point at which that ordering is guaranteed."
   (let ((registry (ensure-type-registry)))
-    (multiple-value-bind (claims highest) (%store-schema-claims (schema graph))
+    (multiple-value-bind (claims stale) (%store-schema-claims (schema graph))
       ;; Read-only pass first: agreement is the overwhelmingly common case and
       ;; the append flock is system-wide, so taking it on every open would
-      ;; serialise every store's open against every other's.
+      ;; serialise every store's open against every other's.  A store with
+      ;; ANY orphaned id does take it on every open, to reclassify and warn
+      ;; under the post-adoption mark; such a store owes a renumbering and is
+      ;; rare (§10.1).
       (when (or (some (lambda (claim)
                         (destructuring-bind (symbol parent id) claim
                           (not (eql id (registry-id-for registry symbol
                                                         parent)))))
                       claims)
-                (some (lambda (cell)
-                        (> (cdr cell) (registry-highest-id registry
-                                                           (car cell))))
-                      highest))
+                stale)
         (with-registry-append-lock (registry)
           ;; Re-derived under the lock: WITH-REGISTRY-APPEND-LOCK re-reads the
           ;; file, so the decisions above are hints, not conclusions.
-          (%reconcile-claims registry claims highest
+          (%reconcile-claims registry claims stale
                              (ignore-errors (location graph))))))))
 
 (defmethod instantiate-node-type ((meta node-type) (graph graph))
@@ -679,18 +694,25 @@ is the only point at which that ordering is guaranteed."
         (error "Cannot update schema for graph ~A: graph not open!" graph-name))))
 
 (defmethod update-schema ((graph graph))
-  ;; *SCHEMA-UPDATE-SUPPRESSED* is bound by MIGRATE-GRAPH alone, which
-  ;; installs by hand the schema each of its two opens is to have: minting
-  ;; registry ids here for a schema discarded on the next form is how the
-  ;; registry ends up holding ids no store uses (GH #186).
-  (unless *schema-update-suppressed*
-    ;; BEFORE the replay, not after: the replay is what mints, and a mint is
-    ;; only safe once the registry knows every id this store occupies (#186).
-    (reconcile-schema-with-registry graph)
-    (with-recursive-lock-held ((schema-lock (schema graph)))
-      (let ((node-metadata (gethash (graph-name graph)
-                                    *schema-node-metadata*)))
-        ;; The list is maintained oldest-first (GH #53); apply in order.
-        (dolist (meta node-metadata)
-          (instantiate-node-type meta graph)))
-      (save-schema (schema graph) graph))))
+  ;; *SCHEMA-UPDATE-SUPPRESSED* is bound by MIGRATE-GRAPH, which installs by
+  ;; hand the schema each of its two opens is to have, and by
+  ;; WITH-SCHEMA-FROZEN (GH #186).  Minting registry ids here for a schema
+  ;; discarded on the next form is how the registry ends up holding ids no
+  ;; store uses; adopting a contradicted store's would be the same mistake
+  ;; the other way.
+  (if *schema-update-suppressed*
+      ;; Remember it: START-REPLICATION refuses a graph whose ids were never
+      ;; checked, because the wire carries them (see CHECK-REPLICABLE).
+      (setf (schema-frozen-p graph) t)
+      (progn
+        ;; BEFORE the replay, not after: the replay is what mints, and a
+        ;; mint is only safe once the registry knows every id this store
+        ;; occupies (#186).
+        (reconcile-schema-with-registry graph)
+        (with-recursive-lock-held ((schema-lock (schema graph)))
+          (let ((node-metadata (gethash (graph-name graph)
+                                        *schema-node-metadata*)))
+            ;; The list is maintained oldest-first (GH #53); apply in order.
+            (dolist (meta node-metadata)
+              (instantiate-node-type meta graph)))
+          (save-schema (schema graph) graph)))))

--- a/schema.lisp
+++ b/schema.lisp
@@ -16,6 +16,10 @@
    #+ecl (make-hash-table :test 'eql
                           #+graph-db-ecl-sync-hash :synchronized
                           #+graph-db-ecl-sync-hash t))
+  ;; DEAD since GH #186 moved assignment to the image registry: nothing reads
+  ;; either slot, and RENUMBER-SCHEMA leaves them stale on purpose (the
+  ;; registry's counters are the live ones).  They stay because CL-STORE
+  ;; restores every schema.dat ever written through this struct definition.
   (next-edge-id 1 :type (unsigned-byte 32))
   (next-vertex-id 1 :type (unsigned-byte 32))
   ;; MVCC: graph-wide default number of prior node versions the reaper retains
@@ -492,6 +496,130 @@ Example:
                           (node-type-keep-revisions meta2))))
             new-slots removed-slots)))
 
+(defun %store-schema-claims (schema)
+  "(values CLAIMS HIGHEST) for SCHEMA's persisted type table.
+
+CLAIMS is (SYMBOL PARENT ID) for every type the store answers to BY NAME.
+HIGHEST is an alist (PARENT . ID) over EVERY integer key in the table, which
+is not the same set: a store's history can leave old metadata at an id its
+name lookup no longer resolves to, and nodes on disk still carry it (spec
+§10.1).  Both are needed -- the first says what must agree, the second says
+which ids must stay out of the registry's reach.
+
+The sub-tables are triple-keyed (id -> meta, symbol -> id, keyword -> id;
+see UPDATE-NODE-TYPE), which is what the key discrimination below is for."
+  (let ((claims nil)
+        (highest (list (cons :vertex 0) (cons :edge 0))))
+    (dolist (parent '(:vertex :edge) (values (nreverse claims) highest))
+      (let ((sub (gethash parent (schema-type-table schema))))
+        (when sub
+          (maphash
+           (lambda (key value)
+             (cond ((and (integerp key) (node-type-p value))
+                    (let ((cell (assoc parent highest)))
+                      (setf (cdr cell) (max (cdr cell) key))))
+                   ((and (symbolp key) (not (keywordp key))
+                         (integerp value))
+                    (push (list key parent value) claims))))
+           sub))))))
+
+(defun %reconcile-claims (registry claims highest location)
+  "Adopt or refuse, under REGISTRY's append lock.  See
+RECONCILE-SCHEMA-WITH-REGISTRY for the policy; this is the half that writes."
+  (let ((tables (list (cons :vertex (registry-ids-table registry :vertex))
+                      (cons :edge   (registry-ids-table registry :edge)))))
+    (dolist (claim claims)
+      (destructuring-bind (symbol parent id) claim
+        (let ((known (registry-id-for registry symbol parent))
+              (holder (gethash id (cdr (assoc parent tables)))))
+          (cond ((and known (eql known id)))    ; already agreed
+                (known
+                 (error 'store-registry-conflict
+                        :reason :name-at-two-ids :location location
+                        :type-name symbol :parent parent
+                        :store-id id :registry-id known))
+                ((and holder (not (eq holder symbol)))
+                 (error 'store-registry-conflict
+                        :reason :id-at-two-names :location location
+                        :type-name symbol :parent parent
+                        :store-id id :holder holder))
+                (t
+                 (%registry-adopt registry symbol parent id)
+                 (setf (gethash id (cdr (assoc parent tables))) symbol))))))
+    ;; Stale ids: metadata the name lookup no longer reaches, but node heads
+    ;; still do.  One at or below the registry's high-water mark can never be
+    ;; minted, so it is merely a store that owes a renumbering (§10.1) and is
+    ;; logged.  One ABOVE it is next in line to be handed to some other type,
+    ;; and there is no honest way to reserve it -- the registry records
+    ;; symbols, not holes -- so refuse.
+    (dolist (cell highest)
+      (let ((parent (car cell)) (top (cdr cell)))
+        (when (> top (registry-highest-id registry parent))
+          (error 'store-registry-conflict
+                 :reason :stale-id :location location
+                 :parent parent :store-id top))))))
+
+(defmacro with-schema-frozen (() &body body)
+  "Run BODY with schema replay AND type-id reconciliation suppressed, so a
+store opens exactly as it stands on disk.
+
+This is how you READ a store the registry does not agree with -- a class
+census, a backup, the before-and-after of an adoption run.  An ordinary open
+refuses such a store, and correctly: it has to be renumbered before this
+system may keep writing through it (GH #186, spec §10.1).
+
+Two things a frozen open does not do: it does not teach the store types
+declared since it was closed, and it does not check its ids against the
+registry.  Writes made through it therefore go out under the STORE's ids,
+which is what a legacy store wants and what a store you intend to keep in
+this system must not have."
+  `(let ((*schema-update-suppressed* t))
+     ,@body))
+
+(defun reconcile-schema-with-registry (graph)
+  "Make GRAPH's persisted type-ids and the image registry agree, or refuse.
+
+The invariant every other part of #186 assumes and none of them establishes:
+a type-id in a store's schema means what the registry says it means.
+INSTANTIATE-NODE-TYPE keeps a persisted id without telling the registry, and
+mints a new one from a counter that has never seen that store's ids, so
+without this an ordinary upgrade -- open an existing store under a fresh
+system directory, then ship one more DEF-VERTEX -- mints an id the store
+already uses and UPDATE-NODE-TYPE overwrites it.  It also makes the peer type
+table honest: the table is the registry and the wire carries store ids.
+
+Per type the store names:
+  - the registry does not know the symbol, and nothing else holds its id:
+    ADOPT the store's id.  Adopting records what is already on disk; it is
+    not recomputation, so D14 stands, and it is the single-store case of
+    REGISTRY-SEED-FROM-STORES;
+  - the registry gives the symbol a DIFFERENT id, or gives that id to another
+    symbol: refuse, naming both sides.  Reconciling here would mean rewriting
+    every node of the losing type because a store was opened.
+
+Adoption raises the registry's counters past every id it takes, so a later
+mint cannot collide.  Runs before UPDATE-SCHEMA instantiates anything, which
+is the only point at which that ordering is guaranteed."
+  (let ((registry (ensure-type-registry)))
+    (multiple-value-bind (claims highest) (%store-schema-claims (schema graph))
+      ;; Read-only pass first: agreement is the overwhelmingly common case and
+      ;; the append flock is system-wide, so taking it on every open would
+      ;; serialise every store's open against every other's.
+      (when (or (some (lambda (claim)
+                        (destructuring-bind (symbol parent id) claim
+                          (not (eql id (registry-id-for registry symbol
+                                                        parent)))))
+                      claims)
+                (some (lambda (cell)
+                        (> (cdr cell) (registry-highest-id registry
+                                                           (car cell))))
+                      highest))
+        (with-registry-append-lock (registry)
+          ;; Re-derived under the lock: WITH-REGISTRY-APPEND-LOCK re-reads the
+          ;; file, so the decisions above are hints, not conclusions.
+          (%reconcile-claims registry claims highest
+                             (ignore-errors (location graph))))))))
+
 (defmethod instantiate-node-type ((meta node-type) (graph graph))
   (with-recursive-lock-held ((schema-lock (schema graph)))
     (let ((cl (find-class (node-type-name meta) nil)))
@@ -556,6 +684,9 @@ Example:
   ;; registry ids here for a schema discarded on the next form is how the
   ;; registry ends up holding ids no store uses (GH #186).
   (unless *schema-update-suppressed*
+    ;; BEFORE the replay, not after: the replay is what mints, and a mint is
+    ;; only safe once the registry knows every id this store occupies (#186).
+    (reconcile-schema-with-registry graph)
     (with-recursive-lock-held ((schema-lock (schema graph)))
       (let ((node-metadata (gethash (graph-name graph)
                                     *schema-node-metadata*)))

--- a/schema.lisp
+++ b/schema.lisp
@@ -146,17 +146,22 @@ persisted type-ids (unlike re-running INIT-SCHEMA from scratch)."
     (setf (schema-class-locks schema) locks)
     schema))
 
-(defmethod get-next-type-id ((schema schema) parent)
-  (with-recursive-lock-held ((schema-lock schema))
-    (cond ((or (eql parent :edge) (eql parent 'edge))
-           (prog1
-               (schema-next-edge-id schema)
-             (incf (schema-next-edge-id schema))))
-          ((or (eql parent :vertex) (eql parent 'vertex))
-           (prog1
-               (schema-next-vertex-id schema)
-             (incf (schema-next-vertex-id schema))))
-          (t (error "Unknown parent type ~S" parent)))))
+(defun %normalize-parent-type (parent)
+  (cond ((or (eql parent :edge) (eql parent 'edge)) :edge)
+        ((or (eql parent :vertex) (eql parent 'vertex)) :vertex)
+        (t (error "Unknown parent type ~S" parent))))
+
+(defun assign-type-id (name parent)
+  "The type-id for NAME under PARENT, minted if this system has not seen it
+before.  Ids come from the image-level registry, not the per-graph counters
+this replaced, so one symbol names one id in every store of the system and no
+two symbols share one (GH #186).  Keyed on the package-qualified symbol.
+
+REGISTRY-INTERN, never REGISTRY-ID-FOR: the latter is lock-free, so its NIL
+is a hint, not proof of absence, and only INTERN re-reads under the lock.
+Signals SYSTEM-DIRECTORY-REQUIRED when *SYSTEM-DIRECTORY* is NIL."
+  (registry-intern (ensure-type-registry) name
+                   (%normalize-parent-type parent)))
 
 (defmethod schema-string-representation ((schema schema))
   "Return a string representation of SCHEMA. Two schemas with the same
@@ -231,17 +236,6 @@ replication for a quick schema compatibility check."
   (finalize-inheritance (find-class (node-type-name meta)))
   (save-schema (schema graph) graph))
 
-(defun %check-node-class-graph-unique (name graph-name)
-  "Signal if NAME is registered under a graph other than GRAPH-NAME. Keys on
-graph-name identity, not presence: a same-graph redefinition legitimately
-re-registers under the same key (GH #53)."
-  (maphash (lambda (gname metas)
-             (unless (equal gname graph-name)
-               (when (find name metas :key #'node-type-name)
-                 (error 'duplicate-node-class-error
-                        :name name :existing-graph gname :new-graph graph-name))))
-           *schema-node-metadata*))
-
 (defmacro def-node-type (name parent-types slot-specs graph-name &key keep-revisions)
   "Define a persistent node type NAME for the graph named GRAPH-NAME.  This is
 the machinery behind DEF-VERTEX and DEF-EDGE; you normally use those instead.
@@ -273,7 +267,8 @@ be defined before or after the graph is created."
                             (append s1 (list :initarg (intern (symbol-name (first s1)) :keyword))))))
                     slot-specs))
       `(progn
-         (%check-node-class-graph-unique ',name ',graph-name)
+         ;; No cross-graph uniqueness check: type-ids are system-wide as of
+         ;; #186, so one class may be instantiated in more than one store.
          (defclass ,name (,@parent-types)
            (,@slot-specs)
            (:metaclass node-class))
@@ -507,8 +502,14 @@ Example:
       (when (typep cl 'node-class) (%invalidate-node-class-caches cl)))
     ;; Check if this type exists and if it differs from old spec
     (log:debug "Looking up ~A: ~A ~A" meta (node-type-name meta) (node-type-parent-type meta))
+    ;; :GRAPH GRAPH, not the ambient *GRAPH*: this branch decides whether the
+    ;; type is new TO THIS STORE, and since #186 that decides whether it takes
+    ;; the store's existing id or asks the registry for one.  *GRAPH* is bound
+    ;; to GRAPH on the open/create paths but is NIL (or another store) when a
+    ;; DEF-VERTEX is evaluated at runtime against an already-open graph.
     (let ((old-meta (lookup-node-type-by-name (node-type-name meta)
-                                              (node-type-parent-type meta))))
+                                              (node-type-parent-type meta)
+                                              :graph graph)))
       (if (node-type-p old-meta)
           (multiple-value-bind (changes-p new-slots removed-slots)
               (node-type-diff old-meta meta)
@@ -522,14 +523,21 @@ Example:
                              (node-type-name meta) new-slots)
                   (update-node-type meta graph))
                 old-meta))
-          ;; Else if new, assign node-type-id
+          ;; Else new TO THIS STORE: the id comes from the system-wide
+          ;; registry, keyed on the type's NAME (GH #186).  Assigned here and
+          ;; not in UPDATE-NODE-TYPE because only this branch knows the store
+          ;; has no id of its own yet -- the redefinition branch above must
+          ;; keep the one already written into every node of that type.
+          ;; Unconditional: META is the object in *SCHEMA-NODE-METADATA*,
+          ;; shared by every store that defines this type, so any id already
+          ;; on it belongs to whichever store instantiated it first.
           (progn
             (setf (gethash (node-type-name meta)
                            (schema-class-locks (schema graph)))
                   (make-rw-lock))
             (setf (node-type-id meta)
-                  (get-next-type-id (schema graph)
-                                    (node-type-parent-type meta)))
+                  (assign-type-id (node-type-name meta)
+                                  (node-type-parent-type meta)))
             (update-node-type meta graph))))))
 
 

--- a/test-mop.lisp
+++ b/test-mop.lisp
@@ -1,6 +1,9 @@
 (in-package :graph-db)
 
 (cl-fad:delete-directory-and-files "/var/tmp/graph/")
+;; A store needs a system directory to take type-ids from (GH #186).
+(setf *system-directory*
+      (namestring (ensure-directories-exist "/var/tmp/graph-system/")))
 (setq *graph* (make-graph :test "/var/tmp/graph/"))
 (def-vertex tv ()
   ((ts1 :type string) (ts2 :type integer))

--- a/test.lisp
+++ b/test.lisp
@@ -80,6 +80,9 @@
   (defvar *edges* nil)
 
   (defun test-create ()
+    ;; A store needs a system directory to take type-ids from (GH #186).
+    (setf *system-directory*
+          (namestring (ensure-directories-exist "/var/tmp/graph-system/")))
     (setq *graph* (make-graph :test "/var/tmp/graph/"))
 #|
     (setq *v1* (make-vertex :generic

--- a/tests/acid/suite.lisp
+++ b/tests/acid/suite.lisp
@@ -13,9 +13,18 @@
   "Run the ACID suite.  Returns T on all-pass.
 Called by (asdf:test-system :graph-db/acid-test)."
   (log:config :error)
-  (let ((results (run 'acid-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'acid-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Temp-directory helpers

--- a/tests/algorithms/suite.lisp
+++ b/tests/algorithms/suite.lisp
@@ -10,6 +10,22 @@
 Invoked by (asdf:test-system :graph-db/algorithms-test)."
   (log:config :error)
   #+ecl (ext:set-limit 'ext:heap-size (* 6 1024 1024 1024))
-  (let ((results (run 'graph-db-algorithms-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  ;; Built inline rather than via FIXTURES.LISP's MAKE-TEMP-DIRECTORY: that
+  ;; file loads after this one, and a forward reference would compile with a
+  ;; style warning.
+  (let* ((system-dir (ensure-directories-exist
+                      (merge-pathnames
+                       (format nil "graph-db-algo-sysdir-~36R/"
+                               (random (expt 36 12) (make-random-state t)))
+                       (uiop:temporary-directory))))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'graph-db-algorithms-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))

--- a/tests/concurrency/suite.lisp
+++ b/tests/concurrency/suite.lisp
@@ -17,9 +17,18 @@
   "Run the concurrency suite.  Returns T on all-pass.
 Called by (asdf:test-system :graph-db/concurrency-test)."
   (log:config :error)
-  (let ((results (run 'concurrency-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'concurrency-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Temp-directory and GC helpers (mirrored from graph-db/test)

--- a/tests/concurrent-stress/suite.lisp
+++ b/tests/concurrent-stress/suite.lisp
@@ -13,9 +13,18 @@
 (defun run-concurrent-stress-tests ()
   "Run the concurrent-stress suite.  Returns T on all-pass."
   (log:config :error)
-  (let ((results (run 'concurrent-stress-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'concurrent-stress-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Thread-count parameter

--- a/tests/geos/suite.lisp
+++ b/tests/geos/suite.lisp
@@ -10,9 +10,18 @@
 Invoked by (asdf:test-system :graph-db/geos)."
   (log:config :error)
   #+ecl (ext:set-limit 'ext:heap-size (* 6 1024 1024 1024))
-  (let ((results (run 'geos-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'geos-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 ;;; A handful of tests need to run with GEOS forced unavailable to prove the
 ;;; fallback path.  This binds the flag off for the dynamic extent of BODY.

--- a/tests/global-type-id-tests.lisp
+++ b/tests/global-type-id-tests.lisp
@@ -1,0 +1,90 @@
+;;;; Type-ids are assigned from the image-level registry (GH #186).
+(in-package #:graph-db/test)
+
+(def-suite global-type-id-suite :in graph-db-suite
+  :description "Type-id assignment through the system-wide registry.")
+(in-suite global-type-id-suite)
+
+;;; Declaration ORDER differs between the two stores on purpose.  Under the
+;;; per-graph counters #186 replaces, SHARED-TYPE would be 1 in one store and
+;;; 2 in the other; declaring it first in both would let the tests below pass
+;;; vacuously against the very implementation they exist to reject.
+(def-vertex shared-type () ((label :type string)) :reg-store-1)
+(def-vertex type-in-one () ((label :type string)) :reg-store-1)
+(def-vertex dual-type   () ((label :type string)) :reg-store-1)
+
+(def-vertex type-in-two () ((label :type string)) :reg-store-2)
+(def-vertex shared-type () ((label :type string)) :reg-store-2)
+(def-vertex dual-type   () ((label :type string)) :reg-store-2)
+
+(defmacro with-two-test-graphs ((g1 g2 sysdir) &body body)
+  "Two stores in ONE image, sharing SYSDIR as their system directory.  The
+existing WITH-TEST-GRAPH binds a single hardcoded graph name and cannot
+express this, which is why #186 needs its own helper."
+  (let ((s (gensym)) (d1 (gensym)) (d2 (gensym)))
+    ;; IGNORABLE, not the caller's (DECLARE (IGNORE ...)): BODY lands inside
+    ;; an UNWIND-PROTECT's PROGN, which is not a declaration context.
+    `(with-temp-directory (,s)
+       (with-temp-directory (,d1)
+         (with-temp-directory (,d2)
+           (let* ((,sysdir (namestring ,s))
+                  (graph-db::*system-directory* ,sysdir))
+             (declare (ignorable ,sysdir))
+             (let ((,g1 (make-graph :reg-store-1 (namestring ,d1)
+                                    :buffer-pool-size 1000))
+                   (,g2 (make-graph :reg-store-2 (namestring ,d2)
+                                    :buffer-pool-size 1000)))
+               (declare (ignorable ,g1 ,g2))
+               (unwind-protect (progn ,@body)
+                 (ignore-errors (close-graph ,g1 :snapshot-p nil))
+                 (ignore-errors (close-graph ,g2 :snapshot-p nil))
+                 (collect-garbage)))))))))
+
+(defun %type-id-of (sym parent graph)
+  (graph-db::node-type-id
+   (graph-db::lookup-node-type-by-name sym parent :graph graph)))
+
+(test two-graphs-in-one-image-share-a-symbol-s-type-id
+  "The unit's entire purpose.  Before #186 each graph counted from 1, so the
+same symbol got different ids in different stores and different symbols
+collided on one id."
+  (with-two-test-graphs (g1 g2 sysdir)
+    (is (= (%type-id-of 'shared-type :vertex g1)
+           (%type-id-of 'shared-type :vertex g2))
+        "one symbol, one id, both stores")))
+
+(test distinct-symbols-never-collide-across-graphs
+  (with-two-test-graphs (g1 g2 sysdir)
+    (is (/= (%type-id-of 'type-in-one :vertex g1)
+            (%type-id-of 'type-in-two :vertex g2))
+        "two symbols never share an id, even in different stores")))
+
+(test opening-a-graph-without-a-system-directory-signals
+  "The directory is mandatory as of #186: the registry has nowhere to live
+without one, and a graph opened outside a system would mint ids that mean
+nothing to anyone else.  Refuse rather than silently fall back to per-graph
+counters -- a silent fallback is how two id regimes diverge unnoticed."
+  (with-temp-directory (dir)
+    (let ((graph-db::*system-directory* nil))
+      (signals graph-db:system-directory-required
+        (make-graph :reg-nodir (namestring dir))))))
+
+(test a-class-may-be-instantiated-in-more-than-one-store
+  "Closes cl-llm#20.  %CHECK-NODE-CLASS-GRAPH-UNIQUE refused this and existed
+only because ids were per-graph."
+  (with-two-test-graphs (g1 g2 sysdir)
+    (is-true (graph-db::lookup-node-type-by-name
+              'dual-type :vertex :graph g1))
+    (is-true (graph-db::lookup-node-type-by-name
+              'dual-type :vertex :graph g2))))
+
+(test the-registry-is-what-the-schema-records
+  "The id in a store's schema is the registry's, not a store-local number:
+otherwise the two could agree by coincidence of declaration order alone."
+  (with-two-test-graphs (g1 g2 sysdir)
+    (let ((r (graph-db::ensure-type-registry)))
+      (is (= (graph-db::registry-id-for r 'shared-type :vertex)
+             (%type-id-of 'shared-type :vertex g1))
+          "the store's id for a symbol is the one the registry holds"))
+    (is (probe-file (merge-pathnames "type-registry.log" sysdir))
+        "assignment is persisted, not merely in-memory")))

--- a/tests/global-type-id-tests.lisp
+++ b/tests/global-type-id-tests.lisp
@@ -293,3 +293,40 @@ names both sides and points at the seeding run; it is not a retryable error."
                      "a frozen open still sees the store's own id")
               (close-graph g :snapshot-p nil))
             (collect-garbage)))))))
+
+(test opening-a-store-whose-symbol-the-registry-numbers-differently
+  "The :NAME-AT-TWO-IDS branch, which the other refusal tests do not reach --
+they hit :ID-AT-TWO-NAMES and :STALE-ID.
+
+The registry is given SHARED-TYPE at 5 and nothing else, so ids 1..4 are FREE.
+That is what makes this test able to fail: delete the branch and the store's
+claim of SHARED-TYPE at 1 falls straight through the holder check into
+%REGISTRY-ADOPT, which its own docstring forbids -- appending a second entry
+for a symbol that already has one and silently rebinding it image-wide.  The
+last check names that harm directly."
+  (with-temp-directory (root)
+    (let ((dir (namestring (merge-pathnames "store/" root))))
+      (with-temp-directory (own)
+        (let ((graph-db::*system-directory* (namestring own))
+              (graph-db::*type-registry* nil))
+          (close-graph (make-graph :reg-store-1 dir :buffer-pool-size 1000)
+                       :snapshot-p nil)
+          (collect-garbage)))
+      (with-temp-directory (sys)
+        (let ((graph-db::*system-directory* (namestring sys))
+              (graph-db::*type-registry* nil))
+          (let ((registry (graph-db::ensure-type-registry)))
+            (graph-db::with-registry-append-lock (registry)
+              (graph-db::%registry-adopt registry 'shared-type :vertex 5))
+            (let ((c (handler-case (progn (open-graph :reg-store-1 dir) nil)
+                       (store-registry-conflict (e) e))))
+              (is (typep c 'store-registry-conflict)
+                  "the open must be refused; it returned ~S" c)
+              (when (typep c 'store-registry-conflict)
+                (is (eq :name-at-two-ids
+                        (store-registry-conflict-reason c))
+                    "and for THIS reason, not another branch"))
+              (is (eql 5 (graph-db::registry-id-for registry 'shared-type
+                                                    :vertex))
+                  "the registry must be untouched: SHARED-TYPE is still ~
+5, not re-bound to the store's id"))))))))

--- a/tests/global-type-id-tests.lisp
+++ b/tests/global-type-id-tests.lisp
@@ -119,3 +119,177 @@ otherwise the two could agree by coincidence of declaration order alone."
           "the store's id for a symbol is the one the registry holds"))
     (is (probe-file (merge-pathnames "type-registry.log" sysdir))
         "assignment is persisted, not merely in-memory")))
+
+;;; ---------------------------------------------------------------------------
+;;; A store's persisted ids and the image registry must agree (GH #186).
+;;;
+;;; INSTANTIATE-NODE-TYPE has two branches and only one of them touches the
+;;; registry: a type already in the store's schema keeps its persisted id and
+;;; the registry is never told, while a type new to the store mints from a
+;;; counter that knows nothing of those ids.  Nothing in between establishes
+;;; that the two agree, so the ordinary upgrade -- open an existing store
+;;; under a fresh system directory, then ship one more DEF-VERTEX -- lets a
+;;; minted id land on an id the store already uses.
+;;; ---------------------------------------------------------------------------
+
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :reg-upgrade *schema-node-metadata*) nil))
+
+;; What release 1 shipped.  Both id spaces start at 1, so the ids that a
+;; later release's fresh registry mints are exactly these.
+(def-vertex ru-shipped-a    () ((label :type string)) :reg-upgrade)
+(def-edge   ru-shipped-link () ()                     :reg-upgrade)
+
+;; What release 2 adds.  Declared here so the classes exist; kept out of the
+;; store by %AS-RELEASE-1 while release 1's store is built.
+(def-vertex ru-added-later  () ((label :type string)) :reg-upgrade)
+(def-edge   ru-added-link   () ()                     :reg-upgrade)
+
+(defparameter *ru-release-2-types* '(ru-added-later ru-added-link))
+
+(defmacro %as-release-1 (&body body)
+  "Run BODY with only release 1's types registered for :REG-UPGRADE, so a
+store built inside it has never heard of the ones release 2 adds."
+  (let ((saved (gensym "SAVED")))
+    `(let ((,saved (gethash :reg-upgrade *schema-node-metadata*)))
+       (unwind-protect
+            (progn
+              (setf (gethash :reg-upgrade *schema-node-metadata*)
+                    (remove-if (lambda (m)
+                                 (member (graph-db::node-type-name m)
+                                         *ru-release-2-types*))
+                               ,saved))
+              ,@body)
+         (setf (gethash :reg-upgrade *schema-node-metadata*) ,saved)))))
+
+(defun %ru-build-release-1-store (location sysdir)
+  "Build the store release 1 leaves behind: two types under their own system
+directory, and one node of each so the persisted ids are in node heads."
+  (let ((graph-db::*system-directory* (namestring sysdir))
+        (graph-db::*type-registry* nil))
+    (%as-release-1
+      (let ((g (make-graph :reg-upgrade (namestring location)
+                           :buffer-pool-size 1000)))
+        (unwind-protect
+             (let ((graph-db::*graph* g))
+               (with-transaction ()
+                 (let ((v1 (graph-db::make-vertex
+                            'ru-shipped-a (list (cons :label "one"))))
+                       (v2 (graph-db::make-vertex
+                            'ru-shipped-a (list (cons :label "two")))))
+                   (graph-db::make-edge 'ru-shipped-link
+                                        (graph-db::id v1) (graph-db::id v2)
+                                        1.0 nil))))
+          (close-graph g :snapshot-p nil))
+        (collect-garbage)))))
+
+(test a-minted-id-never-lands-on-an-id-the-store-already-uses
+  "The ordinary upgrade, one store, no multi-store system required.  A v3
+deployment opens an existing store under a FRESH system directory -- what the
+manual tells an operator to do -- so every persisted type takes the branch
+that keeps its own id and the registry stays EMPTY.  The next release adds one
+DEF-VERTEX, which mints 1 from that empty registry; UPDATE-NODE-TYPE then
+overwrites id 1 -> meta unconditionally and the store's first type is gone
+from its own schema.
+
+Every persisted node of that type now materialises as the type added later,
+new writes of both types go out under one id, and the type-index list for 1
+mixes them.  Silent, and unrecoverable without the pre-upgrade backup.
+
+Both parent kinds are checked because the registry counts them separately and
+both start at 1, so the edge half fails the same way and independently."
+  (with-temp-directory (dir)
+    (with-temp-directory (sys1)
+      (%ru-build-release-1-store dir sys1))
+    (with-temp-directory (sys2)
+      (let ((graph-db::*system-directory* (namestring sys2))
+            (graph-db::*type-registry* nil))
+        (let ((g (open-graph :reg-upgrade (namestring dir))))
+          (unwind-protect
+               (let ((graph-db::*graph* g))
+                 (flet ((id-of (sym parent) (%type-id-of sym parent g))
+                        (name-at (id parent)
+                          (let ((meta (graph-db::lookup-node-type-by-id
+                                       id parent :graph g)))
+                            (and meta (graph-db::node-type-name meta)))))
+                   (is (/= (id-of 'ru-shipped-a :vertex)
+                           (id-of 'ru-added-later :vertex))
+                       "the vertex type added later took id ~D, which ~
+RU-SHIPPED-A already uses"
+                       (id-of 'ru-added-later :vertex))
+                   (is (/= (id-of 'ru-shipped-link :edge)
+                           (id-of 'ru-added-link :edge))
+                       "the edge type added later took id ~D, which ~
+RU-SHIPPED-LINK already uses"
+                       (id-of 'ru-added-link :edge))
+                   ;; The id -> meta direction is the one UPDATE-NODE-TYPE
+                   ;; clobbers, and it is what every node head resolves
+                   ;; through.
+                   (is (eq 'ru-shipped-a
+                           (name-at (id-of 'ru-shipped-a :vertex) :vertex))
+                       "vertex id ~D must still name RU-SHIPPED-A, it names ~S"
+                       (id-of 'ru-shipped-a :vertex)
+                       (name-at (id-of 'ru-shipped-a :vertex) :vertex))
+                   (is (eq 'ru-shipped-link
+                           (name-at (id-of 'ru-shipped-link :edge) :edge))
+                       "edge id ~D must still name RU-SHIPPED-LINK, it ~
+names ~S"
+                       (id-of 'ru-shipped-link :edge)
+                       (name-at (id-of 'ru-shipped-link :edge) :edge)))
+                 ;; And the data: two persisted nodes, both still their own
+                 ;; class.  This is the assertion an operator would notice.
+                 (let ((classes (sort (graph-db::map-vertices
+                                       (lambda (v) (type-of v))
+                                       g :collect-p t)
+                                      #'string< :key #'symbol-name)))
+                   (is (equal '(ru-shipped-a ru-shipped-a) classes)
+                       "the persisted nodes must still materialise as ~
+RU-SHIPPED-A; they came back as ~S" classes)))
+            (close-graph g :snapshot-p nil))
+          (collect-garbage))))))
+
+(test opening-a-store-the-registry-contradicts-is-refused
+  "The other half of reconciliation, and what makes the peer type table
+honest: the table is the registry while the wire carries STORE ids, so a
+store whose ids the registry contradicts must never be opened for use.
+
+Built the only way a real system builds one -- two stores numbered from 1
+under system directories of their own, then brought under a single registry,
+which is the pre-#186 estate the adoption procedure exists for.  The refusal
+names both sides and points at the seeding run; it is not a retryable error."
+  (with-temp-directory (root)
+    (let ((first-dir (namestring (merge-pathnames "one/" root)))
+          (second-dir (namestring (merge-pathnames "two/" root))))
+      ;; Two stores, each numbered from 1 in its own system.
+      (dolist (spec (list (list first-dir "sys-one/" :reg-store-1)
+                          (list second-dir "sys-two/" :reg-store-2)))
+        (destructuring-bind (dir sub name) spec
+          (let ((graph-db::*system-directory*
+                  (namestring (ensure-directories-exist
+                               (merge-pathnames sub root))))
+                (graph-db::*type-registry* nil))
+            (close-graph (make-graph name dir :buffer-pool-size 1000)
+                         :snapshot-p nil)
+            (collect-garbage))))
+      ;; Now one registry for both.  The first store opened adopts; the
+      ;; second contradicts it, because SHARED-TYPE and REG-FILLER both hold
+      ;; vertex id 1 (see the declaration order at the top of this file).
+      (with-temp-directory (shared)
+        (let ((graph-db::*system-directory* (namestring shared))
+              (graph-db::*type-registry* nil))
+          (close-graph (open-graph :reg-store-1 first-dir) :snapshot-p nil)
+          (collect-garbage)
+          (let ((registry (graph-db::ensure-type-registry)))
+            (is (eql 1 (graph-db::registry-id-for registry 'shared-type
+                                                  :vertex))
+                "fixture sanity: the first store's id 1 was adopted"))
+          (signals store-registry-conflict
+            (open-graph :reg-store-2 second-dir))
+          ;; ...and it is readable, so an operator can still get at it.
+          (let ((g (with-schema-frozen ()
+                     (open-graph :reg-store-2 second-dir))))
+            (unwind-protect
+                 (is (eql 1 (%type-id-of 'reg-filler :vertex g))
+                     "a frozen open still sees the store's own id")
+              (close-graph g :snapshot-p nil))
+            (collect-garbage)))))))

--- a/tests/global-type-id-tests.lisp
+++ b/tests/global-type-id-tests.lisp
@@ -5,14 +5,22 @@
   :description "Type-id assignment through the system-wide registry.")
 (in-suite global-type-id-suite)
 
-;;; Declaration ORDER differs between the two stores on purpose.  Under the
-;;; per-graph counters #186 replaces, SHARED-TYPE would be 1 in one store and
-;;; 2 in the other; declaring it first in both would let the tests below pass
-;;; vacuously against the very implementation they exist to reject.
+;;; Declaration ORDER is chosen so that BOTH tests below fail against the
+;;; per-graph counters #186 replaces -- neither may pass vacuously against
+;;; the implementation it exists to reject.  Under those counters the ids
+;;; would be:
+;;;
+;;;   store 1: SHARED-TYPE 1, TYPE-IN-ONE 2, DUAL-TYPE 3
+;;;   store 2: REG-FILLER 1, TYPE-IN-TWO 2, SHARED-TYPE 3, DUAL-TYPE 4
+;;;
+;;; so SHARED-TYPE differs across the stores (1 vs 3) AND TYPE-IN-ONE collides
+;;; with TYPE-IN-TWO (both 2).  REG-FILLER exists only to offset store 2's
+;;; counter; the two properties cannot both be violated without it.
 (def-vertex shared-type () ((label :type string)) :reg-store-1)
 (def-vertex type-in-one () ((label :type string)) :reg-store-1)
 (def-vertex dual-type   () ((label :type string)) :reg-store-1)
 
+(def-vertex reg-filler  () ((label :type string)) :reg-store-2)
 (def-vertex type-in-two () ((label :type string)) :reg-store-2)
 (def-vertex shared-type () ((label :type string)) :reg-store-2)
 (def-vertex dual-type   () ((label :type string)) :reg-store-2)
@@ -68,6 +76,29 @@ counters -- a silent fallback is how two id regimes diverge unnoticed."
     (let ((graph-db::*system-directory* nil))
       (signals graph-db:system-directory-required
         (make-graph :reg-nodir (namestring dir))))))
+
+(test opening-an-existing-graph-without-a-system-directory-signals
+  "The refusal covers OPEN-GRAPH, not only MAKE-GRAPH: reopening replays the
+schema and assigns ids to any type added since (#186)."
+  (with-temp-directory (sysdir)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sysdir)))
+        (close-graph (make-graph :reg-store-1 (namestring dir)
+                                 :buffer-pool-size 1000)
+                     :snapshot-p nil))
+      (collect-garbage)
+      (let ((graph-db::*system-directory* nil))
+        (signals graph-db:system-directory-required
+          (open-graph :reg-store-1 (namestring dir)))))))
+
+(test ensure-type-registry-signals-without-a-system-directory
+  "The accessor every assignment path funnels through refuses on its own.
+The checks in MAKE-GRAPH/OPEN-GRAPH are early, legible ones; this is what
+makes a silent per-graph fallback impossible rather than merely absent from
+those two entry points."
+  (let ((graph-db::*system-directory* nil))
+    (signals graph-db:system-directory-required
+      (graph-db::ensure-type-registry))))
 
 (test a-class-may-be-instantiated-in-more-than-one-store
   "Closes cl-llm#20.  %CHECK-NODE-CLASS-GRAPH-UNIQUE refused this and existed

--- a/tests/multi-graph-tests.lisp
+++ b/tests/multi-graph-tests.lisp
@@ -479,11 +479,12 @@ past the call and often outside any *GRAPH* binding."
 against THAT graph's schema, even when the ambient *GRAPH* is a different graph
 whose schema maps the same type-id to a different class.
 
-Type-ids are per-graph -- assigned by class-registration order -- so the SAME
-integer names different classes in different graphs.  MG-PLAIN is the only user
-class in :MG-ALPHA and MG-TEXT the only one in :MG-BETA, so both are type-id 1
-(the test asserts that collision as a precondition, so a future registration-order
-change reports itself rather than silently no longer exercising the bug).
+Type-ids are system-wide as of #186, so MG-PLAIN and MG-TEXT can no longer
+collide on one integer -- the original collision this test reproduced is gone
+by construction, and the assertion below pins that.  What remains, and is what
+the test now guards, is that the id is resolved against the graph the caller
+NAMED: gb's schema has no entry for ga's id at all, so a read that consults
+the ambient graph materializes nothing or the wrong thing.
 
 This is the reachable form of the wrong-graph materialization class in issue #53.
 It was demonstrated in production: a forensics ACLED-EVENT (type-id 3) read while
@@ -503,18 +504,19 @@ cached with its correct class, so only a from-disk read exercises the deserializ
              (progn
                (let ((*graph* ga))
                  (with-transaction () (setf id (id (make-mg-plain :label "a1")))))
-               ;; precondition: one type-id, two different classes across the graphs
                (setf tid (graph-db::node-type-id
                           (graph-db::lookup-node-type-by-name 'mg-plain :vertex :graph ga)))
                (is (eq 'mg-plain (graph-db::node-type-name
                                   (graph-db::lookup-node-type-by-id tid :vertex :graph ga)))
-                   "precondition: type-id ~D must be MG-PLAIN in ga" tid)
-               (is (eq 'mg-text (graph-db::node-type-name
-                                 (graph-db::lookup-node-type-by-id tid :vertex :graph gb)))
-                   "PRECONDITION FAILED: type-id ~D is not MG-TEXT in gb (~S); registration ~
-                    order changed and this test no longer collides"
-                   tid (let ((m (graph-db::lookup-node-type-by-id tid :vertex :graph gb)))
-                         (and m (graph-db::node-type-name m))))
+                   "type-id ~D must be MG-PLAIN in ga" tid)
+               ;; #186: one id, one class, system-wide -- gb cannot name a
+               ;; different class with ga's id, and here names none at all.
+               (is (not (eq 'mg-text
+                            (let ((m (graph-db::lookup-node-type-by-id
+                                      tid :vertex :graph gb)))
+                              (and m (graph-db::node-type-name m)))))
+                   "type-id ~D must not be MG-TEXT in gb: type-ids are ~
+                    system-wide since #186" tid)
                ;; force a from-disk read so the cache can't hand back the correctly
                ;; classed object written above
                (close-graph ga :snapshot-p t)

--- a/tests/multi-graph-tests.lisp
+++ b/tests/multi-graph-tests.lisp
@@ -1,9 +1,9 @@
 ;;;; Multi-graph coexistence: three graphs, one image.
 ;;;;
-;;;; mine-action runs an ops graph, a knowledge graph and a forensics graph in a
-;;;; single Lisp image, each with its own vertex classes, vector segments and
-;;;; lifecycle.  These tests pin the properties that arrangement depends on.
-;;;; They are engine-level and have no mine-action dependency.
+;;;; An application may run several stores in one Lisp image, each with its
+;;;; own vertex classes, vector segments and lifecycle.  These tests pin the
+;;;; properties that arrangement depends on.  They are engine-level and depend
+;;;; on no application.
 (in-package #:graph-db/test)
 
 (def-suite multi-graph-suite :in graph-db-suite
@@ -12,10 +12,10 @@
 
 ;; Declared once at load time, like the other integration schema in this
 ;; file's neighbours.  Three graph names -- :MG-ALPHA / :MG-BETA / :MG-GAMMA --
-;; stand in for mine-action's ops / knowledge / forensics graphs.  MG-BOTH and
-;; MG-GEO sharing :MG-GAMMA is deliberate: it is the same "text-indexed and
-;; geo-indexed mixins compose, and a geo-only class contributes no vector
-;; segment" property the forensics-graph design rests on (ACLED vs FIRMS).
+;; stand in for an application's three stores.  MG-BOTH and MG-GEO sharing
+;; :MG-GAMMA is deliberate: it is the "text-indexed and geo-indexed mixins
+;; compose, and a geo-only class contributes no vector segment" property any
+;; store with mixed index kinds rests on.
 (def-vertex mg-plain () ((label :type string)) :mg-alpha)
 (def-vertex mg-text  () ((label :type string) (embedding :vector-index t)) :mg-beta)
 (def-vertex mg-geo   () ((label :type string) (lat) (lon)) :mg-gamma)
@@ -47,8 +47,8 @@ at once -- which is the whole point of this suite."
 
 (test three-graphs-open-as-distinct-objects
   "Opening all three graphs in one image yields three distinct GRAPH objects
-with three distinct GRAPH-NAMEs -- the property every downstream forensics-
-graph decision (a third graph alongside ops and knowledge) assumes."
+with three distinct GRAPH-NAMEs -- the property any decision to add a third
+store alongside two existing ones assumes."
   (with-three-graphs (ga gb gc)
     (is (not (eq ga gb)) "mg-alpha and mg-beta must not be the same object")
     (is (not (eq gb gc)) "mg-beta and mg-gamma must not be the same object")
@@ -135,13 +135,13 @@ non-indexed (geo-only) class alongside an indexed one must not spill a
 segment onto the non-indexed class.  mg-geo has no :vector-index slot at
 all, so no key with car MG-GEO may ever appear in mg-gamma's
 vector-segments table.  This is the engine-level version of the spike's
-'fx-hotspot got none' observation (ACLED = both mixins; FIRMS = geo mixin
-alone, the negative case)."
+same observation: a class carrying both mixins gets a segment, and a
+geo-only class -- the negative case -- gets none."
   (with-three-graphs (ga gb gc)
     ;; Keep all three graphs genuinely alive and taking writes, not just gc --
     ;; the property under test is about mg-gamma's own composition, but it
-    ;; should hold with the other two graphs open alongside it, exactly as
-    ;; mine-action's three graphs will be.
+    ;; should hold with the other two graphs open alongside it, exactly as an
+    ;; application's several stores are.
     (let ((*graph* ga)) (with-transaction () (make-mg-plain :label "a1")))
     (let ((*graph* gb))
       (with-transaction () (make-mg-text :label "b1" :embedding (%mg-embedding 4 9.0))))
@@ -240,8 +240,8 @@ established vector segments (mg-beta's and mg-gamma's)."
 ;;; ---------------------------------------------------------------------------
 ;;; keep-revisions retention-cost bound
 ;;;
-;;; mine-action's forensics graph adopts KEEP-REVISIONS = 100 on the strength of
-;;; a single measurement (spec 2026-07-22-forensics-graph-design.md, S5):
+;;; An application that adopts KEEP-REVISIONS = 100 does so on the strength of
+;;; a single measurement:
 ;;; REAP-OLD-VERSIONS runs inside the transaction-manager lock, so its cost is
 ;;; paid by every commit in the graph, not only commits touching a deep version
 ;;; chain.  Without a guard, a future engine change could make retention
@@ -264,14 +264,14 @@ the bounded graph's chain (capped at its KEEP-REVISIONS window) reaches and
 holds steady state for the great majority of the run.")
 
 (defparameter *mg-epsilon-keep-revisions* 100
-  "KEEP-REVISIONS for the bounded graph in the test below -- mine-action's
-chosen forensics-graph policy.  Left as a DEFPARAMETER, not inlined, because
+  "KEEP-REVISIONS for the bounded graph in the test below -- a realistic
+audit-retention policy.  Left as a DEFPARAMETER, not inlined, because
 proving the test discriminates (see the task report) means temporarily setting
 this to 4,000,000,000 -- effectively unbounded within the run -- and confirming
 the assertion fails, then restoring it to 100 before committing.")
 
 (defun %mg-commit-latencies-ms (graph vertex-id n)
-  "Update the vertex at VERTEX-ID in GRAPH N times, using the mine-action
+  "Update the vertex at VERTEX-ID in GRAPH N times, using the ordinary
 update idiom -- (COPY -> SETF -> SAVE) inside its own WITH-TRANSACTION -- and
 return a list of N per-commit wall-clock latencies in milliseconds.  Uses
 LOOKUP-VERTEX and SLOT-VALUE rather than a type-specific accessor, so this one
@@ -294,16 +294,16 @@ helper drives both MG-CTL-COUNTER and MG-BND-COUNTER."
 commits touching a deep version chain: REAP-OLD-VERSIONS runs inside the
 transaction-manager lock (see APPLY-TRANSACTION, transactions.lisp).
 
-Measured 2026-07-22 (the number this bound and mine-action's policy both rest
-on): with KEEP-REVISIONS at 4,000,000,000 -- i.e. effectively never reaping --
+Measured 2026-07-22 (the number this bound rests on): with KEEP-REVISIONS at
+4,000,000,000 -- i.e. effectively never reaping --
 2,000 updates to one vertex degraded mean commit latency 0.378ms -> 1.378ms,
 approximately 3.65x, roughly linearly in chain length (about +0.0005ms per
 retained revision), against a flat ~0.31ms/commit control at KEEP-REVISIONS=0.
 
-mine-action's forensics graph adopts KEEP-REVISIONS=100: the degradation is
-linear in chain length, and its chains are short (FIRMS detections are written
-once; ACLED events see a handful of corrections), so a window of 100 gives
-complete audit history at negligible cost. This test pins that a *bounded*
+An audit-trail store adopts KEEP-REVISIONS=100 on this basis: the degradation
+is linear in chain length, and such chains are short (most records are written
+once, a few see a handful of corrections), so a window of 100 gives complete
+audit history at negligible cost. This test pins that a *bounded*
 window of 100 stays cheap relative to a KEEP-REVISIONS=0 control over the same
 number of updates to a single vertex -- so a future regression that made the
 reaper cost scale with total chain length again, rather than with
@@ -391,8 +391,8 @@ keep-revisions=0 control's ~,4Fms mean over ~D updates (observed ratio ~,3Fx)"
 ;;; VERTEX-HISTORY: the public read path over the retained MVCC chain
 ;;;
 ;;; Retention (above) without a read path is storage we pay for and cannot use.
-;;; mine-action's forensics graph adopts KEEP-REVISIONS=100 specifically to keep
-;;; an audit trail -- what a source told us about an event, and when -- so the
+;;; An application adopts KEEP-REVISIONS=100 specifically to keep an audit
+;;; trail -- what a source said about a record, and when -- so the
 ;;; chain-walk that until now existed only as an internal snapshot-isolation
 ;;; mechanism (RESOLVE-VERSION-AT-EPOCH) needs a supported public form.
 ;;; ---------------------------------------------------------------------------
@@ -487,10 +487,11 @@ NAMED: gb's schema has no entry for ga's id at all, so a read that consults
 the ambient graph materializes nothing or the wrong thing.
 
 This is the reachable form of the wrong-graph materialization class in issue #53.
-It was demonstrated in production: a forensics ACLED-EVENT (type-id 3) read while
-*GRAPH* was the ops graph (type-id 3 = ADMIN-RAION) materialized as ADMIN-RAION,
-its ACLED accessors returning NIL, while the raw type-id and type-index were both
-correct.  MAP-VERTICES already binds *GRAPH* around its scan (edge.lisp / the note
+It was demonstrated in production: a node of the second store's type (type-id
+3) read while *GRAPH* was the first store -- whose own type-id 3 named a
+different class -- materialized as that other class, its accessors returning
+NIL, while the raw type-id and type-index were both correct.  MAP-VERTICES
+already binds *GRAPH* around its scan (edge.lisp / the note
 in MAP-VERTICES) so it was never affected; LOOKUP-OBJECT did not, so a cross-graph
 LOOKUP-VERTEX resolved the type-id against the wrong graph's schema.  The close +
 reopen below forces a fresh disk deserialization: the node written under ga is
@@ -888,11 +889,11 @@ a phantom graph (GH #53)."
 ;; never touches the deserializer, and passes no matter what *GRAPH* is bound
 ;; to.  Reopening forces a genuine disk materialization through
 ;; DESERIALIZE-VERTEX-HEAD's per-graph type-id -> class resolution, the actual
-;; cross-graph hazard (MG-PLAIN and MG-TEXT collide on type-id 1; see
-;; CROSS-GRAPH-LOOKUP-MATERIALIZES-THE-OWNING-GRAPHS-CLASS above).  TYPE-OF is
-;; asserted alongside the slot value because MG-PLAIN and MG-TEXT both declare
-;; a slot named LABEL -- a wrongly-classed node would still return the right
-;; string, so the slot check alone does not discriminate.
+;; cross-graph hazard (before #186 MG-PLAIN and MG-TEXT both held type-id 1;
+;; see CROSS-GRAPH-LOOKUP-MATERIALIZES-THE-OWNING-GRAPHS-CLASS above).
+;; TYPE-OF is asserted alongside the slot value because MG-PLAIN and MG-TEXT
+;; both declare a slot named LABEL -- a wrongly-classed node would still
+;; return the right string, so the slot check alone does not discriminate.
 
 (test slot-reads-resolve-through-the-nodes-own-graph
   "Read a node's slots with *GRAPH* bound to a different graph (GH #53)."

--- a/tests/mvcc-tests.lisp
+++ b/tests/mvcc-tests.lisp
@@ -92,10 +92,14 @@ DEST as a string."
                       :output t :error-output t)
     (namestring dest)))
 
-(test migrate-v1-graph-to-v3
+(test migrate-v1-graph-to-v3-without-renumbering
   "A pre-MVCC (v1, 15-byte head) graph cannot be opened directly by v3 code but
 MIGRATE-GRAPH carries it across (logical snapshot + replay), preserving every
-node, its slot data, the subclass, and the edge topology."
+node, its slot data, the subclass, and the edge topology.
+
+Pins the DEFAULT mode, :RENUMBER-P NIL, which is passed explicitly below: the
+type-id guarantee became mode-dependent at #186 (spec §10.1), and :RENUMBER-P T
+is the exact reverse of what this test asserts."
   ;; The committed v1 fixture's struct.dat/schema.dat were cl-store'd by SBCL.
   ;; cl-store's struct encoding is not portable across implementations, so ECL
   ;; cannot restore an SBCL-written graph (a pre-existing property of the on-disk
@@ -116,6 +120,7 @@ node, its slot data, the subclass, and the edge topology."
       ;; run leaves nothing behind in the system temp directory.
       (let ((g (graph-db::migrate-graph :graph-db-mvcc-migration old-dir new-dir
                                         :package :graph-db/test
+                                        :renumber-p nil
                                         :snapshot-file
                                         (namestring
                                          (merge-pathnames "migrate.snapshot" root)))))

--- a/tests/node-class-tests.lisp
+++ b/tests/node-class-tests.lisp
@@ -260,18 +260,10 @@ made this test fail on ECL against perfectly correct code."
         (graph-db::node-vector-index-slots (find-class name)))))
 
 ;;; One CL class namespace, per-graph schemas (GH #53): DEF-VERTEX/DEF-EDGE
-;;; share the CL class namespace across graphs, so a second graph reusing a
-;;; name used to silently clobber the first class's slots.
-
-(test duplicate-class-name-across-graphs-errors
-  "One CL class namespace, per-graph schemas: a second graph reusing a name
-silently clobbered the first class's slots (GH #53)."
-  (eval '(def-vertex dupchk-thing () ((alpha :type string)) :dupchk-one))
-  (signals duplicate-node-class-error
-    (eval '(def-vertex dupchk-thing () ((beta)) :dupchk-two)))
-  (is (member 'alpha (mapcar #'graph-db::slot-definition-name
-                             (graph-db::class-slots (find-class 'dupchk-thing))))
-      "the original class must be untouched -- the guard runs before DEFCLASS"))
+;;; share the CL class namespace across graphs.  The cross-graph name check
+;;; that used to refuse this is gone as of #186 -- it existed only because
+;;; type-ids were per-graph -- so a class may now be defined for more than
+;;; one store; see GLOBAL-TYPE-ID-SUITE.
 
 (test same-graph-redefinition-still-allowed
   "Runtime schema evolution must keep working; the check is on graph-name
@@ -322,15 +314,15 @@ duplicates costs an instantiation per historical version, forever (GH #53)."
       "and the surviving entry must be the NEWEST definition"))
 
 (test redefinition-keeps-type-id-stable
-  "Registry position drives type-id assignment: UPDATE-SCHEMA replays the list in
-order on graph open and INSTANTIATE-NODE-TYPE hands out ids in that order, so a
-redefined type that moved would get a DIFFERENT type-id on a fresh graph -- and
-type-ids travel on the peer wire (GH #53)."
+  "A redefinition must not renumber the type: its id is already written into
+every node of that type on disk, and it travels on the peer wire (GH #53).
+Since #186 the id is the system registry's id for the type's NAME, so this
+asserts against the registry rather than against a per-graph counter -- and
+covers INSTANTIATE-NODE-TYPE's redefinition branch, which must keep the id
+the store already holds instead of re-interning."
   (setf (gethash :tidchk-graph *schema-node-metadata*) nil)
   (eval '(def-vertex tidchk-a () ((x)) :tidchk-graph))
   (eval '(def-vertex tidchk-b () ((y)) :tidchk-graph))
-  ;; Redefine the FIRST-declared type last; it must not drift to the end.
-  (eval '(def-vertex tidchk-a () ((x) (z)) :tidchk-graph))
   (with-temp-directory (dir)
     (let ((g (make-graph :tidchk-graph (namestring dir) :buffer-pool-size 1000)))
       (unwind-protect
@@ -339,11 +331,22 @@ type-ids travel on the peer wire (GH #53)."
                                                             :graph g)))
                  (id-b (graph-db::node-type-id
                         (graph-db::lookup-node-type-by-name 'tidchk-b :vertex
-                                                            :graph g))))
-             (is (= 1 id-a)
-                 "the first-declared type keeps type-id 1 across a redefinition, got ~a"
-                 id-a)
-             (is (= 2 id-b) "the second-declared type keeps type-id 2, got ~a" id-b))
+                                                            :graph g)))
+                 (r (graph-db::ensure-type-registry)))
+             (is (= id-a (graph-db::registry-id-for r 'tidchk-a :vertex))
+                 "the store's id for TIDCHK-A is the registry's, got ~a" id-a)
+             (is (/= id-a id-b) "two types never share an id")
+             ;; Redefine with the graph OPEN, so the redefinition branch runs
+             ;; against a store that already has an id for this type.
+             (eval '(def-vertex tidchk-a () ((x) (z)) :tidchk-graph))
+             (is (= id-a (graph-db::node-type-id
+                          (graph-db::lookup-node-type-by-name 'tidchk-a :vertex
+                                                              :graph g)))
+                 "a redefinition must not change the type-id, was ~a" id-a)
+             (is (= id-b (graph-db::node-type-id
+                          (graph-db::lookup-node-type-by-name 'tidchk-b :vertex
+                                                              :graph g)))
+                 "and must not disturb its neighbour's"))
         (ignore-errors (close-graph g :snapshot-p nil))
         (collect-garbage)))))
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -223,6 +223,8 @@
                 ;; GH #186: the store/registry type-id agreement guard and
                 ;; the frozen open that reads a store it refuses.
                 #:store-registry-conflict
+                #:store-registry-conflict-reason
+                #:frozen-graph-cannot-replicate
                 #:with-schema-frozen
                 #:with-transaction
                 #:*transaction*

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -220,6 +220,10 @@
                 #:make-graph
                 #:open-graph
                 #:close-graph
+                ;; GH #186: the store/registry type-id agreement guard and
+                ;; the frozen open that reads a store it refuses.
+                #:store-registry-conflict
+                #:with-schema-frozen
                 #:with-transaction
                 #:*transaction*
                 #:transaction-id

--- a/tests/peer-replication-multi/device.lisp
+++ b/tests/peer-replication-multi/device.lisp
@@ -38,6 +38,24 @@
 (log:config :error)
 
 (defparameter *id* (or (uiop:getenv "REPL_DEVICE_ID") "a"))   ; "a" or "b"
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: these harnesses exist because hub and device are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so their registries agree
+;;; and the handshake's registry check (D15) passes -- which is the point.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         (format nil "system-device-~A/" *id*)
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (defun dflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))
 (defun write-flag (name) (with-open-file (s (dflag name) :direction :output
                                             :if-exists :supersede :if-does-not-exist :create)

--- a/tests/peer-replication-multi/hub.lisp
+++ b/tests/peer-replication-multi/hub.lisp
@@ -38,6 +38,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: these harnesses exist because hub and device are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so their registries agree
+;;; and the handshake's registry check (D15) passes -- which is the point.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-hub/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun hflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/peer-replication-push/device.lisp
+++ b/tests/peer-replication-push/device.lisp
@@ -33,6 +33,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: these harnesses exist because hub and device are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so their registries agree
+;;; and the handshake's registry check (D15) passes -- which is the point.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-device/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun dflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/peer-replication-push/hub.lisp
+++ b/tests/peer-replication-push/hub.lisp
@@ -38,6 +38,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: these harnesses exist because hub and device are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so their registries agree
+;;; and the handshake's registry check (D15) passes -- which is the point.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-hub/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun hflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/peer-replication/device.lisp
+++ b/tests/peer-replication/device.lisp
@@ -46,6 +46,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: these harnesses exist because hub and device are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so their registries agree
+;;; and the handshake's registry check (D15) passes -- which is the point.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-device/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun dflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/peer-replication/hub.lisp
+++ b/tests/peer-replication/hub.lisp
@@ -44,6 +44,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: these harnesses exist because hub and device are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so their registries agree
+;;; and the handshake's registry check (D15) passes -- which is the point.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-hub/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun hflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -1,58 +1,89 @@
 ;;;; The peer type table: (kind, type-id, name, supers) shipped to devices.
 ;;;;
-;;;; A type-id is meaningless on its own.  Ids are handed out by DEF-VERTEX/DEF-EDGE
-;;;; evaluation order (GET-NEXT-TYPE-ID), persisted per graph, and NO type NAME ever
-;;;; crosses the wire -- a receiver resolves the raw uint16 against its OWN schema.  A
-;;;; Lisp device gets away with that only because it evaluates the same schema.lisp; a
-;;;; non-Lisp peer (the Kotlin/SQLite device) cannot.  So the hub ships the mapping.
+;;;; A type-id is meaningless on its own.  Ids come from the IMAGE's type
+;;;; registry (GH #186; before that, per-graph counters), and NO type NAME ever
+;;;; crosses the wire -- a receiver resolves the raw id against its OWN schema.
+;;;; A Lisp device gets away with that only because it evaluates the same
+;;;; schema.lisp; a non-Lisp peer (the Kotlin/SQLite device) cannot.  So the hub
+;;;; ships the mapping.
 ;;;;
 ;;;; The load-bearing details these tests pin down:
 ;;;;
-;;;;   - NEXT-VERTEX-ID and NEXT-EDGE-ID are SEPARATE counters that BOTH start at 1, so
-;;;;     a vertex type and an edge type routinely share a numeric id.  Any consumer
-;;;;     keying on the id ALONE silently confuses them.
-;;;;   - DEF-NODE-TYPE does not ENFORCE single inheritance -- it splices PARENT-TYPES
-;;;;     straight into DEFCLASS -- so multiple inheritance really works on the hub.  The
-;;;;     supers field is therefore a LIST, not a scalar; dropping the second parent
-;;;;     would make a device's subclass closure silently disagree with the hub's.
-;;;;   - The format is a FROZEN EXTERNAL CONTRACT (a Kotlin/SQLite device parses it), so
-;;;;     the encoder validates what it emits and the reference parser is strict: both
-;;;;     are the spec.
+;;;;   - The registry's vertex and edge counters are SEPARATE and BOTH start at
+;;;;     1, so a vertex type and an edge type routinely share a numeric id.  Any
+;;;;     consumer keying on the id ALONE silently confuses them.
+;;;;   - DEF-NODE-TYPE does not ENFORCE single inheritance -- it splices
+;;;;     PARENT-TYPES straight into DEFCLASS -- so multiple inheritance really
+;;;;     works on the hub.  The supers field is therefore a LIST, not a scalar;
+;;;;     dropping the second parent would make a device's subclass closure
+;;;;     silently disagree with the hub's.
+;;;;   - The format is a FROZEN EXTERNAL CONTRACT (a Kotlin/SQLite device parses
+;;;;     it), so the encoder validates what it emits and the reference parser is
+;;;;     strict: both are the spec.
+;;;;   - The table is the IMAGE's registry, so the hub's own graph does not
+;;;;     bound it, and the handshake refuses a peer whose registry disagrees
+;;;;     (D15).
 
 (in-package #:graph-db/test)
 
 (def-suite peer-type-table-suite
-  :description "The (kind,id,name,supers) type table shipped in the peer auth-ok plist."
+  :description
+  "The (kind,id,name,supers) type table shipped in the peer auth-ok plist."
   :in graph-db-suite)
 
 (in-suite peer-type-table-suite)
 
-;;; The happy-path tests need no new schema: the g-* schema from graph-tests (loaded
-;;; earlier in the system) is exactly the shape they need -- two vertex types where
-;;; G-EMPLOYEE subclasses G-PERSON, and two edge types.  Both id spaces therefore start
-;;; at 1, which is what makes the collision assertion below meaningful.  WITH-TEST-GRAPH
-;;; (suite.lisp:113) builds a graph of *INTEGRATION-GRAPH-NAME* carrying it.
-;;;
-;;; The multiple-inheritance and encoder-rejection tests each need their OWN graph name:
-;;; the type table is graph-WIDE, and *INTEGRATION-GRAPH-NAME*'s schema is shared with
-;;; every other suite -- a deliberately unrepresentable type added there would break them
-;;; all.  Hence the dedicated schemas below, and WITH-NAMED-TEST-GRAPH.
+;;; Every test here needs its OWN system directory, and that is not tidiness.
+;;; The table is the IMAGE's registry (GH #186) while RUN-TESTS gives the whole
+;;; suite ONE system directory, so against the shared registry these tests would
+;;; encode every type any other file has ever declared -- including this file's
+;;; deliberately unrepresentable ones, which would then make every test here
+;;; signal.  WITH-OWN-REGISTRY* is what keeps each test's table its own.
 
-(defmacro with-named-test-graph ((g name) &body body)
-  "Like WITH-TEST-GRAPH but for a graph of a name OTHER than *INTEGRATION-GRAPH-NAME*."
-  (let ((dir (gensym "DIR")))
+(defmacro with-ptt-registry ((registry) &body body)
+  "Run BODY under a system directory -- hence a type registry -- of its own,
+with REGISTRY bound to that registry."
+  (let ((dir (gensym "SYSDIR")))
     `(with-temp-directory (,dir)
-       (let ((,g (make-graph ,name (namestring ,dir) :buffer-pool-size 1000)))
-         (unwind-protect
-              (let ((*graph* ,g))
-                ,@body)
-           (ignore-errors (close-graph ,g :snapshot-p nil))
-           (collect-garbage))))))
+       (let* ((graph-db::*system-directory* (namestring ,dir))
+              (graph-db::*type-registry* nil)
+              (,registry (graph-db::ensure-type-registry)))
+         (declare (ignorable ,registry))
+         ,@body))))
 
-;;; --- A multiple-inheritance schema. --------------------------------------------
-;;; M-UAV is both an M-HAZARD and an M-ASSET.  The hub agrees: (typep uav 'm-asset) is
-;;; true, and "all m-assets" includes it.  A wire format carrying only the FIRST parent
-;;; would make the device disagree.
+(defmacro with-ptt-registry-graph ((g name &optional (registry (gensym "R")))
+                                   &body body)
+  "A graph of NAME in its own scratch directory AND its own system directory,
+so REGISTRY holds NAME's types and nothing else."
+  (let ((dir (gensym "DIR")))
+    `(with-ptt-registry (,registry)
+       (with-temp-directory (,dir)
+         (let ((,g (make-graph ,name (namestring ,dir) :buffer-pool-size 1000)))
+           (unwind-protect
+                (let ((*graph* ,g))
+                  ,@body)
+             (ignore-errors (close-graph ,g :snapshot-p nil))
+             (collect-garbage)))))))
+
+(defun %ptt-adopt (registry symbol parent id)
+  "Record SYMBOL at exactly ID in REGISTRY, no graph involved.  The tests below
+need registries holding ids and symbols DEF-VERTEX cannot produce -- an id
+above the wire's range, two packages' same-named symbols -- and a store's
+history can produce all of them."
+  (graph-db::with-registry-append-lock (registry)
+    (graph-db::%registry-adopt registry symbol parent id)))
+
+(defun %ptt-refusal-text (thunk)
+  "The report of the PEER-TYPE-REGISTRY-CONFLICT-ERROR THUNK signals, or NIL if
+it signals none.  NIL is the ablated implementation's answer, so every caller
+asserts STRINGP first."
+  (handler-case (progn (funcall thunk) nil)
+    (graph-db::peer-type-registry-conflict-error (c) (princ-to-string c))))
+
+;;; --- A multiple-inheritance schema. ------------------------------------
+;;; M-UAV is both an M-HAZARD and an M-ASSET.  The hub agrees:
+;;; (typep uav 'm-asset) is true, and "all m-assets" includes it.  A wire
+;;; format carrying only the FIRST parent would make the device disagree.
 
 (eval-when (:load-toplevel :execute)
   (setf (gethash :peer-type-table-mi-test *schema-node-metadata*) nil))
@@ -73,10 +104,10 @@
   ()
   :peer-type-table-mi-test)
 
-;;; --- A schema no wire format can represent: a name containing a delimiter. -------
-;;; CL symbol names may contain ANY character via |escaped| syntax, and DEF-VERTEX
-;;; constrains nothing.  The ENCODER is the only possible defense: a table corrupted at
-;;; the source is unrecoverable on the Kotlin side.
+;;; --- A schema no wire format can represent: a name with a delimiter. -----
+;;; CL symbol names may contain ANY character via |escaped| syntax, and
+;;; DEF-VERTEX constrains nothing.  The ENCODER is the only possible defense:
+;;; a table corrupted at the source is unrecoverable on the Kotlin side.
 
 (eval-when (:load-toplevel :execute)
   (setf (gethash :peer-type-table-badname-test *schema-node-metadata*) nil))
@@ -85,7 +116,7 @@
   ()
   :peer-type-table-badname-test)
 
-;;; --- A schema whose names COLLIDE once downcased. --------------------------------
+;;; --- A schema whose names COLLIDE once downcased. ------------------------
 ;;; STRING-DOWNCASE is not injective.
 
 (eval-when (:load-toplevel :execute)
@@ -105,8 +136,9 @@
 
 (test type-table-round-trips
   "PEER-PARSE-TYPE-TABLE inverts PEER-TYPE-TABLE-STRING."
-  (with-test-graph (g)
-    (let* ((s (graph-db::peer-type-table-string g))
+  (with-ptt-registry-graph (g *integration-graph-name*)
+    (declare (ignorable g))
+    (let* ((s (graph-db::peer-type-table-string))
            (parsed (graph-db::peer-parse-type-table s)))
       (is (stringp s))
       (is (plusp (length parsed)))
@@ -119,24 +151,36 @@
         (is (every #'stringp (fourth row)))))))
 
 (test type-table-carries-kind-because-ids-collide
-  "REGRESSION GUARD.  NEXT-VERTEX-ID and NEXT-EDGE-ID both start at 1 (schema.lisp:15-16),
-so a vertex type and an edge type share a numeric id.  The table must therefore be keyed
-on (KIND . ID).  If this ever fails because the ids no longer collide, the KIND field is
-STILL required -- do not 'simplify' it away."
-  (with-test-graph (g)
-    (let* ((parsed (graph-db::peer-parse-type-table (graph-db::peer-type-table-string g)))
-           (vertex-ids (loop for row in parsed when (eq (first row) :vertex) collect (second row)))
-           (edge-ids (loop for row in parsed when (eq (first row) :edge) collect (second row))))
+  "REGRESSION GUARD.  The registry's vertex and edge counters both start at 1
+(type-registry.lisp), so a vertex type and an edge type share a numeric id. The
+table must therefore be keyed on (KIND . ID).  If this ever fails because the
+ids no longer collide, the KIND field is STILL required -- do not 'simplify' it
+away."
+  (with-ptt-registry-graph (g *integration-graph-name*)
+    (declare (ignorable g))
+    (let* ((parsed (graph-db::peer-parse-type-table
+                    (graph-db::peer-type-table-string)))
+           (vertex-ids (loop for row in parsed
+                             when (eq (first row) :vertex)
+                               collect (second row)))
+           (edge-ids (loop for row in parsed
+                           when (eq (first row) :edge)
+                             collect (second row))))
       (is (plusp (length vertex-ids)))
       (is (plusp (length edge-ids)))
       (is (intersection vertex-ids edge-ids))
-      (let ((keys (loop for row in parsed collect (cons (first row) (second row)))))
-        (is (= (length keys) (length (remove-duplicates keys :test #'equal))))))))
+      (let ((keys (loop for row in parsed
+                        collect (cons (first row) (second row)))))
+        (is (= (length keys)
+               (length (remove-duplicates keys :test #'equal))))))))
 
 (test type-table-reports-direct-superclasses-only
-  "A subclass reports its DIRECT parents; a root type reports NIL (not VERTEX/EDGE)."
-  (with-test-graph (g)
-    (let ((parsed (graph-db::peer-parse-type-table (graph-db::peer-type-table-string g))))
+  "A subclass reports its DIRECT parents; a root type reports NIL (not
+VERTEX/EDGE)."
+  (with-ptt-registry-graph (g *integration-graph-name*)
+    (declare (ignorable g))
+    (let ((parsed (graph-db::peer-parse-type-table
+                   (graph-db::peer-type-table-string))))
       (flet ((supers-of (name)
                (fourth (find name parsed :key #'third :test #'string=))))
         (is (equal '("g-person") (supers-of "g-employee")))
@@ -146,8 +190,9 @@ STILL required -- do not 'simplify' it away."
 (test type-table-survives-the-plist-channel
   "The whole point of encoding the table as a STRING: a nested list would trip
 PLIST-TOO-FANCY-ERROR.  Serialize the actual auth-ok plist and read it back."
-  (with-test-graph (g)
-    (let* ((table (graph-db::peer-type-table-string g))
+  (with-ptt-registry-graph (g *integration-graph-name*)
+    (declare (ignorable g))
+    (let* ((table (graph-db::peer-type-table-string))
            (plist (list :peer-control :auth-ok :type-table table))
            (bytes (graph-db::serialize-packet-plist plist))
            (back (graph-db::deserialize-packet-plist bytes)))
@@ -157,25 +202,73 @@ PLIST-TOO-FANCY-ERROR.  Serialize the actual auth-ok plist and read it back."
                  (graph-db::peer-parse-type-table (getf back :type-table)))))))
 
 (test type-table-absent-parses-to-nil
-  "An OLD hub sends no :type-table.  (getf plist :type-table) -> NIL must parse to NIL,
-not signal -- that is the device's back-compat fallback path."
+  "An OLD hub sends no :type-table.  (getf plist :type-table) -> NIL must parse
+to NIL, not signal -- that is the device's back-compat fallback path."
   (is (null (graph-db::peer-parse-type-table nil)))
   (is (null (graph-db::peer-parse-type-table ""))))
+
+;;; ---------------------------------------------------------------------------
+;;; The table is the IMAGE's registry, not one graph's schema (D14)
+;;; ---------------------------------------------------------------------------
+
+(test type-table-is-the-image-registry-not-one-graph-s-schema
+  "Two stores, ONE image, ONE table.  Under the per-graph schema the table
+could only ever name the hub graph's own types; under the registry it names
+every type the SYSTEM has assigned, because a device may be sent an id from any
+of them.
+
+Non-vacuous by construction: each store's schema is asserted NOT to know the
+other's type, so no single SCHEMA-TYPE-TABLE could produce this table -- an
+implementation that still read (SCHEMA GRAPH) fails here whichever graph it
+read."
+  (with-ptt-registry (r)
+    (with-temp-directory (d1)
+      (with-temp-directory (d2)
+        (let ((g1 (make-graph *integration-graph-name* (namestring d1)
+                              :buffer-pool-size 1000))
+              (g2 (make-graph :peer-type-table-mi-test (namestring d2)
+                              :buffer-pool-size 1000)))
+          (unwind-protect
+               (let* ((parsed (graph-db::peer-parse-type-table
+                               (graph-db::peer-type-table-string r))))
+                 (flet ((row (name)
+                          (find name parsed :key #'third :test #'string=))
+                        (knows-p (g sym parent)
+                          (and (graph-db::lookup-node-type-by-name
+                                sym parent :graph g)
+                               t)))
+                   (is (row "g-person")
+                       "the first store's type is in the table")
+                   (is (row "m-uav") "and so is the second store's")
+                   (is (not (knows-p g1 'm-uav :vertex))
+                       "store 1's schema does not know M-UAV")
+                   (is (not (knows-p g2 'g-person :vertex))
+                       "store 2's schema does not know G-PERSON")
+                   ;; The ids are the registry's, not either store's counter.
+                   (is (eql (second (row "m-uav"))
+                            (graph-db::registry-id-for r 'm-uav :vertex)))
+                   (is (eql (second (row "g-knows"))
+                            (graph-db::registry-id-for r 'g-knows :edge)))))
+            (ignore-errors (close-graph g1 :snapshot-p nil))
+            (ignore-errors (close-graph g2 :snapshot-p nil))
+            (collect-garbage)))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Multiple inheritance: the supers field is a LIST
 ;;; ---------------------------------------------------------------------------
 
 (test type-table-carries-every-super-of-a-multiple-inheritance-type
-  "DEF-NODE-TYPE's docstring claims single inheritance but does NOT enforce it -- it
-splices PARENT-TYPES straight into DEFCLASS.  So M-UAV really IS both an M-HAZARD and an
-M-ASSET on the hub.  Emitting only the FIRST parent would silently drop M-UAV from a
-device's \"all m-assets\" closure while the hub kept it: per-peer divergent wrong answers.
-The supers field is therefore a SPACE-SEPARATED LIST."
-  (with-named-test-graph (g :peer-type-table-mi-test)
+  "DEF-NODE-TYPE's docstring claims single inheritance but does NOT enforce it
+-- it splices PARENT-TYPES straight into DEFCLASS.  So M-UAV really IS both an
+M-HAZARD and an M-ASSET on the hub.  Emitting only the FIRST parent would
+silently drop M-UAV from a device's \"all m-assets\" closure while the hub kept
+it: per-peer divergent wrong answers. The supers field is therefore a SPACE-
+SEPARATED LIST."
+  (with-ptt-registry-graph (g :peer-type-table-mi-test)
+    (declare (ignorable g))
     ;; The hub genuinely believes in the second parent.
     (is (subtypep 'm-uav 'm-asset))
-    (let* ((s (graph-db::peer-type-table-string g))
+    (let* ((s (graph-db::peer-type-table-string))
            (parsed (graph-db::peer-parse-type-table s)))
       (is (search ",m-uav,m-hazard m-asset" s))
       (flet ((supers-of (name)
@@ -190,28 +283,173 @@ The supers field is therefore a SPACE-SEPARATED LIST."
 ;;; ---------------------------------------------------------------------------
 
 (test type-table-encoder-rejects-a-name-carrying-a-delimiter
-  "|odd,name| is a legal CL symbol and a legal DEF-VERTEX name, but it cannot be
-represented on the wire: the comma splits it into two fields.  (A |semi;colon| is worse
--- it splits into two RECORDS, the first of which parses SILENTLY.)  The encoder must
-refuse, naming the type, rather than ship a corrupt table to a device that cannot
-possibly recover from it."
-  (with-named-test-graph (g :peer-type-table-badname-test)
-    (signals error (graph-db::peer-type-table-string g))))
+  "|odd,name| is a legal CL symbol and a legal DEF-VERTEX name, but it cannot
+be represented on the wire: the comma splits it into two fields.  (A
+|semi;colon| is worse -- it splits into two RECORDS, the first of which parses
+SILENTLY.)  The encoder must refuse, naming the type, rather than ship a
+corrupt table to a device that cannot possibly recover from it."
+  (with-ptt-registry-graph (g :peer-type-table-badname-test)
+    (declare (ignorable g))
+    (signals error (graph-db::peer-type-table-string))))
 
 (test type-table-encoder-rejects-names-that-collide-when-downcased
-  "STRING-DOWNCASE is not injective: P-PERSON and |P-Person| are distinct CLOS classes
-that emit the SAME name.  A device would resolve one type-id's name to the other type."
-  (with-named-test-graph (g :peer-type-table-dupname-test)
-    (signals error (graph-db::peer-type-table-string g))))
+  "STRING-DOWNCASE is not injective: P-PERSON and |P-Person| are distinct CLOS
+classes that emit the SAME name.  A device would resolve one type-id's name to
+the other type."
+  (with-ptt-registry-graph (g :peer-type-table-dupname-test)
+    (declare (ignorable g))
+    (signals error (graph-db::peer-type-table-string))))
+
+(test type-table-collision-error-names-the-packages
+  "The collision the image-level registry made ordinary: two symbols with the
+SAME name in DIFFERENT packages, registered from different stores (GH #186).
+DEF-VERTEX cannot build this case -- a schema file defines its types in one
+package -- so it is registered directly.
+
+The message must print both symbols PACKAGE-QUALIFIED.  Bare ~S omits the
+package whenever the symbol is accessible in the ambient *PACKAGE*, and an
+error naming PTT-TWIN twice tells an operator with two stores nothing at all.
+It must also stop advising a rename as if both types were in one schema."
+  (with-ptt-registry (r)
+    (let* ((p1 (or (find-package "PTT-PKG-ONE") (make-package "PTT-PKG-ONE")))
+           (p2 (or (find-package "PTT-PKG-TWO") (make-package "PTT-PKG-TWO")))
+           (s1 (intern "PTT-TWIN" p1))
+           (s2 (intern "PTT-TWIN" p2)))
+      (%ptt-adopt r s1 :vertex 1)
+      (%ptt-adopt r s2 :vertex 2)
+      (let ((text (handler-case
+                      (progn (graph-db::peer-type-table-string r) nil)
+                    (error (c) (princ-to-string c)))))
+        (is (stringp text) "the encoder must refuse the collision")
+        (is (search "PTT-PKG-ONE::PTT-TWIN" text)
+            "the first type must be named package-qualified")
+        (is (search "PTT-PKG-TWO::PTT-TWIN" text)
+            "and so must the second")))))
+
+(test type-table-encoder-rejects-an-id-the-wire-cannot-carry
+  "The registry assigns 32-bit type-ids; the wire's ID field is frozen at
+(UNSIGNED-BYTE 16).  Before this the ENCODER emitted the row anyway and only
+the reference PARSER refused, so the failure landed on the device rather than
+on the hub that produced it.  The check is on PEER-TYPE-TABLE-STRING alone
+here, so a parser-only implementation cannot pass: nothing in this test parses
+anything.  Widening the field is GH #199."
+  (with-ptt-registry (r)
+    (%ptt-adopt r 'ptt-too-wide :vertex 70000)
+    (let ((text (handler-case
+                    (progn (graph-db::peer-type-table-string r) nil)
+                  (error (c) (princ-to-string c)))))
+      (is (stringp text) "the encoder must refuse an out-of-range type-id")
+      (is (search "70000" text) "naming the id")
+      (is (search "PTT-TOO-WIDE" text) "and the type"))))
+
+;;; ---------------------------------------------------------------------------
+;;; D15: the handshake refuses a peer whose registry disagrees
+;;; ---------------------------------------------------------------------------
+
+(test handshake-accepts-a-hub-whose-registry-agrees
+  "The control for the two refusal tests below: an implementation that refused
+everything would pass those and fail this one."
+  (with-ptt-registry (r)
+    (%ptt-adopt r 'ptt-agree-a :vertex 1)
+    (%ptt-adopt r 'ptt-agree-b :edge 1)
+    (let* ((table (graph-db::peer-type-table-string r))
+           (rows (graph-db::peer-device-accept-auth-ok
+                  (list :peer-control :auth-ok :type-table table) r)))
+      (is (equal (graph-db::peer-parse-type-table table) rows)
+          "an agreeing table is accepted and returned parsed"))))
+
+(test handshake-refuses-a-hub-that-gives-one-symbol-another-id
+  "D15.  An image with no hub is its own authority, so two of them can hand the
+same symbol different ids; a node arriving under the hub's id would then
+materialise as the wrong class here.  Refuse, and NAME the symbol -- an
+operator has to find it in two stores, so the package has to be in the message.
+
+Reconciling instead would mean rewriting every node of that type because a
+network handshake said so, which is why this is a refusal and not a merge."
+  (with-ptt-registry (r)
+    (%ptt-adopt r 'ptt-conflict-type :vertex 7)
+    (let ((text (%ptt-refusal-text
+                 (lambda ()
+                   (graph-db::peer-device-accept-auth-ok
+                    (list :peer-control :auth-ok
+                          :type-table "v,4,ptt-conflict-type,")
+                    r)))))
+      (is (stringp text) "the handshake must REFUSE a disagreeing registry")
+      (is (search "GRAPH-DB/TEST::PTT-CONFLICT-TYPE" text)
+          "naming the conflicting symbol, package-qualified")
+      (is (search "7" text) "and both ids it is caught between")
+      (is (search "4" text)))))
+
+(test handshake-refuses-a-hub-whose-id-means-another-type-here
+  "The direction a name-keyed comparison MISSES.  The hub's type is unknown in
+this image, so there is no shared name to compare -- but its id already means a
+local type, and a node arriving under it materialises as that local type.  An
+implementation checking only name -> id passes the test above and fails this
+one."
+  (with-ptt-registry (r)
+    (%ptt-adopt r 'ptt-local-only :vertex 3)
+    (let ((text (%ptt-refusal-text
+                 (lambda ()
+                   (graph-db::peer-device-accept-auth-ok
+                    (list :peer-control :auth-ok
+                          :type-table "v,3,ptt-hub-only,")
+                    r)))))
+      (is (stringp text) "an id meaning two types must be refused")
+      (is (search "GRAPH-DB/TEST::PTT-LOCAL-ONLY" text)
+          "naming what the id means HERE")
+      (is (search "ptt-hub-only" text)
+          "and what the hub says it means"))))
+
+(test handshake-refuses-a-conflict-carried-over-the-real-wire
+  "The same refusal, but the table is the one the HUB actually builds (PEER-
+TYPE-TABLE-STRING) and it crosses the real plist codec on the way.  Covers hub
+encode + wire + device refusal in one; only the socket itself is stubbed."
+  (let (hub-table)
+    ;; The hub's image: one symbol, its own registry, its own ids.
+    (with-ptt-registry (hub)
+      (%ptt-adopt hub 'ptt-wire-type :vertex 11)
+      (setf hub-table (graph-db::peer-type-table-string hub)))
+    ;; The device's image: the same symbol, a different id.
+    (with-ptt-registry (device)
+      (%ptt-adopt device 'ptt-wire-type :vertex 12)
+      (let* ((bytes (graph-db::serialize-packet-plist
+                     (list :peer-control :auth-ok :type-table hub-table)))
+             (ctrl (graph-db::deserialize-packet-plist bytes))
+             (text (%ptt-refusal-text
+                    (lambda ()
+                      (graph-db::peer-device-accept-auth-ok ctrl device)))))
+        (is (stringp text)
+            "a conflict that crosses the real wire must still be refused")
+        (is (search "GRAPH-DB/TEST::PTT-WIRE-TYPE" text))))))
+
+(test handshake-still-accepts-a-hub-too-old-to-ship-a-table
+  "The one hole in the guard, kept deliberately and recorded here so it is not
+mistaken for coverage: a hub that ships no :type-table cannot be compared at
+all, so it is trusted.  Removing this back-compat path would break every
+pre-#186 hub."
+  (with-ptt-registry (r)
+    (%ptt-adopt r 'ptt-oldhub-type :vertex 1)
+    (is (null (graph-db::peer-device-accept-auth-ok
+               (list :peer-control :auth-ok) r)))
+    (is (null (graph-db::peer-device-accept-auth-ok
+               (list :peer-control :auth-ok :type-table "") r)))))
+
+(test handshake-still-refuses-an-auth-rejection
+  "The check D15 was added alongside must not have been displaced by it."
+  (with-ptt-registry (r)
+    (signals error
+      (graph-db::peer-device-accept-auth-ok
+       (list :peer-control :auth-failed) r))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; The reference parser IS the spec: it must be strict
 ;;; ---------------------------------------------------------------------------
 
 (test type-table-parser-rejects-malformed-records
-  "Every laxness here is a place the Kotlin parser will silently diverge.  A record has
-EXACTLY 4 fields; KIND is exactly \"v\" or \"e\" (anything else used to become an EDGE);
-ID is an integer in 0..65535 (type-ids are (UNSIGNED-BYTE 16)); no record may be empty."
+  "Every laxness here is a place the Kotlin parser will silently diverge.  A
+record has EXACTLY 4 fields; KIND is exactly \"v\" or \"e\" (anything else used
+to become an EDGE); ID is an integer in 0..65535 (type-ids are (UNSIGNED-BYTE
+16)); no record may be empty."
   ;; Wrong arity.
   (signals error (graph-db::peer-parse-type-table "v,1,foo"))
   (signals error (graph-db::peer-parse-type-table "v,1,foo,,extra"))
@@ -236,11 +474,12 @@ ID is an integer in 0..65535 (type-ids are (UNSIGNED-BYTE 16)); no record may be
              (graph-db::peer-parse-type-table "e,0,foo,bar baz"))))
 
 (test type-table-tolerates-forward-references
-  "Type-ids are STABLE across schema evolution, so the table is sorted by ID, NOT
-topologically.  Adding a superclass ABOVE an existing type therefore produces a FORWARD
-reference -- T-B (id 1) names T-A (id 2).  Parsing must not depend on declaration order;
-consumers MUST two-pass (read all rows, then resolve names).  A single-pass consumer that
-resolves supers as it reads breaks on the first hierarchy refactor."
+  "Type-ids are STABLE across schema evolution, so the table is sorted by ID,
+NOT topologically.  Adding a superclass ABOVE an existing type therefore
+produces a FORWARD reference -- T-B (id 1) names T-A (id 2).  Parsing must not
+depend on declaration order; consumers MUST two-pass (read all rows, then
+resolve names).  A single-pass consumer that resolves supers as it reads breaks
+on the first hierarchy refactor."
   (let ((parsed (graph-db::peer-parse-type-table "v,1,t-b,t-a;v,2,t-a,")))
     (is (= 2 (length parsed)))
     (is (equal '(:vertex 1 "t-b" ("t-a")) (first parsed)))

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -583,3 +583,58 @@ this, a guard that refused every table would pass the test above."
     (let ((c (%ptt-sync-against g (graph-db::peer-type-table-string r))))
       (is (not (typep c 'graph-db::peer-type-registry-conflict-error))
           "an agreeing table must get past the guard; it signalled ~S" c))))
+
+;;; ---------------------------------------------------------------------------
+;;; The escape hatch may READ a contradicted store; it may not SERVE one.
+;;; ---------------------------------------------------------------------------
+
+(test a-frozen-open-refuses-to-start-replication
+  "WITH-SCHEMA-FROZEN exists so an operator can read a store whose ids the
+registry contradicts.  OPEN-GRAPH calls START-REPLICATION unconditionally, so
+without this the same hatch would let them SERVE one -- a hub shipping a type
+table built from the REGISTRY while its node heads carry the STORE's
+contradicted ids.  That corrupts a REMOTE peer, which no local guard sees.
+
+Checked for both peer roles, since a device pushes authored ops to a hub and
+is therefore just as able to send an id that means something else there."
+  (dolist (role '(:hub :device))
+    (with-ptt-registry (r)
+      (with-temp-directory (dir)
+        (let ((c (handler-case
+                     (let ((g (with-schema-frozen ()
+                                (make-graph *integration-graph-name*
+                                            (namestring dir)
+                                            :peer-role role
+                                            :origin-id *ptt-sync-origin*
+                                            :peer-host "127.0.0.1"
+                                            :replication-port 0
+                                            :buffer-pool-size 1000))))
+                       (ignore-errors (close-graph g :snapshot-p nil))
+                       nil)
+                   (frozen-graph-cannot-replicate (e) e))))
+          (is (typep c 'frozen-graph-cannot-replicate)
+              "a frozen ~(~A~) must refuse to start replication; got ~S"
+              role c)
+          (when (typep c 'frozen-graph-cannot-replicate)
+            (is (search "WITH-SCHEMA-FROZEN" (princ-to-string c))
+                "and say why")))
+        (collect-garbage)))))
+
+(test an-ordinary-open-still-starts-replication
+  "The control: the same graph, opened normally, must still come up.  A guard
+that refused every peer-graph would pass the test above."
+  (with-ptt-registry (r)
+    (with-temp-directory (dir)
+      (let ((g (make-graph *integration-graph-name* (namestring dir)
+                           :peer-role :device
+                           :origin-id *ptt-sync-origin*
+                           :peer-host "127.0.0.1" :replication-port 0
+                           :buffer-pool-size 1000)))
+        (unwind-protect
+             (progn
+               (is (not (graph-db::schema-frozen-p g))
+                   "an ordinary open is not frozen")
+               (is (graph-db::peer-writer-mailbox g)
+                   "and its writer funnel is running"))
+          (ignore-errors (close-graph g :snapshot-p nil))))
+      (collect-garbage))))

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -484,3 +484,102 @@ on the first hierarchy refactor."
     (is (= 2 (length parsed)))
     (is (equal '(:vertex 1 "t-b" ("t-a")) (first parsed)))
     (is (equal '(:vertex 2 "t-a" nil) (second parsed)))))
+
+;;; ---------------------------------------------------------------------------
+;;; The call site, over a real socket
+;;;
+;;; Everything above drives PEER-DEVICE-ACCEPT-AUTH-OK directly, which cannot
+;;; tell whether PEER-SYNC still calls it.  The peer harnesses that would --
+;;; tests/peer-replication*/ -- are separate OS processes and are not in this
+;;; suite, so deleting that one line would cost nothing anywhere.
+;;;
+;;; A full hub cannot run in this image (it would share *GRAPHS*, the schema
+;;; registry and *GRAPH* with the device; see run-peer-test.sh).  Nothing here
+;;; needs one: the refusal happens at auth-ok, before a single node moves, so
+;;; a socket that speaks the three plists up to that point is a faithful hub
+;;; for exactly this question.
+;;; ---------------------------------------------------------------------------
+
+(defparameter *ptt-sync-origin*
+  (make-array 16 :element-type '(unsigned-byte 8) :initial-element 23))
+
+(defun %ptt-serve-auth-ok (listener table version)
+  "Accept ONE connection on LISTENER and play hub as far as auth-ok: the
+handshake plist (VERSION is the device's own, so the same-major gate passes),
+read the device's auth, answer :AUTH-OK carrying TABLE.  Then close, which is
+what the device sees if it gets past the guard."
+  (bordeaux-threads:make-thread
+   (lambda ()
+     (ignore-errors
+      (unwind-protect
+           (when (usocket:wait-for-input listener :timeout 20 :ready-only t)
+             (let ((socket (usocket:socket-accept
+                            listener :element-type '(unsigned-byte 8))))
+               (unwind-protect
+                    (progn
+                      (graph-db::peer-write-plist
+                       (list :peer-protocol-version
+                             graph-db::*peer-protocol-version*
+                             :name "PTT-FAKE-HUB"
+                             :schema-major (first version)
+                             :schema-minor (second version)
+                             :schema-digest 0)
+                       socket)
+                      (graph-db::read-plist-packet socket)
+                      (graph-db::peer-write-plist
+                       (list :peer-control :auth-ok :type-table table)
+                       socket))
+                 (ignore-errors (usocket:socket-close socket)))))
+        (ignore-errors (usocket:socket-close listener)))))
+   :name "ptt fake hub"))
+
+(defmacro with-ptt-device ((g registry) &body body)
+  "A device peer-graph under its own system directory, with REGISTRY bound to
+that directory's registry -- the one PEER-SYNC will compare the hub's table
+against."
+  (let ((dir (gensym "DIR")))
+    `(with-ptt-registry (,registry)
+       (with-temp-directory (,dir)
+         (let ((,g (make-graph *integration-graph-name* (namestring ,dir)
+                               :peer-role :device
+                               :origin-id *ptt-sync-origin*
+                               :peer-host "127.0.0.1" :replication-port 0
+                               :buffer-pool-size 1000)))
+           (unwind-protect (let ((*graph* ,g)) ,@body)
+             (ignore-errors (close-graph ,g :snapshot-p nil))
+             (collect-garbage)))))))
+
+(defun %ptt-sync-against (g table)
+  "Point device G at a fake hub answering auth-ok with TABLE, run PEER-SYNC,
+and return the condition it signalled (never NIL: the fake hub closes right
+after auth-ok, so a device that gets past the guard fails on the pull)."
+  (let ((listener (usocket:socket-listen "127.0.0.1" 0 :reuse-address t
+                                         :element-type '(unsigned-byte 8))))
+    (setf (graph-db::replication-port g) (usocket:get-local-port listener))
+    (%ptt-serve-auth-ok listener table (graph-db::peer-schema-version g))
+    (handler-case (progn (graph-db::peer-sync g :attempts 20) nil)
+      (error (c) c))))
+
+(test peer-sync-refuses-a-hub-whose-registry-disagrees
+  "PEER-SYNC itself must run the guard, over a real socket.  The three tests
+above call PEER-DEVICE-ACCEPT-AUTH-OK directly and would all still pass if
+PEER-SYNC stopped calling it."
+  (with-ptt-device (g r)
+    (let* ((mine (graph-db::registry-id-for r 'g-person :vertex))
+           (c (%ptt-sync-against
+               g (format nil "v,~D,g-person," (+ 100 mine)))))
+      (is (typep c 'graph-db::peer-type-registry-conflict-error)
+          "PEER-SYNC must refuse at auth-ok; it signalled ~S" c)
+      (when (typep c 'graph-db::peer-type-registry-conflict-error)
+        (is (search "G-PERSON" (princ-to-string c))
+            "naming the conflicting symbol")))))
+
+(test peer-sync-does-not-refuse-a-hub-whose-registry-agrees
+  "The control: the same socket, the same fake hub, a table built from the
+device's OWN registry.  PEER-SYNC still fails -- the fake hub closes after
+auth-ok and the pull never comes -- but NOT with a registry conflict.  Without
+this, a guard that refused every table would pass the test above."
+  (with-ptt-device (g r)
+    (let ((c (%ptt-sync-against g (graph-db::peer-type-table-string r))))
+      (is (not (typep c 'graph-db::peer-type-registry-conflict-error))
+          "an agreeing table must get past the guard; it signalled ~S" c))))

--- a/tests/perf/benchmarks.lisp
+++ b/tests/perf/benchmarks.lisp
@@ -241,7 +241,11 @@ useless here -- we read (memory-pointer (heap g))."
                       (output (report-pathname tag)))
   "Run the full perf suite at SCALE, record results, write a report to OUTPUT.
 Measurement-only; always returns T."
-  (let ((*perf-scale* scale))
+  ;; A system directory for the stores these benchmarks open (GH #186).
+  (let* ((*perf-scale* scale)
+         (system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
     (reset-perf-report)
     (format t "~&=== graph-db perf (~A, scale ~A) ===~%" *lisp-impl* scale)
     (finish-output)
@@ -255,7 +259,9 @@ Measurement-only; always returns T."
     (bench-concurrent-rw)
     (bench-disk-growth)
     (bench-snapshot-restore-reopen)
-    (write-perf-report output :tag tag))
+    (write-perf-report output :tag tag)
+    (uiop:delete-directory-tree system-dir :validate t
+                                           :if-does-not-exist :ignore))
   t)
 
 ;; Alias so the headless driver can call (graph-db/perf-test:perf-suite).

--- a/tests/replication/master.lisp
+++ b/tests/replication/master.lisp
@@ -27,6 +27,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: this harness exists because master and slave are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so they agree on every
+;;; type-id -- which is what lets a raw id cross the wire.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-master/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun mflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/replication/slave.lisp
+++ b/tests/replication/slave.lisp
@@ -28,6 +28,24 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+
+;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
+;;; #186), so this process needs one before it opens anything.  Its OWN,
+;;; under REPL_WORK: this harness exists because master and slave are
+;;; separate IMAGES, and a shared registry would quietly undo that.  Both
+;;; ends evaluate one schema.lisp in one order, so they agree on every
+;;; type-id -- which is what lets a raw id cross the wire.
+;;;
+;;; SETF, not a LET around the body: replication runs on threads that do
+;;; not inherit dynamic bindings.
+(setf *system-directory*
+      (namestring
+       (ensure-directories-exist
+        (merge-pathnames
+         "system-slave/"
+         ;; Trailing slash: REPL_WORK has none, and MERGE-PATHNAMES
+         ;; would otherwise treat its last component as a file name.
+         (format nil "~A/" (or (uiop:getenv "REPL_WORK") "/tmp"))))))
 (log:config :error)
 
 (defun sflag (name) (format nil "~A/~A" (uiop:getenv "REPL_WORK") name))

--- a/tests/spacetime/suite.lisp
+++ b/tests/spacetime/suite.lisp
@@ -9,9 +9,18 @@
   "Run the spacetime suite.  Returns T when every test passed.
 Invoked by (asdf:test-system :graph-db/spacetime)."
   (log:config :error)
-  (let ((results (run 'spacetime-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'spacetime-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 (defun exact-interval (s e)
   "An interval extent with exact endpoints.  Three lines, duplicated from

--- a/tests/stress/suite.lisp
+++ b/tests/stress/suite.lisp
@@ -13,9 +13,18 @@
   "Run the stress suite.  Returns T on all-pass.
 Called by (asdf:test-system :graph-db/stress-test)."
   (log:config :error)
-  (let ((results (run 'stress-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so every store this suite
+  ;; opens needs a system directory (GH #186).  One for the whole run, which
+  ;; is the shape a real system has: many stores, one registry.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'stress-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Scale control

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -16,9 +16,20 @@ Invoked by (asdf:test-system :graph-db)."
   ;; and aborts with EXT:STORAGE-EXHAUSTED.  Raise the ceiling (a limit, not a
   ;; reservation) so the suite fits.  SBCL/CCL grow their heaps automatically.
   #+ecl (ext:set-limit 'ext:heap-size (* 6 1024 1024 1024))
-  (let ((results (run 'graph-db-suite)))
-    (explain! results)
-    (results-status results)))
+  ;; Type-ids come from the system-wide registry, so a system directory is
+  ;; mandatory for every store the suite opens (GH #186).  One directory for
+  ;; the whole run, which is the shape a real system has: many stores, one
+  ;; registry.  Tests that need their own bind GRAPH-DB::*SYSTEM-DIRECTORY*
+  ;; themselves.
+  (let* ((system-dir (make-temp-directory))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'graph-db-suite)))
+           (explain! results)
+           (results-status results))
+      (uiop:delete-directory-tree system-dir :validate t
+                                             :if-does-not-exist :ignore))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Temp-file fixtures

--- a/tests/type-id-seeding-tests.lisp
+++ b/tests/type-id-seeding-tests.lisp
@@ -136,7 +136,13 @@ carries them across (§10.1, the case no seeding policy exempts)."
       (collect-garbage)
       (setq old-id (%move-current-type-id location 'ts-delta-thing :vertex
                                           new-id))
-      (let ((g (open-graph :ts-delta location :buffer-pool-size 1000)))
+      ;; FROZEN, and the store is why WITH-SCHEMA-FROZEN exists: the move
+      ;; just made this store's current id disagree with the registry that
+      ;; assigned it, which an ordinary open refuses (GH #186).  That is the
+      ;; whole point of the fixture -- a store §10.1 says must be renumbered
+      ;; -- and the nodes below have to be written under the MOVED id.
+      (let ((g (with-schema-frozen ()
+                 (open-graph :ts-delta location :buffer-pool-size 1000))))
         (unwind-protect (%add-vertices g 'ts-delta-thing after)
           (close-graph g)))
       (collect-garbage))
@@ -439,8 +445,13 @@ still an instance of the class it was."
         (let ((before nil) (after nil))
           (let ((graph-db::*system-directory* sysdir)
                 (graph-db::*type-registry* nil))
-            (let ((old (open-graph :ts-beta beta :buffer-pool-p nil
-                                   :gc-heap-p nil)))
+            ;; FROZEN: seeding put :TS-BETA in the renumber set, so its ids
+            ;; and the registry's disagree by construction and an ordinary
+            ;; open refuses.  Censusing it before the migration is precisely
+            ;; the read WITH-SCHEMA-FROZEN is for (GH #186).
+            (let ((old (with-schema-frozen ()
+                         (open-graph :ts-beta beta :buffer-pool-p nil
+                                     :gc-heap-p nil))))
               (unwind-protect (setq before (%class-census old))
                 (close-graph old :snapshot-p nil)))
             (let ((g (graph-db::migrate-graph
@@ -491,8 +502,12 @@ across loses 4 and fails the census."
         (let ((before nil))
           (let ((graph-db::*system-directory* sysdir)
                 (graph-db::*type-registry* nil))
-            (let ((old (open-graph :ts-delta location :buffer-pool-p nil
-                                   :gc-heap-p nil)))
+            ;; FROZEN: this is the fixture whose current id no longer
+            ;; matches the registry that assigned it, so an ordinary open
+            ;; refuses (GH #186).  See %SPLIT-HISTORY-STORE.
+            (let ((old (with-schema-frozen ()
+                         (open-graph :ts-delta location :buffer-pool-p nil
+                                     :gc-heap-p nil))))
               (unwind-protect (setq before (%class-census old))
                 (close-graph old :snapshot-p nil)))
             (collect-garbage)
@@ -794,3 +809,36 @@ the hash table.  The home package is the tie-break."
         "same name, different packages: order by package")
     (is (string= "TS-ORD-TWIN" (symbol-name s1)))
     (is (string= "TS-ORD-TWIN" (symbol-name s2)))))
+
+(test a-stale-id-above-the-registry-s-reach-is-refused
+  "The third shape of disagreement, and the one adoption cannot fix.  A store
+whose history left metadata at an id its own name lookup no longer reaches
+still has NODES at that id.  If it sits above every id the registry has
+assigned, the registry's next mint takes it -- and the registry cannot be told
+to hold it back, because it records symbols, not holes.  Refuse instead.
+
+The fixture moves the current id up to 9 and then back to 1, so the store
+answers to 1 (which a fresh registry adopts, leaving its high-water mark at 1)
+while metadata sits at 9.  The stale id is therefore ABOVE the mark, which is
+the whole condition -- %SPLIT-HISTORY-STORE's stale id is BELOW it and opens
+without complaint."
+  (with-temp-directory (root)
+    (let ((location (%build-legacy-store :ts-delta root 4 nil
+                                         '(ts-delta-thing))))
+      (%move-current-type-id location 'ts-delta-thing :vertex 9)
+      (%move-current-type-id location 'ts-delta-thing :vertex 1)
+      (multiple-value-bind (registry sysdir) (%fresh-registry root "stale/")
+        (declare (ignore registry))
+        (let ((graph-db::*system-directory* sysdir)
+              (graph-db::*type-registry* nil))
+          (signals store-registry-conflict
+            (open-graph :ts-delta location :buffer-pool-size 1000))
+          ;; ...and the store is still readable, which is the whole point of
+          ;; refusing rather than corrupting.
+          (let ((g (with-schema-frozen ()
+                     (open-graph :ts-delta location :buffer-pool-size 1000))))
+            (unwind-protect
+                 (is (eql 1 (%type-id-in g 'ts-delta-thing :vertex))
+                     "a frozen open still sees the store's current id")
+              (close-graph g :snapshot-p nil))
+            (collect-garbage)))))))

--- a/tests/type-id-seeding-tests.lisp
+++ b/tests/type-id-seeding-tests.lisp
@@ -1,0 +1,483 @@
+;;;; Adopting global type-ids on a system that already has stores (GH #186).
+;;;; The policy under test is spec §10.1's, and so is the shape of the
+;;;; fixture: several stores, the low ids contested by nearly all of them,
+;;;; and the store with the MOST types deliberately the SMALLEST on disk.
+;;;; See docs/superpowers/specs/2026-08-20-namespaces-design.md.
+(in-package #:graph-db/test)
+
+(def-suite type-id-seeding-suite :in graph-db-suite
+  :description "Seeding the type registry from populated stores, and the
+renumbering migration that follows.")
+(in-suite type-id-seeding-suite)
+
+;;; Four stores' worth of types.  TS-SHARED-THING is declared under all four
+;;; graph names -- one class instantiated in several stores, which is the
+;;; case #186 makes legal -- and everything else is local to one store.
+;;; Declaration order is what makes the ids collide: each store counts from
+;;; 1, so vertex id 1 names a different symbol in every one of them.
+(eval-when (:load-toplevel :execute)
+  (dolist (name '(:ts-alpha :ts-beta :ts-gamma :ts-delta))
+    (setf (gethash name *schema-node-metadata*) nil)))
+
+(def-vertex ts-shared-thing () ((label :type string)) :ts-alpha)
+(def-vertex ts-alpha-thing  () ((label :type string)) :ts-alpha)
+(def-edge   ts-shared-link  () () :ts-alpha)
+
+(def-vertex ts-beta-thing   () ((label :type string)) :ts-beta)
+(def-vertex ts-shared-thing () ((label :type string)) :ts-beta)
+(def-edge   ts-beta-link    () () :ts-beta)
+
+(def-vertex ts-gamma-a      () ((label :type string)) :ts-gamma)
+(def-vertex ts-gamma-b      () ((label :type string)) :ts-gamma)
+(def-vertex ts-gamma-c      () ((label :type string)) :ts-gamma)
+(def-vertex ts-shared-thing () ((label :type string)) :ts-gamma)
+(def-edge   ts-gamma-link   () () :ts-gamma)
+
+(def-vertex ts-delta-thing  () ((label :type string)) :ts-delta)
+(def-vertex ts-shared-thing () ((label :type string)) :ts-delta)
+
+(defun %fill-store (graph vertices edge-type extra-types)
+  "Put VERTICES TS-SHARED-THINGs in GRAPH, chained by EDGE-TYPE edges when
+one is given, plus one vertex of each of EXTRA-TYPES.  Nodes are made
+through MAKE-VERTEX by type NAME so the store's own type-ids -- whatever
+they are -- go into the heads."
+  (let ((graph-db::*graph* graph)
+        (previous nil))
+    (with-transaction ()
+      (dotimes (i vertices)
+        (let ((v (graph-db::make-vertex
+                  'ts-shared-thing
+                  (list (cons :label (format nil "n~36R" i))))))
+          (when (and previous edge-type)
+            (graph-db::make-edge edge-type (graph-db::id previous)
+                                 (graph-db::id v) 1.0 nil))
+          (setq previous v)))
+      (dolist (type extra-types)
+        (graph-db::make-vertex type (list (cons :label "x")))))))
+
+(defun %build-legacy-store (name root vertices edge-type extra-types)
+  "Create the store NAME under ROOT, fill it, close it, return its location.
+
+The store gets its OWN system directory, which is the whole point: that is
+the pre-#186 shape this task exists for, where every store's type-ids count
+from 1 and so the low ids name different classes in different stores.  The
+private directory is left under ROOT and never read again."
+  (let ((sysdir (namestring (merge-pathnames (format nil "sys-~A/" name)
+                                             root)))
+        (location (namestring (merge-pathnames (format nil "~A/" name)
+                                               root))))
+    (ensure-directories-exist sysdir)
+    (ensure-directories-exist location)
+    (let ((graph-db::*system-directory* sysdir)
+          (graph-db::*type-registry* nil))
+      (let ((g (make-graph name location :buffer-pool-size 1000)))
+        (unwind-protect (%fill-store g vertices edge-type extra-types)
+          (close-graph g))))
+    (collect-garbage)
+    location))
+
+(defmacro with-legacy-stores ((stores root) &body body)
+  "Bind ROOT to a scratch directory and STORES to ((:alpha . location) ...)
+for four closed, populated stores whose type-ids all count from 1.
+
+Sizes are chosen to separate the two rankings §10.1 says must not be
+confused: :GAMMA has the most types and the fewest bytes, :ALPHA the most
+bytes.  A seeding policy that counted types would pick :GAMMA."
+  `(with-temp-directory (,root)
+     (let ((,stores
+             (list (cons :alpha (%build-legacy-store
+                                 :ts-alpha ,root 120 'ts-shared-link
+                                 '(ts-alpha-thing)))
+                   (cons :beta (%build-legacy-store
+                                :ts-beta ,root 40 'ts-beta-link
+                                '(ts-beta-thing)))
+                   (cons :gamma (%build-legacy-store
+                                 :ts-gamma ,root 3 'ts-gamma-link
+                                 '(ts-gamma-a ts-gamma-b ts-gamma-c)))
+                   (cons :delta (%build-legacy-store
+                                 :ts-delta ,root 10 nil
+                                 '(ts-delta-thing))))))
+       ,@body)))
+
+(defun %fresh-registry (root &optional (name "system/"))
+  "(values REGISTRY SYSDIR) for an empty system directory under ROOT."
+  (let ((sysdir (namestring (merge-pathnames name root))))
+    (ensure-directories-exist sysdir)
+    (values (graph-db::open-type-registry sysdir) sysdir)))
+
+(defun %store-entries (location)
+  "(SYMBOL PARENT ID) for every type in the store at LOCATION, from its
+schema.dat."
+  (graph-db::%store-type-entries (graph-db::%store-schema location)))
+
+(defun %store-duplicates (location)
+  "The symbols the store at LOCATION holds more than one id for."
+  (nth-value 1 (%store-entries location)))
+
+(defun %seed-locations (stores)
+  (mapcar #'cdr stores))
+
+(defun %store-of (key stores)
+  (cdr (assoc key stores)))
+
+(defun %renumbered-p (location report)
+  (and (member location (graph-db::seeding-report-renumber report)
+               :test #'equal)
+       t))
+
+(defun %type-id-in (graph name parent)
+  (graph-db::node-type-id
+   (graph-db::lookup-node-type-by-name name parent :graph graph)))
+
+(defun %stale-type-id (location name parent stale-id)
+  "Leave the store at LOCATION holding a SECOND id for NAME, by writing a
+stale copy of its metadata into schema.dat at STALE-ID.  This is §10.1's
+one case no seeding policy exempts, and the shape a store's own history
+produces -- the measured system had three of them."
+  (let* ((file (format nil "~Aschema.dat" (pathname location)))
+         (schema (cl-store:restore file))
+         (sub (gethash parent (graph-db::schema-type-table schema)))
+         (stale (graph-db::copy-node-type
+                 (gethash (gethash name sub) sub))))
+    (setf (graph-db::node-type-id stale) stale-id)
+    (setf (gethash stale-id sub) stale)
+    (setf (graph-db::schema-class-locks schema) nil)
+    (setf (graph-db::schema-lock schema) nil)
+    (cl-store:store schema file)
+    location))
+
+;;; ---------------------------------------------------------------------------
+;;; Seeding
+;;; ---------------------------------------------------------------------------
+
+(test the-fixture-really-does-collide-on-the-low-ids
+  "Guard on the fixture itself.  Every test below is about resolving a
+collision, so a fixture that stopped colliding would leave them all passing
+vacuously.  Vertex id 1 must name four different symbols."
+  (with-legacy-stores (stores root)
+    (declare (ignore root))
+    (let ((claimants
+            (remove-duplicates
+             (mapcar (lambda (store)
+                       (first (find-if (lambda (e)
+                                         (and (eq (second e) :vertex)
+                                              (eql (third e) 1)))
+                                       (%store-entries (cdr store)))))
+                     stores))))
+      (is (= 4 (length claimants))
+          "vertex id 1 must name four DIFFERENT symbols across the four ~
+stores, got ~S" claimants))))
+
+(test seeding-favours-the-largest-store-not-the-type-richest
+  "Spec §10.1's policy, and the measurement behind it: all but one store
+renumbers whichever is favoured, so the cost is bytes replayed.  The
+type-richest store here is the smallest, exactly as on the measured system
+where it held 59 of 95 types -- a policy that counted types would pick it
+and rewrite the largest store instead."
+  (with-legacy-stores (stores root)
+    (multiple-value-bind (registry sysdir) (%fresh-registry root)
+      (declare (ignore sysdir))
+      (let* ((report (graph-db::registry-seed-from-stores
+                      registry (%seed-locations stores)))
+             (sizes (graph-db::seeding-report-sizes report))
+             (alpha (%store-of :alpha stores))
+             (gamma (%store-of :gamma stores)))
+        (is (> (length (%store-entries gamma))
+               (length (%store-entries alpha)))
+            "fixture sanity: the gamma store must hold MORE types than the ~
+alpha store, or this test cannot tell the two rankings apart")
+        (is (< (cdr (assoc gamma sizes :test #'equal))
+               (cdr (assoc alpha sizes :test #'equal)))
+            "fixture sanity: the type-richest store must be the smaller one")
+        (is (equal alpha (graph-db::seeding-report-seed report))
+            "the largest store on disk is the one the registry adopts")
+        (is (not (%renumbered-p alpha report))
+            "and it is therefore the store that does NOT get rewritten")))))
+
+(test the-seed-store-keeps-every-type-id-it-had
+  "Adoption is verbatim: the seed store's ids are already written into every
+node head, ve-key and type-index it owns, so keeping them is the whole
+saving."
+  (with-legacy-stores (stores root)
+    (multiple-value-bind (registry sysdir) (%fresh-registry root)
+      (declare (ignore sysdir))
+      (graph-db::registry-seed-from-stores registry (%seed-locations stores))
+      (dolist (entry (%store-entries (%store-of :alpha stores)))
+        (destructuring-bind (symbol parent id) entry
+          (is (eql id (graph-db::registry-id-for registry symbol parent))
+              "~A must keep the id ~A it already holds on disk, got ~A"
+              symbol id
+              (graph-db::registry-id-for registry symbol parent)))))))
+
+(test every-store-that-cannot-keep-its-ids-is-listed-for-renumbering
+  "The report is the operator's whole instruction sheet: a store missing
+from it is a store left holding ids that mean something else system-wide."
+  (with-legacy-stores (stores root)
+    (multiple-value-bind (registry sysdir) (%fresh-registry root)
+      (declare (ignore sysdir))
+      (let ((report (graph-db::registry-seed-from-stores
+                     registry (%seed-locations stores))))
+        (dolist (key '(:beta :gamma :delta))
+          (let ((location (%store-of key stores)))
+            (is (%renumbered-p location report)
+                "the ~A store contests the seed store's low ids and must be ~
+listed for renumbering" key)
+            (is (find location (graph-db::seeding-report-changes report)
+                      :key #'first :test #'equal)
+                "and the report must say which of its ids moved")))))))
+
+(test seeding-gives-one-symbol-one-id-and-one-id-one-symbol
+  "The property the whole unit exists for, asserted over every type in the
+system rather than over a chosen pair."
+  (with-legacy-stores (stores root)
+    (multiple-value-bind (registry sysdir) (%fresh-registry root)
+      (declare (ignore sysdir))
+      (graph-db::registry-seed-from-stores registry (%seed-locations stores))
+      (let ((entries (graph-db::registry-entries registry))
+            (by-symbol (make-hash-table :test 'equal))
+            (by-id (make-hash-table :test 'equal)))
+        (dolist (entry entries)
+          (destructuring-bind (symbol parent id) entry
+            (push id (gethash (cons symbol parent) by-symbol))
+            (push symbol (gethash (cons parent id) by-id))))
+        (is (plusp (hash-table-count by-symbol))
+            "fixture sanity: seeding recorded something at all")
+        (maphash (lambda (key ids)
+                   (is (= 1 (length ids))
+                       "~S must hold exactly one id, holds ~S" key ids))
+                 by-symbol)
+        (maphash (lambda (key symbols)
+                   (is (= 1 (length symbols))
+                       "~S must name exactly one symbol, names ~S"
+                       key symbols))
+                 by-id)))))
+
+(test a-symbol-holding-two-ids-in-one-store-is-reported-and-renumbered
+  "§10.1: no seeding policy exempts this case.  The store here is the ONLY
+one seeded, so it wins every contest and would otherwise be left alone --
+it must still be named, because its two ids have to unify."
+  (with-temp-directory (root)
+    (let ((location (%stale-type-id
+                     (%build-legacy-store :ts-delta root 10 nil
+                                          '(ts-delta-thing))
+                     'ts-delta-thing :vertex 9)))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (declare (ignore sysdir))
+        (let ((report (graph-db::registry-seed-from-stores
+                       registry (list location))))
+          (is (equal location (graph-db::seeding-report-seed report))
+              "fixture sanity: the only store is the seed store")
+          (is (null (graph-db::seeding-report-changes report))
+              "fixture sanity: nothing contests it, so no id moves")
+          (is (equal (list (list location 'ts-delta-thing :vertex 1 9))
+                     (graph-db::seeding-report-duplicates report))
+              "the two ids one symbol holds must be reported, both of them")
+          (is (%renumbered-p location report)
+              "and the store must be in the migration set anyway"))))))
+
+(test seeding-defers-to-ids-the-registry-already-holds
+  "The registry is the authority and may already have been distributed to
+peers, so entries in it outrank even the largest store -- which then has to
+renumber after all.  This is also the state MIGRATE-GRAPH used to leave
+behind (#186): entries at ids no store uses."
+  (with-legacy-stores (stores root)
+    (multiple-value-bind (registry sysdir) (%fresh-registry root)
+      (declare (ignore sysdir))
+      (graph-db::registry-intern registry 'ts-prior-claim :vertex)
+      (let* ((prior (graph-db::registry-intern registry 'ts-shared-thing
+                                               :vertex))
+             (report (graph-db::registry-seed-from-stores
+                      registry (%seed-locations stores)))
+             (alpha (%store-of :alpha stores)))
+        (is (eql prior (graph-db::registry-id-for registry 'ts-shared-thing
+                                                  :vertex))
+            "an id already in the registry is never reassigned by seeding")
+        (is (eql 1 (third (find 'ts-shared-thing (%store-entries alpha)
+                                :key #'first)))
+            "fixture sanity: the seed store holds a different id on disk")
+        (is (%renumbered-p alpha report)
+            "so even the largest store is listed for renumbering")))))
+
+;;; ---------------------------------------------------------------------------
+;;; The renumbering migration
+;;; ---------------------------------------------------------------------------
+
+(defun %class-census (graph)
+  "((class . count) ...) over GRAPH's live vertices, sorted by class name --
+what must survive a renumbering, since the id under it does not."
+  (let ((counts (make-hash-table :test 'eq))
+        (graph-db::*graph* graph))   ; MAP-VERTICES' all-types branch reads it
+    (graph-db::map-vertices (lambda (v) (incf (gethash (type-of v) counts 0)))
+                            graph)
+    (sort (alexandria:hash-table-alist counts) #'string< :key #'car)))
+
+(test renumbering-migration-gives-colliding-stores-distinct-ids
+  "The unit's payload.  Two stores that both called a type id 1 come out of
+the migration agreeing: the shared symbol has ONE id in both, the two
+formerly-colliding local symbols have different ones, and every node is
+still an instance of the class it was."
+  (with-legacy-stores (stores root)
+    (multiple-value-bind (registry sysdir) (%fresh-registry root)
+      (let ((beta (%store-of :beta stores)))
+        (graph-db::registry-seed-from-stores registry
+                                             (%seed-locations stores))
+        (let ((before nil) (after nil))
+          (let ((graph-db::*system-directory* sysdir)
+                (graph-db::*type-registry* nil))
+            (let ((old (open-graph :ts-beta beta :buffer-pool-p nil
+                                   :gc-heap-p nil)))
+              (unwind-protect (setq before (%class-census old))
+                (close-graph old :snapshot-p nil)))
+            (let ((g (graph-db::migrate-graph
+                      :ts-beta beta
+                      (namestring (merge-pathnames "beta-renumbered/" root))
+                      :package :graph-db/test :renumber-p t)))
+              (unwind-protect
+                   (progn
+                     (setq after (%class-census g))
+                     (is (eql (graph-db::registry-id-for
+                               registry 'ts-shared-thing :vertex)
+                              (%type-id-in g 'ts-shared-thing :vertex))
+                         "the migrated store's id for the shared symbol is ~
+the registry's, which is the id the seed store already holds")
+                     (is (not (eql (%type-id-in g 'ts-beta-thing :vertex)
+                                   (graph-db::registry-id-for
+                                    registry 'ts-shared-thing :vertex)))
+                         "and the symbol that used to share id 1 with it no ~
+longer does")
+                     (is (eql (graph-db::registry-id-for
+                               registry 'ts-beta-link :edge)
+                              (%type-id-in g 'ts-beta-link :edge))
+                         "edges are a separate id space and are renumbered ~
+too"))
+                (close-graph g)))
+            (collect-garbage))
+          (is (equal before after)
+              "every node keeps its CLASS across a renumbering: ~S became ~S"
+              before after)
+          (is (< 0 (length after))
+              "fixture sanity: the store is not empty"))))))
+
+(test renumbering-migration-unifies-a-symbol-that-held-two-ids
+  "The unification §10.1 requires, and MIGRATE-GRAPH says so in its second
+value rather than picking one id and moving on."
+  (with-temp-directory (root)
+    (let ((location (%stale-type-id
+                     (%build-legacy-store :ts-delta root 10 nil
+                                          '(ts-delta-thing))
+                     'ts-delta-thing :vertex 9)))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (declare (ignore registry))
+        (let ((graph-db::*system-directory* sysdir)
+              (graph-db::*type-registry* nil))
+          (multiple-value-bind (g unified)
+              (graph-db::migrate-graph
+               :ts-delta location
+               (namestring (merge-pathnames "delta-renumbered/" root))
+               :package :graph-db/test :renumber-p t)
+            (unwind-protect
+                 ;; Both duplicate lists are bound BEFORE the checks rather
+                 ;; than read inside one: FiveAM pulls a check's form apart
+                 ;; to report it, and an NTH-VALUE at the top of one reads
+                 ;; back NIL however many values the call really returned.
+                 (let ((source (%store-duplicates location))
+                       (migrated (nth-value 1 (graph-db::%store-type-entries
+                                               (graph-db::schema g)))))
+                   (is (equal '((ts-delta-thing :vertex (1 9) 1)) unified)
+                       "the migration must name the symbol, both its old ~
+ids and the one they unified to, got ~S" unified)
+                   (is (consp source)
+                       "fixture sanity: the SOURCE store still holds the ~
+duplicate -- MIGRATE-GRAPH does not rewrite it")
+                   (is (null migrated)
+                       "the migrated store holds exactly one id for it, ~
+holds ~S" migrated)
+                   (is (= 10 (length (graph-db::map-vertices
+                                      #'graph-db::id g :collect-p t
+                                      :vertex-type 'ts-shared-thing)))
+                       "and no node is lost to the unification"))
+              (close-graph g))))))))
+
+(test migrating-without-renumbering-leaves-the-registry-untouched
+  "MIGRATE-GRAPH's default preserves the source's per-graph type-ids, so it
+must not ALSO claim ids for those names in the system registry: the store
+would then be using one set of ids while the registry published another,
+which is the two-regime divergence #186 exists to remove -- arriving through
+the migration path.  Before the fix, MAKE-GRAPH's UPDATE-SCHEMA interned
+every type of the graph and the schema swap on the next form threw the ids
+away, leaving the registry holding ids no store uses."
+  (with-temp-directory (root)
+    (let ((location (%build-legacy-store :ts-delta root 10 nil
+                                         '(ts-delta-thing))))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (declare (ignore registry))
+        (let ((graph-db::*system-directory* sysdir)
+              (graph-db::*type-registry* nil))
+          (close-graph
+           (graph-db::migrate-graph
+            :ts-delta location
+            (namestring (merge-pathnames "delta-preserved/" root))
+            :package :graph-db/test)))
+        (collect-garbage)
+        (is (null (graph-db::registry-entries
+                   (graph-db::open-type-registry sysdir)))
+            "a :RENUMBER-P NIL migration must leave the registry empty, ~
+it holds ~S"
+            (graph-db::registry-entries
+             (graph-db::open-type-registry sysdir)))))))
+
+(test migrating-without-renumbering-preserves-every-type-id
+  "The other half of the mode-dependent guarantee (#166 asserts this of the
+v1 and v2 fixtures; here it is on a current-format store, beside the
+renumbering test it is the exact reverse of)."
+  (with-temp-directory (root)
+    (let ((location (%build-legacy-store :ts-delta root 10 nil
+                                         '(ts-delta-thing))))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (declare (ignore registry))
+        (let ((expected (%store-entries location)))
+          (let ((graph-db::*system-directory* sysdir)
+                (graph-db::*type-registry* nil))
+            (let ((g (graph-db::migrate-graph
+                      :ts-delta location
+                      (namestring (merge-pathnames "delta-preserved/" root))
+                      :package :graph-db/test :renumber-p nil)))
+              (unwind-protect
+                   (dolist (entry expected)
+                     (destructuring-bind (symbol parent id) entry
+                       (is (eql id (%type-id-in g symbol parent))
+                           "~A's type-id must survive a :RENUMBER-P NIL ~
+migration unchanged (expected ~A, got ~A)"
+                           symbol id (%type-id-in g symbol parent))))
+                (close-graph g))))
+          (collect-garbage))))))
+
+(test migration-does-not-rewrite-the-source-s-schema
+  "The manual's rollback story says MIGRATE-GRAPH leaves the source alone;
+until #186 that came with an exception -- every open rewrote schema.dat --
+and the exception was load-bearing, because that same UPDATE-SCHEMA is what
+minted the registry ids the migration then discarded.  Both opens now skip
+the schema replay, so the file is not touched at all."
+  (with-temp-directory (root)
+    (let* ((location (%build-legacy-store :ts-delta root 10 nil
+                                          '(ts-delta-thing)))
+           (file (merge-pathnames "schema.dat" (pathname location)))
+           (before-date (file-write-date file))
+           (before-size (with-open-file (s file :element-type
+                                             '(unsigned-byte 8))
+                          (file-length s))))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (declare (ignore registry))
+        (let ((graph-db::*system-directory* sysdir)
+              (graph-db::*type-registry* nil))
+          (close-graph (graph-db::migrate-graph
+                        :ts-delta location
+                        (namestring (merge-pathnames "out/" root))
+                        :package :graph-db/test)))
+        (collect-garbage)
+        (is (eql before-date (file-write-date file))
+            "the source's schema.dat must not be rewritten by a migration")
+        (is (eql before-size
+                 (with-open-file (s file :element-type '(unsigned-byte 8))
+                   (file-length s)))
+            "nor changed in size")))))

--- a/tests/type-id-seeding-tests.lisp
+++ b/tests/type-id-seeding-tests.lisp
@@ -213,6 +213,25 @@ schema.dat."
   "The symbols the store at LOCATION holds more than one id for."
   (nth-value 1 (%store-entries location)))
 
+(defun %prime-registry-past (registry entries)
+  "Intern filler names into REGISTRY until its next free id under each parent
+is above every id ENTRIES uses.
+
+RENUMBER-SCHEMA mints in a deterministic order since GH #186 task 4, so a
+legacy id surviving is no longer a lucky draw -- it is systematic, and a test
+asserting \"the id moved\" has to make every legacy id unreachable rather than
+merely unlikely.  One filler per parent used to be enough only because MAPHASH
+order was arbitrary."
+  (dolist (parent '(:vertex :edge))
+    (let ((high (loop for (nil p id) in entries
+                      when (eq p parent) maximize id into m
+                      finally (return (or m 0)))))
+      (dotimes (i high)
+        (graph-db::registry-intern
+         registry
+         (intern (format nil "TS-PRIME-~:@(~A~)-~D" parent i) :graph-db/test)
+         parent)))))
+
 (defun %seed-locations (stores)
   "The store locations to seed from, deliberately REVERSED -- delta, gamma,
 beta, alpha.  That is neither the by-bytes ranking nor its reverse, so a
@@ -655,10 +674,9 @@ into a registry the :RENUMBER-P NIL migration is supposed to leave alone
   "A v2 (31-byte head, 2-byte type-id) source migrated with :RENUMBER-P T
 keeps every node, revision, slot value and edge endpoint -- and takes its
 type-ids from the registry, which is the exact reverse of what
-MIGRATE-V2-GRAPH-TO-V3-WITHOUT-RENUMBERING pins.  The registry is primed
-with one filler name per parent first, so NO source id can survive by
-coincidence and 'the id moved' is a real observation rather than a lucky
-draw."
+MIGRATE-V2-GRAPH-TO-V3-WITHOUT-RENUMBERING pins.  The registry is primed past
+the source's highest id under each parent first, so NO legacy id is reachable
+at all and 'the id moved' is a real observation rather than a lucky draw."
   #+ecl
   (skip "v2 fixture was cl-store'd by SBCL; ECL's cl-store cannot restore it ~
 (graph on-disk dirs are not portable across Lisp implementations).")
@@ -669,9 +687,8 @@ draw."
       (multiple-value-bind (registry sysdir) (%fresh-registry root)
         (let ((graph-db::*system-directory* sysdir)
               (graph-db::*type-registry* nil))
-          (graph-db::registry-intern registry 'ts-filler-vertex :vertex)
-          (graph-db::registry-intern registry 'ts-filler-edge :edge)
           (let ((source-ids (%store-entries old-dir)))
+            (%prime-registry-past registry source-ids)
             (multiple-value-bind (expected-v expected-k expected-l)
                 (%read-v2-graph old-dir)
               (is (= 12 (length expected-v))
@@ -708,3 +725,72 @@ draw."
 :RENUMBER-P T migration" symbol id))))
                   (close-graph g))
                 (collect-garbage)))))))))
+
+;;; ---------------------------------------------------------------------------
+;;; Minting order (GH #186, task 4)
+;;;
+;;; RENUMBER-SCHEMA used to iterate survivors with MAPHASH, whose order is
+;;; unspecified.  A fresh registry mints in the order it is asked, so two
+;;; images renumbering ONE store into two EMPTY registries could assign
+;;; different ids -- a disagreement the replication handshake then refuses
+;;; (D15) even though nothing about the two systems actually differed.
+;;; ---------------------------------------------------------------------------
+
+(defun %ts-schema-of (names parent)
+  "A bare SCHEMA holding one node-type per NAME under PARENT, numbered 1..N in
+the order given.  Triple-keyed like UPDATE-NODE-TYPE writes it (id -> meta,
+symbol -> id, keyword -> id), which is what RENUMBER-SCHEMA reads."
+  (let ((schema (graph-db::make-schema))
+        (sub (make-hash-table :test 'eql)))
+    (loop for name in names
+          for id from 1
+          do (let ((meta (graph-db::make-node-type
+                          :name name :parent-type parent :id id)))
+               (setf (gethash id sub) meta)
+               (setf (gethash name sub) id)
+               (setf (gethash (intern (symbol-name name) :keyword) sub) id)))
+    (setf (gethash parent (graph-db::schema-type-table schema)) sub)
+    schema))
+
+(test renumbering-mints-in-one-order-whatever-the-image
+  "Two images renumbering the same store into two EMPTY registries must reach
+the same answer, so the minting order cannot be a hash table's.
+
+The ten names are given to the schema SCRAMBLED and numbered 1..10 in that
+scrambled order, so neither 'keep the source id' nor 'follow the table' can
+produce the expected result -- only sorting can.  Against MAPHASH order this
+fails unless SBCL's EQ-table order happens to be alphabetical for these ten
+symbols."
+  (with-temp-directory (sysdir)
+    (let* ((graph-db::*system-directory* (namestring sysdir))
+           (graph-db::*type-registry* nil)
+           (registry (graph-db::ensure-type-registry))
+           (names '(ts-order-h ts-order-c ts-order-a ts-order-j ts-order-e
+                    ts-order-b ts-order-i ts-order-d ts-order-g ts-order-f))
+           (sorted (sort (copy-list names) #'string< :key #'symbol-name)))
+      (graph-db::renumber-schema (%ts-schema-of names :vertex) registry)
+      (is (equal (loop for i from 1 to (length names) collect i)
+                 (mapcar (lambda (n)
+                           (graph-db::registry-id-for registry n :vertex))
+                         sorted))
+          "a fresh registry must mint in name order, not hash order")
+      ;; The scrambled input really is not already sorted, so the check above
+      ;; is not satisfiable by leaving the order alone.
+      (is (not (equal names sorted))))))
+
+(test minting-order-breaks-ties-on-the-package
+  "Two packages' same-named symbols are exactly what the image-level registry
+made ordinary (GH #186), and a sort on SYMBOL-NAME alone leaves their order to
+the hash table.  The home package is the tie-break."
+  (let* ((p1 (or (find-package "TS-ORD-PKG-A") (make-package "TS-ORD-PKG-A")))
+         (p2 (or (find-package "TS-ORD-PKG-B") (make-package "TS-ORD-PKG-B")))
+         (s1 (intern "TS-ORD-TWIN" p1))
+         (s2 (intern "TS-ORD-TWIN" p2))
+         (table (make-hash-table :test 'eq)))
+    ;; Inserted B first, so "insertion order" is not the expected answer.
+    (setf (gethash s2 table) t)
+    (setf (gethash s1 table) t)
+    (is (equal (list s1 s2) (graph-db::%registry-mint-order table))
+        "same name, different packages: order by package")
+    (is (string= "TS-ORD-TWIN" (symbol-name s1)))
+    (is (string= "TS-ORD-TWIN" (symbol-name s2)))))

--- a/tests/type-id-seeding-tests.lisp
+++ b/tests/type-id-seeding-tests.lisp
@@ -842,3 +842,38 @@ without complaint."
                      "a frozen open still sees the store's current id")
               (close-graph g :snapshot-p nil))
             (collect-garbage)))))))
+
+(test an-orphaned-id-below-the-registry-s-mark-is-tolerated
+  "The other side of the stale-id rule, and the one that must NOT refuse.  A
+legacy store whose history moved a type's id UP leaves the old, lower id
+orphaned -- metadata the name lookup no longer returns, with nodes still on
+disk under it.  Once the registry has adopted the higher id nothing can mint
+onto the lower one, so the open succeeds and only warns; the store still owes
+a renumbering (§10.1, and GH #202 on why the tolerance is a policy choice
+rather than a proof).
+
+Together with A-STALE-ID-ABOVE-THE-REGISTRY-S-REACH-IS-REFUSED this pins both
+sides of the same rule -- an implementation that refused every orphaned id
+would pass that test and fail this one."
+  (with-temp-directory (root)
+    (let ((location (%build-legacy-store :ts-alpha root 4 nil
+                                         '(ts-alpha-thing))))
+      ;; 1 -> 10 leaves the old id orphaned and BELOW the id the registry is
+      ;; about to adopt.
+      (let ((old (%move-current-type-id location 'ts-alpha-thing :vertex 10)))
+        (is (< old 10) "fixture sanity: the orphaned id is the lower one"))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root "tolerate/")
+        (declare (ignore registry))
+        (let ((graph-db::*system-directory* sysdir)
+              (graph-db::*type-registry* nil))
+          (let ((g (open-graph :ts-alpha location :buffer-pool-size 1000)))
+            (unwind-protect
+                 (progn
+                   (is (eql 10 (%type-id-in g 'ts-alpha-thing :vertex))
+                       "the store's current id stands")
+                   (is (eql 10 (graph-db::registry-id-for
+                                (graph-db::ensure-type-registry)
+                                'ts-alpha-thing :vertex))
+                       "and the registry adopted it rather than refusing"))
+              (close-graph g :snapshot-p nil))
+            (collect-garbage)))))))

--- a/tests/type-id-seeding-tests.lisp
+++ b/tests/type-id-seeding-tests.lisp
@@ -36,6 +36,14 @@ renumbering migration that follows.")
 (def-vertex ts-delta-thing  () ((label :type string)) :ts-delta)
 (def-vertex ts-shared-thing () ((label :type string)) :ts-delta)
 
+;; Declared against a graph name nothing here ever creates, so no fixture
+;; store holds it.  %WITH-LATE-TYPE splices a copy of its metadata into
+;; another graph's list at RUN time, which is the shape MIGRATE-GRAPH's
+;; source open must not act on (GH #186).
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :ts-unbuilt *schema-node-metadata*) nil))
+(def-vertex ts-late-thing () ((label :type string)) :ts-unbuilt)
+
 (defun %fill-store (graph vertices edge-type extra-types)
   "Put VERTICES TS-SHARED-THINGs in GRAPH, chained by EDGE-TYPE edges when
 one is given, plus one vertex of each of EXTRA-TYPES.  Nodes are made
@@ -55,15 +63,19 @@ they are -- go into the heads."
       (dolist (type extra-types)
         (graph-db::make-vertex type (list (cons :label "x")))))))
 
+(defun %store-sysdir (name root)
+  "The private system directory a legacy fixture store is built under."
+  (namestring (merge-pathnames (format nil "sys-~A/" name) root)))
+
 (defun %build-legacy-store (name root vertices edge-type extra-types)
   "Create the store NAME under ROOT, fill it, close it, return its location.
 
 The store gets its OWN system directory, which is the whole point: that is
 the pre-#186 shape this task exists for, where every store's type-ids count
 from 1 and so the low ids name different classes in different stores.  The
-private directory is left under ROOT and never read again."
-  (let ((sysdir (namestring (merge-pathnames (format nil "sys-~A/" name)
-                                             root)))
+private directory is left under ROOT and read again only by
+%SPLIT-HISTORY-STORE."
+  (let ((sysdir (%store-sysdir name root))
         (location (namestring (merge-pathnames (format nil "~A/" name)
                                                root))))
     (ensure-directories-exist sysdir)
@@ -76,13 +88,70 @@ private directory is left under ROOT and never read again."
     (collect-garbage)
     location))
 
+(defun %add-vertices (graph type n)
+  "Write N vertices of TYPE into GRAPH, under whatever type-id its schema
+currently gives TYPE."
+  (let ((graph-db::*graph* graph))
+    (with-transaction ()
+      (dotimes (i n)
+        (graph-db::make-vertex type
+                               (list (cons :label (format nil "m~D" i))))))))
+
+(defun %move-current-type-id (location name parent new-id)
+  "Rewrite LOCATION's schema.dat so NAME's CURRENT id under PARENT becomes
+NEW-ID, leaving the metadata at the old id in place -- which is how a store
+comes to hold two ids for one name across its history.  Returns the old id."
+  (let* ((file (format nil "~Aschema.dat" (pathname location)))
+         (schema (cl-store:restore file))
+         (sub (gethash parent (graph-db::schema-type-table schema)))
+         (old-id (gethash name sub))
+         (moved (graph-db::copy-node-type (gethash old-id sub))))
+    (setf (graph-db::node-type-id moved) new-id)
+    (setf (gethash new-id sub) moved)
+    (setf (gethash name sub) new-id)
+    (setf (gethash (intern (symbol-name name) :keyword) sub) new-id)
+    (setf (graph-db::schema-class-locks schema) nil)
+    (setf (graph-db::schema-lock schema) nil)
+    (cl-store:store schema file)
+    old-id))
+
+(defun %split-history-store (root before after new-id)
+  "A :TS-DELTA store whose history really does hold TS-DELTA-THING nodes
+under TWO type-ids: BEFORE of them written under the id it was assigned,
+then the schema moved so the type's CURRENT id is NEW-ID, then AFTER more
+written under that one.  Returns (values LOCATION OLD-ID).
+
+Built by writing nodes on both sides of the move rather than by editing
+metadata around nodes that never used the losing id: only then can a
+migration that DROPS the nodes at the losing id be told from one that
+carries them across (§10.1, the case no seeding policy exempts)."
+  (let* ((location (%build-legacy-store :ts-delta root 10 nil nil))
+         (sysdir (%store-sysdir :ts-delta root))
+         (old-id nil))
+    (let ((graph-db::*system-directory* sysdir)
+          (graph-db::*type-registry* nil))
+      (let ((g (open-graph :ts-delta location :buffer-pool-size 1000)))
+        (unwind-protect (%add-vertices g 'ts-delta-thing before)
+          (close-graph g)))
+      (collect-garbage)
+      (setq old-id (%move-current-type-id location 'ts-delta-thing :vertex
+                                          new-id))
+      (let ((g (open-graph :ts-delta location :buffer-pool-size 1000)))
+        (unwind-protect (%add-vertices g 'ts-delta-thing after)
+          (close-graph g)))
+      (collect-garbage))
+    (values location old-id)))
+
 (defmacro with-legacy-stores ((stores root) &body body)
   "Bind ROOT to a scratch directory and STORES to ((:alpha . location) ...)
 for four closed, populated stores whose type-ids all count from 1.
 
-Sizes are chosen to separate the two rankings §10.1 says must not be
-confused: :GAMMA has the most types and the fewest bytes, :ALPHA the most
-bytes.  A seeding policy that counted types would pick :GAMMA."
+Sizes are chosen to separate the three rankings a seeding policy could be
+confusing: :GAMMA has the most types and the fewest bytes, :ALPHA the most
+bytes, and %SEED-LOCATIONS hands them over in an order that is neither.
+A policy that counted types would pick :GAMMA; one that took the first (or
+the last) location given would pick :DELTA (or :ALPHA) for the wrong
+reason."
   `(with-temp-directory (,root)
      (let ((,stores
              (list (cons :alpha (%build-legacy-store
@@ -95,9 +164,39 @@ bytes.  A seeding policy that counted types would pick :GAMMA."
                                  :ts-gamma ,root 3 'ts-gamma-link
                                  '(ts-gamma-a ts-gamma-b ts-gamma-c)))
                    (cons :delta (%build-legacy-store
-                                 :ts-delta ,root 10 nil
+                                 :ts-delta ,root 25 nil
                                  '(ts-delta-thing))))))
        ,@body)))
+
+(defmacro %with-late-type ((graph-name) &body body)
+  "Run BODY with TS-LATE-THING registered as a type of GRAPH-NAME that no
+store on disk has, restoring the metadata list afterwards.
+
+This is the state MIGRATE-GRAPH's SOURCE open has to be inert against: the
+schema replay would otherwise add the type to the source store and mint a
+registry id for it, in a store whose every other id is per-graph (#186).
+A store that simply reopens is supposed to pick the type up -- only the
+migration's two opens are suppressed -- so the registration is undone here
+rather than left for the next test."
+  (let ((saved (gensym "SAVED")) (name (gensym "NAME")))
+    `(let* ((,name ,graph-name)
+            (,saved (gethash ,name *schema-node-metadata*)))
+       (unwind-protect
+            (progn
+              (setf (gethash ,name *schema-node-metadata*)
+                    (append ,saved
+                            (list (graph-db::copy-node-type
+                                   (first (gethash :ts-unbuilt
+                                                   *schema-node-metadata*))))))
+              ,@body)
+         (setf (gethash ,name *schema-node-metadata*) ,saved)))))
+
+(defun %knows-type-p (location name parent)
+  "True when the store at LOCATION's own schema.dat holds NAME."
+  (and (find-if (lambda (entry)
+                  (and (eq (first entry) name) (eq (second entry) parent)))
+                (%store-entries location))
+       t))
 
 (defun %fresh-registry (root &optional (name "system/"))
   "(values REGISTRY SYSDIR) for an empty system directory under ROOT."
@@ -115,7 +214,11 @@ schema.dat."
   (nth-value 1 (%store-entries location)))
 
 (defun %seed-locations (stores)
-  (mapcar #'cdr stores))
+  "The store locations to seed from, deliberately REVERSED -- delta, gamma,
+beta, alpha.  That is neither the by-bytes ranking nor its reverse, so a
+seeding policy that ranked by argument position rather than by size cannot
+produce the expected answer by accident (spec §10.1)."
+  (reverse (mapcar #'cdr stores)))
 
 (defun %store-of (key stores)
   (cdr (assoc key stores)))
@@ -128,23 +231,6 @@ schema.dat."
 (defun %type-id-in (graph name parent)
   (graph-db::node-type-id
    (graph-db::lookup-node-type-by-name name parent :graph graph)))
-
-(defun %stale-type-id (location name parent stale-id)
-  "Leave the store at LOCATION holding a SECOND id for NAME, by writing a
-stale copy of its metadata into schema.dat at STALE-ID.  This is §10.1's
-one case no seeding policy exempts, and the shape a store's own history
-produces -- the measured system had three of them."
-  (let* ((file (format nil "~Aschema.dat" (pathname location)))
-         (schema (cl-store:restore file))
-         (sub (gethash parent (graph-db::schema-type-table schema)))
-         (stale (graph-db::copy-node-type
-                 (gethash (gethash name sub) sub))))
-    (setf (graph-db::node-type-id stale) stale-id)
-    (setf (gethash stale-id sub) stale)
-    (setf (graph-db::schema-class-locks schema) nil)
-    (setf (graph-db::schema-lock schema) nil)
-    (cl-store:store schema file)
-    location))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Seeding
@@ -189,6 +275,15 @@ alpha store, or this test cannot tell the two rankings apart")
         (is (< (cdr (assoc gamma sizes :test #'equal))
                (cdr (assoc alpha sizes :test #'equal)))
             "fixture sanity: the type-richest store must be the smaller one")
+        (is (not (equal (%seed-locations stores) (mapcar #'car sizes)))
+            "fixture sanity: the order the locations were PASSED in must ~
+differ from the ranking, or this test cannot tell size from position")
+        (is (equal (list alpha (%store-of :beta stores)
+                         (%store-of :delta stores) gamma)
+                   (mapcar #'car sizes))
+            "the whole ranking, in order, is by bytes on disk -- not by ~
+type count and not by the order the locations were given: got ~S"
+            (mapcar #'car sizes))
         (is (equal alpha (graph-db::seeding-report-seed report))
             "the largest store on disk is the one the registry adopts")
         (is (not (%renumbered-p alpha report))
@@ -257,10 +352,7 @@ system rather than over a chosen pair."
 one seeded, so it wins every contest and would otherwise be left alone --
 it must still be named, because its two ids have to unify."
   (with-temp-directory (root)
-    (let ((location (%stale-type-id
-                     (%build-legacy-store :ts-delta root 10 nil
-                                          '(ts-delta-thing))
-                     'ts-delta-thing :vertex 9)))
+    (multiple-value-bind (location old-id) (%split-history-store root 4 6 9)
       (multiple-value-bind (registry sysdir) (%fresh-registry root)
         (declare (ignore sysdir))
         (let ((report (graph-db::registry-seed-from-stores
@@ -269,7 +361,7 @@ it must still be named, because its two ids have to unify."
               "fixture sanity: the only store is the seed store")
           (is (null (graph-db::seeding-report-changes report))
               "fixture sanity: nothing contests it, so no id moves")
-          (is (equal (list (list location 'ts-delta-thing :vertex 1 9))
+          (is (equal (list (list location 'ts-delta-thing :vertex old-id 9))
                      (graph-db::seeding-report-duplicates report))
               "the two ids one symbol holds must be reported, both of them")
           (is (%renumbered-p location report)
@@ -311,6 +403,10 @@ what must survive a renumbering, since the id under it does not."
                             graph)
     (sort (alexandria:hash-table-alist counts) #'string< :key #'car)))
 
+(defun %census-count (census class)
+  "How many nodes of CLASS the census counted, 0 if none."
+  (or (cdr (assoc class census)) 0))
+
 (test renumbering-migration-gives-colliding-stores-distinct-ids
   "The unit's payload.  Two stores that both called a type id 1 come out of
 the migration agreeing: the shared symbol has ONE id in both, the two
@@ -340,11 +436,15 @@ still an instance of the class it was."
                               (%type-id-in g 'ts-shared-thing :vertex))
                          "the migrated store's id for the shared symbol is ~
 the registry's, which is the id the seed store already holds")
+                     (is (eql (graph-db::registry-id-for
+                               registry 'ts-beta-thing :vertex)
+                              (%type-id-in g 'ts-beta-thing :vertex))
+                         "the symbol that used to share id 1 with it takes ~
+the registry's id too -- not merely SOME other id")
                      (is (not (eql (%type-id-in g 'ts-beta-thing :vertex)
                                    (graph-db::registry-id-for
                                     registry 'ts-shared-thing :vertex)))
-                         "and the symbol that used to share id 1 with it no ~
-longer does")
+                         "so the two no longer collide")
                      (is (eql (graph-db::registry-id-for
                                registry 'ts-beta-link :edge)
                               (%type-id-in g 'ts-beta-link :edge))
@@ -359,44 +459,71 @@ too"))
               "fixture sanity: the store is not empty"))))))
 
 (test renumbering-migration-unifies-a-symbol-that-held-two-ids
-  "The unification §10.1 requires, and MIGRATE-GRAPH says so in its second
-value rather than picking one id and moving on."
+  "The unification §10.1 requires: the nodes written under BOTH of the
+store's ids for one name come across under the single surviving id, and
+MIGRATE-GRAPH says which name it did that to rather than picking an id and
+moving on.  The fixture wrote 4 nodes under the losing id and 6 under the
+winning one, so an implementation that carried only the current id's nodes
+across loses 4 and fails the census."
   (with-temp-directory (root)
-    (let ((location (%stale-type-id
-                     (%build-legacy-store :ts-delta root 10 nil
-                                          '(ts-delta-thing))
-                     'ts-delta-thing :vertex 9)))
+    (multiple-value-bind (location old-id) (%split-history-store root 4 6 9)
       (multiple-value-bind (registry sysdir) (%fresh-registry root)
         (declare (ignore registry))
-        (let ((graph-db::*system-directory* sysdir)
-              (graph-db::*type-registry* nil))
-          (multiple-value-bind (g unified)
-              (graph-db::migrate-graph
-               :ts-delta location
-               (namestring (merge-pathnames "delta-renumbered/" root))
-               :package :graph-db/test :renumber-p t)
-            (unwind-protect
-                 ;; Both duplicate lists are bound BEFORE the checks rather
-                 ;; than read inside one: FiveAM pulls a check's form apart
-                 ;; to report it, and an NTH-VALUE at the top of one reads
-                 ;; back NIL however many values the call really returned.
-                 (let ((source (%store-duplicates location))
-                       (migrated (nth-value 1 (graph-db::%store-type-entries
-                                               (graph-db::schema g)))))
-                   (is (equal '((ts-delta-thing :vertex (1 9) 1)) unified)
-                       "the migration must name the symbol, both its old ~
-ids and the one they unified to, got ~S" unified)
-                   (is (consp source)
-                       "fixture sanity: the SOURCE store still holds the ~
+        (let ((before nil))
+          (let ((graph-db::*system-directory* sysdir)
+                (graph-db::*type-registry* nil))
+            (let ((old (open-graph :ts-delta location :buffer-pool-p nil
+                                   :gc-heap-p nil)))
+              (unwind-protect (setq before (%class-census old))
+                (close-graph old :snapshot-p nil)))
+            (collect-garbage)
+            (is (equal '(10 . 10) (cons (%census-count before 'ts-delta-thing)
+                                        (%census-count before
+                                                       'ts-shared-thing)))
+                "fixture sanity: the source must hold all 10 TS-DELTA-THINGs ~
+-- 4 under the losing id and 6 under the winning one -- and 10 ~
+TS-SHARED-THINGs, got ~S" before)
+            (multiple-value-bind (g unified)
+                (graph-db::migrate-graph
+                 :ts-delta location
+                 (namestring (merge-pathnames "delta-renumbered/" root))
+                 :package :graph-db/test :renumber-p t)
+              (unwind-protect
+                   ;; The duplicate list is bound BEFORE the checks rather
+                   ;; than read inside one: FiveAM pulls a check's form
+                   ;; apart to report it, and an NTH-VALUE at the top of one
+                   ;; reads back NIL however many values the call returned.
+                   (let ((source (%store-duplicates location))
+                         (migrated (nth-value 1
+                                    (graph-db::%store-type-entries
+                                     (graph-db::schema g))))
+                         (entry (first unified)))
+                     (is (= 1 (length unified))
+                         "exactly one name unified, got ~S" unified)
+                     (is (equal (list 'ts-delta-thing :vertex
+                                      (sort (list old-id 9) #'<))
+                                (list (first entry) (second entry)
+                                      (third entry)))
+                         "the migration must name the symbol and BOTH its ~
+old ids, got ~S" entry)
+                     ;; The unified id is whatever the registry minted, so
+                     ;; assert it against the store rather than a literal --
+                     ;; a fresh registry's assignment order is not fixed.
+                     (is (eql (fourth entry)
+                              (%type-id-in g 'ts-delta-thing :vertex))
+                         "and the id it reports must be the one the ~
+migrated store actually uses")
+                     (is (consp source)
+                         "fixture sanity: the SOURCE store still holds the ~
 duplicate -- MIGRATE-GRAPH does not rewrite it")
-                   (is (null migrated)
-                       "the migrated store holds exactly one id for it, ~
+                     (is (null migrated)
+                         "the migrated store holds exactly one id for it, ~
 holds ~S" migrated)
-                   (is (= 10 (length (graph-db::map-vertices
-                                      #'graph-db::id g :collect-p t
-                                      :vertex-type 'ts-shared-thing)))
-                       "and no node is lost to the unification"))
-              (close-graph g))))))))
+                     (is (equal before (%class-census g))
+                         "every node written under EITHER id comes across, ~
+under the unified one: ~S became ~S" before (%class-census g)))
+                (close-graph g)))
+            (collect-garbage)))))))
 
 (test migrating-without-renumbering-leaves-the-registry-untouched
   "MIGRATE-GRAPH's default preserves the source's per-graph type-ids, so it
@@ -481,3 +608,103 @@ the schema replay, so the file is not touched at all."
                  (with-open-file (s file :element-type '(unsigned-byte 8))
                    (file-length s)))
             "nor changed in size")))))
+
+(test migration-does-not-add-a-late-type-to-the-source
+  "The SOURCE half of the suppression, which the two tests above cannot
+reach: they declare only types the source already holds, so the schema
+replay takes its already-known branch and never mints anything.  Register a
+type the source has NEVER seen against its graph name, and an unsuppressed
+source open would both write it into the source's schema.dat and take a
+registry id for it -- into a store whose every other id is per-graph, and
+into a registry the :RENUMBER-P NIL migration is supposed to leave alone
+(GH #186)."
+  (with-temp-directory (root)
+    (let ((location (%build-legacy-store :ts-delta root 10 nil
+                                         '(ts-delta-thing))))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (declare (ignore registry))
+        (is (not (%knows-type-p location 'ts-late-thing :vertex))
+            "fixture sanity: the source must not already know the type")
+        (%with-late-type (:ts-delta)
+          (let ((graph-db::*system-directory* sysdir)
+                (graph-db::*type-registry* nil))
+            (close-graph
+             (graph-db::migrate-graph
+              :ts-delta location
+              (namestring (merge-pathnames "delta-late/" root))
+              :package :graph-db/test)))
+          (collect-garbage))
+        (is (not (%knows-type-p location 'ts-late-thing :vertex))
+            "the migration must not add the type to the SOURCE store")
+        (is (null (graph-db::registry-entries
+                   (graph-db::open-type-registry sysdir)))
+            "nor take a registry id for it: the registry holds ~S"
+            (graph-db::registry-entries
+             (graph-db::open-type-registry sysdir)))))))
+
+;;; ---------------------------------------------------------------------------
+;;; The renumbering mode against a LEGACY source.  Everything above builds its
+;;; stores in this image and in the current format; this is the combination
+;;; the unit is named for -- #166's head-shim replay plus RENUMBER-SCHEMA over
+;;; a schema cl-store'd by a pre-widening build.  Reuses the v2 fixture and
+;;; its readers from tests/type-id-width-tests.lisp, whose own migration test
+;;; pins the opposite mode.
+;;; ---------------------------------------------------------------------------
+
+(test renumbering-migration-carries-a-v2-source-to-registry-ids
+  "A v2 (31-byte head, 2-byte type-id) source migrated with :RENUMBER-P T
+keeps every node, revision, slot value and edge endpoint -- and takes its
+type-ids from the registry, which is the exact reverse of what
+MIGRATE-V2-GRAPH-TO-V3-WITHOUT-RENUMBERING pins.  The registry is primed
+with one filler name per parent first, so NO source id can survive by
+coincidence and 'the id moved' is a real observation rather than a lucky
+draw."
+  #+ecl
+  (skip "v2 fixture was cl-store'd by SBCL; ECL's cl-store cannot restore it ~
+(graph on-disk dirs are not portable across Lisp implementations).")
+  #-ecl
+  (with-temp-directory (root)
+    (let ((old-dir (extract-v2-fixture (merge-pathnames "v2/" root)))
+          (new-dir (namestring (merge-pathnames "v3-renumbered/" root))))
+      (multiple-value-bind (registry sysdir) (%fresh-registry root)
+        (let ((graph-db::*system-directory* sysdir)
+              (graph-db::*type-registry* nil))
+          (graph-db::registry-intern registry 'ts-filler-vertex :vertex)
+          (graph-db::registry-intern registry 'ts-filler-edge :edge)
+          (let ((source-ids (%store-entries old-dir)))
+            (multiple-value-bind (expected-v expected-k expected-l)
+                (%read-v2-graph old-dir)
+              (is (= 12 (length expected-v))
+                  "fixture sanity: 12 people expected before migration")
+              (let ((g (graph-db::migrate-graph
+                        :ti-migration-fixture old-dir new-dir
+                        :package :graph-db/test :renumber-p t
+                        :snapshot-file
+                        (namestring
+                         (merge-pathnames "migrate.snapshot" root)))))
+                (unwind-protect
+                     ;; Re-read the registry from disk: MIGRATE-GRAPH interns
+                     ;; through ENSURE-TYPE-REGISTRY's own object, so the one
+                     ;; opened above has no idea what it just assigned.
+                     (let ((graph-db::*graph* g)
+                           (registry (graph-db::open-type-registry sysdir)))
+                       (is (equalp expected-v (%fixture-vertices g))
+                           "vertices survive a renumbering intact")
+                       (is (equalp expected-k
+                                   (%fixture-edges g 'ti-mig-knows))
+                           "knows edges survive a renumbering intact")
+                       (is (equalp expected-l
+                                   (%fixture-edges g 'ti-mig-likes))
+                           "likes edges survive a renumbering intact")
+                       (dolist (entry source-ids)
+                         (destructuring-bind (symbol parent id) entry
+                           (is (eql (graph-db::registry-id-for
+                                     registry symbol parent)
+                                    (%type-id-in g symbol parent))
+                               "~A must take the registry's id, got ~A"
+                               symbol (%type-id-in g symbol parent))
+                           (is (not (eql id (%type-id-in g symbol parent)))
+                               "~A's legacy id ~A must NOT survive a ~
+:RENUMBER-P T migration" symbol id))))
+                  (close-graph g))
+                (collect-garbage)))))))))

--- a/tests/type-id-width-tests.lisp
+++ b/tests/type-id-width-tests.lisp
@@ -310,11 +310,12 @@ tables -- used to assert MIGRATE-GRAPH leaves OLD-LOCATION's DATA untouched.
 Excludes schema.dat and tx/: an ordinary open rewrites schema.dat
 (UPDATE-SCHEMA calls SAVE-SCHEMA on every open; same content, re-serialized)
 and creates a new empty tx/replication-*.log file (the transaction manager
-always opens one).  MIGRATE-GRAPH's own opens no longer rewrite schema.dat at
-all -- the schema replay is suppressed for both of them (#186) -- but the
-guard open in %READ-V2-GRAPH still does, so the exclusion stays.  Neither is
-data loss; both were confirmed to be the ONLY two things that change, by
-exhaustive diff during the #166 migration work.  Shells out (find +
+always opens one).  No open in these tests rewrites schema.dat any more --
+MIGRATE-GRAPH suppresses the replay for both of its own, and %READ-V2-GRAPH's
+guard open is frozen (#186) -- but the exclusion stays: it names what an
+ORDINARY open does, which is what the assertion is defending against.
+Neither is data loss; both were confirmed to be the ONLY two things that
+change, by exhaustive diff during the #166 migration work.  Shells out (find +
 sha256sum), the same portability boundary EXTRACT-V1-FIXTURE already accepts
 by shelling out to tar."
   (uiop:run-program
@@ -328,11 +329,17 @@ by shelling out to tar."
 uses) and return (values vertices knows likes) via %FIXTURE-VERTICES /
 %FIXTURE-EDGES.  Used both to capture MIGRATE-GRAPH's expected input and to
 confirm, post-migration, that OLD-LOCATION still opens at v2 and still holds
-every node -- the guarantee that actually backs the rollback story."
+every node -- the guarantee that actually backs the rollback story.
+
+FROZEN: a v2 store's ids are its own and this system's registry has no
+opinion on them, so an ordinary open would reconcile -- and refuse as soon as
+a caller has primed the registry (GH #186).  Reading a store the registry
+disagrees with is exactly what WITH-SCHEMA-FROZEN is for."
   (let ((graph-db::*node-head-reader* 'graph-db::deserialize-node-head-v2))
-    (let ((g (graph-db:open-graph :ti-mig-guard dir
-                                  :accept-versions '(2)
-                                  :gc-heap-p nil :buffer-pool-p nil)))
+    (let ((g (graph-db:with-schema-frozen ()
+               (graph-db:open-graph :ti-mig-guard dir
+                                    :accept-versions '(2)
+                                    :gc-heap-p nil :buffer-pool-p nil))))
       (unwind-protect
            (let ((graph-db::*graph* g))
              (values (%fixture-vertices g)
@@ -397,10 +404,14 @@ counterpart tests."
           (let (expected-type-ids)
             (let ((graph-db::*node-head-reader*
                    'graph-db::deserialize-node-head-v2))
-              (let ((old (graph-db:open-graph :ti-mig-guard old-dir
-                                              :accept-versions '(2)
-                                              :gc-heap-p nil
-                                              :buffer-pool-p nil)))
+              ;; FROZEN, like %READ-V2-GRAPH: reading a v2 source's own
+              ;; type-ids is exactly the read an ordinary open refuses once
+              ;; the registry has an opinion about those ids (GH #186).
+              (let ((old (graph-db:with-schema-frozen ()
+                           (graph-db:open-graph :ti-mig-guard old-dir
+                                                :accept-versions '(2)
+                                                :gc-heap-p nil
+                                                :buffer-pool-p nil))))
                 (unwind-protect
                      (setq expected-type-ids
                            (mapcar

--- a/tests/type-id-width-tests.lisp
+++ b/tests/type-id-width-tests.lisp
@@ -176,11 +176,27 @@
                (is (= 30 offset))))
         (graph-db::munmap-file mf)))))
 
-(test schema-can-assign-a-type-id-above-16-bits
-  (let ((s (graph-db::make-schema)))
-    (setf (graph-db::schema-next-vertex-id s) 70000)
-    (is (= 70000 (graph-db::get-next-type-id s :vertex)))
-    (is (= 70001 (graph-db::schema-next-vertex-id s)))))
+(test the-registry-can-assign-a-type-id-above-16-bits
+  "Assignment moved from the per-graph counter to the system registry (#186);
+the id it hands out must still span the full 32-bit type-id field."
+  (with-temp-directory (dir)
+    ;; Seed through the FILE, not the struct slot: REGISTRY-INTERN re-reads
+    ;; under its lock and recomputes the next id from what is on disk, so a
+    ;; slot poked in memory would be discarded before the assignment.
+    (with-open-file (out (merge-pathnames "type-registry.log" dir)
+                         :direction :output :if-does-not-exist :create)
+      (let ((*package* (find-package :keyword))
+            (*print-pretty* nil))
+        (format out "~S~%" (list :symbol 'tiw-seed :parent :vertex
+                                 :id 69999))))
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (progn
+             (is (= 69999 (graph-db::registry-id-for r 'tiw-seed :vertex))
+                 "a persisted id above 16 bits reads back intact")
+             (is (= 70000 (graph-db::registry-intern r 'tiw-wide :vertex))
+                 "and assignment continues above it"))
+        (graph-db::close-type-registry r)))))
 
 (test prev-pointer-offset-lands-on-prev-pointer
   ;; The reaper patches this window in place; a wrong offset is invisible for

--- a/tests/type-id-width-tests.lisp
+++ b/tests/type-id-width-tests.lisp
@@ -314,8 +314,9 @@ always opens one).  MIGRATE-GRAPH's own opens no longer rewrite schema.dat at
 all -- the schema replay is suppressed for both of them (#186) -- but the
 guard open in %READ-V2-GRAPH still does, so the exclusion stays.  Neither is
 data loss; both were confirmed to be the ONLY two things that change, by
-exhaustive diff during the #166 migration work.  Shells out (find + sha256sum), the same portability
-boundary EXTRACT-V1-FIXTURE already accepts by shelling out to tar."
+exhaustive diff during the #166 migration work.  Shells out (find +
+sha256sum), the same portability boundary EXTRACT-V1-FIXTURE already accepts
+by shelling out to tar."
   (uiop:run-program
    (format nil "find ~A -type f -not -name schema.dat -not -path '*/tx/*' ~
 -print0 | sort -z | xargs -0 sha256sum"

--- a/tests/type-id-width-tests.lisp
+++ b/tests/type-id-width-tests.lisp
@@ -307,14 +307,14 @@ return DEST as a string."
 (defun %data-fingerprint (dir)
   "A sorted SHA256 listing of every file under DIR's heap and node/index
 tables -- used to assert MIGRATE-GRAPH leaves OLD-LOCATION's DATA untouched.
-Excludes schema.dat and tx/: opening a graph at all -- even read-only, even
-to just look -- unconditionally rewrites schema.dat (UPDATE-SCHEMA calls
-SAVE-SCHEMA on every open; same content, re-serialized, so this is not a
-type-id change, see MIGRATE-V2-GRAPH-TO-V3's own type-id assertions) and
-creates a new empty tx/replication-*.log file (the transaction manager always
-opens one).  Neither is data loss; both are confirmed here to be the ONLY
-two things that change, by exhaustive diff during Task 3's development (see
-task-3-report.md).  Shells out (find + sha256sum), the same portability
+Excludes schema.dat and tx/: an ordinary open rewrites schema.dat
+(UPDATE-SCHEMA calls SAVE-SCHEMA on every open; same content, re-serialized)
+and creates a new empty tx/replication-*.log file (the transaction manager
+always opens one).  MIGRATE-GRAPH's own opens no longer rewrite schema.dat at
+all -- the schema replay is suppressed for both of them (#186) -- but the
+guard open in %READ-V2-GRAPH still does, so the exclusion stays.  Neither is
+data loss; both were confirmed to be the ONLY two things that change, by
+exhaustive diff during the #166 migration work.  Shells out (find + sha256sum), the same portability
 boundary EXTRACT-V1-FIXTURE already accepts by shelling out to tar."
   (uiop:run-program
    (format nil "find ~A -type f -not -name schema.dat -not -path '*/tx/*' ~
@@ -362,13 +362,19 @@ by SINCE (edges with no SINCE slot -- ti-mig-likes -- sort first)."
          graph :collect-p t :edge-type type)
         #'< :key (lambda (row) (or (fourth row) -1))))
 
-(test migrate-v2-graph-to-v3
+(test migrate-v2-graph-to-v3-without-renumbering
   "A v2 (31-byte head, 2-byte type-id) graph cannot be opened directly by v3
 code but MIGRATE-GRAPH carries it across (logical snapshot + replay),
 preserving every node's id, revision, type, slot values and type-id, and
 leaving OLD-LOCATION's data untouched and the source itself still openable
-at v2 afterward -- see %DATA-FINGERPRINT for the two bookkeeping files
-(schema.dat, tx/*) that DO change and why that is not data loss."
+at v2 afterward -- see %DATA-FINGERPRINT for the bookkeeping file (tx/*)
+that DOES change and why that is not data loss.
+
+Pins the DEFAULT mode, :RENUMBER-P NIL, which is passed explicitly below.
+The type-id half of this guarantee became mode-dependent at #186 (spec
+§10.1): under :RENUMBER-P T every id is taken from the system registry
+instead, which is the exact reverse.  See the seeding suite for that mode's
+counterpart tests."
   #+ecl
   (skip "v2 fixture was cl-store'd by SBCL; ECL's cl-store cannot restore it ~
 (graph on-disk dirs are not portable across Lisp implementations).")
@@ -419,6 +425,7 @@ at v2 afterward -- see %DATA-FINGERPRINT for the two bookkeeping files
             (let ((g (graph-db::migrate-graph
                       :ti-migration-fixture old-dir new-dir
                       :package :graph-db/test
+                      :renumber-p nil
                       :snapshot-file
                       (namestring
                        (merge-pathnames "migrate.snapshot" root)))))
@@ -442,9 +449,9 @@ exactly")
 exactly")
                      (is (equalp expected-likes (%fixture-edges g likes))
                          "likes edges: from+to+weight must match exactly")
-                     ;; Type-ids preserved, not renumbered (#186 is where
-                     ;; they would be renumbered; this unit must not do
-                     ;; that).
+                     ;; Type-ids preserved, because :RENUMBER-P is NIL.
+                     ;; The other mode is asserted in the seeding suite
+                     ;; (#186, spec §10.1).
                      (dolist (expected expected-type-ids)
                        (let* ((name (car expected))
                               (parent (if (member name '(ti-mig-person
@@ -454,8 +461,9 @@ exactly")
                                        (graph-db::lookup-node-type-by-name
                                         name parent :graph g))))
                          (is (= (cdr expected) actual)
-                             "~A's type-id must survive migration unchanged ~
-(expected ~A, got ~A)" name (cdr expected) actual))))
+                             "~A's type-id must survive a :RENUMBER-P NIL ~
+migration unchanged (expected ~A, got ~A)"
+                             name (cdr expected) actual))))
                 (graph-db:close-graph g)))
             ;; OLD-LOCATION's DATA is untouched -- scoped past schema.dat and
             ;; tx/, the two bookkeeping files any OPEN rewrites/creates (see

--- a/tests/type-registry-tests.lisp
+++ b/tests/type-registry-tests.lisp
@@ -45,17 +45,64 @@ same symbol may hold a different id in each."
 (test registry-distinguishes-same-name-in-two-packages
   "The registry is keyed on the PACKAGE-QUALIFIED symbol.  Keying on the name
 would collide two packages' types -- the defect #190 records in the per-graph
-keyword alias, which this must not reproduce."
+keyword alias, which this must not reproduce.
+
+Each symbol is interned with its OWN home package bound as the ambient
+*PACKAGE*, matching a real caller registering its own type, and each goes
+through a fresh OPEN-TYPE-REGISTRY so the second interning re-parses the
+first's persisted record rather than reusing an in-memory hit.  Printing
+that omits the package prefix when the symbol happens to be accessible in
+the current *PACKAGE* -- the ordinary printer behaviour -- would read the
+first record back as the SECOND symbol here, since both are named
+\"REG-SPECIES\"; this only passes if the record survives the change in
+ambient package intact."
   (with-temp-directory (dir)
     (flet ((pkg (n) (or (find-package n) (make-package n :use '()))))
-      (let* ((s1 (intern "SPECIES" (pkg "REG-TEST-1")))
-             (s2 (intern "SPECIES" (pkg "REG-TEST-2")))
-             (r (graph-db::open-type-registry (namestring dir))))
-        (unwind-protect
-             (is (/= (graph-db::registry-intern r s1 :vertex)
-                     (graph-db::registry-intern r s2 :vertex))
-                 "same name, different packages, different ids")
-          (graph-db::close-type-registry r))))))
+      (let* ((p1 (pkg "REG-TEST-1"))
+             (p2 (pkg "REG-TEST-2"))
+             (s1 (intern "REG-SPECIES" p1))
+             (s2 (intern "REG-SPECIES" p2))
+             (id1 (let ((*package* p1))
+                    (let ((r (graph-db::open-type-registry (namestring dir))))
+                      (unwind-protect
+                           (graph-db::registry-intern r s1 :vertex)
+                        (graph-db::close-type-registry r)))))
+             (id2 (let ((*package* p2))
+                    (let ((r (graph-db::open-type-registry (namestring dir))))
+                      (unwind-protect
+                           (graph-db::registry-intern r s2 :vertex)
+                        (graph-db::close-type-registry r))))))
+        (is (/= id1 id2) "same name, different packages, different ids")))))
+
+(test registry-symbol-identity-survives-an-ambient-package-change
+  "GH #186's whole point: two images (or two call sites) with different
+*PACKAGE* bindings must agree on what a type-id means.  Writing a record
+while the symbol's own home package is ambient, then reading it back with
+an unrelated package ambient, must yield the SAME symbol object -- not a
+different one the reader happened to intern into whatever package was
+current at read time.  Reproduces the collision the reviewer found in
+round 1: printing without an explicit *PACKAGE* binding depends on the
+CALLER's ambient package, so this test fails against the unfixed code and
+REGISTRY-DISTINGUISHES-SAME-NAME-IN-TWO-PACKAGES alone does not catch it,
+since that test's packages are never accessible from the ambient package
+either way."
+  (with-temp-directory (dir)
+    (let* ((home (or (find-package "REG-TEST-HOME")
+                      (make-package "REG-TEST-HOME" :use '())))
+           (sym (intern "REG-ALPHA" home)))
+      (let ((*package* home))
+        (let ((r (graph-db::open-type-registry (namestring dir))))
+          (unwind-protect
+               (graph-db::registry-intern r sym :vertex)
+            (graph-db::close-type-registry r))))
+      (let ((*package* (find-package "COMMON-LISP-USER")))
+        (let ((r2 (graph-db::open-type-registry (namestring dir))))
+          (unwind-protect
+               (let ((got (first (first (graph-db::registry-entries r2)))))
+                 (is (eq sym got)
+                     "the re-read symbol must be EQ to the one written, not
+a same-named symbol interned under the ambient package at read time"))
+            (graph-db::close-type-registry r2)))))))
 
 (test registry-tolerates-a-torn-final-record
   "GH #191: the lifecycle journal signals on a truncated tail and loses the
@@ -77,9 +124,12 @@ record earlier still signals."
           (graph-db::close-type-registry r2))))))
 
 (test registry-assignment-is-serialised-across-open-file-descriptions
-  "Two images assigning concurrently must not hand the same id to different
-symbols.  flock attaches to the open file description, so two registries on one
-directory in this image contend exactly as two processes would."
+  "Two registries on one directory in this image, used SEQUENTIALLY (both
+calls run in one thread -- this is not a concurrency test; POSIX-TESTS
+covers flock's cross-open-file-description semantics directly).  What this
+proves: the second REGISTRY-INTERN re-reads the persisted file under its
+own lock and sees the first's write, rather than assigning from a stale
+idea of \"next id\" cached at open time."
   (with-temp-directory (dir)
     (let ((r1 (graph-db::open-type-registry (namestring dir)))
           (r2 (graph-db::open-type-registry (namestring dir))))

--- a/tests/type-registry-tests.lisp
+++ b/tests/type-registry-tests.lisp
@@ -1,0 +1,93 @@
+;;;; The image-level type-id registry (GH #186).
+(in-package #:graph-db/test)
+
+(def-suite type-registry-suite :in graph-db-suite
+  :description "The persisted, image-level type-id registry.")
+(in-suite type-registry-suite)
+
+(test registry-assigns-distinct-ids-to-distinct-symbols
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (let ((a (graph-db::registry-intern r 'reg-alpha :vertex))
+                 (b (graph-db::registry-intern r 'reg-beta :vertex)))
+             (is (integerp a))
+             (is (/= a b) "two symbols never share an id"))
+        (graph-db::close-type-registry r)))))
+
+(test registry-is-idempotent-for-one-symbol
+  "The whole point of a registry: asking twice gives the same answer, and
+asking in another image after a reopen still does."
+  (with-temp-directory (dir)
+    (let* ((r (graph-db::open-type-registry (namestring dir)))
+           (first (graph-db::registry-intern r 'reg-gamma :vertex)))
+      (is (= first (graph-db::registry-intern r 'reg-gamma :vertex)))
+      (graph-db::close-type-registry r)
+      (let ((r2 (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (= first (graph-db::registry-intern r2 'reg-gamma :vertex))
+                 "the assignment is durable, not in-memory")
+          (graph-db::close-type-registry r2))))))
+
+(test registry-separates-vertex-and-edge-spaces
+  "Vertices and edges are distinct spaces, as they are per-graph today; the
+same symbol may hold a different id in each."
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (let ((v (graph-db::registry-intern r 'reg-delta :vertex))
+                 (e (graph-db::registry-intern r 'reg-delta :edge)))
+             (is (integerp v)) (is (integerp e))
+             (is (= v (graph-db::registry-id-for r 'reg-delta :vertex)))
+             (is (= e (graph-db::registry-id-for r 'reg-delta :edge))))
+        (graph-db::close-type-registry r)))))
+
+(test registry-distinguishes-same-name-in-two-packages
+  "The registry is keyed on the PACKAGE-QUALIFIED symbol.  Keying on the name
+would collide two packages' types -- the defect #190 records in the per-graph
+keyword alias, which this must not reproduce."
+  (with-temp-directory (dir)
+    (flet ((pkg (n) (or (find-package n) (make-package n :use '()))))
+      (let* ((s1 (intern "SPECIES" (pkg "REG-TEST-1")))
+             (s2 (intern "SPECIES" (pkg "REG-TEST-2")))
+             (r (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (/= (graph-db::registry-intern r s1 :vertex)
+                     (graph-db::registry-intern r s2 :vertex))
+                 "same name, different packages, different ids")
+          (graph-db::close-type-registry r))))))
+
+(test registry-tolerates-a-torn-final-record
+  "GH #191: the lifecycle journal signals on a truncated tail and loses the
+whole file.  The registry is the ONLY record of what a type-id means -- losing
+it is worse -- so a torn FINAL record is dropped with a log, while a malformed
+record earlier still signals."
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (graph-db::registry-intern r 'reg-keep-1 :vertex)
+      (graph-db::registry-intern r 'reg-keep-2 :vertex)
+      (graph-db::close-type-registry r))
+    (let ((f (merge-pathnames "type-registry.log" dir)))
+      (with-open-file (s f :direction :output :if-exists :append)
+        (format s "(:SYMBOL REG-TORN :PARENT :VERT"))   ; truncated, no newline
+      (let ((r2 (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (= 2 (length (graph-db::registry-entries r2)))
+                 "the two intact records survive a torn tail")
+          (graph-db::close-type-registry r2))))))
+
+(test registry-assignment-is-serialised-across-open-file-descriptions
+  "Two images assigning concurrently must not hand the same id to different
+symbols.  flock attaches to the open file description, so two registries on one
+directory in this image contend exactly as two processes would."
+  (with-temp-directory (dir)
+    (let ((r1 (graph-db::open-type-registry (namestring dir)))
+          (r2 (graph-db::open-type-registry (namestring dir))))
+      (unwind-protect
+           (let ((a (graph-db::registry-intern r1 'reg-race-a :vertex))
+                 (b (graph-db::registry-intern r2 'reg-race-b :vertex)))
+             (is (/= a b)
+                 "the second assigner re-read the tail under the lock and did
+not reuse the first's id"))
+        (graph-db::close-type-registry r1)
+        (graph-db::close-type-registry r2)))))

--- a/transaction-streaming.lisp
+++ b/transaction-streaming.lisp
@@ -459,6 +459,7 @@ retryable network error, retries with an exponential retry timeout."
 ;; without this network-transport file.  Only the master/slave methods remain.
 (defmethod start-replication ((graph master-graph) &key (package :graph-db))
   (declare (ignore package))
+  (check-replicable graph)                      ; GH #186
   (setf (stop-replication-p graph) nil)
   (setf (replication-listener graph)
         (bordeaux-threads:make-thread
@@ -478,6 +479,7 @@ retryable network error, retries with an exponential retry timeout."
 
 (defmethod start-replication ((graph slave-graph) &key package)
   (declare (ignore package))
+  (check-replicable graph)                      ; GH #186
   (setf (stop-replication-p graph) nil)
   (setf (slave-thread graph)
         (bordeaux-threads:make-thread

--- a/type-index.lisp
+++ b/type-index.lisp
@@ -76,10 +76,12 @@
     idx))
 
 (defun %ti-ensure-capacity (idx type-id)
-  "Grow IDX's table so TYPE-ID has a slot.  Type-ids are assigned sequentially
-from 1 (schema.lisp), so most stores never call this: the table is sized at
-open for the types actually in use (+TYPE-INDEX-INITIAL-TYPES+), not the id
-ceiling.  Doubles the capacity until TYPE-ID fits and extends the mmap in
+  "Grow IDX's table so TYPE-ID has a slot.  Type-ids come from the system-wide
+registry (schema.lisp's ASSIGN-TYPE-ID, #186), so a store's ids are SPARSE:
+the table is sized for the highest id it holds, not the count of its types,
+and never for the id ceiling.  Most stores still never call this -- the
+initial +TYPE-INDEX-INITIAL-TYPES+ slots cover a system with that many types.
+Doubles the capacity until TYPE-ID fits and extends the mmap in
 place via EXTEND-MAPPED-FILE (mmap.lisp) -- the same primitive
 GROW-MEMORY/ACQUIRE-OVERFLOW-BUCKET use for the heap and the linear hash, not
 the vector-segment's relocating grow: that one moves the mapping's base

--- a/type-registry.lisp
+++ b/type-registry.lisp
@@ -189,6 +189,28 @@ lock of its own: %REGISTRY-LOAD's table swap (not a lock here) is what
 keeps this safe to call from any thread at any time."
   (gethash symbol (%registry-table registry parent)))
 
+(defun registry-ids-table (registry parent)
+  "A fresh id -> symbol table for PARENT.  %REGISTRY-ADOPT's precondition is
+that no OTHER symbol already holds the id, and REGISTRY-ID-FOR only answers
+the other direction; building this once beats rescanning the entries per
+type."
+  (let ((table (make-hash-table :test 'eql)))
+    (dolist (entry (type-registry-entries registry) table)
+      (destructuring-bind (symbol entry-parent id) entry
+        (when (eq entry-parent parent)
+          (setf (gethash id table) symbol))))))
+
+(defun registry-highest-id (registry parent)
+  "The highest id REGISTRY has ever handed out under PARENT, or 0.
+
+Derived from the counter, not from a scan: %REGISTRY-ASSIGN only ever hands
+out the counter's value, so nothing at or below this can be minted later,
+and an id ABOVE it is still free for the taking.  That is what makes it the
+test for whether an id a store occupies is safe (GH #186)."
+  (1- (ecase parent
+        (:vertex (type-registry-next-vertex registry))
+        (:edge   (type-registry-next-edge registry)))))
+
 (defun registry-entries (registry)
   "Every (SYMBOL PARENT ID) in REGISTRY, oldest first."
   (type-registry-entries registry))

--- a/type-registry.lisp
+++ b/type-registry.lisp
@@ -146,6 +146,28 @@ append lock and has already re-checked SYMBOL is absent."
                  (list (list symbol parent id))))
     id))
 
+(defun %registry-adopt (registry symbol parent id)
+  "Record SYMBOL under PARENT at exactly ID, rather than at the next free
+one, and persist it.  This is how a populated store keeps ids it has already
+written into every node of that type -- see REGISTRY-SEED-FROM-STORES and
+spec §10.1.  Caller holds the append lock and has checked that SYMBOL is
+absent AND that no other symbol holds ID under PARENT; adopting over either
+would give one name two ids or one id two names, which is what #186 exists
+to prevent."
+  (%registry-append registry (list :symbol symbol :parent parent :id id))
+  (setf (gethash symbol (%registry-table registry parent)) id)
+  (setf (type-registry-entries registry)
+        (nconc (type-registry-entries registry)
+               (list (list symbol parent id))))
+  ;; Adopted ids are arbitrary, so the next fresh one must clear the highest
+  ;; adopted so far -- %REGISTRY-LOAD derives the counters the same way.
+  (ecase parent
+    (:vertex (setf (type-registry-next-vertex registry)
+                   (max (type-registry-next-vertex registry) (1+ id))))
+    (:edge (setf (type-registry-next-edge registry)
+                 (max (type-registry-next-edge registry) (1+ id)))))
+  id)
+
 (defun open-type-registry (location)
   "Open or create the type-id registry rooted at LOCATION.  Reads the
 current file once; REGISTRY-INTERN's own re-read under lock -- not this
@@ -171,25 +193,40 @@ keeps this safe to call from any thread at any time."
   "Every (SYMBOL PARENT ID) in REGISTRY, oldest first."
   (type-registry-entries registry))
 
+(defmacro with-registry-append-lock ((registry) &body body)
+  "Run BODY holding REGISTRY's exclusive flock, its in-memory state re-read
+from disk first so BODY decides against what is actually on it.  Signals
+TYPE-REGISTRY-BUSY when another image holds the lock.
+
+BODY may call %REGISTRY-ASSIGN and %REGISTRY-ADOPT; it may NOT call
+REGISTRY-INTERN.  flock is per open file description, so intern's own fd on
+the same file is refused by this one -- from this very process -- and the
+call signals TYPE-REGISTRY-BUSY against itself (GH #186)."
+  (let ((r (gensym "REGISTRY")) (file (gensym "FILE")) (fd (gensym "FD")))
+    `(let* ((,r ,registry))
+       (with-recursive-lock-held ((type-registry-lock ,r))
+         (let* ((,file (%registry-file (type-registry-location ,r)))
+                (,fd (%posix-open ,file (logior +o-creat+ +o-rdwr+))))
+           (unwind-protect
+                (progn
+                  (unless (%posix-flock ,fd (logior +lock-ex+ +lock-nb+))
+                    (error 'type-registry-busy
+                           :location (type-registry-location ,r)))
+                  ;; Re-read under the lock: another image may have appended
+                  ;; between our last load and our taking it.
+                  (%registry-load ,r)
+                  ,@body)
+             (%posix-close ,fd)))))))
+
 (defun registry-intern (registry symbol parent)
   "The id for SYMBOL under PARENT, assigning one if absent.  The read-decide-
 append runs under an exclusive flock: two images that both find SYMBOL absent
 would otherwise assign it different ids, or one id to two symbols (#186)."
   (with-recursive-lock-held ((type-registry-lock registry))
     (or (registry-id-for registry symbol parent)
-        (let* ((file (%registry-file (type-registry-location registry)))
-               (fd (%posix-open file (logior +o-creat+ +o-rdwr+))))
-          (unwind-protect
-               (progn
-                 (unless (%posix-flock fd (logior +lock-ex+ +lock-nb+))
-                   (error 'type-registry-busy
-                          :location (type-registry-location registry)))
-                 ;; Re-read under the lock: another image may have assigned
-                 ;; SYMBOL between our miss above and taking the lock.
-                 (%registry-load registry)
-                 (or (registry-id-for registry symbol parent)
-                     (%registry-assign registry symbol parent)))
-            (%posix-close fd))))))
+        (with-registry-append-lock (registry)
+          (or (registry-id-for registry symbol parent)
+              (%registry-assign registry symbol parent))))))
 
 (defvar *registry-open-lock* (make-lock "type registry open"))
 

--- a/type-registry.lisp
+++ b/type-registry.lisp
@@ -190,3 +190,21 @@ would otherwise assign it different ids, or one id to two symbols (#186)."
                  (or (registry-id-for registry symbol parent)
                      (%registry-assign registry symbol parent)))
             (%posix-close fd))))))
+
+(defvar *registry-open-lock* (make-lock "type registry open"))
+
+(defun ensure-type-registry ()
+  "The type registry for this image, opened from *SYSTEM-DIRECTORY* on first
+use and reopened whenever that changes (tests rebind it per store).  Signals
+SYSTEM-DIRECTORY-REQUIRED when it is NIL: assignment has nowhere authoritative
+to go, and a per-graph fallback would silently reintroduce the divergence #186
+removes."
+  (let ((dir *system-directory*))
+    (unless dir
+      (error 'system-directory-required :operation 'ensure-type-registry))
+    (with-lock-held (*registry-open-lock*)
+      (unless (and *type-registry*
+                   (equal (pathname (type-registry-location *type-registry*))
+                          (pathname dir)))
+        (setf *type-registry* (open-type-registry dir)))
+      *type-registry*)))

--- a/type-registry.lisp
+++ b/type-registry.lisp
@@ -1,0 +1,163 @@
+(in-package :graph-db)
+
+;;; The image-level type-id registry (GH #186).  Append-only; hosts read it,
+;;; none recompute it (D14).  Keyed on the PACKAGE-QUALIFIED symbol, so two
+;;; packages' same-named types never collide (cf. #190).
+;;;
+;;; Unlike the system clock (#182), the append lock here is taken fresh for
+;;; each REGISTRY-INTERN call and held only across its read-decide-append --
+;;; never for the registry's lifetime.  Opening a registry must not exclude
+;;; another image from opening one too; only a concurrent assignment needs
+;;; exclusion.
+
+(defstruct (type-registry (:constructor %make-type-registry))
+  (location nil)
+  ;; symbol -> id, per parent.  Rebuilt from the file at open and at every
+  ;; REGISTRY-INTERN re-read.
+  (vertex (make-hash-table :test 'eq))
+  (edge   (make-hash-table :test 'eq))
+  (next-vertex 1 :type (unsigned-byte 32))
+  (next-edge   1 :type (unsigned-byte 32))
+  ;; Oldest-first; rebuilt alongside the hash tables.
+  (entries nil :type list)
+  (lock (make-recursive-lock "type registry")))
+
+(define-condition type-registry-busy (error)
+  ((location :initarg :location :reader type-registry-busy-location))
+  (:report
+   (lambda (c s)
+     (format s "The type registry at ~A is held by another image's ~
+REGISTRY-INTERN.  Retry once the holder's assignment completes (GH #186)."
+             (type-registry-busy-location c)))))
+
+(defun %registry-file (location)
+  (make-pathname :name "type-registry" :type "log" :defaults location))
+
+(defun %registry-table (registry parent)
+  (ecase parent
+    (:vertex (type-registry-vertex registry))
+    (:edge   (type-registry-edge registry))))
+
+(defun %parse-registry-record (line)
+  "Read LINE as a (:SYMBOL :PARENT :ID) plist.  Signals on anything else --
+trailing garbage, an unbalanced form, or a missing/wrong-typed key.
+*READ-EVAL* is NIL: the file is data and must never execute."
+  (let ((*read-eval* nil))
+    (multiple-value-bind (form pos) (read-from-string line)
+      (unless (= pos (length line))
+        (error "trailing garbage in type registry record: ~S" line))
+      (destructuring-bind (&key symbol parent id) form
+        (unless (and (symbolp symbol)
+                     (member parent '(:vertex :edge))
+                     (integerp id))
+          (error "malformed type registry record: ~S" line))
+        (list symbol parent id)))))
+
+(defun %registry-load (registry)
+  "Rebuild REGISTRY's in-memory state from disk, oldest record first.
+Tolerates a truncated FINAL record (logs and stops); signals on a malformed
+record anywhere earlier -- GH #191 is the defect this must not repeat, since
+the registry is the only record of what a type-id means."
+  (with-recursive-lock-held ((type-registry-lock registry))
+    (clrhash (type-registry-vertex registry))
+    (clrhash (type-registry-edge registry))
+    (let ((file (%registry-file (type-registry-location registry)))
+          (max-vertex 0)
+          (max-edge 0)
+          (entries nil))
+      (when (probe-file file)
+        (with-open-file (s file :direction :input)
+          (loop
+            (multiple-value-bind (line missing-newline-p)
+                (read-line s nil :eof)
+              (when (eq line :eof) (return))
+              (let ((parsed
+                      (handler-case (%parse-registry-record line)
+                        (error (e)
+                          (if missing-newline-p
+                              (progn
+                                (log:warn "type registry: dropping torn ~
+final record in ~A: ~A" file e)
+                                (return))
+                              (error "malformed type registry record in ~
+~A: ~A" file e))))))
+                (destructuring-bind (symbol parent id) parsed
+                  (setf (gethash symbol (%registry-table registry parent))
+                        id)
+                  (push (list symbol parent id) entries)
+                  (ecase parent
+                    (:vertex (setf max-vertex (max max-vertex id)))
+                    (:edge   (setf max-edge (max max-edge id))))))))))
+      (setf (type-registry-entries registry) (nreverse entries))
+      (setf (type-registry-next-vertex registry) (1+ max-vertex))
+      (setf (type-registry-next-edge registry) (1+ max-edge))))
+  registry)
+
+(defun %registry-append (registry record)
+  "Append RECORD (a plist) as one `~S' line and flush.  Caller holds the
+append lock."
+  (let ((file (%registry-file (type-registry-location registry))))
+    (with-open-file (s file :direction :output
+                            :if-exists :append
+                            :if-does-not-exist :create)
+      (let ((*print-readably* nil) (*print-pretty* nil))
+        (format s "~S~%" record))
+      (finish-output s))))
+
+(defun %registry-assign (registry symbol parent)
+  "Assign SYMBOL a fresh id under PARENT and persist it.  Caller holds the
+append lock and has already re-checked SYMBOL is absent."
+  (let ((id (ecase parent
+              (:vertex (prog1 (type-registry-next-vertex registry)
+                         (incf (type-registry-next-vertex registry))))
+              (:edge (prog1 (type-registry-next-edge registry)
+                       (incf (type-registry-next-edge registry)))))))
+    (%registry-append registry (list :symbol symbol :parent parent :id id))
+    (setf (gethash symbol (%registry-table registry parent)) id)
+    (setf (type-registry-entries registry)
+          (nconc (type-registry-entries registry)
+                 (list (list symbol parent id))))
+    id))
+
+(defun open-type-registry (location)
+  "Open or create the type-id registry rooted at LOCATION.  Reads the
+current file once; REGISTRY-INTERN's own re-read under lock -- not this
+call -- is what makes concurrent assignment safe."
+  (ensure-directories-exist location)
+  (let ((registry (%make-type-registry :location location)))
+    (%registry-load registry)
+    registry))
+
+(defun close-type-registry (registry)
+  "No persistent state to release: the append lock is per-call, not held
+for the registry's lifetime (contrast the system clock, #182)."
+  registry)
+
+(defun registry-id-for (registry symbol parent)
+  "The id for SYMBOL under PARENT, or NIL.  A pure read of in-memory
+state -- never touches disk or the append lock."
+  (gethash symbol (%registry-table registry parent)))
+
+(defun registry-entries (registry)
+  "Every (SYMBOL PARENT ID) in REGISTRY, oldest first."
+  (type-registry-entries registry))
+
+(defun registry-intern (registry symbol parent)
+  "The id for SYMBOL under PARENT, assigning one if absent.  The read-decide-
+append runs under an exclusive flock: two images that both find SYMBOL absent
+would otherwise assign it different ids, or one id to two symbols (#186)."
+  (with-recursive-lock-held ((type-registry-lock registry))
+    (or (registry-id-for registry symbol parent)
+        (let* ((file (%registry-file (type-registry-location registry)))
+               (fd (%posix-open file (logior +o-creat+ +o-rdwr+))))
+          (unwind-protect
+               (progn
+                 (unless (%posix-flock fd (logior +lock-ex+ +lock-nb+))
+                   (error 'type-registry-busy
+                          :location (type-registry-location registry)))
+                 ;; Re-read under the lock: another image may have assigned
+                 ;; SYMBOL between our miss above and taking the lock.
+                 (%registry-load registry)
+                 (or (registry-id-for registry symbol parent)
+                     (%registry-assign registry symbol parent)))
+            (%posix-close fd))))))

--- a/type-registry.lisp
+++ b/type-registry.lisp
@@ -38,11 +38,24 @@ REGISTRY-INTERN.  Retry once the holder's assignment completes (GH #186)."
     (:vertex (type-registry-vertex registry))
     (:edge   (type-registry-edge registry))))
 
+;; Printing/reading always happens with *PACKAGE* bound to KEYWORD -- a
+;; package nothing is ever accessible in -- so every non-keyword symbol
+;; prints fully package-qualified regardless of what package happens to be
+;; ambient at the call site.  Without this, CL's printer omits the package
+;; prefix whenever the symbol is accessible in the CURRENT *package*, which
+;; is the ordinary case for a caller registering its own type: the record
+;; would round-trip correctly only by accident of which package is current
+;; at read time.  That is the same defect #190 records for the per-graph
+;; keyword alias, just one level up.  Round-trip review, GH #186 task 1.
+(defun %registry-print-package ()
+  (load-time-value (find-package "KEYWORD")))
+
 (defun %parse-registry-record (line)
   "Read LINE as a (:SYMBOL :PARENT :ID) plist.  Signals on anything else --
 trailing garbage, an unbalanced form, or a missing/wrong-typed key.
 *READ-EVAL* is NIL: the file is data and must never execute."
-  (let ((*read-eval* nil))
+  (let ((*read-eval* nil)
+        (*package* (%registry-print-package)))
     (multiple-value-bind (form pos) (read-from-string line)
       (unless (= pos (length line))
         (error "trailing garbage in type registry record: ~S" line))
@@ -57,40 +70,52 @@ trailing garbage, an unbalanced form, or a missing/wrong-typed key.
   "Rebuild REGISTRY's in-memory state from disk, oldest record first.
 Tolerates a truncated FINAL record (logs and stops); signals on a malformed
 record anywhere earlier -- GH #191 is the defect this must not repeat, since
-the registry is the only record of what a type-id means."
+the registry is the only record of what a type-id means.
+
+Builds fresh hash tables and swaps them into REGISTRY only once fully
+populated, rather than CLRHASH-ing the live ones in place: a concurrent
+REGISTRY-ID-FOR (deliberately lock-free -- see its docstring) must always
+see either the old, complete table or the new one, never a window where
+both are empty and every symbol reads back a spurious NIL."
   (with-recursive-lock-held ((type-registry-lock registry))
-    (clrhash (type-registry-vertex registry))
-    (clrhash (type-registry-edge registry))
     (let ((file (%registry-file (type-registry-location registry)))
+          (vertex (make-hash-table :test 'eq))
+          (edge   (make-hash-table :test 'eq))
           (max-vertex 0)
           (max-edge 0)
           (entries nil))
-      (when (probe-file file)
-        (with-open-file (s file :direction :input)
-          (loop
-            (multiple-value-bind (line missing-newline-p)
-                (read-line s nil :eof)
-              (when (eq line :eof) (return))
-              (let ((parsed
-                      (handler-case (%parse-registry-record line)
-                        (error (e)
-                          (if missing-newline-p
-                              (progn
-                                (log:warn "type registry: dropping torn ~
+      (flet ((table-for (parent)
+               (ecase parent
+                 (:vertex vertex)
+                 (:edge   edge))))
+        (when (probe-file file)
+          (with-open-file (s file :direction :input)
+            (loop
+              (multiple-value-bind (line missing-newline-p)
+                  (read-line s nil :eof)
+                (when (eq line :eof) (return))
+                (let ((parsed
+                        (handler-case (%parse-registry-record line)
+                          (error (e)
+                            (if missing-newline-p
+                                (progn
+                                  (log:warn "type registry: dropping torn ~
 final record in ~A: ~A" file e)
-                                (return))
-                              (error "malformed type registry record in ~
+                                  (return))
+                                (error "malformed type registry record in ~
 ~A: ~A" file e))))))
-                (destructuring-bind (symbol parent id) parsed
-                  (setf (gethash symbol (%registry-table registry parent))
-                        id)
-                  (push (list symbol parent id) entries)
-                  (ecase parent
-                    (:vertex (setf max-vertex (max max-vertex id)))
-                    (:edge   (setf max-edge (max max-edge id))))))))))
+                  (destructuring-bind (symbol parent id) parsed
+                    (setf (gethash symbol (table-for parent)) id)
+                    (push (list symbol parent id) entries)
+                    (ecase parent
+                      (:vertex (setf max-vertex (max max-vertex id)))
+                      (:edge   (setf max-edge (max max-edge id)))))))))))
       (setf (type-registry-entries registry) (nreverse entries))
       (setf (type-registry-next-vertex registry) (1+ max-vertex))
-      (setf (type-registry-next-edge registry) (1+ max-edge))))
+      (setf (type-registry-next-edge registry) (1+ max-edge))
+      ;; The swap: readers see VERTEX/EDGE either fully old or fully new.
+      (setf (type-registry-vertex registry) vertex)
+      (setf (type-registry-edge registry) edge)))
   registry)
 
 (defun %registry-append (registry record)
@@ -100,7 +125,9 @@ append lock."
     (with-open-file (s file :direction :output
                             :if-exists :append
                             :if-does-not-exist :create)
-      (let ((*print-readably* nil) (*print-pretty* nil))
+      (let ((*print-readably* nil)
+            (*print-pretty* nil)
+            (*package* (%registry-print-package)))
         (format s "~S~%" record))
       (finish-output s))))
 
@@ -135,7 +162,9 @@ for the registry's lifetime (contrast the system clock, #182)."
 
 (defun registry-id-for (registry symbol parent)
   "The id for SYMBOL under PARENT, or NIL.  A pure read of in-memory
-state -- never touches disk or the append lock."
+state -- never touches disk or the append lock, and deliberately takes no
+lock of its own: %REGISTRY-LOAD's table swap (not a lock here) is what
+keeps this safe to call from any thread at any time."
   (gethash symbol (%registry-table registry parent)))
 
 (defun registry-entries (registry)

--- a/type-seeding.lisp
+++ b/type-seeding.lisp
@@ -169,6 +169,34 @@ distributed to peers."
                          (mapcar #'car sizes)))
     report))
 
+(defun %symbol-home-package-name (symbol)
+  "SYMBOL's home package name, or \"\" when it is uninterned.  Uninterned
+symbols cannot round-trip through the registry file anyway (GH #186 task 1),
+so they only have to sort somewhere stable."
+  (let ((package (symbol-package symbol)))
+    (if package (package-name package) "")))
+
+(defun %registry-mint-order (table)
+  "TABLE's symbol keys ordered by package name, then symbol name.
+
+MAPHASH order is unspecified and a fresh registry mints ids in the order it
+is asked, so without this two images renumbering ONE store into two EMPTY
+registries assign different ids -- which the replication handshake then
+refuses (D15).  A sort is nearly free and a migration that is not
+reproducible cannot be verified by re-running it.
+
+This buys reproducibility of a SINGLE migration.  It is NOT a substitute for
+distributing the registry (D14): two images that opened different stores, or
+the same stores in a different order, still disagree, and that disagreement
+is the operator event D15 exists to name.  GH #186."
+  (sort (loop for name being the hash-keys in table collect name)
+        (lambda (a b)
+          (let ((pa (%symbol-home-package-name a))
+                (pb (%symbol-home-package-name b)))
+            (if (string= pa pb)
+                (and (string< (symbol-name a) (symbol-name b)) t)
+                (and (string< pa pb) t))))))
+
 (defun renumber-schema (schema registry)
   "Replace every type-id in SCHEMA with the one REGISTRY holds for that
 type's NAME, minting where it holds none.  Returns (values SCHEMA UNIFIED).
@@ -196,18 +224,20 @@ from the source store, which is closed by then and does not own it."
                      (setf (gethash name survivors) meta)))))
              sub)
             (clrhash sub)
-            (maphash
-             (lambda (name meta)
-               (let ((new (registry-intern registry name parent))
-                     (ids (sort (gethash name old-ids) #'<)))
-                 (when (rest ids)
-                   (push (list name parent ids new) unified))
-                 (setf (node-type-id meta) new)
-                 (setf (gethash new sub) meta)
-                 (setf (gethash name sub) new)
-                 ;; The keyword alias UPDATE-NODE-TYPE also writes; it is
-                 ;; package-blind, which is #190, not this task's to fix.
-                 (setf (gethash (intern (symbol-name name) :keyword) sub)
-                       new)))
-             survivors)))))
+            ;; %REGISTRY-MINT-ORDER, not MAPHASH: minting order decides the
+            ;; ids a fresh registry hands out, and it must not vary between
+            ;; images.  See that function (GH #186).
+            (dolist (name (%registry-mint-order survivors))
+              (let ((meta (gethash name survivors))
+                    (new (registry-intern registry name parent))
+                    (ids (sort (gethash name old-ids) #'<)))
+                (when (rest ids)
+                  (push (list name parent ids new) unified))
+                (setf (node-type-id meta) new)
+                (setf (gethash new sub) meta)
+                (setf (gethash name sub) new)
+                ;; The keyword alias UPDATE-NODE-TYPE also writes; it is
+                ;; package-blind, which is #190, not this task's to fix.
+                (setf (gethash (intern (symbol-name name) :keyword) sub)
+                      new)))))))
     (values schema (nreverse unified))))

--- a/type-seeding.lisp
+++ b/type-seeding.lisp
@@ -124,7 +124,16 @@ distributed to peers."
                                 (let ((l (%seeding-location location)))
                                   (cons l (%store-heap-bytes l))))
                               locations)
-                      #'> :key #'cdr))
+                      ;; Ties broken on the location, because SORT is not
+                      ;; required to be stable and equal high-water marks are
+                      ;; ordinary (fresh or empty stores).  Two images ranking
+                      ;; one store set differently would seed two different
+                      ;; registries -- the hole %REGISTRY-MINT-ORDER closes a
+                      ;; level up (GH #186).
+                      (lambda (a b)
+                        (if (= (cdr a) (cdr b))
+                            (and (string< (car a) (car b)) t)
+                            (> (cdr a) (cdr b))))))
          (report (make-seeding-report :sizes sizes
                                       :seed (car (first sizes)))))
     (with-registry-append-lock (registry)

--- a/type-seeding.lisp
+++ b/type-seeding.lisp
@@ -1,0 +1,213 @@
+(in-package :graph-db)
+
+;;; Adopting global type-ids on a system that already has stores (GH #186).
+;;; The policy here is derived from the measurement in spec §10.1
+;;; (docs/superpowers/specs/2026-08-20-namespaces-design.md), not invented:
+;;; every store's schema counted from 1, so the low ids are contested
+;;; system-wide and all but one store must be renumbered whichever one is
+;;; favoured.  The cost of favouring wrongly is measured in BYTES REPLAYED,
+;;; so the ranking is by store size and never by type count.
+;;;
+;;; This file loads after SCHEMA and ALLOCATOR because it reads a store's
+;;; schema.dat and heap header directly; TYPE-REGISTRY cannot hold it, since
+;;; SCHEMA depends on TYPE-REGISTRY for ASSIGN-TYPE-ID.
+
+(defstruct (seeding-report (:conc-name seeding-report-))
+  "What REGISTRY-SEED-FROM-STORES did, and what the operator must do next."
+  ;; The store whose ids were offered first -- the largest on disk.
+  (seed nil)
+  ;; ((location . bytes) ...), largest first.
+  (sizes nil)
+  ;; Locations that must now be MIGRATE-GRAPHed with :RENUMBER-P T.
+  (renumber nil)
+  ;; (location symbol parent id ...) for a symbol one store's history left
+  ;; holding more than one id.
+  (duplicates nil)
+  ;; (location symbol parent old-id new-id) for every id that moved.
+  (changes nil))
+
+(defun %store-heap-bytes (location)
+  "Bytes the store at LOCATION has handed out of its heap: the allocation
+high-water mark from heap.dat's header, read without opening the graph.
+
+Deliberately not the file's length.  heap.dat is created at
+*DEFAULT-HEAP-SIZE* and is sparse, so its length is the same number whether
+the store holds ten nodes or ten million -- useless for the one thing §10.1
+needs a size for, which is deciding which store is too expensive to rewrite."
+  (let ((mf (mmap-file (format nil "~A/heap.dat" (pathname location))
+                       :create-p nil)))
+    (unwind-protect
+         (max 0 (- (deserialize-uint64 mf +memory-memory-pointer-offset+)
+                   +memory-usable-offset+))
+      (munmap-file mf))))
+
+(defun %store-schema (location)
+  "The persisted SCHEMA of the store at LOCATION, restored without opening
+the graph.  Every type name's package must exist in this image -- the same
+requirement reading the registry itself carries (GH #195)."
+  (let ((file (format nil "~A/schema.dat" (pathname location))))
+    (unless (probe-file file)
+      (error "No schema.dat at ~A: not a graph location." location))
+    (cl-store:restore file)))
+
+(defun %store-type-entries (schema)
+  "(values ENTRIES DUPLICATES) for SCHEMA, read from its type-table.
+
+ENTRIES is (SYMBOL PARENT ID) ascending by id, where ID is the one the
+store's own name lookup resolves to today.  DUPLICATES is (SYMBOL PARENT
+ID ...) for a symbol the store's history left holding more than one id --
+§10.1's case that no seeding policy exempts, since those ids must unify
+whichever store wins."
+  (let ((entries nil) (duplicates nil))
+    (dolist (parent '(:vertex :edge))
+      (let ((sub (gethash parent (schema-type-table schema)))
+            (by-name (make-hash-table :test 'eq)))
+        (when sub
+          ;; Integer keys map to the metadata; the symbol and keyword keys
+          ;; are aliases onto the current id (see UPDATE-NODE-TYPE).
+          (maphash (lambda (key meta)
+                     (when (and (integerp key) (node-type-p meta))
+                       (push key (gethash (node-type-name meta) by-name))))
+                   sub)
+          (maphash (lambda (name ids)
+                     (let* ((sorted (sort (copy-list ids) #'<))
+                            (named (gethash name sub))
+                            (current (if (integerp named)
+                                         named
+                                         (car (last sorted)))))
+                       (push (list name parent current) entries)
+                       (when (rest sorted)
+                         (push (list* name parent sorted) duplicates))))
+                   by-name))))
+    (values (sort entries #'< :key #'third) (nreverse duplicates))))
+
+(defun %registry-claimed-ids (registry)
+  "(values VERTEX EDGE): ID -> SYMBOL tables built from REGISTRY's entries.
+Adoption needs the reverse of REGISTRY-ID-FOR -- an id that already means
+another symbol cannot be adopted, however large the store asking for it."
+  (let ((vertex (make-hash-table))
+        (edge (make-hash-table)))
+    (dolist (entry (registry-entries registry) (values vertex edge))
+      (destructuring-bind (symbol parent id) entry
+        (setf (gethash id (ecase parent (:vertex vertex) (:edge edge)))
+              symbol)))))
+
+(defun %seeding-location (location)
+  "LOCATION as a namestring that compares with EQUAL.  Signals if it does
+not exist, which is the right moment to find that out."
+  (namestring (truename (merge-pathnames "" location))))
+
+(defun registry-seed-from-stores (registry locations)
+  "Seed REGISTRY from the stores at LOCATIONS and report which of them must
+now be renumbered.  Opens no graph: each store is read from its schema.dat
+and its heap header.  Returns a SEEDING-REPORT.
+
+Stores are offered their ids LARGEST FIRST, and each keeps every id it can:
+a symbol REGISTRY has not seen, at an id no other symbol has claimed, is
+adopted verbatim.  So the store that costs most to rewrite wins every
+contest.  That is the whole of spec §10.1's policy -- all but one store
+renumbers whichever is favoured, so favour the one measured in bytes, not
+the one with the most types (on the measured system the type-richest store
+held 59 of 95 types and was among the smallest; seeding from it would have
+replayed ~4.9 GB instead of ~1.1 GB).
+
+A store lands in the report's RENUMBER list when any of its symbols ends up
+at an id other than the one on its disk, or when its own history holds two
+ids for one symbol.  Migrate each of those with
+  (MIGRATE-GRAPH name location new-location :RENUMBER-P T)
+and leave the rest alone.
+
+REGISTRY need not be empty.  Entries already in it win over every store,
+including the largest -- it is the authority, and it may already have been
+distributed to peers."
+  (let* ((sizes (sort (mapcar (lambda (location)
+                                (let ((l (%seeding-location location)))
+                                  (cons l (%store-heap-bytes l))))
+                              locations)
+                      #'> :key #'cdr))
+         (report (make-seeding-report :sizes sizes
+                                      :seed (car (first sizes)))))
+    (with-registry-append-lock (registry)
+      (multiple-value-bind (vertex-claims edge-claims)
+          (%registry-claimed-ids registry)
+        (loop for (location . nil) in sizes do
+          (multiple-value-bind (entries duplicates)
+              (%store-type-entries (%store-schema location))
+            (dolist (duplicate duplicates)
+              (push (cons location duplicate)
+                    (seeding-report-duplicates report))
+              (pushnew location (seeding-report-renumber report)
+                       :test #'equal))
+            (dolist (entry entries)
+              (destructuring-bind (symbol parent id) entry
+                (let* ((claims (ecase parent
+                                 (:vertex vertex-claims)
+                                 (:edge edge-claims)))
+                       (known (registry-id-for registry symbol parent))
+                       (new (cond
+                              (known known)
+                              ;; The id means another symbol already: this
+                              ;; store cannot keep it and must renumber.
+                              ((gethash id claims)
+                               (%registry-assign registry symbol parent))
+                              (t (%registry-adopt registry symbol parent
+                                                  id)))))
+                  (setf (gethash new claims) symbol)
+                  (unless (eql new id)
+                    (push (list location symbol parent id new)
+                          (seeding-report-changes report))
+                    (pushnew location (seeding-report-renumber report)
+                             :test #'equal)))))))))
+    (setf (seeding-report-changes report)
+          (nreverse (seeding-report-changes report)))
+    (setf (seeding-report-duplicates report)
+          (nreverse (seeding-report-duplicates report)))
+    (setf (seeding-report-renumber report)
+          (remove-if-not (lambda (l)
+                           (member l (seeding-report-renumber report)
+                                   :test #'equal))
+                         (mapcar #'car sizes)))
+    report))
+
+(defun renumber-schema (schema registry)
+  "Replace every type-id in SCHEMA with the one REGISTRY holds for that
+type's NAME, minting where it holds none.  Returns (values SCHEMA UNIFIED).
+
+UNIFIED is (SYMBOL PARENT (OLD-ID ...) NEW-ID) for each symbol the store's
+history left at more than one id.  Those collapse to one id here, which is
+why §10.1 says such a store is always in the migration set; the surviving
+metadata is the one the store's own name lookup resolved to.
+
+SCHEMA is mutated in place.  MIGRATE-GRAPH passes the schema it restored
+from the source store, which is closed by then and does not own it."
+  (let ((unified nil))
+    (dolist (parent '(:vertex :edge))
+      (let ((sub (gethash parent (schema-type-table schema))))
+        (when sub
+          (let ((survivors (make-hash-table :test 'eq))
+                (old-ids (make-hash-table :test 'eq)))
+            (maphash
+             (lambda (key meta)
+               (when (and (integerp key) (node-type-p meta))
+                 (let ((name (node-type-name meta)))
+                   (push key (gethash name old-ids))
+                   (when (or (null (gethash name survivors))
+                             (eql key (gethash name sub)))
+                     (setf (gethash name survivors) meta)))))
+             sub)
+            (clrhash sub)
+            (maphash
+             (lambda (name meta)
+               (let ((new (registry-intern registry name parent))
+                     (ids (sort (gethash name old-ids) #'<)))
+                 (when (rest ids)
+                   (push (list name parent ids new) unified))
+                 (setf (node-type-id meta) new)
+                 (setf (gethash new sub) meta)
+                 (setf (gethash name sub) new)
+                 ;; The keyword alias UPDATE-NODE-TYPE also writes; it is
+                 ;; package-blind, which is #190, not this task's to fix.
+                 (setf (gethash (intern (symbol-name name) :keyword) sub)
+                       new)))
+             survivors)))))
+    (values schema (nreverse unified))))


### PR DESCRIPTION
Namespaces **unit 1b**. `type-id` was **per-graph**: every store's schema counted from 1, so
one id named different classes in different stores and the same class held different ids.
This makes a type-id mean the same thing across a system, keyed on the **package-qualified
symbol**.

Closes #186. Unblocks #167 (with #190, #196, #201).

Spec: `docs/superpowers/specs/2026-08-20-namespaces-design.md` §3.4 (D14, D15), §10.1.

## What lands

**A persisted, image-level registry** (`type-registry.lisp`) in the system directory,
append-only, keyed on package-qualified symbol. Its own `flock`, held only across
read-decide-append — deliberately **not** #182's lifetime clock lock, which with a mandatory
directory would have meant one image per system for *any* graph.

**Assignment moves onto it** (`schema.lisp`). The **system directory is now mandatory** —
`*system-clock*` stays optional, its directory does not. `%check-node-class-graph-unique` is
deleted, which is what permits a class in more than one store (D4, closing cl-llm#20).

**Existing systems adopt it** (`type-seeding.lisp`, `backup.lisp`).
`registry-seed-from-stores` plus `:renumber-p` on `migrate-graph`. Seeding favours the store
**largest on disk** — see the measurement below.

**The registry travels** (`peer-streaming.lisp`). The frozen type-table wire carries the
image registry, and a handshake **refuses** a peer whose registry disagrees, naming the
symbols (D15). Refusal, not reconciliation: reconciling would mean a data migration
triggered by a network handshake.

## The migration, measured rather than assumed

§10.1 was missing entirely — the unit described the steady state and never said how a
populated system reaches it. Measured on a real five-store system, read from `schema.dat`
with no store opened:

| | symbols | distinct ids | ids claimed by >1 symbol |
|---|---:|---:|---:|
| vertex | 66 | 36 | 11 |
| edge | 29 | 23 | 3 |

Five different classes on id 1. Near-total collision at the low end, exactly what "every
schema counts from 1" produces.

**Cost is bounded by bytes, not type count.** All but one store renumbers whichever is
favoured, so seeding ranks by heap high-water. On the measured system, ranking by type count
would have picked a store holding 59 of 95 types that was among the *smallest*, forcing a
rewrite of the largest — ~4.9 GB of replay instead of ~1.1 GB.

## Reconcile at open — the invariant the unit rests on

**The whole-branch review found silent data corruption on the ordinary upgrade path**, after
all four task reviews had passed. Nothing established that a store's persisted ids agree
with the registry. A single-store deployment that upgraded, set a fresh system directory as
documented, and later added one type would mint an id already in use — silently
reinterpreting every persisted node of the clobbered type. No multi-store estate required.

`open-graph` now **reconciles**: adopt the store's id when the registry has never seen the
symbol and nothing else holds that id; refuse otherwise, naming the type, both ids and the
remedy. Adopting *learns* an id, it does not *derive* one, so D14 stands.

A refused store stays readable through the new **`with-schema-frozen`** — but not
servable: `check-replicable` refuses to start replication for a frozen graph on the peer,
master **and** slave paths, since all three put raw type-ids on the wire.

**Behavioural change:** a store in the renumber set is no longer openable for use. Intended,
documented in the manual, CHANGELOG and the refusal message.

## The fixed-width audit

§3.4 required asking the question that produced #187 — not "what scales with
`+max-node-types+`?" but **"where else is a type-id serialised at a fixed width?"** Fifteen
sites enumerated. It found one: the **peer type table's `id` field is contract-bounded to 16
bits, and the parser enforced it while the encoder did not.** Encoder refusal added here;
widening the frozen field is #199.

## Testing

Full suite **3982 checks, 3972 pass, 10 skip, 0 fail**. Every task's delta reconciled
exactly against the previous.

Written test-first throughout, with **twelve ablations**. The one that matters: the
corruption test fails 5/5 against the pre-fix tree, and ablating
`reconcile-schema-with-registry` takes the suite 17/17 → 9 pass / 8 fail.

Also closed: eight out-of-process harness groups that had silently stopped running (none
were in the check count), and a real loopback `peer-sync` test — previously the only
end-to-end coverage of that call site was those dead harnesses.

## Known follow-ups, all filed

**#202** the §10.1 tolerance rests on a guarantee that is not true — `%registry-adopt` hands
out arbitrary ids, so a later adopt can land on an orphaned one. Strictly better than before
this branch, but the comment now says policy, not proof. **#199** 16-bit wire field.
**#200** empty `supers` ambiguity. **#201** the downcase-collision refusal now forbids §3.1's
own motivating example — **gates #167**. **#194** GC enumeration coverage. **#195** an
unloaded package makes `make-graph` fail. **#190**, **#196**, **#197**, **#198**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o9cANB4ycNnbr4zjduxyA
