### PR TITLE
A torn final record no longer takes the whole journal (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,6 +588,14 @@ between releases; cutting a release renames it to the new version and dates it.
   written, and stale aliases in old `schema.dat` files are ignored.
   (#190)
 
+- A torn final record in the system-clock journal (a power loss
+  mid-append) made every record unreadable, since the reader signalled
+  on the incomplete form. The reader now drops a torn tail — truncating
+  it atomically and signalling the `system-journal-torn-tail` warning —
+  and returns the intact history; damage anywhere other than the tail
+  still signals, as `system-journal-corrupt`. The writer is unchanged:
+  per-record fsync was considered and rejected in the issue. (#191)
+
 ### Changed
 
 - **The hub resolves its type registry on the thread that starts

--- a/docs/superpowers/plans/2026-08-22-torn-journal-191.md
+++ b/docs/superpowers/plans/2026-08-22-torn-journal-191.md
@@ -1,0 +1,440 @@
+# Torn-Tail-Tolerant System Journal (#191) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A torn final record in the system-clock journal (power loss
+mid-append) no longer makes the whole journal unreadable: the reader drops
+the torn tail — truncating it atomically and warning loudly — and returns
+the intact history. Corruption anywhere *other* than the tail still
+signals.
+
+**Architecture:** `journal-records` reads record-by-record, capturing
+`file-position` before each `read`. On a reader error it decides
+torn-tail vs mid-file by scanning the remainder of the file for any later
+complete record: one found → signal new condition `system-journal-corrupt`
+(carrying the original reader condition as `cause`); none found → truncate
+the file to the last good byte position (write good prefix to a temp file,
+`rename-file` over — atomic), `warn` new condition
+`system-journal-torn-tail`, return the records read so far. The writer is
+untouched — the issue explicitly rejects fsync-per-record.
+
+**Tech Stack:** Common Lisp (SBCL primary), FiveAM.
+
+**Spec:** GH #191 (authoritative: tolerant reader, not synchronous
+writer; tail-only tolerance; log loudly), namespaces design §6 (the
+clock), and the existing durability comment in `%write-clock-ceiling`
+("survives a process crash, not a power loss").
+
+## Global Constraints
+
+- Lisp: spaces only, never tabs; hard 80-column limit (a 96-column line is
+  a defect).
+- Comments terse: invariant + `(GH #191)`.
+- SBCL suites need `--dynamic-space-size 16384`; every SBCL run in the
+  worktree must FIRST
+  `--eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))'`
+  (Quicklisp resolves `:graph-db` to the main checkout otherwise).
+- Suite counts are TOTAL CHECKS. Baseline on `experiment` (post-#205,
+  878c50a): 4000 checks / 3990 pass / 10 skip / 0 fail. This plan reworks
+  one existing 1-check test into 2 checks and adds three tests
+  (6 + 2 + 3 checks) → net +12 → 4012 / 4002 / 10 / 0. Reconcile exactly.
+- Ablate the guards (nearest wrong implementations named per test; Step 5
+  names which ablations to actually run).
+- ECL demoted: verify on SBCL only, say so. (`rename-file` over an
+  existing target replaces on SBCL/POSIX; an `#+ecl` revisit is future
+  work, not this unit's.)
+- Host safety: live `ma-dev-server` on this host — NEVER
+  `pkill`/`killall`/`pgrep`; kill only a PID you started; one SBCL at a
+  time; never touch `/data0`. Never end a turn waiting on a background
+  run — bounded foreground stretches
+  (`timeout 570 bash -c 'while kill -0 <PID> 2>/dev/null; do sleep 15; done'`).
+- Worktree `.worktrees/191-torn-journal`, branch `191-torn-journal` off
+  `experiment` (878c50a). PR against `experiment`. Pushing explicit-only.
+
+---
+
+### Task 1: Tolerant reader, conditions, tests
+
+**Files:**
+- Modify: `system-clock.lisp` (two conditions + two helpers above
+  `journal-records`; rewrite `journal-records`)
+- Modify: `package.lisp` (export both conditions + readers, next to
+  `#:journal-records` ~line 38)
+- Modify: `tests/system-clock-tests.lisp` (rework
+  `journal-refuses-to-evaluate-on-read`; add three tests)
+
+**Interfaces:**
+- Produces: `system-journal-corrupt` (error; readers
+  `journal-corrupt-file`, `journal-corrupt-position`,
+  `journal-corrupt-cause`), `system-journal-torn-tail` (warning; readers
+  `journal-torn-file`, `journal-torn-position`). `journal-records` keeps
+  its signature and now returns `(values records torn-p)`; existing
+  callers use the first value only. Task 2 documents these.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/system-clock-tests.lisp`, REPLACE the whole
+`journal-refuses-to-evaluate-on-read` test with the following block, and
+ADD the other three tests after it:
+
+```lisp
+(test journal-refuses-to-evaluate-on-read
+  ;; A journal is data.  Reading it must never evaluate.  The #. bomb sits
+  ;; MID-FILE (a good record follows) because a torn TAIL is now dropped,
+  ;; not signalled (GH #191).  Must assert the wrapped condition's CAUSE
+  ;; is a READER-ERROR: under *READ-EVAL* T the bomb's own ERROR call
+  ;; would be caught and wrapped too, so asserting only the wrapper
+  ;; proves nothing -- the cause type is what distinguishes the reader
+  ;; REFUSING from the form EVALUATING.
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append
+                       :if-does-not-exist :create)
+      (format s "(:kind :bogus :value #.(error \"evaluated\"))~%")
+      (format s "(:kind :attach :epoch 3 :store :after-bomb)~%"))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let ((condition
+                   (handler-case (progn (journal-records c2) nil)
+                     (graph-db:system-journal-corrupt (e) e))))
+             (is-true condition
+                      "mid-file unreadable record must signal")
+             (is (typep (graph-db:journal-corrupt-cause condition)
+                        'reader-error)
+                 "the cause must be the READER refusing, not evaluation"))
+        (close-system-clock c2)))))
+
+(test torn-final-record-is-dropped-with-a-warning
+  "Power loss mid-append tears the LAST record; the intact history must
+survive (GH #191).  Nearest wrong implementation: signal on any reader
+error (the pre-#191 behaviour).  The non-ASCII store name pins
+byte-accurate truncation; the append-after-recovery check pins that the
+truncation reopened the writer (a stale stream would append to the old,
+renamed-away inode and the record would vanish)."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (journal-append c :detach :store "café-store")
+      (journal-append c :attach :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      ;; No closing paren, no newline: a torn tail.
+      (write-string "(:kind :retire :epoch 9 :store" s))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (signals graph-db:system-journal-torn-tail
+               (journal-records c2))
+             ;; The truncation is durable: a second read is clean.
+             (let ((rs nil))
+               (is-true (handler-case (progn (setq rs (journal-records c2))
+                                             t)
+                          (graph-db:system-journal-torn-tail () nil))
+                        "second read must not warn -- tail was truncated")
+               (is (= 3 (length rs)))
+               (is (equal '(:create :detach :attach)
+                          (mapcar (lambda (r) (getf r :kind)) rs)))
+               (is (equal "café-store" (getf (second rs) :store))
+                   "byte-accurate truncation: multibyte record intact"))
+             (journal-append c2 :retire :store :alpha)
+             (is (= 4 (length (journal-records c2)))
+                 "append after recovery must land in the LIVE file"))
+        (close-system-clock c2)))))
+
+(test mid-file-corruption-still-signals
+  "A bad record with good records AFTER it is not a torn tail -- it is
+corruption of a different kind and must signal, and the reader must not
+truncate anything (GH #191).  Nearest wrong implementation: treat every
+reader error as a torn tail and truncate."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      (format s "%%% not a lisp form %%%~%")
+      (format s "(:kind :attach :epoch 5 :store :alpha)~%"))
+    (let ((before (alexandria:read-file-into-string
+                   (merge-pathnames "system-journal.log" dir))))
+      (let ((c2 (open-system-clock (namestring dir))))
+        (unwind-protect
+             (progn
+               (signals graph-db:system-journal-corrupt
+                 (journal-records c2))
+               (is (equal before
+                          (alexandria:read-file-into-string
+                           (merge-pathnames "system-journal.log" dir)))
+                   "mid-file corruption must not be truncated away"))
+          (close-system-clock c2))))))
+
+(defvar *journal-eval-sentinel* nil)
+
+(test tail-read-eval-form-is-dropped-not-evaluated
+  "A #. form AT the tail is dropped like any torn tail -- but it must be
+dropped WITHOUT evaluating (GH #191).  The sentinel proves it: under
+*READ-EVAL* T the form would set it before the reader error paths could
+classify anything."
+  (setq *journal-eval-sentinel* nil)
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      (format s "(:kind :bogus :value ~
+#.(setq graph-db/test::*journal-eval-sentinel* t))~%"))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (signals graph-db:system-journal-torn-tail
+               (journal-records c2))
+             (is (null *journal-eval-sentinel*)
+                 "the #. form must never evaluate")
+             (is (= 1 (length (journal-records c2)))))
+        (close-system-clock c2)))))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+sbcl --dynamic-space-size 16384 --non-interactive \
+  --eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))' \
+  --eval '(ql:quickload :graph-db)' \
+  --eval '(asdf:load-system :graph-db/test)' \
+  --eval '(fiveam:run! (quote graph-db/test::system-clock-suite))'
+```
+
+As in #190/#196, the conditions + exports (first hunk of Step 3) may land
+first so the test file compiles; then the behavioral RED must show:
+`torn-final-record-...` and `tail-read-eval-form-...` fail (reader still
+signals raw `reader-error`/`end-of-file` on the tail),
+`journal-refuses-to-evaluate-on-read` fails (raw condition, not the
+wrapper), `mid-file-corruption-still-signals` fails on the wrapper type.
+
+- [ ] **Step 3: Implement**
+
+In `system-clock.lisp`, insert above `journal-records`:
+
+```lisp
+(define-condition system-journal-corrupt (error)
+  ((file :initarg :file :reader journal-corrupt-file)
+   (position :initarg :position :reader journal-corrupt-position)
+   (cause :initarg :cause :reader journal-corrupt-cause))
+  (:report
+   (lambda (c s)
+     (format s "System journal ~A is unreadable at byte ~D, and intact ~
+records FOLLOW the damage, so this is not a torn tail from a power loss ~
+-- the file is corrupt and no record can be trusted (GH #191).  ~
+Underlying reader condition: ~A"
+             (journal-corrupt-file c)
+             (journal-corrupt-position c)
+             (journal-corrupt-cause c)))))
+
+(define-condition system-journal-torn-tail (warning)
+  ((file :initarg :file :reader journal-torn-file)
+   (position :initarg :position :reader journal-torn-position))
+  (:report
+   (lambda (c s)
+     (format s "System journal ~A ends in a torn record at byte ~D -- ~
+one lifecycle event was in flight during a power loss.  Dropping the ~
+tail; the preceding history is intact (GH #191)."
+             (journal-torn-file c)
+             (journal-torn-position c)))))
+
+(defun %journal-later-record-p (file pos)
+  "True when FILE holds a complete readable record after the failed read
+at byte POS -- corruption mid-file, not a torn tail.  Skips forward a
+line at a time and retries; a torn TAIL by definition has nothing
+readable after it.  Stream position after a failed READ is unspecified,
+so the next READ-LINE may re-skip part of the bad text -- harmless: the
+scan only has to find ONE later record or reach EOF (GH #191)."
+  (with-open-file (s file :direction :input)
+    (file-position s pos)
+    (let ((*read-eval* nil))
+      (loop
+        (unless (read-line s nil) (return nil))
+        (handler-case
+            (let ((r (read s nil :eof)))
+              (return (not (eq r :eof))))
+          (error () nil))))))
+
+(defun %journal-truncate-to (clock file pos)
+  "Drop everything at and after byte POS: write the good prefix to a temp
+file and RENAME-FILE over the original, so a crash here cannot lose the
+intact history too.  Closes the append stream first -- after the rename
+it would still reference the OLD inode and later appends would vanish.
+Caller holds the clock lock.  POS is octets: SBCL's FILE-POSITION on
+character streams reports octet offsets, which the multibyte test pins
+(GH #191)."
+  (when (system-clock-journal clock)
+    (close (system-clock-journal clock))
+    (setf (system-clock-journal clock) nil))
+  (let ((tmp (make-pathname :type "tmp" :defaults file))
+        (buf (make-byte-vector pos)))
+    (with-open-file (in file :direction :input
+                             :element-type '(unsigned-byte 8))
+      (unless (= pos (read-sequence buf in))
+        (error "Short read rewriting ~A" file)))
+    (with-open-file (out tmp :direction :output
+                             :element-type '(unsigned-byte 8)
+                             :if-exists :supersede)
+      (write-sequence buf out)
+      (finish-output out))
+    ;; Replaces the target (POSIX rename semantics on SBCL).
+    (rename-file tmp file)))
+```
+
+Replace `journal-records` with:
+
+```lisp
+(defun journal-records (clock)
+  "Every lifecycle record, oldest first, as (values RECORDS TORN-P).
+Read with evaluation disabled -- the journal is data and must never
+execute.  A torn FINAL record (power loss mid-append) is dropped: the
+tail is truncated, SYSTEM-JOURNAL-TORN-TAIL is warned, and the intact
+history is returned with TORN-P true.  Damage anywhere ELSE signals
+SYSTEM-JOURNAL-CORRUPT and touches nothing (GH #191)."
+  (let ((file (%clock-journal-file (system-clock-location clock))))
+    (with-recursive-lock-held ((system-clock-lock clock))
+      (when (system-clock-journal clock)
+        (finish-output (system-clock-journal clock)))
+      (when (probe-file file)
+        (with-open-file (s file :direction :input)
+          (let ((*read-eval* nil)
+                (records nil)
+                (torn-p nil))
+            (loop
+              (let* ((pos (file-position s))
+                     (r (handler-case (read s nil :eof)
+                          (error (e)
+                            (when (%journal-later-record-p file pos)
+                              (error 'system-journal-corrupt
+                                     :file file :position pos :cause e))
+                            (%journal-truncate-to clock file pos)
+                            (setq torn-p t)
+                            (warn 'system-journal-torn-tail
+                                  :file file :position pos)
+                            :eof))))
+                (when (eq r :eof)
+                  (return (values (nreverse records) torn-p)))
+                (push r records)))))))))
+```
+
+In `package.lisp`, next to `#:journal-records` add:
+
+```lisp
+           #:system-journal-corrupt
+           #:journal-corrupt-file
+           #:journal-corrupt-position
+           #:journal-corrupt-cause
+           #:system-journal-torn-tail
+           #:journal-torn-file
+           #:journal-torn-position
+```
+
+Implementation notes the implementer must respect:
+- `journal-records` now takes the clock's recursive lock (it may close
+  and null the append stream); `journal-append` reopens lazily, which is
+  the existing behaviour — verify no deadlock (the lock is recursive and
+  `journal-append` takes the same one).
+- `alexandria:read-file-into-string` is already a dependency (alexandria
+  is in the .asd deps); if the test package does not import it, use the
+  package-qualified name as written.
+
+- [ ] **Step 4: Run the focused suite, then the full suite; reconcile**
+
+`system-clock-suite` fully green. Full suite: expected exactly
+4012 checks / 4002 pass / 10 skip / 0 fail (baseline 4000/3990/10/0;
+rework nets +1, new tests +6, +2, +3). Any other delta: account check by
+check. Output cleanliness: no stray torn-tail warnings from other suites.
+
+- [ ] **Step 5: Ablation — actually run (a) and (c)**
+
+(a) Make the reader treat EVERY reader error as a torn tail (bypass
+`%journal-later-record-p`): `mid-file-corruption-still-signals` and
+`journal-refuses-to-evaluate-on-read` must FAIL. (c) Skip the
+close-append-stream step in `%journal-truncate-to`: the
+append-after-recovery check in `torn-final-record-...` must FAIL (the
+post-recovery record vanishes into the renamed-away inode). Ablation (b)
+— signal on the tail too — is the pre-#191 behaviour already shown RED in
+Step 2; do not re-run it. Revert, focused suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add system-clock.lisp package.lisp tests/system-clock-tests.lisp
+git commit -m "fix(clock): a torn final record no longer takes the whole journal (#191)"
+```
+
+---
+
+### Task 2: Documentation
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## [Unreleased]` / `### Fixed`)
+- Modify: `docs/superpowers/specs/2026-08-20-namespaces-design.md` §6 (a
+  short durability note where the journal is specified; match the
+  "**Fixed (#190):**"/"**Guarded (#196):**" note style —
+  "**Hardened (#191):** ...")
+- Modify: `docs/vivace-graph-v3-doc.org` ONLY IF it documents the system
+  journal (search for `system-journal` / `journal-records`); if it does
+  not, say so in the report and skip it — do not invent a section.
+
+**Interfaces:**
+- Consumes: condition names `system-journal-corrupt` /
+  `system-journal-torn-tail` and the `(values records torn-p)` return.
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `## [Unreleased]` / `### Fixed`:
+
+```markdown
+- A torn final record in the system-clock journal (a power loss
+  mid-append) made every record unreadable, since the reader signalled
+  on the incomplete form. The reader now drops a torn tail — truncating
+  it atomically and signalling the `system-journal-torn-tail` warning —
+  and returns the intact history; damage anywhere other than the tail
+  still signals, as `system-journal-corrupt`. The writer is unchanged:
+  per-record fsync was considered and rejected in the issue. (#191)
+```
+
+- [ ] **Step 2: Spec (+ manual only if applicable)**
+
+Spec §6, one short note in the established style:
+**Hardened (#191):** the journal reader tolerates a torn final record
+(truncate + `system-journal-torn-tail` warning, history preserved);
+mid-file damage signals `system-journal-corrupt`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md docs/superpowers/specs/2026-08-20-namespaces-design.md
+# plus docs/vivace-graph-v3-doc.org if edited
+git commit -m "docs: torn-tail-tolerant system journal (#191)"
+```
+
+- [ ] **Step 4 (controller): whole-branch review, then PR**
+
+Whole-branch review (capable model) over the branch range; PR against
+`experiment` titled "A torn final record no longer takes the whole
+journal (#191)". Full diff to Kevin before push; pushing explicit-only.
+
+---
+
+## Self-Review
+
+- Spec coverage: #191's suggested shape is implemented exactly — tolerant
+  reader, tail-only, truncate + loud log, mid-file still signals, no
+  fsync. The read-eval security property is preserved and its test
+  strengthened (cause-type assertion), with the tail-`#.` case pinned as
+  dropped-not-evaluated via a side-effect sentinel.
+- The one behavior change to an existing contract —
+  `journal-refuses-to-evaluate-on-read`'s bomb moving mid-file — is
+  argued in the test's own comment.
+- Types: condition names and readers consistent across code, exports,
+  tests, and docs; `(values records torn-p)` stated in docstring and
+  CHANGELOG.
+- Placeholders: none.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -294,6 +294,10 @@ wrong derived data whose provenance does not record the skew.
   *devices* — separate images — and **stays per-graph**; and the per-node 32-bit `revision`,
   untouched. Stated so nobody globalises the lamport counter by analogy.
 
+**Hardened (#191):** the journal reader tolerates a torn final record
+(truncate + `system-journal-torn-tail` warning, history preserved);
+mid-file damage signals `system-journal-corrupt`.
+
 **Sequencing:** the debt is monotonic. Every write before the migration lands below the
 watermark permanently. This does not block other units, but its cost accrues daily.
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3274,6 +3274,17 @@ is never evaluated.** This is load-bearing, not a stylistic default —
 without re-checking them, so a record must never be able to execute code
 just by being read back.
 
+**Hardened (#191):** ~journal-records~ returns two values, the record
+list and a torn-tail flag. A torn final record — the shape left by power
+loss mid-append — is dropped: the file is truncated atomically to the
+last complete record and the ~system-journal-torn-tail~ warning is
+signalled, with the intact history still returned. Damage anywhere
+other than the tail is left untouched and signals
+~system-journal-corrupt~ instead, whose ~journal-corrupt-file~,
+~journal-corrupt-position~ and ~journal-corrupt-cause~ readers name
+what was found. The writer is unchanged; per-record fsync was
+considered and rejected in GH #191.
+
 *** Cross-image effects: a peer sync can advance the clock
 
 A pulled node carries the *hub's* commit epoch, and ~peer-observe-epoch~

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3283,7 +3283,11 @@ other than the tail is left untouched and signals
 ~system-journal-corrupt~ instead, whose ~journal-corrupt-file~,
 ~journal-corrupt-position~ and ~journal-corrupt-cause~ readers name
 what was found. The writer is unchanged; per-record fsync was
-considered and rejected in GH #191.
+considered and rejected in GH #191. **Truncation only happens while the
+clock holds the directory lock;** a stale/closed clock's read stays
+tolerant (warns, returns the torn-tail flag) but leaves the file
+untouched, so the next reader that owns the lock is the one that
+truncates it (GH #182, #191).
 
 *** Cross-image effects: a peer sync can advance the clock
 

--- a/package.lisp
+++ b/package.lisp
@@ -36,6 +36,13 @@
            #:clock-lease-epochs
            #:journal-append
            #:journal-records
+           #:system-journal-corrupt
+           #:journal-corrupt-file
+           #:journal-corrupt-position
+           #:journal-corrupt-cause
+           #:system-journal-torn-tail
+           #:journal-torn-file
+           #:journal-torn-position
            #:graph-system-clock
            #:attach-to-system-clock
            ;; image-level type-id registry (GH #186)

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -133,18 +133,104 @@ later open in this image, for the life of the process (GH #182)."
         (finish-output s)))
     record))
 
+(define-condition system-journal-corrupt (error)
+  ((file :initarg :file :reader journal-corrupt-file)
+   (position :initarg :position :reader journal-corrupt-position)
+   (cause :initarg :cause :reader journal-corrupt-cause))
+  (:report
+   (lambda (c s)
+     (format s "System journal ~A is unreadable at byte ~D, and intact ~
+records FOLLOW the damage, so this is not a torn tail from a power loss ~
+-- the file is corrupt and no record can be trusted (GH #191).  ~
+Underlying reader condition: ~A"
+             (journal-corrupt-file c)
+             (journal-corrupt-position c)
+             (journal-corrupt-cause c)))))
+
+(define-condition system-journal-torn-tail (warning)
+  ((file :initarg :file :reader journal-torn-file)
+   (position :initarg :position :reader journal-torn-position))
+  (:report
+   (lambda (c s)
+     (format s "System journal ~A ends in a torn record at byte ~D -- ~
+one lifecycle event was in flight during a power loss.  Dropping the ~
+tail; the preceding history is intact (GH #191)."
+             (journal-torn-file c)
+             (journal-torn-position c)))))
+
+(defun %journal-later-record-p (file pos)
+  "True when FILE holds a complete readable record after the failed read
+at byte POS -- corruption mid-file, not a torn tail.  Skips forward a
+line at a time and retries; a torn TAIL by definition has nothing
+readable after it.  Stream position after a failed READ is unspecified,
+so the next READ-LINE may re-skip part of the bad text -- harmless: the
+scan only has to find ONE later record or reach EOF (GH #191)."
+  (with-open-file (s file :direction :input)
+    (file-position s pos)
+    (let ((*read-eval* nil))
+      (loop
+        (unless (read-line s nil) (return nil))
+        (handler-case
+            (let ((r (read s nil :eof)))
+              (return (not (eq r :eof))))
+          (error () nil))))))
+
+(defun %journal-truncate-to (clock file pos)
+  "Drop everything at and after byte POS: write the good prefix to a temp
+file and RENAME-FILE over the original, so a crash here cannot lose the
+intact history too.  Closes the append stream first -- after the rename
+it would still reference the OLD inode and later appends would vanish.
+Caller holds the clock lock.  POS is octets: SBCL's FILE-POSITION on
+character streams reports octet offsets, which the multibyte test pins
+(GH #191)."
+  (when (system-clock-journal clock)
+    (close (system-clock-journal clock))
+    (setf (system-clock-journal clock) nil))
+  (let ((tmp (make-pathname :type "tmp" :defaults file))
+        (buf (make-byte-vector pos)))
+    (with-open-file (in file :direction :input
+                             :element-type '(unsigned-byte 8))
+      (unless (= pos (read-sequence buf in))
+        (error "Short read rewriting ~A" file)))
+    (with-open-file (out tmp :direction :output
+                             :element-type '(unsigned-byte 8)
+                             :if-exists :supersede)
+      (write-sequence buf out)
+      (finish-output out))
+    ;; Replaces the target (POSIX rename semantics on SBCL).
+    (rename-file tmp file)))
+
 (defun journal-records (clock)
-  "Every lifecycle record, oldest first.  Read with evaluation disabled --
-the journal is data and must never execute."
+  "Every lifecycle record, oldest first, as (values RECORDS TORN-P).
+Read with evaluation disabled -- the journal is data and must never
+execute.  A torn FINAL record (power loss mid-append) is dropped: the
+tail is truncated, SYSTEM-JOURNAL-TORN-TAIL is warned, and the intact
+history is returned with TORN-P true.  Damage anywhere ELSE signals
+SYSTEM-JOURNAL-CORRUPT and touches nothing (GH #191)."
   (let ((file (%clock-journal-file (system-clock-location clock))))
-    (when (system-clock-journal clock)
-      (finish-output (system-clock-journal clock)))
-    (when (probe-file file)
-      (with-open-file (s file :direction :input)
-        (let ((*read-eval* nil))
-          (loop for r = (read s nil :eof)
-                until (eq r :eof)
-                collect r))))))
+    (with-recursive-lock-held ((system-clock-lock clock))
+      (when (system-clock-journal clock)
+        (finish-output (system-clock-journal clock)))
+      (when (probe-file file)
+        (with-open-file (s file :direction :input)
+          (let ((*read-eval* nil)
+                (records nil)
+                (torn-p nil))
+            (loop
+              (let* ((pos (file-position s))
+                     (r (handler-case (read s nil :eof)
+                          (error (e)
+                            (when (%journal-later-record-p file pos)
+                              (error 'system-journal-corrupt
+                                     :file file :position pos :cause e))
+                            (%journal-truncate-to clock file pos)
+                            (setq torn-p t)
+                            (warn 'system-journal-torn-tail
+                                  :file file :position pos)
+                            :eof))))
+                (when (eq r :eof)
+                  (return (values (nreverse records) torn-p)))
+                (push r records)))))))))
 
 (defun %clock-reserve (clock needed)
   "Raise the durable ceiling so COUNTER + NEEDED stays below it.  Caller

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -164,7 +164,11 @@ at byte POS -- corruption mid-file, not a torn tail.  Skips forward a
 line at a time and retries; a torn TAIL by definition has nothing
 readable after it.  Stream position after a failed READ is unspecified,
 so the next READ-LINE may re-skip part of the bad text -- harmless: the
-scan only has to find ONE later record or reach EOF (GH #191)."
+scan only has to find ONE later record or reach EOF (GH #191).  If the
+damage destroys the newline so the last GOOD record shares a line with
+leading garbage, the line-at-a-time scan skips both and truncation drops
+that good record too -- outside #191's power-loss model, where a torn
+append is always a strict suffix with the prior newline intact."
   (with-open-file (s file :direction :input)
     (file-position s pos)
     (let ((*read-eval* nil))
@@ -180,9 +184,13 @@ scan only has to find ONE later record or reach EOF (GH #191)."
 file and RENAME-FILE over the original, so a crash here cannot lose the
 intact history too.  Closes the append stream first -- after the rename
 it would still reference the OLD inode and later appends would vanish.
-Caller holds the clock lock.  POS is octets: SBCL's FILE-POSITION on
-character streams reports octet offsets, which the multibyte test pins
-(GH #191)."
+Caller holds the clock lock AND the directory flock (SYSTEM-CLOCK-LOCK-FD
+non-nil) -- a stale CLOCK whose lock was released by CLOSE-SYSTEM-CLOCK
+must never call this: another process may hold the real lock and be
+mid-append, and renaming out from under it silently loses every record
+appended after the rename (GH #182, #191).  POS is octets: SBCL's
+FILE-POSITION on character streams reports octet offsets, which the
+multibyte test pins (GH #191)."
   (when (system-clock-journal clock)
     (close (system-clock-journal clock))
     (setf (system-clock-journal clock) nil))
@@ -206,7 +214,14 @@ Read with evaluation disabled -- the journal is data and must never
 execute.  A torn FINAL record (power loss mid-append) is dropped: the
 tail is truncated, SYSTEM-JOURNAL-TORN-TAIL is warned, and the intact
 history is returned with TORN-P true.  Damage anywhere ELSE signals
-SYSTEM-JOURNAL-CORRUPT and touches nothing (GH #191)."
+SYSTEM-JOURNAL-CORRUPT and touches nothing (GH #191).
+
+Truncation only runs while CLOCK holds the directory flock
+(SYSTEM-CLOCK-LOCK-FD non-nil) -- after CLOSE-SYSTEM-CLOCK the lock is
+released and another process may own the file and be mid-append; an
+unowned CLOCK still warns and returns TORN-P true but leaves the file
+untouched, so it re-warns on every read until an owning reader truncates
+it.  That repeated warning is the accepted cost (GH #182, #191)."
   (let ((file (%clock-journal-file (system-clock-location clock))))
     (with-recursive-lock-held ((system-clock-lock clock))
       (when (system-clock-journal clock)
@@ -223,7 +238,8 @@ SYSTEM-JOURNAL-CORRUPT and touches nothing (GH #191)."
                             (when (%journal-later-record-p file pos)
                               (error 'system-journal-corrupt
                                      :file file :position pos :cause e))
-                            (%journal-truncate-to clock file pos)
+                            (when (system-clock-lock-fd clock)
+                              (%journal-truncate-to clock file pos))
                             (setq torn-p t)
                             (warn 'system-journal-torn-tail
                                   :file file :position pos)

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -208,6 +208,39 @@ renamed-away inode and the record would vanish)."
                  "append after recovery must land in the LIVE file"))
         (close-system-clock c2)))))
 
+(test torn-tail-recovery-with-a-live-writer
+  "The torn-tail path is usually hit by a FRESH clock reopening after a
+crash, but it can also be hit by the SAME clock that still holds its own
+append stream open -- e.g. another writer tore the tail while this
+process kept running.  That is the case %JOURNAL-TRUNCATE-TO's
+close-the-append-stream step exists for (GH #191).  Nearest wrong
+implementation: skip that close -- the post-recovery append below then
+lands on the renamed-away (unlinked) inode and silently vanishes."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             ;; This APPEND opens and leaves open C's own stream on the
+             ;; journal file -- unlike the fresh-reopen tests above.
+             (journal-append c :create :store :alpha)
+             ;; Tear the tail out-of-band, through a second stream, while
+             ;; C's stream is still open on the same file -- the
+             ;; power-loss shape: a write in flight, not a fresh process
+             ;; discovering old damage.
+             (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                                :direction :output :if-exists :append)
+               (write-string "(:kind :retire :epoch 9 :store" s))
+             (signals graph-db:system-journal-torn-tail
+               (journal-records c))
+             (journal-append c :attach :store :beta)
+             (let ((rs (journal-records c)))
+               (is (= 2 (length rs))
+                   "post-recovery append must land in the LIVE file, ~
+not the renamed-away inode")
+               (is (equal '(:create :attach)
+                          (mapcar (lambda (r) (getf r :kind)) rs)))))
+        (close-system-clock c)))))
+
 (test mid-file-corruption-still-signals
   "A bad record with good records AFTER it is not a torn tail -- it is
 corruption of a different kind and must signal, and the reader must not

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -298,6 +298,79 @@ classify anything."
              (is (= 1 (length (journal-records c2)))))
         (close-system-clock c2)))))
 
+(test torn-tail-second-value-reports-torn-p
+  "TORN-P is FiveAM-blind: every torn-tail test above uses SIGNALS, which
+exits non-locally before JOURNAL-RECORDS returns any values, so none of
+them ever observed the second value.  Pin it directly on an OWNED clock:
+true on the read that truncates, nil on the clean read after (GH #191)."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      (write-string "(:kind :retire :epoch 9 :store" s))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (multiple-value-bind (rs torn-p)
+                 (handler-bind
+                     ((graph-db:system-journal-torn-tail #'muffle-warning))
+                   (journal-records c2))
+               (is-true torn-p "first (owned) read must report torn-p")
+               (is (= 1 (length rs))))
+             (multiple-value-bind (rs2 torn-p2)
+                 (journal-records c2)
+               (declare (ignore rs2))
+               (is (null torn-p2)
+                   "second read after truncation must report torn-p nil")))
+        (close-system-clock c2)))))
+
+(test stale-clock-does-not-truncate-a-torn-tail
+  "After CLOSE-SYSTEM-CLOCK the directory flock is released
+(SYSTEM-CLOCK-LOCK-FD nil), but the struct survives.  JOURNAL-RECORDS on
+that stale struct must not rename-truncate the file: another process may
+hold the real lock and be mid-append, and truncating out from under it
+would silently drop every record it appends after the rename (GH #182,
+#191).  An unowned read still warns and reports TORN-P true, but leaves
+the bytes alone -- it re-warns on every read until an OWNING clock
+truncates it.  Ablation: removing the lock-fd guard in JOURNAL-RECORDS
+makes the file-unchanged assertion below fail (see fix-wave-report.md)."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      (write-string "(:kind :retire :epoch 9 :store" s))
+    (let ((before (alexandria:read-file-into-string
+                   (merge-pathnames "system-journal.log" dir)))
+          (stale (open-system-clock (namestring dir))))
+      (close-system-clock stale)
+      ;; STALE's lock-fd is now nil -- exactly the post-close shape the
+      ;; ownership check must catch.
+      (multiple-value-bind (rs torn-p)
+          (handler-bind
+              ((graph-db:system-journal-torn-tail #'muffle-warning))
+            (journal-records stale))
+        (is-true torn-p "an unowned read must still report torn-p")
+        (is (= 1 (length rs))))
+      (is (equal before
+                 (alexandria:read-file-into-string
+                  (merge-pathnames "system-journal.log" dir)))
+          "an unowned read must leave the torn bytes untouched")
+      ;; A fresh, OWNING clock can still recover it.
+      (let ((owner (open-system-clock (namestring dir))))
+        (unwind-protect
+             (progn
+               (signals graph-db:system-journal-torn-tail
+                 (journal-records owner))
+               (is-true
+                (handler-case (progn (journal-records owner) t)
+                  (graph-db:system-journal-torn-tail () nil))
+                "an owning read truncates -- the second read stays clean"))
+          (close-system-clock owner))))))
+
 ;;; Routing epoch allocation through the clock (GH #168 task 3).
 
 (test two-stores-on-one-clock-get-disjoint-ordered-epochs

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -143,20 +143,126 @@ clean write masking what's actually durable."
         (close-system-clock c2)))))
 
 (test journal-refuses-to-evaluate-on-read
-  ;; A journal is data.  Reading it must never evaluate.  Must assert the
-  ;; condition TYPE: bare `signals error' passes under *READ-EVAL* T too
-  ;; (the crafted form's own ERROR call also signals an ERROR), so it
-  ;; proves nothing.  READER-ERROR only comes from the reader refusing.
+  ;; A journal is data.  Reading it must never evaluate.  The #. bomb sits
+  ;; MID-FILE (a good record follows) because a torn TAIL is now dropped,
+  ;; not signalled (GH #191).  Must assert the wrapped condition's CAUSE
+  ;; is a READER-ERROR: under *READ-EVAL* T the bomb's own ERROR call
+  ;; would be caught and wrapped too, so asserting only the wrapper
+  ;; proves nothing -- the cause type is what distinguishes the reader
+  ;; REFUSING from the form EVALUATING.
   (with-temp-directory (dir)
     (let ((c (open-system-clock (namestring dir))))
       (close-system-clock c))
     (with-open-file (s (merge-pathnames "system-journal.log" dir)
                        :direction :output :if-exists :append
                        :if-does-not-exist :create)
-      (format s "(:kind :bogus :value #.(error \"evaluated\"))~%"))
+      (format s "(:kind :bogus :value #.(error \"evaluated\"))~%")
+      (format s "(:kind :attach :epoch 3 :store :after-bomb)~%"))
     (let ((c2 (open-system-clock (namestring dir))))
       (unwind-protect
-           (signals reader-error (journal-records c2))
+           (let ((condition
+                   (handler-case (progn (journal-records c2) nil)
+                     (graph-db:system-journal-corrupt (e) e))))
+             (is-true condition
+                      "mid-file unreadable record must signal")
+             (is (typep (graph-db:journal-corrupt-cause condition)
+                        'reader-error)
+                 "the cause must be the READER refusing, not evaluation"))
+        (close-system-clock c2)))))
+
+(test torn-final-record-is-dropped-with-a-warning
+  "Power loss mid-append tears the LAST record; the intact history must
+survive (GH #191).  Nearest wrong implementation: signal on any reader
+error (the pre-#191 behaviour).  The non-ASCII store name pins
+byte-accurate truncation; the append-after-recovery check pins that the
+truncation reopened the writer (a stale stream would append to the old,
+renamed-away inode and the record would vanish)."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (journal-append c :detach :store "café-store")
+      (journal-append c :attach :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      ;; No closing paren, no newline: a torn tail.
+      (write-string "(:kind :retire :epoch 9 :store" s))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (signals graph-db:system-journal-torn-tail
+               (journal-records c2))
+             ;; The truncation is durable: a second read is clean.
+             (let ((rs nil))
+               (is-true (handler-case (progn (setq rs (journal-records c2))
+                                             t)
+                          (graph-db:system-journal-torn-tail () nil))
+                        "second read must not warn -- tail was truncated")
+               (is (= 3 (length rs)))
+               (is (equal '(:create :detach :attach)
+                          (mapcar (lambda (r) (getf r :kind)) rs)))
+               (is (equal "café-store" (getf (second rs) :store))
+                   "byte-accurate truncation: multibyte record intact"))
+             (journal-append c2 :retire :store :alpha)
+             (is (= 4 (length (journal-records c2)))
+                 "append after recovery must land in the LIVE file"))
+        (close-system-clock c2)))))
+
+(test mid-file-corruption-still-signals
+  "A bad record with good records AFTER it is not a torn tail -- it is
+corruption of a different kind and must signal, and the reader must not
+truncate anything (GH #191).  Nearest wrong implementation: treat every
+reader error as a torn tail and truncate."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      ;; A lone close-paren is a genuine reader error (unmatched close);
+      ;; unlike "%%% not a lisp form %%%" -- which the brief originally
+      ;; specified but which READs cleanly as bare symbols under CL's
+      ;; standard readtable (`%' is symbol-constituent) and so never
+      ;; signals at all.  Fixed here; see task-1-report.md (GH #191).
+      (format s ")~%")
+      (format s "(:kind :attach :epoch 5 :store :alpha)~%"))
+    (let ((before (alexandria:read-file-into-string
+                   (merge-pathnames "system-journal.log" dir))))
+      (let ((c2 (open-system-clock (namestring dir))))
+        (unwind-protect
+             (progn
+               (signals graph-db:system-journal-corrupt
+                 (journal-records c2))
+               (is (equal before
+                          (alexandria:read-file-into-string
+                           (merge-pathnames "system-journal.log" dir)))
+                   "mid-file corruption must not be truncated away"))
+          (close-system-clock c2))))))
+
+(defvar *journal-eval-sentinel* nil)
+
+(test tail-read-eval-form-is-dropped-not-evaluated
+  "A #. form AT the tail is dropped like any torn tail -- but it must be
+dropped WITHOUT evaluating (GH #191).  The sentinel proves it: under
+*READ-EVAL* T the form would set it before the reader error paths could
+classify anything."
+  (setq *journal-eval-sentinel* nil)
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (journal-append c :create :store :alpha)
+      (close-system-clock c))
+    (with-open-file (s (merge-pathnames "system-journal.log" dir)
+                       :direction :output :if-exists :append)
+      (format s "(:kind :bogus :value ~
+#.(setq graph-db/test::*journal-eval-sentinel* t))~%"))
+    (let ((c2 (open-system-clock (namestring dir))))
+      (unwind-protect
+           (progn
+             (signals graph-db:system-journal-torn-tail
+               (journal-records c2))
+             (is (null *journal-eval-sentinel*)
+                 "the #. form must never evaluate")
+             (is (= 1 (length (journal-records c2)))))
         (close-system-clock c2)))))
 
 ;;; Routing epoch allocation through the clock (GH #168 task 3).


### PR DESCRIPTION
Fixes #191. The system-clock journal is read back with `read`, so a truncated
final record — the shape a power loss leaves mid-append — made every record in
the journal unreadable, not just the last. The lifecycle history #170 and #171
will consume was one torn line from gone.

## What changed

- **Tolerant reader, exactly the issue's shape.** `journal-records` now
  returns `(values records torn-p)` and reads record-by-record. A reader error
  with no complete record after it is a torn tail: the file is truncated to
  the last complete record (good prefix to a temp file, `rename-file` over —
  atomic; the clock's append stream is closed first so recovery cannot strand
  later appends on the renamed-away inode), the `system-journal-torn-tail`
  warning is signalled, and the intact history is returned. A reader error
  with intact records after it is corruption of a different kind: it signals
  `system-journal-corrupt` (carrying the original condition as `cause`) and
  touches nothing.
- **Truncation requires owning the directory flock** (found by the
  whole-branch review): after `close-system-clock` the struct survives with
  the #182 lock released, and an unguarded read could rename-truncate a
  journal another process now owns, silently orphaning its appends. An
  unowned read stays tolerant — warns, returns `torn-p` — but leaves the file
  untouched.
- **The writer is unchanged.** Per-record fsync was considered and rejected in
  the issue; the loss window remains one in-flight record.
- The read-eval security property is preserved and strengthened: the existing
  test's `#.` bomb moved mid-file (a torn tail is now dropped, not signalled)
  and asserts the wrapped cause is a `reader-error`; a new sentinel test pins
  that a tail `#.` form is dropped *without* evaluating.
- Docs: CHANGELOG, spec §6 "Hardened (#191)", manual lifecycle-journal
  section (conditions, readers, two-values return, lock-gated truncation).

## Verification

- Real gate `(asdf:test-system :graph-db)` on SBCL: **4023 checks — 4013 pass
  / 10 skip / 0 fail** (baseline 4000/3990/10/0; the 23 new checks account
  for the entire delta; skips are the pre-existing GEOS ones). ECL skipped
  per the standing demotion; the SBCL octet `file-position` assumption is
  noted in the code for the eventual ECL pass.
- Every guard ablation-tested with recorded output: signal-on-any-error fails
  the mid-file tests; skipping the close-stream step fails the live-writer
  test (the post-recovery append vanishes); removing the ownership guard
  fails the stale-clock byte-identity test. Byte-accurate truncation is
  pinned with a multibyte record ahead of the torn tail.
- Two plan defects were caught during execution and fixed rather than
  papered over: a "corrupt" test line that actually read cleanly as symbols,
  and an ablation the prescribed test could not observe.

Unblocks #170 (detach/attach quiescence) and #171 (restore manifest,
cascade). Chip carried on the issue: record-shape validation for journal
contents belongs to the #170/#171 work, where the records become
load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95