### PR TITLE
Warn when one class diverges across stores (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- Defining one class name in two stores with *different* slot sets now
+  signals `divergent-node-type-redefinition` (a `style-warning`): both
+  definitions name one CLOS class, so the last one loaded determines the
+  slots and the earlier store's data becomes unreachable through the API
+  (the GH #53 failure). Identical slot sets — the multi-store feature —
+  stay silent. (#196)
+
 - **A store's persisted type-ids are reconciled with the registry at open,
   or the open is refused** (#186). This is the invariant the rest of the unit
   assumed and nothing established. `instantiate-node-type` keeps a persisted

--- a/docs/superpowers/plans/2026-08-22-divergent-slots-196.md
+++ b/docs/superpowers/plans/2026-08-22-divergent-slots-196.md
@@ -1,0 +1,311 @@
+# Divergent Slot-Set Warning (#196) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Defining one class name in two stores with *different* slot sets
+warns (a `style-warning` naming both stores and the consequence); identical
+slot sets — the feature — stay silent.
+
+**Architecture:** A new condition `divergent-node-type-redefinition`
+(subtype of `style-warning`) and a helper `%warn-if-divergent-across-stores`
+that scans `*schema-node-metadata*` for the same class symbol registered
+under a different graph-name with a non-`equal` slot list. `def-node-type`
+calls the helper when its meta is built. Metadata-level only — no graph
+need be open, no error, no behavior change.
+
+**Tech Stack:** Common Lisp (SBCL primary; nothing impl-conditional),
+FiveAM.
+
+**Spec:** GH #196 (authoritative statement: warning not error; the design
+deliberately permits the redefinition), namespaces design
+`docs/superpowers/specs/2026-08-20-namespaces-design.md` §3.3, and GH #53
+(the historical failure this re-guards: second definition silently
+replaced the first class's slots, leaving stored data unreachable through
+the API).
+
+## Global Constraints
+
+- Lisp: spaces only, never tabs; hard 80-column limit (a 96-column line is
+  a defect).
+- Comments terse: invariant + `(GH #196)`; history in the issue.
+- SBCL suites need `--dynamic-space-size 16384`.
+- Quicklisp resolves `:graph-db` to the MAIN checkout: every SBCL run in
+  the worktree must first
+  `--eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))'`.
+- Suite counts are TOTAL CHECKS. Baseline on `experiment` (post-#204
+  merge, b019679): 3997 checks / 3987 pass / 10 skip / 0 fail. This plan
+  adds 3 checks → 4000 / 3990 / 10 / 0. Any other delta must be accounted
+  check by check.
+- Ablate every guard (nearest wrong implementations are named per test).
+- ECL demoted: verify on SBCL only, say so.
+- Host safety: live `ma-dev-server` on this host — NEVER
+  `pkill`/`killall`/`pgrep` on sbcl or paths; kill only a PID you started;
+  one SBCL at a time; never touch `/data0`. Never end a turn to "wait" on
+  a background run — bounded foreground stretches
+  (`timeout 570 bash -c 'while kill -0 <PID> 2>/dev/null; do sleep 15; done'`).
+- Worktree `.worktrees/196-divergent-slots`, branch `196-divergent-slots`
+  off `experiment` (b019679). PR against `experiment`. Pushing is
+  explicit-only.
+
+---
+
+### Task 1: Condition, helper, def-node-type hook, tests
+
+**Files:**
+- Modify: `schema.lisp` (new condition + helper directly above
+  `def-node-type` ~line 296; one call inside the macro's expansion; the
+  stale "No cross-graph uniqueness check" comment at ~line 328 gains a
+  pointer)
+- Modify: `package.lisp` (export the condition name, next to
+  `#:ambiguous-node-type-name` ~line 179)
+- Modify: `tests/global-type-id-tests.lisp` (three tests appended — this
+  file owns the multi-store area and already holds
+  `a-class-may-be-instantiated-in-more-than-one-store`)
+
+**Interfaces:**
+- Produces: condition `divergent-node-type-redefinition` (subtype of
+  `style-warning`; exported) with readers `divergent-type-name`,
+  `divergent-type-graph-name`, `divergent-type-other-graphs`; helper
+  `%warn-if-divergent-across-stores (meta)`. Task 2 documents these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/global-type-id-tests.lisp`:
+
+```lisp
+;;; ---------------------------------------------------------------------------
+;;; Divergent slot sets across stores warn; identical ones stay silent
+;;; (GH #196, re-guarding GH #53's failure mode after
+;;; %CHECK-NODE-CLASS-GRAPH-UNIQUE was correctly deleted by #186).
+;;;
+;;; The DEF-VERTEX forms are EVAL'd inside the tests, not written at
+;;; toplevel: the divergent pair would otherwise warn at load time of
+;;; this file, polluting every suite run's output.  No graph is opened
+;;; and no system directory is needed -- the check is metadata-level.
+;;; ---------------------------------------------------------------------------
+
+(test divergent-slot-sets-across-stores-warn
+  "Same class symbol, two stores, DIFFERENT slots: the second definition
+must signal.  Nearest wrong implementation: never warn (the guard
+deleted by #186 with nothing in its place)."
+  (eval '(def-vertex gdiv-probe () ((div-a :type string)) :gdiv-store-a))
+  (signals graph-db:divergent-node-type-redefinition
+    (eval '(def-vertex gdiv-probe () ((div-b :type string))
+             :gdiv-store-b))))
+
+(test identical-slot-sets-across-stores-stay-silent
+  "Same class symbol, two stores, SAME slots: the feature, and it must
+stay silent.  Nearest wrong implementation: warn on any cross-store
+redefinition regardless of the slots."
+  (eval '(def-vertex gdiv-same () ((div-c :type string)) :gdiv-store-c))
+  (is-true
+   (handler-case
+       (progn (eval '(def-vertex gdiv-same () ((div-c :type string))
+                       :gdiv-store-d))
+              t)
+     (graph-db:divergent-node-type-redefinition () nil))))
+
+(test divergence-warning-is-a-style-warning
+  "STYLE-WARNING, not a bare WARNING: the design deliberately permits the
+redefinition (GH #196), so it must be muffleable by severity class."
+  (is (subtypep 'graph-db:divergent-node-type-redefinition
+                'style-warning)))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+From the worktree:
+
+```
+sbcl --dynamic-space-size 16384 --non-interactive \
+  --eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))' \
+  --eval '(ql:quickload :graph-db)' \
+  --eval '(asdf:load-system :graph-db/test)' \
+  --eval '(fiveam:run! (quote graph-db/test::global-type-id-suite))'
+```
+
+Expected: the test file cannot reference `graph-db:divergent-node-type-
+redefinition` until the condition+export exist — as in #190, it is
+acceptable to land the condition + export first (the first hunk of
+Step 3), then run and observe the three tests fail BEHAVIORALLY:
+`divergent-slot-sets-across-stores-warn` fails (nothing signals),
+`identical-...-stay-silent` passes vacuously (pin), `...-is-a-style-warning`
+passes once the condition exists (pin). The signaling test is the RED.
+
+- [ ] **Step 3: Implement**
+
+In `schema.lisp`, directly above `def-node-type` (after
+`lookup-node-type-by-id`/`update-node-type` region, ~line 296), add:
+
+```lisp
+(define-condition divergent-node-type-redefinition (style-warning)
+  ((name :initarg :name :reader divergent-type-name)
+   (graph-name :initarg :graph-name :reader divergent-type-graph-name)
+   (other-graphs :initarg :other-graphs
+                 :reader divergent-type-other-graphs))
+  (:report
+   (lambda (c s)
+     (format s "Node type ~S is being defined for ~S with a slot set ~
+that differs from its definition for ~{~S~^, ~}.  All of these name ONE ~
+CLOS class, so the last definition loaded determines the slots; data ~
+stored under the other slot set stays on disk but becomes unreachable ~
+through the API (GH #196, GH #53).  Keep the slot sets identical, or ~
+use different type names."
+             (divergent-type-name c)
+             (divergent-type-graph-name c)
+             (divergent-type-other-graphs c)))))
+
+(defun %warn-if-divergent-across-stores (meta)
+  "STYLE-WARNING when META's class symbol is already registered under a
+DIFFERENT graph-name with a non-EQUAL slot list.  Identical slots are the
+multi-store feature and stay silent; a same-store redefinition is schema
+evolution and is not this guard's business (GH #196)."
+  (let ((divergent nil))
+    (maphash
+     (lambda (graph-name metas)
+       (unless (eq graph-name (node-type-graph-name meta))
+         (let ((other (find (node-type-name meta) metas
+                            :key #'node-type-name)))
+           (when (and other
+                      (not (equal (node-type-slots other)
+                                  (node-type-slots meta))))
+             (push graph-name divergent)))))
+     *schema-node-metadata*)
+    (when divergent
+      (warn 'divergent-node-type-redefinition
+            :name (node-type-name meta)
+            :graph-name (node-type-graph-name meta)
+            :other-graphs (nreverse divergent)))))
+```
+
+In `def-node-type`'s expansion, immediately after the `(let* ((,meta
+(make-node-type ...)))` binding closes and before
+`(finalize-inheritance ...)`, insert one form:
+
+```lisp
+           (%warn-if-divergent-across-stores ,meta)
+```
+
+Update the comment at ~line 328 from:
+
+```lisp
+         ;; No cross-graph uniqueness check: type-ids are system-wide as of
+         ;; #186, so one class may be instantiated in more than one store.
+```
+
+to:
+
+```lisp
+         ;; No cross-graph uniqueness check: type-ids are system-wide as of
+         ;; #186, so one class may be instantiated in more than one store.
+         ;; Divergent slot sets across stores warn instead (GH #196).
+```
+
+In `package.lisp`, next to `#:ambiguous-node-type-name` add:
+
+```lisp
+           #:divergent-node-type-redefinition
+           #:divergent-type-name
+           #:divergent-type-graph-name
+           #:divergent-type-other-graphs
+```
+
+- [ ] **Step 4: Run the focused suite, then the full suite; reconcile**
+
+Focused: `global-type-id-suite` all green including the 3 new checks.
+Full suite (same invocation shape, `(asdf:test-system :graph-db)`):
+expected exactly 4000 checks / 3990 pass / 10 skip / 0 fail. Watch test
+OUTPUT cleanliness too: the existing multi-store fixtures (`dual-type` in
+two stores, identical slots; `shared-type` likewise) must NOT now print
+warnings during the load or run — if they do, the guard is wrong, not the
+fixtures.
+
+- [ ] **Step 5: Ablation — actually run both**
+
+(a) Make `%warn-if-divergent-across-stores` a no-op: confirm
+`divergent-slot-sets-across-stores-warn` FAILS. (b) Drop the
+`(not (equal ...))` clause (warn on any cross-store redefinition):
+confirm `identical-slot-sets-across-stores-stay-silent` FAILS — and note
+whether the full-suite load now warns on `dual-type`/`shared-type`
+(it should, which double-confirms the clause is load-bearing). Revert,
+re-run focused suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add schema.lisp package.lisp tests/global-type-id-tests.lisp
+git commit -m "feat(schema): warn when one class diverges across stores (#196)"
+```
+
+---
+
+### Task 2: Documentation
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## [Unreleased]` → `### Added`, creating the
+  heading only if absent; match existing conventions)
+- Modify: `docs/vivace-graph-v3-doc.org` (~line 2961: the "Both
+  definitions define the *same CLOS class*..." passage)
+- Modify: `docs/superpowers/specs/2026-08-20-namespaces-design.md` §3.3
+  (one-sentence fixed-note, same style as §3.4's #190 note)
+
+**Interfaces:**
+- Consumes: the condition name `divergent-node-type-redefinition` from
+  Task 1 (documented verbatim).
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `## [Unreleased]` / `### Added`:
+
+```markdown
+- Defining one class name in two stores with *different* slot sets now
+  signals `divergent-node-type-redefinition` (a `style-warning`): both
+  definitions name one CLOS class, so the last one loaded determines the
+  slots and the earlier store's data becomes unreachable through the API
+  (the GH #53 failure). Identical slot sets — the multi-store feature —
+  stay silent. (#196)
+```
+
+- [ ] **Step 2: Manual + spec**
+
+In `docs/vivace-graph-v3-doc.org` at the "Both definitions define the
+*same CLOS class*, so the last one loaded determines its slots" passage
+(~2961), append one sentence in the file's prose style: as of #196,
+declaring *different* slot sets signals a ~divergent-node-type-
+redefinition~ style-warning naming both stores; identical slot sets stay
+silent.
+
+In the namespaces spec §3.3, add a one-line note (mirroring §3.4's
+"**Fixed (#190):**" style): **Guarded (#196):** divergent slot sets
+across stores now signal `divergent-node-type-redefinition`; identical
+sets stay silent.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md docs/vivace-graph-v3-doc.org \
+        docs/superpowers/specs/2026-08-20-namespaces-design.md
+git commit -m "docs: divergent slot sets across stores warn (#196)"
+```
+
+- [ ] **Step 4 (controller): whole-branch review, then PR**
+
+Whole-branch review on a capable model over the branch range; PR against
+`experiment` titled "Warn when one class diverges across stores (#196)".
+Full diff to Kevin before push; pushing is explicit-only.
+
+---
+
+## Self-Review
+
+- Spec coverage: #196 asks for (a) a style-warning at `def-node-type` when
+  a name registered under a different graph-name is defined with a
+  non-`equal` slot set — Task 1; (b) a test pinning the divergent case —
+  Task 1's first test; the silent identical case and severity class are
+  pinned too. Warning-not-error honored (style-warning).
+- The check runs at def time with no graph open (metadata scan), so the
+  warning also fires for stores not yet created — intended: the metadata
+  is what `update-schema` will replay.
+- Types: reader names match between condition definition, exports, and
+  docs.
+- Placeholders: none.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -82,6 +82,9 @@ carry their home graph.
 `*schema-node-metadata*` stops being keyed by graph-name. The registry becomes global; each
 store instantiates the types it holds.
 
+**Guarded (#196):** divergent slot sets across stores now signal
+`divergent-node-type-redefinition`; identical sets stay silent.
+
 ### 3.4 The global type registry
 
 One type-id space across the image, keyed by package-qualified symbol — structurally

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2961,7 +2961,10 @@ runtime.
 Both definitions define the *same CLOS class*, so the last one loaded
 determines its slots; declaring different slot sets for the two stores is how
 you get a class whose accessors return ~NIL~ against one of them. Keep the
-definitions identical, or give the two stores different type names.
+definitions identical, or give the two stores different type names. Since
+GH #196, declaring different slot sets across stores signals
+~divergent-node-type-redefinition~, a ~style-warning~ naming both stores;
+identical slot sets stay silent.
 
 Before #186 the second definition signalled ~duplicate-node-class-error~,
 because the two stores would otherwise have disagreed about what their type-ids

--- a/package.lisp
+++ b/package.lisp
@@ -180,6 +180,10 @@
            #:ambiguous-type-name
            #:ambiguous-type-parent
            #:ambiguous-type-candidates
+           #:divergent-node-type-redefinition
+           #:divergent-type-name
+           #:divergent-type-graph-name
+           #:divergent-type-other-graphs
            #:instantiate-node-type
            #:*schema-node-metadata*
            #:with-write-locked-class

--- a/schema.lisp
+++ b/schema.lisp
@@ -294,6 +294,48 @@ non-keyword symbol is the type's identity and is looked up directly."
   (finalize-inheritance (find-class (node-type-name meta)))
   (save-schema (schema graph) graph))
 
+(define-condition divergent-node-type-redefinition (style-warning)
+  ((name :initarg :name :reader divergent-type-name)
+   (graph-name :initarg :graph-name :reader divergent-type-graph-name)
+   (other-graphs :initarg :other-graphs
+                 :reader divergent-type-other-graphs))
+  (:report
+   (lambda (c s)
+     (format s "Node type ~S is being defined for ~S with a slot set ~
+that differs from its definition for ~{~S~^, ~}.  All of these name ONE ~
+CLOS class, so the last definition loaded determines the slots; data ~
+stored under the other slot set stays on disk but becomes unreachable ~
+through the API (GH #196, GH #53).  Keep the slot sets identical, or ~
+use different type names."
+             (divergent-type-name c)
+             (divergent-type-graph-name c)
+             (divergent-type-other-graphs c)))))
+
+(defun %warn-if-divergent-across-stores (meta)
+  "STYLE-WARNING when META's class symbol is already registered under a
+DIFFERENT graph-name with a non-EQUAL slot list.  Identical slots are the
+multi-store feature and stay silent; a same-store redefinition is schema
+evolution and is not this guard's business (GH #196)."
+  (let ((divergent nil))
+    (maphash
+     (lambda (graph-name metas)
+       ;; EQUAL, not EQ: GRAPH-NAME may be a string (GH #53's
+       ;; strchk-one fixture), and EQ would misdiagnose a same-store
+       ;; redefinition as cross-store divergence (GH #196).
+       (unless (equal graph-name (node-type-graph-name meta))
+         (let ((other (find (node-type-name meta) metas
+                            :key #'node-type-name)))
+           (when (and other
+                      (not (equal (node-type-slots other)
+                                  (node-type-slots meta))))
+             (push graph-name divergent)))))
+     *schema-node-metadata*)
+    (when divergent
+      (warn 'divergent-node-type-redefinition
+            :name (node-type-name meta)
+            :graph-name (node-type-graph-name meta)
+            :other-graphs (nreverse divergent)))))
+
 (defmacro def-node-type (name parent-types slot-specs graph-name &key keep-revisions)
   "Define a persistent node type NAME for the graph named GRAPH-NAME.  This is
 the machinery behind DEF-VERTEX and DEF-EDGE; you normally use those instead.
@@ -327,6 +369,7 @@ be defined before or after the graph is created."
       `(progn
          ;; No cross-graph uniqueness check: type-ids are system-wide as of
          ;; #186, so one class may be instantiated in more than one store.
+         ;; Divergent slot sets across stores warn instead (GH #196).
          (defclass ,name (,@parent-types)
            (,@slot-specs)
            (:metaclass node-class))
@@ -340,6 +383,7 @@ be defined before or after the graph is created."
                   :package (package-name *package*)
                   :constructor ',constructor
                   :keep-revisions ,keep-revisions)))
+           (%warn-if-divergent-across-stores ,meta)
            ;; FIXME: why is this necessary when inheriting from another node subclass?
            ;;(unless (class-finalized-p (find-class ',name))
            (finalize-inheritance (find-class ',name))

--- a/tests/global-type-id-tests.lisp
+++ b/tests/global-type-id-tests.lisp
@@ -330,3 +330,45 @@ last check names that harm directly."
                                                     :vertex))
                   "the registry must be untouched: SHARED-TYPE is still ~
 5, not re-bound to the store's id"))))))))
+
+;;; -----------------------------------------------------------------------
+;;; Divergent slot sets across stores warn; identical ones stay silent
+;;; (GH #196, re-guarding GH #53's failure mode after
+;;; %CHECK-NODE-CLASS-GRAPH-UNIQUE was correctly deleted by #186).
+;;;
+;;; The DEF-VERTEX forms are EVAL'd inside the tests, not written at
+;;; toplevel: the divergent pair would otherwise warn at load time of
+;;; this file, polluting every suite run's output.  No graph is opened
+;;; and no system directory is needed -- the check is metadata-level.
+;;; -----------------------------------------------------------------------
+
+(test divergent-slot-sets-across-stores-warn
+  "Same class symbol, two stores, DIFFERENT slots: the second definition
+must signal.  Nearest wrong implementation: never warn (the guard
+deleted by #186 with nothing in its place)."
+  (handler-bind ((warning #'muffle-warning))
+    (eval '(def-vertex gdiv-probe () ((div-a :type string))
+             :gdiv-store-a)))
+  (signals graph-db:divergent-node-type-redefinition
+    (eval '(def-vertex gdiv-probe () ((div-b :type string))
+             :gdiv-store-b))))
+
+(test identical-slot-sets-across-stores-stay-silent
+  "Same class symbol, two stores, SAME slots: the feature, and it must
+stay silent.  Nearest wrong implementation: warn on any cross-store
+redefinition regardless of the slots."
+  (handler-bind ((warning #'muffle-warning))
+    (eval '(def-vertex gdiv-same () ((div-c :type string))
+             :gdiv-store-c)))
+  (is-true
+   (handler-case
+       (progn (eval '(def-vertex gdiv-same () ((div-c :type string))
+                       :gdiv-store-d))
+              t)
+     (graph-db:divergent-node-type-redefinition () nil))))
+
+(test divergence-warning-is-a-style-warning
+  "STYLE-WARNING, not a bare WARNING: the design deliberately permits the
+redefinition (GH #196), so it must be muffleable by severity class."
+  (is (subtypep 'graph-db:divergent-node-type-redefinition
+                'style-warning)))


### PR DESCRIPTION
Fixes #196. After #186 correctly deleted `%check-node-class-graph-unique` (one
class may now be instantiated in more than one store), nothing replaced the
protection it incidentally carried against GH #53's failure: a second store
defining the same class with a *different* slot set silently replaced the CLOS
class's slots, leaving the first store's data on disk but unreachable through
the API.

## What changed

- New condition `divergent-node-type-redefinition` — a `style-warning`
  (warning, not error: the design deliberately permits the redefinition),
  exported with readers `divergent-type-name` / `divergent-type-graph-name` /
  `divergent-type-other-graphs`.
- `def-node-type` calls `%warn-if-divergent-across-stores` when a type's
  metadata is built: same class symbol registered under a *different*
  graph-name with a non-`equal` slot list → warn, naming every divergent
  store. Identical slot sets (the multi-store feature) and same-store
  redefinition (schema evolution) stay silent. Metadata-level — fires at
  definition time with no graph open.
- Graph-names compare with `equal`, not `eq` — they may be strings, and the
  system's own store identity (`*schema-node-metadata*`'s test) is `equal`.
- Docs: CHANGELOG, manual (the multi-store passage), namespaces spec §3.3.

## Verification

- Full suite on SBCL: **4000 checks — 3990 pass / 10 skip / 0 fail**
  (baseline 3997 / 3987; the 3 new checks account for the whole delta; skips
  are the pre-existing GEOS ones). ECL skipped per the standing demotion.
- Ablations run: a no-op guard fails `divergent-slot-sets-across-stores-warn`;
  dropping the non-`equal` clause fails
  `identical-slot-sets-across-stores-stay-silent` AND makes the existing
  multi-store fixtures (`dual-type`, `shared-type`, `ts-shared-thing`) warn —
  proving the clause is what keeps the feature silent.
- Whole-branch review swept every writer of `*schema-node-metadata*`:
  `def-node-type` is the only registrar, so the single choke point holds (no
  #190-style second path). Verdict: ready to merge; three doc-grade minors
  parked (option order counts in the slot comparison; a transient warning
  mid-reload until all stores' forms reload; the spec's future
  metadata-de-keying must update `%warn-if-divergent-across-stores`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95