### PR TITLE
Tagged UUIDv8 store field: O(1) endpoint resolution and the detached-read marker (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **New node ids are tagged UUIDv8, carrying a 12-bit store field** for
+  O(1) cross-store resolution; existing v5 ids are unchanged and a v5
+  id still resolves via a per-open-store scan, so there is no flag
+  day. The tag is a stable numeric id from a new append-only
+  `store-registry.log` in the system directory (one entry per
+  graph-name, never reused). `resolve-node-graph` reports
+  `:resolved`/`:detached`/`:unknown`; `lookup-vertex-anywhere` returns
+  the vertex, an `unresolved-node` marker for a registered-but-closed
+  store, or (with `:if-detached :error`) signals
+  `store-detached-error`. `traverse` surfaces a cross-store endpoint or
+  a detached-store marker in its results without walking past it —
+  continuing across stores is left to a follow-on. `active-edge-p`
+  resolves cross-store endpoints too, with two narrow, documented gaps
+  (no cross-store scan for an untagged v5 endpoint; an unregistered tag
+  counts as live) tracked as #208. `backup` now includes a dangling
+  cross-store edge rather than dropping it, and warns with
+  `dangling-edge-warning` naming the edge, the missing endpoint and its
+  store; a backup with no cross-store gaps never warns. (#169)
+
 - Defining one class name in two stores with *different* slot sets now
   signals `divergent-node-type-redefinition` (a `style-warning`): both
   definitions name one CLOS class, so the last one loaded determines the

--- a/backup.lisp
+++ b/backup.lisp
@@ -155,6 +155,34 @@ RECREATE-GRAPH's :PACKAGE-NAME."
                :deleted-p (deleted-p e))))
     (write-backup-plist plist stream)))
 
+(define-condition dangling-edge-warning (warning)
+  ((edge-id :initarg :edge-id :reader dangling-edge-id)
+   (endpoint-id :initarg :endpoint-id :reader dangling-edge-endpoint-id)
+   (store-id :initarg :store-id :reader dangling-edge-store-id))
+  (:report
+   (lambda (c s)
+     (format s "Backup includes edge ~A whose endpoint ~A lives in ~
+store ~A, which is not open -- the edge is written, connectivity is ~
+preserved, and restoring it before that store is attached leaves it ~
+dangling (GH #169, spec sec.7)."
+             (dangling-edge-id c) (dangling-edge-endpoint-id c)
+             (dangling-edge-store-id c)))))
+
+(defun %warn-if-dangling-endpoint (edge endpoint-id graph)
+  "Signal DANGLING-EDGE-WARNING for ENDPOINT-ID when it is absent from
+GRAPH's own table and either detached (registered, not open) or
+resolved to a DIFFERENT open graph -- both cases leave it absent from
+this backup file (GH #169, spec sec.7).  EDGE is still written either
+way; this only reports the gap."
+  (unless (lookup-vertex endpoint-id :graph graph)
+    (multiple-value-bind (endpoint-graph status store-id)
+        (resolve-node-graph endpoint-id)
+      (when (or (eq status :detached)
+                (and (eq status :resolved) (not (eq endpoint-graph graph))))
+        (warn 'dangling-edge-warning
+              :edge-id (id edge) :endpoint-id endpoint-id
+              :store-id store-id)))))
+
 (defmethod backup ((graph graph) location &key include-deleted-p)
   (ensure-directories-exist location)
   (let ((count 0))
@@ -172,7 +200,9 @@ RECREATE-GRAPH's :PACKAGE-NAME."
       (map-edges (lambda (e)
                    (maybe-init-node-data e :graph graph)
                    (incf count)
-                   (backup e out))
+                   (backup e out)
+                   (%warn-if-dangling-endpoint e (from e) graph)
+                   (%warn-if-dangling-endpoint e (to e) graph))
                  graph :include-deleted-p include-deleted-p)
       (values count location))))
 

--- a/docs/superpowers/plans/2026-08-22-tagged-uuid-169.md
+++ b/docs/superpowers/plans/2026-08-22-tagged-uuid-169.md
@@ -1,0 +1,989 @@
+# Tagged UUIDv8 Store Field (#169) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** New node ids are UUIDv8 carrying a stable numeric store tag;
+a resolver maps any id to its open store in O(1) (v8) or by per-store scan
+(legacy v5); a read reaching into a store that is registered but not open
+yields an honest answer — an `unresolved-node` marker for incidental
+traversal, `store-detached-error` for explicit access; `backup` warns on a
+dangling cross-store edge instead of silently including or refusing.
+
+**Architecture:** Five layers. (1) A persistent **store registry** in the
+system directory (mirrors the type registry's append-only/flock/reconcile
+idioms, GH #186): graph-name → stable numeric store-id, 1..4095, never
+reused. Each open graph gets a `store-id` slot and a slot in the
+`*store-id->graph*` open-store vector, maintained where graphs enter and
+leave `*graphs*`. (2) **Generation**: `gen-v8-uuid` fills 16 random bytes,
+stamps version 8 (byte 6 high nibble), RFC variant (byte 8 top bits), and
+a 12-bit store tag in the low nibble of byte 14 plus byte 15.
+`gen-vertex-id`/`gen-edge-id` take an optional tag; nil → v5 exactly as
+today (memory graphs and any legacy path keep working untagged). (3)
+**Resolver**: `resolve-node-graph id` → `(values graph status store-id)`,
+status ∈ `:resolved`/`:detached`/`:unknown` — v8 reads the tag and indexes
+the vector; v5 tries each open graph's vertex table. (4) **Semantics**:
+`lookup-vertex-anywhere` returns the vertex, an `unresolved-node` marker
+(detached), or nil; `:if-detached :error` signals instead. `traverse`
+resolves endpoints through it: a cross-store vertex appears in results but
+is not walked further (cross-store *continuation* is future work); a
+detached endpoint contributes the marker. (5) `backup`'s edge pass warns
+per dangling cross-store edge. Spec decisions D5/D8 are taken as given;
+the store-occupancy set of §5.4 is explicitly OUT of this unit.
+
+**Tech Stack:** Common Lisp (SBCL primary), FiveAM.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-namespaces-design.md` §5, §7
+(D5, D8) and GH #169 (authoritative scope, incl. the why-not-v5 record).
+
+## Global Constraints
+
+- Lisp: spaces only, never tabs; hard 80-column limit (96 is a defect).
+- Comments terse: invariant + `(GH #169)`.
+- Every SBCL run: from the worktree, FIRST
+  `--eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))'`,
+  and `--dynamic-space-size 16384`.
+- **The merge gate is `(asdf:test-system :graph-db)` and the controller
+  runs it** — implementers run focused suites only and report expected
+  gate deltas. Focused standalone runs of some suites show ~14
+  environmental `SYSTEM-DIRECTORY-REQUIRED` failures; compare deltas, not
+  absolutes. Suite counts are TOTAL CHECKS; branch baseline (post-#207,
+  729f014): 4023 checks / 4013 pass / 10 skip / 0 fail. Every task states
+  its delta; account exactly.
+- Ablate every guard; each test names its nearest wrong implementation.
+- ECL demoted: verify on SBCL only, say so.
+- Host safety: live `ma-dev-server` on this host — NEVER
+  `pkill`/`killall`/`pgrep`; kill only a PID you started; one SBCL at a
+  time; never touch `/data0`. Never end a turn waiting on a background
+  run — bounded foreground stretches
+  (`timeout 570 bash -c 'while kill -0 <PID> 2>/dev/null; do sleep 15; done'`).
+- Worktree `.worktrees/169-tagged-uuid`, branch `169-tagged-uuid` off
+  `experiment` (729f014). PR against `experiment`. Pushing explicit-only.
+- PUBLIC repo: domain-neutral text everywhere.
+
+---
+
+### Task 1: The store registry and the open-store vector
+
+**Files:**
+- Create: `store-registry.lisp`
+- Modify: `graph-db.asd` (add `(:file "store-registry")` immediately after
+  `(:file "type-registry")` in the component chain, same `:depends-on`
+  shape as its neighbor)
+- Modify: `graph-class.lisp` (new `store-id` slot on class `graph`,
+  `:initform nil`; new `*store-id->graph*` defvar; helpers
+  `%register-open-store` / `%unregister-open-store`)
+- Modify: `graph.lisp` (~461, ~668: call `%register-open-store` next to
+  the `(setf (gethash name *graphs*) graph)` registration; call
+  `%unregister-open-store` in `close-graph`)
+- Modify: `memory-graph.lisp` (~264, ~991: same registration; the
+  memory-graph close path gets `%unregister-open-store`)
+- Create: `tests/store-registry-tests.lisp`
+- Modify: `graph-db.asd` (test file after `(:file "keyword-alias-tests")`)
+
+**Interfaces:**
+- Produces: `ensure-store-registry` → registry;
+  `store-registry-intern (name)` → id (assigns if new; signals
+  `system-directory-required` when `*system-directory*` is nil, reusing
+  the existing condition; signals `store-registry-full` past 4095);
+  `store-registry-id-for (name)` → id or nil;
+  `store-registry-name-for (id)` → graph-name or nil;
+  `+store-tag-bits+` = 12, `+max-store-tag+` = 4095;
+  `*store-id->graph*` (simple-vector 4096, slot 0 unused);
+  `(store-id graph)` accessor (nil ⇒ untagged/legacy);
+  `%register-open-store (graph)` — interns the graph-name when
+  `*system-directory*` is bound (leaving `store-id` nil otherwise, which
+  is the memory-graph/legacy fallback), stores graph in the vector;
+  `%unregister-open-store (graph)` — clears the vector slot, keeps the
+  registry entry (ids are never reused). Tasks 2–4 consume these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/store-registry-tests.lisp`:
+
+```lisp
+;;;; Stable numeric store-ids and the open-store vector (GH #169).
+(in-package #:graph-db/test)
+
+(def-suite store-registry-suite :in graph-db-suite
+  :description "Store-id registry: stable, persistent, never reused.")
+(in-suite store-registry-suite)
+
+(test store-ids-are-stable-and-distinct
+  "One name, one id, forever; two names never share.  Nearest wrong
+implementation: a per-image counter that restarts at 1 (ids would
+collide across sessions -- the persistence test below catches that
+half; distinctness catches the other)."
+  (with-temp-directory (sys)
+    (let ((graph-db::*system-directory* (namestring sys)))
+      (let ((a (store-registry-intern :sr-store-a))
+            (b (store-registry-intern :sr-store-b)))
+        (is (integerp a))
+        (is (/= a b))
+        (is (= a (store-registry-intern :sr-store-a))
+            "re-interning returns the same id")
+        (is (eq :sr-store-b (store-registry-name-for b)))))))
+
+(test store-ids-survive-a-fresh-registry-open
+  "The registry is persisted in the system directory; a fresh open (a
+new image, simulated by clearing the cached registry) reads the same
+assignments back."
+  (with-temp-directory (sys)
+    (let ((graph-db::*system-directory* (namestring sys)))
+      (let ((id (store-registry-intern :sr-persist)))
+        (setq graph-db::*store-registry* nil)
+        (is (= id (store-registry-id-for :sr-persist)))
+        (is (= id (store-registry-intern :sr-persist)))))))
+
+(test store-registry-accepts-string-names
+  "Graph names may be strings (cf. the strchk fixtures); the registry
+must key them by content, not identity."
+  (with-temp-directory (sys)
+    (let ((graph-db::*system-directory* (namestring sys)))
+      (let ((id (store-registry-intern (copy-seq "sr-stringly"))))
+        (is (= id (store-registry-intern (copy-seq "sr-stringly"))))))))
+
+(test store-registry-requires-a-system-directory
+  (let ((graph-db::*system-directory* nil)
+        (graph-db::*store-registry* nil))
+    (signals graph-db:system-directory-required
+      (store-registry-intern :sr-nodir))))
+
+(test open-graph-carries-its-store-id
+  "MAKE-GRAPH interns the graph-name and exposes the id on the graph;
+the open-store vector maps it back; CLOSE-GRAPH clears the vector slot
+but the registry keeps the assignment.  Nearest wrong implementation:
+a vector slot that survives close (a stale graph object would be
+returned for a closed store)."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys)))
+        (let* ((g (make-graph :sr-open-store (namestring dir)
+                              :buffer-pool-size 1000))
+               (sid (graph-db::store-id g)))
+          (unwind-protect
+               (progn
+                 (is (integerp sid))
+                 (is (eq g (svref graph-db::*store-id->graph* sid))))
+            (close-graph g :snapshot-p nil))
+          (is (null (svref graph-db::*store-id->graph* sid)))
+          (is (= sid (store-registry-id-for :sr-open-store))
+              "the assignment outlives the open"))))))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+sbcl --dynamic-space-size 16384 --non-interactive \
+  --eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))' \
+  --eval '(ql:quickload :graph-db)' \
+  --eval '(asdf:load-system :graph-db/test)' \
+  --eval '(fiveam:run! (quote graph-db/test::store-registry-suite))'
+```
+
+As in prior units, land the skeleton (file + exports) first if the test
+file cannot compile, then observe the behavioral RED.
+
+- [ ] **Step 3: Implement**
+
+`store-registry.lisp` (new). Model: `type-registry.lisp` (GH #186) — same
+append-only file, same flock discipline, same torn-tail tolerance (GH
+#191's lesson), simplified to one table. Complete implementation:
+
+```lisp
+(in-package :graph-db)
+
+;;; The image-level store-id registry (GH #169).  One stable numeric id
+;;; per graph-name, 1..4095, never reused: the id rides inside every v8
+;;; node id, so reuse would rebind existing ids to the wrong store.
+;;; Append-only; same idioms as the type registry (GH #186, #191).
+
+(defconstant +store-tag-bits+ 12)
+(defconstant +max-store-tag+ 4095)
+
+(defstruct (store-registry (:constructor %make-store-registry))
+  (location nil)
+  ;; name (symbol or string) -> id.  EQUAL: string names compare by
+  ;; content (cf. the strchk fixtures), symbols by identity.
+  (names (make-hash-table :test 'equal))
+  (next 1 :type (unsigned-byte 16))
+  (lock (make-recursive-lock "store registry")))
+
+(define-condition store-registry-full (error)
+  ((location :initarg :location :reader store-registry-full-location))
+  (:report
+   (lambda (c s)
+     (format s "The store registry at ~A has assigned all ~D ids.  The ~
+v8 store tag is ~D bits (GH #169); widening it is a format change."
+             (store-registry-full-location c)
+             +max-store-tag+ +store-tag-bits+))))
+
+(defvar *store-registry* nil)
+(defvar *store-registry-open-lock* (make-lock "store registry open"))
+
+(defun %store-registry-file (location)
+  (make-pathname :name "store-registry" :type "log" :defaults location))
+
+(defun %store-registry-lock-file (location)
+  (make-pathname :name "store-registry" :type "lock" :defaults location))
+
+(defun %parse-store-registry-record (line)
+  "LINE as (:NAME <symbol-or-string> :ID <int>).  *READ-EVAL* nil: data,
+never code (GH #169)."
+  (let ((*read-eval* nil)
+        (*package* (%registry-print-package)))
+    (multiple-value-bind (form pos) (read-from-string line)
+      (unless (= pos (length line))
+        (error "trailing garbage in store registry record: ~S" line))
+      (destructuring-bind (&key name id) form
+        (unless (and (or (symbolp name) (stringp name)) (integerp id))
+          (error "malformed store registry record: ~S" line))
+        (list name id)))))
+
+(defun %store-registry-load (registry)
+  "Rebuild from disk.  Torn FINAL record: drop and warn; damage earlier:
+signal (the #191 policy -- this file is the only record of what a store
+tag means)."
+  (with-recursive-lock-held ((store-registry-lock registry))
+    (let ((file (%store-registry-file (store-registry-location registry)))
+          (names (make-hash-table :test 'equal))
+          (max-id 0))
+      (when (probe-file file)
+        (with-open-file (s file :direction :input)
+          (loop
+            (multiple-value-bind (line missing-newline-p)
+                (read-line s nil :eof)
+              (when (eq line :eof) (return))
+              (let ((parsed
+                      (handler-case (%parse-store-registry-record line)
+                        (error (e)
+                          (if missing-newline-p
+                              (progn
+                                (log:warn "store registry: dropping torn ~
+final record in ~A: ~A" file e)
+                                (return))
+                              (error "malformed store registry record ~
+in ~A: ~A" file e))))))
+                (destructuring-bind (name id) parsed
+                  (setf (gethash name names) id)
+                  (setf max-id (max max-id id))))))))
+      (setf (store-registry-next registry) (1+ max-id))
+      ;; Swap, never clrhash: lock-free readers see old-complete or new.
+      (setf (store-registry-names registry) names)))
+  registry)
+
+(defun ensure-store-registry ()
+  "The image's store registry, opening it on first use.  Signals
+SYSTEM-DIRECTORY-REQUIRED without *SYSTEM-DIRECTORY* -- a store id must
+mean the same thing to every image of the system (GH #169, #186)."
+  (unless *system-directory*
+    (error 'system-directory-required))
+  (with-lock-held (*store-registry-open-lock*)
+    (or *store-registry*
+        (setf *store-registry*
+              (%store-registry-load
+               (%make-store-registry :location *system-directory*))))))
+
+(defun store-registry-id-for (name &optional
+                                     (registry (ensure-store-registry)))
+  "NAME's store id, or NIL.  Lock-free read: NIL is a hint, not proof --
+only STORE-REGISTRY-INTERN re-checks under the lock."
+  (gethash name (store-registry-names registry)))
+
+(defun store-registry-name-for (id &optional
+                                     (registry (ensure-store-registry)))
+  "The graph-name assigned ID, or NIL."
+  (maphash (lambda (name known)
+             (when (eql known id) (return-from store-registry-name-for
+                                    name)))
+           (store-registry-names registry))
+  nil)
+
+(defun store-registry-intern (name &optional
+                                     (registry (ensure-store-registry)))
+  "NAME's store id, minted if this system has not seen it.  Read-decide-
+append under the registry flock, re-reading first: another image may
+have assigned since our last load (GH #169; same discipline as
+REGISTRY-INTERN, #186)."
+  (or (store-registry-id-for name registry)
+      (let ((fd (%posix-open (%store-registry-lock-file
+                              (store-registry-location registry))
+                             (logior +o-creat+ +o-rdwr+))))
+        (unwind-protect
+             (progn
+               (%posix-flock fd +lock-ex+)
+               (%store-registry-load registry)
+               (or (store-registry-id-for name registry)
+                   (let ((id (store-registry-next registry)))
+                     (when (> id +max-store-tag+)
+                       (error 'store-registry-full
+                              :location (store-registry-location
+                                         registry)))
+                     (with-open-file
+                         (s (%store-registry-file
+                             (store-registry-location registry))
+                            :direction :output
+                            :if-exists :append
+                            :if-does-not-exist :create)
+                       (let ((*package* (%registry-print-package))
+                             (*print-pretty* nil)
+                             (*print-readably* t))
+                         (format s "~S~%" (list :name name :id id)))
+                       (finish-output s))
+                     (setf (gethash name (store-registry-names registry))
+                           id)
+                     (setf (store-registry-next registry) (1+ id))
+                     id)))
+          (%posix-close fd)))))
+```
+
+`graph-class.lisp`: add to `defclass graph`, next to `graph-name`:
+
+```lisp
+   ;; Stable numeric id from the store registry; rides in every v8 node
+   ;; id minted for this store.  NIL = untagged (no system directory,
+   ;; e.g. a memory graph outside a system): ids stay v5 (GH #169).
+   (store-id :accessor store-id :initarg :store-id :initform nil)
+```
+
+and, after `*graphs*`:
+
+```lisp
+(defvar *store-id->graph*
+  (make-array (1+ +max-store-tag+) :initial-element nil)
+  "Open-store vector: store-id -> open GRAPH, nil when not open.  The v8
+resolver's O(1) step (GH #169).  Slot 0 unused (0 is never assigned).
+Writes only under *GRAPHS*' registration points; readers are lock-free
+-- a stale nil costs a fallback, never a wrong graph.")
+
+(defun %register-open-store (graph)
+  "Give GRAPH its registry store-id and publish it in the open-store
+vector.  Outside a system (*SYSTEM-DIRECTORY* nil) the graph stays
+untagged -- ids remain v5 -- rather than failing the open (GH #169)."
+  (when *system-directory*
+    (setf (store-id graph) (store-registry-intern (graph-name graph)))
+    (setf (svref *store-id->graph* (store-id graph)) graph))
+  graph)
+
+(defun %unregister-open-store (graph)
+  "Retract GRAPH from the open-store vector.  The registry entry stays:
+ids are never reused (GH #169)."
+  (let ((sid (store-id graph)))
+    (when (and sid (eq graph (svref *store-id->graph* sid)))
+      (setf (svref *store-id->graph* sid) nil))))
+```
+
+Wire the helpers in `graph.lisp` (both `(setf (gethash name *graphs*)
+graph)` sites, ~461 and ~668) and `memory-graph.lisp` (~264, ~991):
+`(%register-open-store graph)` immediately after the *graphs*
+registration (the variable holding the graph may be named differently at
+each site — match it). In `close-graph` (both the disk and memory
+variants — find every method that removes the graph from `*graphs*` or
+marks it closed) call `(%unregister-open-store graph)`.
+
+NOTE: `store-registry.lisp` must load before `graph-class.lisp`? No —
+`+max-store-tag+` is referenced by `graph-class.lisp`'s defvar, so the
+.asd position of `store-registry` must precede `graph-class`. Place it
+right after `type-registry` only if `type-registry` precedes
+`graph-class`; otherwise place it immediately before `graph-class` and
+say so in your report. (`%registry-print-package`, `%posix-open`,
+`+o-creat+`, `+lock-ex+`, `%posix-flock`, `%posix-close`,
+`system-directory-required` must all be defined by then — they are in
+`type-registry.lisp`/`posix.lisp`/`globals.lisp`; verify with grep and
+adjust position accordingly, reporting what you chose.)
+
+Exports in `package.lisp` (next to the type-registry exports):
+`#:ensure-store-registry #:store-registry-intern #:store-registry-id-for
+#:store-registry-name-for #:store-registry-full #:store-id
+#:+store-tag-bits+ #:+max-store-tag+`.
+
+- [ ] **Step 4: Focused suite green; count and report the delta**
+
+The five tests above carry 13 checks (4+3+1+1+4 — recount from what you
+actually wrote and state the number). Run the focused suite; then run
+`global-type-id-suite` too (its graphs now intern store-ids — confirm no
+breakage from the new registration step).
+
+- [ ] **Step 5: Ablation**
+
+Ablate the never-reuse property: make `%unregister-open-store` also
+remove the name from the registry hash — `store-ids-survive-...` and
+`open-graph-carries-its-store-id`'s final check must fail. Revert, green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add store-registry.lisp graph-class.lisp graph.lisp memory-graph.lisp \
+        package.lisp graph-db.asd tests/store-registry-tests.lisp
+git commit -m "feat(store): stable numeric store-ids and the open-store vector (#169)"
+```
+
+---
+
+### Task 2: UUIDv8 generation with the store tag
+
+**Files:**
+- Modify: `node-id.lisp` (add `gen-v8-uuid` inside the existing
+  random-states closure; `uuid-v8-p`, `id-store-tag`;
+  `gen-vertex-id`/`gen-edge-id` gain `&optional store-tag`)
+- Modify: `vertex.lisp` (~32 `%make-vertex` fresh-id branch; ~157 the
+  duplicate-key retry) and `edge.lisp` (~40, ~252 likewise): pass the
+  graph's tag
+- Modify: `package.lisp` (export `#:uuid-v8-p #:id-store-tag`)
+- Modify: `tests/store-registry-tests.lisp` (append the id tests — same
+  suite, the fixtures are already there)
+
+**Interfaces:**
+- Consumes: `store-id` from Task 1.
+- Produces: `gen-v8-uuid (store-tag)` → 16-byte id;
+  `(uuid-v8-p id)` → boolean; `(id-store-tag id)` → tag or nil (nil for
+  v5 and any non-v8). Layout, frozen by this task: version nibble
+  `#x8` at byte 6 bits 4-7; RFC variant `#b10` at byte 8 bits 6-7; store
+  tag = low nibble of byte 14 (bits 8-11 of the tag) then byte 15 (bits
+  0-7); all other bits random. Task 3's resolver reads
+  `id-store-tag`.
+
+- [ ] **Step 1: Write the failing tests** (append to
+  `tests/store-registry-tests.lisp`)
+
+```lisp
+(test v8-ids-carry-the-store-tag
+  "Layout pin: version nibble 8, RFC variant, and the tag readable back
+from bytes 14-15.  Nearest wrong implementation: tag written but
+version left 5 (ID-STORE-TAG must return NIL for it)."
+  (let ((id (graph-db::gen-v8-uuid 2749)))
+    (is (= 16 (length id)))
+    (is (graph-db:uuid-v8-p id))
+    (is (= #b10 (ldb (byte 2 6) (aref id 8))) "RFC 9562 variant")
+    (is (= 2749 (graph-db:id-store-tag id)))))
+
+(test v5-ids-have-no-store-tag
+  "Legacy ids answer NIL, never a garbage tag read out of hash bytes."
+  (let ((id (graph-db::gen-v5-uuid graph-db::*vertex-namespace*)))
+    (is (not (graph-db:uuid-v8-p id)))
+    (is (null (graph-db:id-store-tag id)))))
+
+(test gen-ids-fall-back-to-v5-without-a-tag
+  "GEN-VERTEX-ID/GEN-EDGE-ID with no (or nil) tag are byte-layout v5 --
+the memory-graph/legacy path is unchanged (GH #169)."
+  (is (not (graph-db:uuid-v8-p (graph-db::gen-vertex-id))))
+  (is (not (graph-db:uuid-v8-p (graph-db::gen-edge-id nil)))))
+
+(test new-nodes-in-a-store-get-tagged-ids
+  "End to end: a vertex and an edge created in an open store carry ids
+whose tag is that store's id.  Nearest wrong implementation: generation
+still v5 everywhere (the whole point of the unit)."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys)))
+        (let ((g (make-graph :sr-tagged-store (namestring dir)
+                             :buffer-pool-size 1000)))
+          (unwind-protect
+               (let (v1 v2 e)
+                 (with-transaction (:graph g)
+                   (setq v1 (make-vertex :generic nil :graph g))
+                   (setq v2 (make-vertex :generic nil :graph g))
+                   (setq e (make-edge :generic (id v1) (id v2) 1.0 nil
+                                      :graph g)))
+                 (is (= (graph-db::store-id g)
+                        (graph-db:id-store-tag (id v1))))
+                 (is (= (graph-db::store-id g)
+                        (graph-db:id-store-tag (id e)))))
+            (close-graph g :snapshot-p nil)))))))
+```
+
+NOTE for the implementer: check `with-transaction`'s actual lambda list
+and `make-vertex`/`make-edge`'s positional arguments against the source
+(`vertex.lisp`, `edge.lisp`, `transactions.lisp`) before running — the
+forms above follow `example.lisp`'s conventions but the test must call
+what the code actually accepts; fix mechanically and note it.
+
+- [ ] **Step 2: Run to verify failure** (same invocation; the four tests
+  RED — no `gen-v8-uuid`, no exports)
+
+- [ ] **Step 3: Implement**
+
+In `node-id.lisp`, inside the existing `(let ((random-states ...)) ...)`
+closure add (alongside `generate-uuid-name`):
+
+```lisp
+  (defun gen-v8-uuid (store-tag)
+    "A UUIDv8 (RFC 9562 vendor layout) node id: 110 random bits, the
+12-bit STORE-TAG in the low nibble of byte 14 plus byte 15, version and
+variant stamped.  The tag is the O(1) resolver's index (GH #169)."
+    (declare (optimize (speed 3) (safety 0))
+             (type (unsigned-byte 12) store-tag))
+    (let ((id (make-array 16 :element-type '(unsigned-byte 8))))
+      (dotimes (i 16)
+        (setf (aref id i) (random 256 (nth (random 2) random-states))))
+      (setf (aref id 6) (dpb #x8 (byte 4 4) (aref id 6)))
+      (setf (aref id 8) (dpb #b10 (byte 2 6) (aref id 8)))
+      (setf (aref id 14) (dpb (ldb (byte 4 8) store-tag) (byte 4 0)
+                              (aref id 14)))
+      (setf (aref id 15) (ldb (byte 8 0) store-tag))
+      id))
+```
+
+After the closure:
+
+```lisp
+(defun uuid-v8-p (id)
+  "True when ID's version nibble says v8 -- our tagged layout.  Legacy
+ids are v5 (GH #169)."
+  (= #x8 (ldb (byte 4 4) (aref id 6))))
+
+(defun id-store-tag (id)
+  "ID's 12-bit store tag, or NIL for a non-v8 id.  Never read the tag
+bytes of a v5 id: they are SHA1 output and would name a random store."
+  (when (uuid-v8-p id)
+    (logior (ash (ldb (byte 4 0) (aref id 14)) 8)
+            (aref id 15))))
+```
+
+`gen-vertex-id` / `gen-edge-id` become:
+
+```lisp
+(declaim (inline gen-edge-id))
+(defun gen-edge-id (&optional store-tag)
+  (if store-tag (gen-v8-uuid store-tag) (gen-v5-uuid *edge-namespace*)))
+
+(declaim (inline gen-vertex-id))
+(defun gen-vertex-id (&optional store-tag)
+  (if store-tag (gen-v8-uuid store-tag) (gen-v5-uuid *vertex-namespace*)))
+```
+
+Call sites — pass the graph's tag at each of the four:
+`vertex.lisp:~32` and `edge.lisp:~40` are inside the low-level
+`%make-vertex`/`%make-edge` constructors; confirm each has a `graph`
+binding in scope (their `make-vertex`/`make-edge` callers pass
+`:graph`); if one genuinely does not, thread it or report NEEDS_CONTEXT
+— do not fall back to `*graph*` silently. The retry sites
+(`vertex.lisp:~157`, `edge.lisp:~252`) have `graph` lexically visible.
+Each becomes `(gen-vertex-id (and graph (store-id graph)))` (edge
+likewise).
+
+- [ ] **Step 4: Focused suite green; state the check delta.** Also run
+  `graph-db/test::acid...` no — controller runs the gate; run
+  `store-registry-suite` plus `graph-suite`-adjacent basics you judge
+  cheapest to catch id-shape fallout (`reopen-tests` suite is a good
+  canary: ids round-trip through close/open).
+
+- [ ] **Step 5: Ablation.** Stamp the version nibble as 5 instead of 8 in
+  `gen-v8-uuid`: `v8-ids-carry-the-store-tag` and
+  `new-nodes-in-a-store-get-tagged-ids` must fail (`id-store-tag` refuses
+  a v5-claiming id). Revert, green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add node-id.lisp vertex.lisp edge.lisp package.lisp \
+        tests/store-registry-tests.lisp
+git commit -m "feat(id): UUIDv8 node ids carry the store tag (#169)"
+```
+
+---
+
+### Task 3: The resolver, the marker, and the detached semantics
+
+**Files:**
+- Modify: `graph-class.lisp` (resolver + marker + condition, after the
+  open-store vector; or `interface.lisp` if load order demands — say
+  which and why)
+- Modify: `traverse.lisp` (the two `lookup-vertex` endpoint sites)
+- Modify: `package.lisp` (exports)
+- Create: `tests/store-resolver-tests.lisp` (+ .asd entry after
+  `store-registry-tests`)
+
+**Interfaces:**
+- Consumes: `*store-id->graph*`, `store-registry-name-for`,
+  `id-store-tag`, `uuid-v8-p`.
+- Produces:
+
+```lisp
+(defstruct (unresolved-node (:constructor make-unresolved-node
+                                          (id store-id store-name)))
+  id store-id store-name)
+```
+
+  `resolve-node-graph (id)` → `(values graph-or-nil status store-id)`
+  with status ∈ `:resolved :detached :unknown`;
+  `lookup-vertex-anywhere (id &key (if-detached :marker))` → vertex |
+  unresolved-node | nil (`:if-detached :error` signals
+  `store-detached-error`);
+  condition `store-detached-error` (readers `store-detached-name`,
+  `store-detached-id`). #170 consumes all three.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/store-resolver-tests.lisp`:
+
+```lisp
+;;;; The tagged-id resolver and the detached-read semantics (GH #169).
+(in-package #:graph-db/test)
+
+(def-suite store-resolver-suite :in graph-db-suite
+  :description "O(1) v8 resolution; v5 scan; markers for the detached.")
+(in-suite store-resolver-suite)
+
+(defmacro with-two-stores ((g1 g2 sys) &body body)
+  "Two open disk stores under one system directory."
+  (let ((d1 (gensym)) (d2 (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,d1)
+         (with-temp-directory (,d2)
+           (let ((graph-db::*system-directory* (namestring ,sys)))
+             (let ((,g1 (make-graph :rsv-store-1 (namestring ,d1)
+                                    :buffer-pool-size 1000))
+                   (,g2 (make-graph :rsv-store-2 (namestring ,d2)
+                                    :buffer-pool-size 1000)))
+               (unwind-protect (progn ,@body)
+                 (ignore-errors (close-graph ,g1 :snapshot-p nil))
+                 (ignore-errors (close-graph ,g2 :snapshot-p nil))
+                 (collect-garbage)))))))))
+
+(test v8-resolution-is-by-tag
+  "A v8 id resolves to its OWN open store without consulting the store
+it was found in.  Nearest wrong implementation: resolve everything via
+*GRAPH* (the pre-#169 assumption)."
+  (with-two-stores (g1 g2 sys)
+    (let (v)
+      (with-transaction (:graph g2)
+        (setq v (make-vertex :generic nil :graph g2)))
+      (multiple-value-bind (graph status sid)
+          (graph-db:resolve-node-graph (id v))
+        (is (eq g2 graph))
+        (is (eq :resolved status))
+        (is (= (graph-db::store-id g2) sid))))))
+
+(test v5-resolution-scans-open-stores
+  "A legacy v5 id resolves by trying each open store's vertex table --
+slower, correct, and the reason there is no flag day (GH #169)."
+  (with-two-stores (g1 g2 sys)
+    (let ((vid (graph-db::gen-vertex-id)))   ; untagged v5
+      (with-transaction (:graph g2)
+        (make-vertex :generic nil :id vid :graph g2))
+      (multiple-value-bind (graph status sid)
+          (graph-db:resolve-node-graph vid)
+        (declare (ignore sid))
+        (is (eq g2 graph))
+        (is (eq :resolved status))))))
+
+(test detached-store-yields-a-marker
+  "A v8 id whose store is REGISTERED but not OPEN is detached: known,
+findable, offline.  Incidental access gets the marker, never a raw NIL
+(indistinguishable from 'no such node') and never an error.  Nearest
+wrong implementation: return NIL (silent skipping, rejected by D8)."
+  (with-two-stores (g1 g2 sys)
+    (let (v)
+      (with-transaction (:graph g2)
+        (setq v (make-vertex :generic nil :graph g2)))
+      (close-graph g2 :snapshot-p nil)
+      (let ((r (graph-db:lookup-vertex-anywhere (id v))))
+        (is (graph-db:unresolved-node-p r))
+        (is (equalp (id v) (graph-db:unresolved-node-id r)))
+        (is (eq :rsv-store-2 (graph-db:unresolved-node-store-name r)))))))
+
+(test explicit-access-to-a-detached-store-signals
+  "The caller who ASKS for the detached store gets the error, per D8's
+explicit-versus-incidental split."
+  (with-two-stores (g1 g2 sys)
+    (let (v)
+      (with-transaction (:graph g2)
+        (setq v (make-vertex :generic nil :graph g2)))
+      (close-graph g2 :snapshot-p nil)
+      (signals graph-db:store-detached-error
+        (graph-db:lookup-vertex-anywhere (id v) :if-detached :error)))))
+
+(test unknown-tag-is-unknown-not-detached
+  "A v8 id with a tag the registry never assigned is :UNKNOWN -- the
+resolver must not fabricate a detached store out of it."
+  (with-two-stores (g1 g2 sys)
+    (let ((id (graph-db::gen-v8-uuid 4000)))
+      (multiple-value-bind (graph status sid)
+          (graph-db:resolve-node-graph id)
+        (declare (ignore sid))
+        (is (null graph))
+        (is (eq :unknown status))))))
+
+(test traversal-reaches-across-open-stores-and-marks-detached
+  "A cross-store edge: with both stores open, TRAVERSE surfaces the
+far-end vertex in its results (it is not walked further -- cross-store
+continuation is #170+ work); with the far store closed, the results
+carry the unresolved marker instead.  Nearest wrong implementation:
+LOOKUP-VERTEX in the local store only -- the far end silently vanishes
+from results in BOTH cases."
+  (with-two-stores (g1 g2 sys)
+    (let (v1 v2)
+      (with-transaction (:graph g1)
+        (setq v1 (make-vertex :generic nil :graph g1)))
+      (with-transaction (:graph g2)
+        (setq v2 (make-vertex :generic nil :graph g2)))
+      (with-transaction (:graph g1)
+        (make-edge :generic (id v1) (id v2) 1.0 nil :graph g1))
+      (let ((results (traverse v1 :graph g1 :direction :out)))
+        (is (find-if (lambda (r)
+                       (and (vertex-p r) (equalp (id v2) (id r))))
+                     results)
+            "open far store: the vertex itself is in the results"))
+      (close-graph g2 :snapshot-p nil)
+      (let ((results (traverse v1 :graph g1 :direction :out)))
+        (is (find-if (lambda (r)
+                       (and (graph-db:unresolved-node-p r)
+                            (equalp (id v2)
+                                    (graph-db:unresolved-node-id r))))
+                     results)
+            "closed far store: the marker is in the results")))))
+```
+
+Same NOTE as Task 2 about verifying `with-transaction`/constructor
+lambda lists against the source before running.
+
+- [ ] **Step 2: Run to verify failure** (skeleton-first allowed; then
+  behavioral RED on every test)
+
+- [ ] **Step 3: Implement**
+
+In `graph-class.lisp`, after `%unregister-open-store`:
+
+```lisp
+(defstruct (unresolved-node (:constructor make-unresolved-node
+                                          (id store-id store-name)))
+  "The honest answer for a read that reaches into a detached store:
+there IS a node here, its store is known, and the store is offline
+(GH #169, D8).  Never a raw NIL -- that is indistinguishable from 'no
+such node' -- and never an error from mid-traversal."
+  id store-id store-name)
+
+(define-condition store-detached-error (error)
+  ((name :initarg :name :reader store-detached-name)
+   (id :initarg :id :reader store-detached-id))
+  (:report
+   (lambda (c s)
+     (format s "Store ~S (id ~D) is registered but not open -- ~
+detached.  Explicit access signals; incidental traversal would have ~
+received an UNRESOLVED-NODE marker instead (GH #169, D8)."
+             (store-detached-name c) (store-detached-id c)))))
+
+(defun resolve-node-graph (id)
+  "The open store holding ID, as (values GRAPH STATUS STORE-ID) with
+STATUS one of :RESOLVED, :DETACHED (registry knows the tag, no open
+graph carries it) or :UNKNOWN.  A v8 id indexes the open-store vector,
+O(1); a v5 id is tried against each open store's vertex table -- the
+no-flag-day fallback (GH #169, D5).  For a v5 id STORE-ID is the
+holding store's id (or NIL when untagged/unknown)."
+  (let ((tag (id-store-tag id)))
+    (if tag
+        (let ((graph (svref *store-id->graph* tag)))
+          (cond (graph (values graph :resolved tag))
+                ((and *system-directory*
+                      (store-registry-name-for tag))
+                 (values nil :detached tag))
+                (t (values nil :unknown tag))))
+        (progn
+          (maphash (lambda (name graph)
+                     (declare (ignore name))
+                     (when (and (graph-open-p graph)
+                                (lookup-vertex id :graph graph))
+                       (return-from resolve-node-graph
+                         (values graph :resolved (store-id graph)))))
+                   *graphs*)
+          (values nil :unknown nil)))))
+
+(defun lookup-vertex-anywhere (id &key (if-detached :marker))
+  "ID's vertex from whichever open store holds it; an UNRESOLVED-NODE
+marker when its store is detached (or, with :IF-DETACHED :ERROR, a
+STORE-DETACHED-ERROR -- the explicit-access half of D8); NIL when no
+store known to the system holds it (GH #169)."
+  (multiple-value-bind (graph status tag) (resolve-node-graph id)
+    (ecase status
+      (:resolved (lookup-vertex id :graph graph))
+      (:detached
+       (let ((name (store-registry-name-for tag)))
+         (ecase if-detached
+           (:marker (make-unresolved-node id tag name))
+           (:error (error 'store-detached-error :name name :id tag)))))
+      (:unknown nil))))
+```
+
+(If `lookup-vertex` is not yet defined at `graph-class.lisp`'s load
+position, put the two functions that call it in `interface.lisp` instead
+and leave the struct + condition in `graph-class.lisp`; report the
+placement.)
+
+`traverse.lisp`: in both endpoint sites, replace
+`(lookup-vertex (to edge))` with:
+
+```lisp
+(or (lookup-vertex (to edge))
+    (lookup-vertex-anywhere (to edge)))
+```
+
+(mirror for `from`), and guard the walk so only same-graph vertices are
+enqueued — the enqueue form becomes conditional:
+
+```lisp
+(when (and to-vertex (vertex-p to-vertex))
+  (unless (gethash to-vertex memory)
+    (setf (gethash to-vertex memory) t)
+    (enqueue queue new-traversal)))
+```
+
+BUT a cross-store vertex (resolved in another open graph) must also not
+be enqueued — its adjacency lives in the other store and `map-edges`
+here runs against GRAPH. Gate the enqueue on
+`(eq (node-graph to-vertex) graph)` if vertices carry their graph
+(check `node-graph` — `vertex.lisp:~150` sets it), else compare
+`(id-store-tag (id to-vertex))` to `(store-id graph)` with a nil-safe
+fallback to enqueue (v5 same-store ids). The result-table `setf` stays
+unconditional — markers and cross-store vertices belong in RESULTS, not
+in the walk. Add one terse comment: cross-store continuation is future
+work (GH #169 → #170+).
+
+Exports: `#:resolve-node-graph #:lookup-vertex-anywhere
+#:unresolved-node #:unresolved-node-p #:unresolved-node-id
+#:unresolved-node-store-id #:unresolved-node-store-name
+#:store-detached-error #:store-detached-name #:store-detached-id`.
+
+- [ ] **Step 4: Focused suites green** (`store-resolver-suite`,
+  `store-registry-suite`, plus `traverse-tests`' suite — the traverse
+  change must not disturb single-store traversal). State check deltas.
+
+- [ ] **Step 5: Ablations — run both.** (a) Make `:detached` return NIL
+  from `lookup-vertex-anywhere` (silent-skip, the rejected design):
+  `detached-store-yields-a-marker` and the traversal marker check must
+  fail. (b) Revert the traverse wiring to plain `lookup-vertex`:
+  `traversal-reaches-across-open-stores-and-marks-detached` must fail on
+  BOTH halves. Revert, green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add graph-class.lisp interface.lisp traverse.lisp package.lisp \
+        graph-db.asd tests/store-resolver-tests.lisp
+git commit -m "feat(resolve): O(1) tagged resolution and the detached-read marker (#169)"
+```
+
+---
+
+### Task 4: Backup warns on a dangling cross-store edge
+
+**Files:**
+- Modify: `backup.lisp` (the `map-edges` pass of
+  `(defmethod backup ((graph graph) ...))`, ~line 158; new warning
+  condition beside it)
+- Modify: `package.lisp` (export `#:dangling-edge-warning` + readers)
+- Modify: `tests/store-resolver-tests.lisp` (append one test)
+
+**Interfaces:**
+- Consumes: `resolve-node-graph`.
+- Produces: `dangling-edge-warning` (warning; readers
+  `dangling-edge-id`, `dangling-edge-endpoint-id`,
+  `dangling-edge-store-id`).
+
+- [ ] **Step 1: The failing test** (append):
+
+```lisp
+(test backup-includes-and-warns-on-a-dangling-cross-store-edge
+  "D12/§7: BACKUP writes the edge (connectivity survives) and signals
+DANGLING-EDGE-WARNING naming the offline endpoint.  Nearest wrong
+implementations: omit the edge silently, or refuse the backup."
+  (with-two-stores (g1 g2 sys)
+    (with-temp-directory (bdir)
+      (let (v1 v2 e)
+        (with-transaction (:graph g1)
+          (setq v1 (make-vertex :generic nil :graph g1)))
+        (with-transaction (:graph g2)
+          (setq v2 (make-vertex :generic nil :graph g2)))
+        (with-transaction (:graph g1)
+          (setq e (make-edge :generic (id v1) (id v2) 1.0 nil
+                             :graph g1)))
+        (close-graph g2 :snapshot-p nil)
+        (let ((file (merge-pathnames "dangle.backup" bdir))
+              (warned nil))
+          (handler-bind ((graph-db:dangling-edge-warning
+                           (lambda (w)
+                             (setq warned w)
+                             (muffle-warning w))))
+            (backup g1 (namestring file)))
+          (is-true warned "the backup must warn")
+          (is (equalp (id e) (graph-db:dangling-edge-id warned)))
+          (is-true (probe-file file))
+          (is-true (search (format nil "~A" (string-id e))
+                           (alexandria:read-file-into-string file))
+                   "the dangling edge is IN the backup"))))))
+```
+
+(`string-id` — verify the actual exported name for id→string; the
+existing rest-tests use one; adjust mechanically.)
+
+- [ ] **Step 2: RED, Step 3: Implement**
+
+In `backup.lisp`:
+
+```lisp
+(define-condition dangling-edge-warning (warning)
+  ((edge-id :initarg :edge-id :reader dangling-edge-id)
+   (endpoint-id :initarg :endpoint-id :reader dangling-edge-endpoint-id)
+   (store-id :initarg :store-id :reader dangling-edge-store-id))
+  (:report
+   (lambda (c s)
+     (format s "Backup includes edge ~A whose endpoint ~A lives in ~
+store ~A, which is not open -- the edge is written, connectivity is ~
+preserved, and restoring it before that store is attached leaves it ~
+dangling (GH #169, spec sec.7)."
+             (dangling-edge-id c) (dangling-edge-endpoint-id c)
+             (dangling-edge-store-id c)))))
+```
+
+In the graph `backup` method's edge lambda, after writing the edge,
+check both endpoints: for each of `(from e)` / `(to e)` not found in
+GRAPH (`lookup-vertex ... :graph graph` nil), call `resolve-node-graph`;
+when status is `:detached` (or `:resolved` in a DIFFERENT graph — that
+endpoint is also absent from THIS backup file; warn for it too, same
+condition), warn once per offending endpoint. Keep it terse; the edge is
+always written either way.
+
+- [ ] **Step 4: Focused green + backup-tests suite; Step 5: Ablation** —
+  drop the warn call: the test's `warned` check fails. Revert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backup.lisp package.lisp tests/store-resolver-tests.lisp
+git commit -m "feat(backup): include and warn on dangling cross-store edges (#169)"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:** `CHANGELOG.md` (`### Added`), manual
+`docs/vivace-graph-v3-doc.org` (id/UUID section — search `v5`/`UUID`;
+plus a short cross-store-reads note where traversal or the REST of
+multi-store behavior is documented), spec §5/§7 get "**Built (#169):**"
+notes in the established style. Domain-neutral; 80-col; spaces.
+
+- [ ] CHANGELOG entry: new ids are v8 with a 12-bit store tag (existing
+  v5 ids unchanged, resolver falls back to a scan); store registry file
+  `store-registry.log` in the system directory; `resolve-node-graph`,
+  `lookup-vertex-anywhere`, `unresolved-node`, `store-detached-error`;
+  traverse surfaces cross-store endpoints and markers; backup warns on
+  dangling cross-store edges. (#169)
+- [ ] Manual + spec notes; commit
+  `docs: tagged UUIDv8 store field and the detached-read marker (#169)`.
+- [ ] **Step (controller): whole-branch review, then PR.**
+
+---
+
+## Self-Review
+
+- Spec coverage: §5.3 layout + width (12 bits within the 8–12 guidance),
+  registry never-reuse, v5 fallback/no flag day; §7 marker vs error split
+  and the backup warn — each has a task. §5.4's occupancy set explicitly
+  out of scope (stated in the architecture note). #169's "why not v5"
+  needs no code.
+- The riskiest judgment is Task 3's traverse gating (surface, don't
+  walk); it is stated as the deliberately narrow reading of D8 and
+  marked as #170+ follow-on.
+- Test forms follow example.lisp conventions; both Task-2/3 NOTEs demand
+  verification against the real lambda lists before first run.
+- Placeholders: none; every step carries code or an exact command.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -218,6 +218,17 @@ the vertex table, both ve-indexes, the vev-index and the type-index. "Move a nod
 store" is copy-and-delete with a new id. Re-homing a *class* does not re-home existing
 *nodes*.
 
+**Built (#169):** 12-bit tag, at the wide end of the 8–12 bit range.
+`gen-v8-uuid` stamps it plus version/variant; `uuid-v8-p`/`id-store-tag`
+read it back, never trusting a v5 id's corresponding bytes (SHA1
+output, not a tag). The registry is an append-only
+`store-registry.log` under the system directory, one line per
+graph-name, ids 1..4095 and never reused; `store-registry-intern`
+mints under the same read-decide-append-under-`flock` discipline as
+the type registry. `resolve-node-graph` is the resolver: O(1)
+open-store-vector index for v8, per-open-store scan for v5, exactly as
+designed above.
+
 ### 5.4 Inbound and outbound cross-store lookup
 
 Indexes live in stores, and stores stay few, so an unhinted sweep is a handful of lookups.
@@ -320,6 +331,18 @@ report "not found anywhere" and could not distinguish an absent store from a mis
 **Explicit versus incidental access.** A call naming a detached store **signals**
 (`store-detached-error`) — the caller asked for something specific. Incidental traversal
 into one yields the marker — that caller merely walked there.
+
+**Built (#169):** `backup` writes the edge and warns via
+`dangling-edge-warning` (edge, endpoint, store) for a detached or
+different-open-store endpoint; a clean backup stays silent.
+`lookup-vertex-anywhere` returns an `unresolved-node` marker by
+default and signals `store-detached-error` for `:if-detached :error`,
+matching the explicit/incidental split above. `traverse` is the
+incidental caller: a cross-store endpoint or marker lands in the
+result but is not walked past — full cross-store continuation is
+#170+. `active-edge-p` resolves cross-store endpoints for liveness,
+with two scoped gaps tracked as #208 (no v5 cross-store scan; an
+unregistered tag counts as live).
 
 ## 8. Bulk load and detach
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -574,7 +574,12 @@ VivaceGraph's most distinctive feature is its deep integration with the Common L
 
 At the top of the hierarchy is the ~node~ class, defined in ~clos.lisp~ and ~node-class.lisp~. It is the abstract superclass for anything that can exist in the graph. Every ~node~ instance has a set of core, built-in properties that are essential for the database's internal management:
 
-- ~id~ :: A 16-byte UUID that uniquely identifies the node across the entire database.
+- ~id~ :: A 16-byte UUID that uniquely identifies the node across the
+  entire database. An older id is v5 (SHA1-based, no store information
+  in its bytes); since GH #169 a store attached to a system directory
+  mints v8 ids instead, each carrying a 12-bit store tag used for O(1)
+  cross-store resolution -- see Chapter 17, "Tagged node ids: the
+  store registry and UUIDv8".
 - ~revision~ :: An integer that increments with every update, used for optimistic concurrency control.
 - ~%deleted-p~ :: A boolean flag indicating whether the node has been marked for deletion.
 - ~%data-pointer~ :: A 64-bit integer pointing to the location of the node's serialized data in the heap file.
@@ -1960,6 +1965,15 @@ The resulting file contains a series of Lisp s-expressions, one for each node in
 **** The ~backup~ Function
 
 The ~backup~ function is the underlying worker called by ~snapshot~. It handles the process of iterating through all nodes and writing their serialized representations to a Lisp stream. While you can call it directly, it does not provide the safety guarantees (locking and integrity checks) of `snapshot`, so its direct use is discouraged for production backups.
+
+**Cross-store edges (GH #169).** An edge whose endpoint lives in
+another store is written to the backup file as-is -- connectivity is
+never dropped. If that endpoint's store is *detached* (registered but
+not open) or is a *different* open store than the one being backed up,
+~backup~ also signals ~dangling-edge-warning~, naming the edge, the
+missing endpoint and its store: restoring this file before that other
+store is attached would leave the edge dangling. A backup with no such
+gaps never warns.
 
 *** Restoring a Graph from a Snapshot (~replay~)
 
@@ -3347,6 +3361,70 @@ price of giving a cross-store query a genuine shared instant (spec §6);
 without it, one store's reaper could free a version a snapshot on another
 store still depends on.
 
+*** Tagged node ids: the store registry and UUIDv8
+
+Every node id is already global -- a node's store is where you find
+it, not part of what it is -- but a v5 id carries no way to find that
+store short of asking every open one. As of GH #169, a store attached
+to a system directory mints ids as *UUIDv8* (RFC 9562's vendor layout)
+instead: 110 bits of random fill, version and variant stamped, and a
+12-bit *store tag* in the low nibble of byte 14 plus byte 15. A store
+opened with no ~*system-directory*~ bound stays untagged and keeps
+minting v5 ids exactly as before -- there is no flag day.
+
+The tag is a stable numeric *store-id*, assigned from a second,
+separate registry -- distinct from the type registry earlier in this
+chapter, and from that registry's own ~store-registry-conflict~
+condition, which is about type-id disagreement, not this id. This one
+lives in ~store-registry.log~, a sibling of ~type-registry.log~ under
+~*system-directory*~, one line per graph-name the system has ever
+opened, 1 through 4095. Ids are never reused: a store-id rides inside
+every v8 node id that store mints, so reusing one would silently rebind
+existing ids to the wrong store. Assignment is
+~store-registry-intern~, which serialises through the same
+read-decide-append-under-~flock~ discipline as the type registry;
+plain lookups (~store-registry-id-for~, ~store-registry-name-for~) take
+no lock. A system that has assigned all 4095 ids signals
+~store-registry-full~ -- widening the tag is a format change, not a
+runtime one.
+
+~uuid-v8-p~ tests the version nibble and ~id-store-tag~ reads the tag
+(NIL for a v5 id -- never read a v5 id's byte 14/15 as a tag, since
+that is SHA1 output and would name a random store). ~resolve-node-graph~
+is the reader built on top: for a v8 id it indexes the open-store
+vector directly, O(1); for a v5 id it falls back to asking each open
+store's own vertex table, same cost as before #169. It returns three
+values -- the graph (or NIL), a status of ~:resolved~, ~:detached~ (the
+registry knows the tag but no open graph currently carries it) or
+~:unknown~ (an unregistered tag, or a v5 id no open store holds), and
+the store-id when one is known.
+
+*** Cross-store reads: markers, detached stores, and traversal
+
+~lookup-vertex-anywhere~ wraps ~resolve-node-graph~ for the common case
+of reading a node whose store you cannot assume. A resolved id reads
+normally; an unknown one returns NIL, same as an ordinary miss. A
+*detached* store -- registered, but not currently open -- is the new
+case: by default it returns an ~unresolved-node~ marker struct (id,
+store-id, store-name), never a bare NIL, because NIL there would be
+indistinguishable from "no such node." Passing ~:if-detached :error~
+instead signals ~store-detached-error~, for callers that named a
+specific node and want to know its store is offline rather than
+silently walking around it.
+
+That split -- marker for incidental access, error for explicit access
+-- is deliberate (spec sec.7). ~traverse~ takes the incidental side: an
+edge whose endpoint resolves to a *different* open store, or to a
+detached one, still lands in the traversal's results (the vertex
+object, or the ~unresolved-node~ marker), but the walk does not
+continue past it into the other store's own adjacency -- following a
+cross-store edge across the boundary is left to a later unit. Likewise
+~active-edge-p~ resolves a cross-store endpoint to decide whether an
+edge is still live, with two narrow, accepted gaps documented at the
+call site and tracked as GH #208: an untagged v5 endpoint gets no
+cross-store scan on this hot path, and an unregistered tag is treated
+as live rather than proven dead, since it cannot be disproved.
+
 ** Chapter 18: Temporal Extents — graph-db/spacetime (optional)
 
 Every timestamp a real system records comes with some story about how sure
@@ -4264,7 +4342,32 @@ This chapter provides a categorized reference for the most important exported sy
   As ~outgoing-edges~, for incoming edges.
 
 - ~traverse (vertex &key ... )~ ::
-  Performs a breadth-first search traversal starting from a given vertex.
+  Performs a breadth-first search traversal starting from a given
+  vertex. A cross-store endpoint or a detached-store marker (see
+  below) appears in the results but is not walked past (GH #169; see
+  Chapter 17).
+
+- ~resolve-node-graph (id)~ ::
+  Returns ~(values graph status store-id)~ for a node id: the open
+  graph holding it (or NIL) and a status of ~:resolved~, ~:detached~
+  (registered store, not open) or ~:unknown~. O(1) for a v8 id, a
+  per-open-store scan for a v5 id. See Chapter 17.
+
+- ~lookup-vertex-anywhere (id &key if-detached)~ ::
+  Reads ID's vertex from whichever open store holds it. Returns an
+  ~unresolved-node~ marker (default, ~:if-detached :marker~) or
+  signals ~store-detached-error~ (~:if-detached :error~) when ID's
+  store is registered but not open; NIL when ID is unknown to the
+  system.
+
+- ~unresolved-node~ (struct) ::
+  Marks a read that reached a real node in a detached store.
+  Readers: ~unresolved-node-id~, ~-store-id~, ~-store-name~.
+
+- ~store-detached-error~ (condition) ::
+  Signalled by ~lookup-vertex-anywhere :if-detached :error~ for a node
+  whose store is registered but not currently open. Readers:
+  ~store-detached-name~, ~store-detached-id~.
 
 **** Replication
 - ~start-replication (graph &key ... )~ ::

--- a/edge.lisp
+++ b/edge.lisp
@@ -28,14 +28,21 @@
 (defun %make-edge (&key id type-id revision deleted-p data-pointer data bytes from
                      to weight written-p heap-written-p type-idx-written-p
                      ve-written-p vev-written-p views-written-p
-                     commit-epoch prev-pointer (class 'edge))
+                     commit-epoch prev-pointer (class 'edge) graph)
   ;; ECL ONLY: construct the target CLASS directly (ECL's CHANGE-CLASS leaks per
   ;; call -- #47), giving up the node buffer pool on ECL.  SBCL/CCL/LispWorks
   ;; keep the pooled base EDGE + CHANGE-CLASS path (no leak, pool is a perf win).
   (let ((edge #+ecl (let ((*initializing-node* t)) (make-instance class))
               #-ecl (get-edge-buffer)))
+    ;; GET-EDGE-BUFFER may hand back a pool-warmed instance that already
+    ;; carries an untagged v5 id (MAKE-EDGE-BUFFER has no graph to tag
+    ;; with) -- the +NULL-KEY+ check alone would never fire and every
+    ;; tagged store would silently get untagged ids.  A known store tag
+    ;; always wins and mints fresh, even over a pooled id (GH #169).
     (cond (id
            (setf (id edge) id))
+          ((and graph (store-id graph))
+           (setf (id edge) (gen-edge-id (store-id graph))))
           ((equalp +null-key+ (id edge))
            (setf (id edge) (gen-edge-id))))
     (when from (setf (from edge) from))
@@ -236,7 +243,8 @@ regenerates the id on a duplicate-key collision."
                    :to to
                    :weight weight
                    :bytes bytes
-                   :data data)))
+                   :data data
+                   :graph graph)))
           (setf (bytes e) bytes)
           ;; Stamped from birth: the edge is live for the whole creating
           ;; transaction, long before commit stamps it (GH #53).
@@ -249,7 +257,7 @@ regenerates the id on a duplicate-key collision."
                     (log:error "EDGE: Duplicate key error: ~A. Retrying MAKE-EDGE"
                                (id e))
                     (make-edge type from to weight data
-                               :id (gen-edge-id)
+                               :id (gen-edge-id (and graph (store-id graph)))
                                :revision revision
                                :deleted-p deleted-p :graph graph))
                   (error c)))))

--- a/edge.lisp
+++ b/edge.lisp
@@ -300,7 +300,17 @@ an edge with a genuinely absent endpoint is inactive; :UNKNOWN for a
 cross-store id whose store is detached or unregistered -- can't disprove
 liveness, so it must not silently kill the edge (D8; GH #169).
 LOOKUP-VERTEX-ANYWHERE is defined in interface.lisp, loaded after this
-file; resolved at runtime like PIN-READ-EPOCH in graph-class.lisp."
+file; resolved at runtime like PIN-READ-EPOCH in graph-class.lisp.
+
+Two accepted scoped gaps here, not full parity with the resolver
+(GH #208): (1) an untagged v5 id gets NO cross-store scan -- a same-
+store miss is :MISSING/inactive even if the vertex lives in another
+open store, unlike LOOKUP-VERTEX-ANYWHERE's own v5 fallback; a
+deliberate hot-path tradeoff, this runs on every MAP-EDGES emit.
+(2) an unregistered v8 tag (:UNKNOWN) counts as active -- we cannot
+disprove liveness -- so a compacting/GC pass over edges will never
+collect such an edge, where pre-#169 it eventually would have; a
+conservative choice, not a bug."
   (let ((v (lookup-vertex id :graph graph)))
     (cond
       (v (values v :found))

--- a/edge.lisp
+++ b/edge.lisp
@@ -291,16 +291,35 @@ regenerates the id on a duplicate-key collision."
            :node edge))
   (delete-node edge graph))
 
+(defun %active-endpoint-status (id graph)
+  "(values VERTEX-OR-NIL STATUS) for edge endpoint ID against GRAPH, for
+ACTIVE-EDGE-P.  :FOUND when GRAPH's own table (or, for a definitely
+cross-store v8 id, LOOKUP-VERTEX-ANYWHERE) resolves a live vertex;
+:MISSING for a same-store/untagged miss -- unchanged pre-#169 semantics,
+an edge with a genuinely absent endpoint is inactive; :UNKNOWN for a
+cross-store id whose store is detached or unregistered -- can't disprove
+liveness, so it must not silently kill the edge (D8; GH #169).
+LOOKUP-VERTEX-ANYWHERE is defined in interface.lisp, loaded after this
+file; resolved at runtime like PIN-READ-EPOCH in graph-class.lisp."
+  (let ((v (lookup-vertex id :graph graph)))
+    (cond
+      (v (values v :found))
+      (t (let ((tag (id-store-tag id)))
+           (if (and tag (not (eql tag (store-id graph))))
+               (let ((r (lookup-vertex-anywhere id)))
+                 (if (vertex-p r) (values r :found) (values nil :unknown)))
+               (values nil :missing)))))))
+
 (defmethod active-edge-p ((edge edge) &key (graph *graph*))
-  (and (not (deleted-p edge))
-       (let ((from (lookup-vertex (from edge) :graph graph)))
-         (if (vertex-p from)
-             (not (deleted-p from))
-             nil))
-       (let ((to (lookup-vertex (to edge) :graph graph)))
-         (if (vertex-p to)
-             (not (deleted-p to))
-             nil))))
+  (flet ((endpoint-active-p (id)
+           (multiple-value-bind (v status) (%active-endpoint-status id graph)
+             (ecase status
+               (:found (not (deleted-p v)))
+               (:unknown t)
+               (:missing nil)))))
+    (and (not (deleted-p edge))
+         (endpoint-active-p (from edge))
+         (endpoint-active-p (to edge)))))
 
 (defmethod edge-exists-p (edge-type (vertex1 vertex) (vertex2 vertex)
                           &key (graph *graph*))

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -18,27 +18,52 @@ resolver's O(1) step (GH #169).  Slot 0 unused (0 is never assigned).
 Writes only under *GRAPHS*' registration points; readers are lock-free
 -- a stale nil costs a fallback, never a wrong graph.")
 
+(define-condition store-id-collision-error (error)
+  ((id :initarg :id :reader store-id-collision-id)
+   (existing-name :initarg :existing-name :reader store-id-collision-existing-name)
+   (existing-location :initarg :existing-location
+                      :reader store-id-collision-existing-location)
+   (new-name :initarg :new-name :reader store-id-collision-new-name)
+   (new-location :initarg :new-location :reader store-id-collision-new-location))
+  (:report
+   (lambda (c s)
+     (format s "Store id ~D is already held by open graph ~S at ~S; ~
+cannot also register ~S at ~S -- one system directory per image ~
+(GH #169, #209)."
+             (store-id-collision-id c)
+             (store-id-collision-existing-name c)
+             (store-id-collision-existing-location c)
+             (store-id-collision-new-name c)
+             (store-id-collision-new-location c)))))
+
 (defun %register-open-store (graph)
   "Give GRAPH its registry store-id and publish it in the open-store
 vector.  Outside a system (*SYSTEM-DIRECTORY* nil) the graph stays
 untagged -- ids remain v5 -- rather than failing the open (GH #169).
-Signals if the slot already holds an open graph of a DIFFERENT NAME:
-one registry (hence one name<->id mapping) per image is the invariant,
-and two names sharing a slot means two DIFFERENT system directories
-handed out the same id -- silently overwriting would make
-RESOLVE-NODE-GRAPH answer with the wrong store.  Same name, same id is
+
+Signals STORE-ID-COLLISION-ERROR if the slot already holds a DIFFERENT
+open graph whose NAME or LOCATION disagrees with GRAPH's: one system
+directory per image is the invariant, and two system directories can
+each mint id 1 for their own first store -- if those stores happen to
+share a NAME too, comparing name alone would miss the collision.
+LOCATION is what distinguishes them, since two directories can never
+be the same path.  Same name AND same location reusing the slot is
 always fine (e.g. a crash-simulating test that re-registers a store by
-name without going through %UNREGISTER-OPEN-STORE first) (GH #169,
-#209)."
+name, at the same location, without going through
+%UNREGISTER-OPEN-STORE first) (GH #169, #209)."
   (when *system-directory*
     (setf (store-id graph) (store-registry-intern (graph-name graph)))
     (let* ((id (store-id graph))
            (existing (svref *store-id->graph* id)))
       (when (and existing (not (eq existing graph)) (graph-open-p existing)
-                 (not (equal (graph-name existing) (graph-name graph))))
-        (error "Store id ~D is already held by open graph ~S; cannot ~
-also register ~S -- one system directory per image (GH #169, #209)."
-               id (graph-name existing) (graph-name graph)))
+                 (or (not (equal (graph-name existing) (graph-name graph)))
+                     (not (equal (location existing) (location graph)))))
+        (error 'store-id-collision-error
+               :id id
+               :existing-name (graph-name existing)
+               :existing-location (location existing)
+               :new-name (graph-name graph)
+               :new-location (location graph)))
       (setf (svref *store-id->graph* id) graph)))
   graph)
 

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -21,10 +21,25 @@ Writes only under *GRAPHS*' registration points; readers are lock-free
 (defun %register-open-store (graph)
   "Give GRAPH its registry store-id and publish it in the open-store
 vector.  Outside a system (*SYSTEM-DIRECTORY* nil) the graph stays
-untagged -- ids remain v5 -- rather than failing the open (GH #169)."
+untagged -- ids remain v5 -- rather than failing the open (GH #169).
+Signals if the slot already holds an open graph of a DIFFERENT NAME:
+one registry (hence one name<->id mapping) per image is the invariant,
+and two names sharing a slot means two DIFFERENT system directories
+handed out the same id -- silently overwriting would make
+RESOLVE-NODE-GRAPH answer with the wrong store.  Same name, same id is
+always fine (e.g. a crash-simulating test that re-registers a store by
+name without going through %UNREGISTER-OPEN-STORE first) (GH #169,
+#209)."
   (when *system-directory*
     (setf (store-id graph) (store-registry-intern (graph-name graph)))
-    (setf (svref *store-id->graph* (store-id graph)) graph))
+    (let* ((id (store-id graph))
+           (existing (svref *store-id->graph* id)))
+      (when (and existing (not (eq existing graph)) (graph-open-p existing)
+                 (not (equal (graph-name existing) (graph-name graph))))
+        (error "Store id ~D is already held by open graph ~S; cannot ~
+also register ~S -- one system directory per image (GH #169, #209)."
+               id (graph-name existing) (graph-name graph)))
+      (setf (svref *store-id->graph* id) graph)))
   graph)
 
 (defun %unregister-open-store (graph)

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -11,8 +11,35 @@
   (make-hash-table :test 'equal #+graph-db-ecl-sync-hash :synchronized
                     #+graph-db-ecl-sync-hash t))
 
+(defvar *store-id->graph*
+  (make-array (1+ +max-store-tag+) :initial-element nil)
+  "Open-store vector: store-id -> open GRAPH, nil when not open.  The v8
+resolver's O(1) step (GH #169).  Slot 0 unused (0 is never assigned).
+Writes only under *GRAPHS*' registration points; readers are lock-free
+-- a stale nil costs a fallback, never a wrong graph.")
+
+(defun %register-open-store (graph)
+  "Give GRAPH its registry store-id and publish it in the open-store
+vector.  Outside a system (*SYSTEM-DIRECTORY* nil) the graph stays
+untagged -- ids remain v5 -- rather than failing the open (GH #169)."
+  (when *system-directory*
+    (setf (store-id graph) (store-registry-intern (graph-name graph)))
+    (setf (svref *store-id->graph* (store-id graph)) graph))
+  graph)
+
+(defun %unregister-open-store (graph)
+  "Retract GRAPH from the open-store vector.  The registry entry stays:
+ids are never reused (GH #169)."
+  (let ((sid (store-id graph)))
+    (when (and sid (eq graph (svref *store-id->graph* sid)))
+      (setf (svref *store-id->graph* sid) nil))))
+
 (defclass graph ()
   ((graph-name :accessor graph-name :initarg :graph-name)
+   ;; Stable numeric id from the store registry; rides in every v8 node
+   ;; id minted for this store.  NIL = untagged (no system directory,
+   ;; e.g. a memory graph outside a system): ids stay v5 (GH #169).
+   (store-id :accessor store-id :initarg :store-id :initform nil)
    (graph-open-p :accessor graph-open-p :initarg :graph-open-p :initform nil)
    ;; T when this graph was opened inside WITH-SCHEMA-FROZEN, so its
    ;; persisted type-ids were never checked against the registry.  Set by

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -34,6 +34,24 @@ ids are never reused (GH #169)."
     (when (and sid (eq graph (svref *store-id->graph* sid)))
       (setf (svref *store-id->graph* sid) nil))))
 
+(defstruct (unresolved-node (:constructor make-unresolved-node
+                                          (id store-id store-name)))
+  "The honest answer for a read that reaches into a detached store:
+there IS a node here, its store is known, and the store is offline
+(GH #169, D8).  Never a raw NIL -- that is indistinguishable from 'no
+such node' -- and never an error from mid-traversal."
+  id store-id store-name)
+
+(define-condition store-detached-error (error)
+  ((name :initarg :name :reader store-detached-name)
+   (id :initarg :id :reader store-detached-id))
+  (:report
+   (lambda (c s)
+     (format s "Store ~S (id ~D) is registered but not open -- ~
+detached.  Explicit access signals; incidental traversal would have ~
+received an UNRESOLVED-NODE marker instead (GH #169, D8)."
+             (store-detached-name c) (store-detached-id c)))))
+
 (defclass graph ()
   ((graph-name :accessor graph-name :initarg :graph-name)
    ;; Stable numeric id from the store registry; rides in every v8 node

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -60,13 +60,16 @@
                ;; The image-level type-id registry (GH #186).  Same shape as
                ;; system-clock: no graph dependency, loads early.
                (:file "type-registry" :depends-on ("serialize" "utilities"))
+               ;; The image-level store-id registry (GH #169).  Same shape
+               ;; as type-registry; graph-class references +MAX-STORE-TAG+.
+               (:file "store-registry" :depends-on ("type-registry"))
                (:file "geometry" :depends-on ("serialize"))
                (:file "geometry-ops" :depends-on ("geometry"))
                (:file "geohash" :depends-on ("package"))
                (:file "linear-hash" :depends-on ("serialize"))
                (:file "allocator" :depends-on ("serialize"))
                (:file "segment" :depends-on ("allocator" "mmap"))
-               (:file "graph-class" :depends-on ("globals"))
+               (:file "graph-class" :depends-on ("globals" "store-registry"))
                (:file "cursors" :depends-on ("package"))
                (:file "skip-list" :depends-on ("allocator" "linear-hash"))
                (:file "skip-list-cursors" :depends-on ("skip-list" "cursors"))
@@ -525,6 +528,7 @@ cl-temporal-extent."
                (:file "global-type-id-tests")     ; GH #186
                (:file "type-id-seeding-tests")    ; GH #186
                (:file "keyword-alias-tests")      ; GH #190
+               (:file "store-registry-tests")     ; GH #169
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -529,6 +529,7 @@ cl-temporal-extent."
                (:file "type-id-seeding-tests")    ; GH #186
                (:file "keyword-alias-tests")      ; GH #190
                (:file "store-registry-tests")     ; GH #169
+               (:file "store-resolver-tests")     ; GH #169
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph.lisp
+++ b/graph.lisp
@@ -458,7 +458,8 @@ to disk and remove it."
         (rebuild-spatial-indexes graph)
         (with-open-file (out dirty-file :direction :output)
           (format out "~S" (get-universal-time)))
-        (setf (gethash name *graphs*) graph))
+        (setf (gethash name *graphs*) graph)
+        (%register-open-store graph))
       (when slave-p
         (setf (master-host graph) master-host)
         ;; Set the subset filter before replay/replication so the slave applies
@@ -666,6 +667,7 @@ ids to types added since (GH #186)."
         (with-open-file (out dirty-file :direction :output)
           (format out "~S" (get-universal-time)))
         (setf (gethash name *graphs*) graph)
+        (%register-open-store graph)
         (when gc-heap-p
           (gc-heap graph))
         ;; A non-empty WAL tail means this open is a CRASH RECOVERY: the .txn files
@@ -754,6 +756,7 @@ a snapshot failure does NOT abort the close (GH #120)."
     (when (graph-open-p graph)
       (stop-replication graph)
       (remhash (graph-name graph) *graphs*)
+      (%unregister-open-store graph)
       ;; Unique constraints (#6): persist the on-disk unique skip-lists' roots
       ;; while the heap is still open, so OPEN can reopen them without a scan.
       ;; No-op on a memory graph.

--- a/interface.lisp
+++ b/interface.lisp
@@ -1,5 +1,49 @@
 (in-package :graph-db)
 
+;; LOOKUP-VERTEX is defined in vertex.lisp, which loads after GRAPH-CLASS but
+;; before this file -- these two live here (not graph-class.lisp, alongside
+;; the UNRESOLVED-NODE struct and STORE-DETACHED-ERROR condition they use)
+;; because they call it (GH #169).
+(defun resolve-node-graph (id)
+  "The open store holding ID, as (values GRAPH STATUS STORE-ID) with
+STATUS one of :RESOLVED, :DETACHED (registry knows the tag, no open
+graph carries it) or :UNKNOWN.  A v8 id indexes the open-store vector,
+O(1); a v5 id is tried against each open store's vertex table -- the
+no-flag-day fallback (GH #169, D5).  For a v5 id STORE-ID is the
+holding store's id (or NIL when untagged/unknown)."
+  (let ((tag (id-store-tag id)))
+    (if tag
+        (let ((graph (svref *store-id->graph* tag)))
+          (cond (graph (values graph :resolved tag))
+                ((and *system-directory*
+                      (store-registry-name-for tag))
+                 (values nil :detached tag))
+                (t (values nil :unknown tag))))
+        (progn
+          (maphash (lambda (name graph)
+                     (declare (ignore name))
+                     (when (and (graph-open-p graph)
+                                (lookup-vertex id :graph graph))
+                       (return-from resolve-node-graph
+                         (values graph :resolved (store-id graph)))))
+                   *graphs*)
+          (values nil :unknown nil)))))
+
+(defun lookup-vertex-anywhere (id &key (if-detached :marker))
+  "ID's vertex from whichever open store holds it; an UNRESOLVED-NODE
+marker when its store is detached (or, with :IF-DETACHED :ERROR, a
+STORE-DETACHED-ERROR -- the explicit-access half of D8); NIL when no
+store known to the system holds it (GH #169)."
+  (multiple-value-bind (graph status tag) (resolve-node-graph id)
+    (ecase status
+      (:resolved (lookup-vertex id :graph graph))
+      (:detached
+       (let ((name (store-registry-name-for tag)))
+         (ecase if-detached
+           (:marker (make-unresolved-node id tag name))
+           (:error (error 'store-detached-error :name name :id tag)))))
+      (:unknown nil))))
+
 (defgeneric copy (node)
   (:documentation
    "Return a mutable copy of vertex or edge NODE, registered with the current

--- a/interface.lisp
+++ b/interface.lisp
@@ -10,7 +10,13 @@ STATUS one of :RESOLVED, :DETACHED (registry knows the tag, no open
 graph carries it) or :UNKNOWN.  A v8 id indexes the open-store vector,
 O(1); a v5 id is tried against each open store's vertex table -- the
 no-flag-day fallback (GH #169, D5).  For a v5 id STORE-ID is the
-holding store's id (or NIL when untagged/unknown)."
+holding store's id (or NIL when untagged/unknown).  ID may be a
+32-hex-digit string, coerced like LOOKUP-VERTEX (GH #209).  A tag whose
+store the registry once knew but *SYSTEM-DIRECTORY* is unbound at
+query time also reports :UNKNOWN, not :DETACHED -- :DETACHED requires
+a live registry to confirm the tag (GH #169, #209)."
+  (when (stringp id)
+    (setq id (read-id-array-from-string id)))
   (let ((tag (id-store-tag id)))
     (if tag
         (let ((graph (svref *store-id->graph* tag)))

--- a/memory-graph.lisp
+++ b/memory-graph.lisp
@@ -261,7 +261,8 @@ Registers the graph and returns it."
       (init-schema graph)
       (update-schema graph)
       (%write-dirty-marker path)
-      (setf (gethash name *graphs*) graph))
+      (setf (gethash name *graphs*) graph)
+      (%register-open-store graph))
     (when peer-role
       (%init-memory-peer-slots graph :make path peer-role origin-id peer-host
                                export-predicate device-registry merge-policy
@@ -989,6 +990,7 @@ as deferred blobs and materialize on first touch (needs a VG-native image)."
       (update-schema graph)
       (%write-dirty-marker path)
       (setf (gethash name *graphs*) graph)
+      (%register-open-store graph)
       ;; Restore the checkpoint, then replay the journal tail committed after it.
       ;; Recovery runs BEFORE the transaction-manager is installed (the reaper
       ;; tolerates the unbound slot); the retain hook keeps the journal.

--- a/node-id.lisp
+++ b/node-id.lisp
@@ -28,7 +28,23 @@
               (incf offset)))
           (loop for i from offset below total-bytes do
                (setf (aref vec i) (random 256 (nth (random 2) random-states))))
-          vec))))
+          vec)))
+
+  (defun gen-v8-uuid (store-tag)
+    "A UUIDv8 (RFC 9562 vendor layout) node id: 110 random bits, the
+12-bit STORE-TAG in the low nibble of byte 14 plus byte 15, version and
+variant stamped.  The tag is the O(1) resolver's index (GH #169)."
+    (declare (optimize (speed 3) (safety 0))
+             (type (unsigned-byte 12) store-tag))
+    (let ((id (make-array 16 :element-type '(unsigned-byte 8))))
+      (dotimes (i 16)
+        (setf (aref id i) (random 256 (nth (random 2) random-states))))
+      (setf (aref id 6) (dpb #x8 (byte 4 4) (aref id 6)))
+      (setf (aref id 8) (dpb #b10 (byte 2 6) (aref id 8)))
+      (setf (aref id 14) (dpb (ldb (byte 4 8) store-tag) (byte 4 0)
+                              (aref id 14)))
+      (setf (aref id 15) (ldb (byte 8 0) store-tag))
+      id)))
 
 (defun gen-v5-uuid (namespace)
   "Generates a version 5 (name based SHA1) uuid.  Code stolen from the UUID library."
@@ -51,10 +67,22 @@
                 (dpb #b10 (byte 2 6) (aref hash 8)))
           id)))))
 
+(defun uuid-v8-p (id)
+  "True when ID's version nibble says v8 -- our tagged layout.  Legacy
+ids are v5 (GH #169)."
+  (= #x8 (ldb (byte 4 4) (aref id 6))))
+
+(defun id-store-tag (id)
+  "ID's 12-bit store tag, or NIL for a non-v8 id.  Never read the tag
+bytes of a v5 id: they are SHA1 output and would name a random store."
+  (when (uuid-v8-p id)
+    (logior (ash (ldb (byte 4 0) (aref id 14)) 8)
+            (aref id 15))))
+
 (declaim (inline gen-edge-id))
-(defun gen-edge-id ()
-  (gen-v5-uuid *edge-namespace*))
+(defun gen-edge-id (&optional store-tag)
+  (if store-tag (gen-v8-uuid store-tag) (gen-v5-uuid *edge-namespace*)))
 
 (declaim (inline gen-vertex-id))
-(defun gen-vertex-id ()
-  (gen-v5-uuid *vertex-namespace*))
+(defun gen-vertex-id (&optional store-tag)
+  (if store-tag (gen-v8-uuid store-tag) (gen-v5-uuid *vertex-namespace*)))

--- a/package.lisp
+++ b/package.lisp
@@ -67,6 +67,8 @@
            #:store-id
            #:+store-tag-bits+
            #:+max-store-tag+
+           #:uuid-v8-p
+           #:id-store-tag
            ;; GH #186: a store's persisted type-ids disagree with the
            ;; image registry.  Operator-facing -- the remedy is a seeding
            ;; run plus a renumbering migration, not a retry.

--- a/package.lisp
+++ b/package.lisp
@@ -80,6 +80,12 @@
            #:store-detached-error
            #:store-detached-name
            #:store-detached-id
+           #:store-id-collision-error
+           #:store-id-collision-id
+           #:store-id-collision-existing-name
+           #:store-id-collision-existing-location
+           #:store-id-collision-new-name
+           #:store-id-collision-new-location
            ;; GH #169: BACKUP warns on a dangling cross-store edge.
            #:dangling-edge-warning
            #:dangling-edge-id

--- a/package.lisp
+++ b/package.lisp
@@ -80,6 +80,11 @@
            #:store-detached-error
            #:store-detached-name
            #:store-detached-id
+           ;; GH #169: BACKUP warns on a dangling cross-store edge.
+           #:dangling-edge-warning
+           #:dangling-edge-id
+           #:dangling-edge-endpoint-id
+           #:dangling-edge-store-id
            ;; GH #186: a store's persisted type-ids disagree with the
            ;; image registry.  Operator-facing -- the remedy is a seeding
            ;; run plus a renumbering migration, not a retry.

--- a/package.lisp
+++ b/package.lisp
@@ -58,6 +58,15 @@
            #:*type-registry*
            #:system-directory-required
            #:system-directory-required-operation
+           ;; image-level store-id registry (GH #169)
+           #:ensure-store-registry
+           #:store-registry-intern
+           #:store-registry-id-for
+           #:store-registry-name-for
+           #:store-registry-full
+           #:store-id
+           #:+store-tag-bits+
+           #:+max-store-tag+
            ;; GH #186: a store's persisted type-ids disagree with the
            ;; image registry.  Operator-facing -- the remedy is a seeding
            ;; run plus a renumbering migration, not a retry.

--- a/package.lisp
+++ b/package.lisp
@@ -69,6 +69,17 @@
            #:+max-store-tag+
            #:uuid-v8-p
            #:id-store-tag
+           ;; GH #169: the tagged-id resolver and detached-read markers.
+           #:resolve-node-graph
+           #:lookup-vertex-anywhere
+           #:unresolved-node
+           #:unresolved-node-p
+           #:unresolved-node-id
+           #:unresolved-node-store-id
+           #:unresolved-node-store-name
+           #:store-detached-error
+           #:store-detached-name
+           #:store-detached-id
            ;; GH #186: a store's persisted type-ids disagree with the
            ;; image registry.  Operator-facing -- the remedy is a seeding
            ;; run plus a renumbering migration, not a retry.

--- a/store-registry.lisp
+++ b/store-registry.lisp
@@ -1,0 +1,157 @@
+(in-package :graph-db)
+
+;;; The image-level store-id registry (GH #169).  One stable numeric id
+;;; per graph-name, 1..4095, never reused: the id rides inside every v8
+;;; node id, so reuse would rebind existing ids to the wrong store.
+;;; Append-only; same idioms as the type registry (GH #186, #191).
+
+(defconstant +store-tag-bits+ 12)
+(defconstant +max-store-tag+ 4095)
+
+(defstruct (store-registry (:constructor %make-store-registry))
+  (location nil)
+  ;; name (symbol or string) -> id.  EQUAL: string names compare by
+  ;; content (cf. the strchk fixtures), symbols by identity.
+  (names (make-hash-table :test 'equal))
+  (next 1 :type (unsigned-byte 16))
+  (lock (make-recursive-lock "store registry")))
+
+(define-condition store-registry-full (error)
+  ((location :initarg :location :reader store-registry-full-location))
+  (:report
+   (lambda (c s)
+     (format s "The store registry at ~A has assigned all ~D ids.  The ~
+v8 store tag is ~D bits (GH #169); widening it is a format change."
+             (store-registry-full-location c)
+             +max-store-tag+ +store-tag-bits+))))
+
+(defvar *store-registry* nil)
+(defvar *store-registry-open-lock* (make-lock "store registry open"))
+
+(defun %store-registry-file (location)
+  (make-pathname :name "store-registry" :type "log" :defaults location))
+
+(defun %store-registry-lock-file (location)
+  (make-pathname :name "store-registry" :type "lock" :defaults location))
+
+(defun %parse-store-registry-record (line)
+  "LINE as (:NAME <symbol-or-string> :ID <int>).  *READ-EVAL* nil: data,
+never code (GH #169)."
+  (let ((*read-eval* nil)
+        (*package* (%registry-print-package)))
+    (multiple-value-bind (form pos) (read-from-string line)
+      (unless (= pos (length line))
+        (error "trailing garbage in store registry record: ~S" line))
+      (destructuring-bind (&key name id) form
+        (unless (and (or (symbolp name) (stringp name)) (integerp id))
+          (error "malformed store registry record: ~S" line))
+        (list name id)))))
+
+(defun %store-registry-load (registry)
+  "Rebuild from disk.  Torn FINAL record: drop and warn; damage earlier:
+signal (the #191 policy -- this file is the only record of what a store
+tag means)."
+  (with-recursive-lock-held ((store-registry-lock registry))
+    (let ((file (%store-registry-file (store-registry-location registry)))
+          (names (make-hash-table :test 'equal))
+          (max-id 0))
+      (when (probe-file file)
+        (with-open-file (s file :direction :input)
+          (loop
+            (multiple-value-bind (line missing-newline-p)
+                (read-line s nil :eof)
+              (when (eq line :eof) (return))
+              (let ((parsed
+                      (handler-case (%parse-store-registry-record line)
+                        (error (e)
+                          (if missing-newline-p
+                              (progn
+                                (log:warn "store registry: dropping torn ~
+final record in ~A: ~A" file e)
+                                (return))
+                              (error "malformed store registry record ~
+in ~A: ~A" file e))))))
+                (destructuring-bind (name id) parsed
+                  (setf (gethash name names) id)
+                  (setf max-id (max max-id id))))))))
+      (setf (store-registry-next registry) (1+ max-id))
+      ;; Swap, never clrhash: lock-free readers see old-complete or new.
+      (setf (store-registry-names registry) names)))
+  registry)
+
+(defun ensure-store-registry ()
+  "The image's store registry, opening it on first use and reopening
+whenever *SYSTEM-DIRECTORY* changes (tests rebind it per store; mirrors
+ENSURE-TYPE-REGISTRY, #186).  Signals SYSTEM-DIRECTORY-REQUIRED without
+*SYSTEM-DIRECTORY* -- a store id must mean the same thing to every image
+of the system (GH #169, #186)."
+  (unless *system-directory*
+    (error 'system-directory-required))
+  (with-lock-held (*store-registry-open-lock*)
+    (unless (and *store-registry*
+                 (equal (pathname (store-registry-location *store-registry*))
+                        (pathname *system-directory*)))
+      (setf *store-registry*
+            (%store-registry-load
+             (%make-store-registry :location *system-directory*))))
+    *store-registry*))
+
+(defun store-registry-id-for (name &optional
+                                     (registry (ensure-store-registry)))
+  "NAME's store id, or NIL.  Lock-free read: NIL is a hint, not proof --
+only STORE-REGISTRY-INTERN re-checks under the lock."
+  (gethash name (store-registry-names registry)))
+
+(defun store-registry-name-for (id &optional
+                                     (registry (ensure-store-registry)))
+  "The graph-name assigned ID, or NIL."
+  (maphash (lambda (name known)
+             (when (eql known id) (return-from store-registry-name-for
+                                    name)))
+           (store-registry-names registry))
+  nil)
+
+(defun store-registry-intern (name &optional
+                                     (registry (ensure-store-registry)))
+  "NAME's store id, minted if this system has not seen it.  Read-decide-
+append under the registry flock, re-reading first: another image may
+have assigned since our last load (GH #169; same discipline as
+REGISTRY-INTERN, #186).
+
+Also serializes same-image callers under REGISTRY's own recursive lock:
+flock() locks an open file DESCRIPTION, not a process, so two threads in
+this image each opening their own fd on the lock file would otherwise
+hold independent, non-conflicting locks and could both mint an id for
+the same name (a defect the type-registry idiom this mirrors avoids via
+REGISTRY-INTERN's outer WITH-RECURSIVE-LOCK-HELD -- #186)."
+  (with-recursive-lock-held ((store-registry-lock registry))
+    (or (store-registry-id-for name registry)
+        (let ((fd (%posix-open (%store-registry-lock-file
+                                 (store-registry-location registry))
+                                (logior +o-creat+ +o-rdwr+))))
+          (unwind-protect
+               (progn
+                 (%posix-flock fd +lock-ex+)
+                 (%store-registry-load registry)
+                 (or (store-registry-id-for name registry)
+                     (let ((id (store-registry-next registry)))
+                       (when (> id +max-store-tag+)
+                         (error 'store-registry-full
+                                :location (store-registry-location
+                                           registry)))
+                       (with-open-file
+                           (s (%store-registry-file
+                               (store-registry-location registry))
+                              :direction :output
+                              :if-exists :append
+                              :if-does-not-exist :create)
+                         (let ((*package* (%registry-print-package))
+                               (*print-pretty* nil)
+                               (*print-readably* t))
+                           (format s "~S~%" (list :name name :id id)))
+                         (finish-output s))
+                       (setf (gethash name (store-registry-names registry))
+                             id)
+                       (setf (store-registry-next registry) (1+ id))
+                       id)))
+            (%posix-close fd))))))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -226,6 +226,10 @@
                 #:store-registry-conflict
                 #:store-registry-conflict-reason
                 #:frozen-graph-cannot-replicate
+                ;; store-id registry (GH #169)
+                #:store-registry-intern
+                #:store-registry-id-for
+                #:store-registry-name-for
                 #:with-schema-frozen
                 #:with-transaction
                 #:*transaction*

--- a/tests/store-registry-tests.lisp
+++ b/tests/store-registry-tests.lisp
@@ -1,0 +1,71 @@
+;;;; Stable numeric store-ids and the open-store vector (GH #169).
+(in-package #:graph-db/test)
+
+(def-suite store-registry-suite :in graph-db-suite
+  :description "Store-id registry: stable, persistent, never reused.")
+(in-suite store-registry-suite)
+
+(test store-ids-are-stable-and-distinct
+  "One name, one id, forever; two names never share.  Nearest wrong
+implementation: a per-image counter that restarts at 1 (ids would
+collide across sessions -- the persistence test below catches that
+half; distinctness catches the other)."
+  (with-temp-directory (sys)
+    (let ((graph-db::*system-directory* (namestring sys))
+          (graph-db::*store-registry* nil))
+      (let ((a (store-registry-intern :sr-store-a))
+            (b (store-registry-intern :sr-store-b)))
+        (is (integerp a))
+        (is (/= a b))
+        (is (= a (store-registry-intern :sr-store-a))
+            "re-interning returns the same id")
+        (is (eq :sr-store-b (store-registry-name-for b)))))))
+
+(test store-ids-survive-a-fresh-registry-open
+  "The registry is persisted in the system directory; a fresh open (a
+new image, simulated by clearing the cached registry) reads the same
+assignments back."
+  (with-temp-directory (sys)
+    (let ((graph-db::*system-directory* (namestring sys))
+          (graph-db::*store-registry* nil))
+      (let ((id (store-registry-intern :sr-persist)))
+        (setq graph-db::*store-registry* nil)
+        (is (= id (store-registry-id-for :sr-persist)))
+        (is (= id (store-registry-intern :sr-persist)))))))
+
+(test store-registry-accepts-string-names
+  "Graph names may be strings (cf. the strchk fixtures); the registry
+must key them by content, not identity."
+  (with-temp-directory (sys)
+    (let ((graph-db::*system-directory* (namestring sys))
+          (graph-db::*store-registry* nil))
+      (let ((id (store-registry-intern (copy-seq "sr-stringly"))))
+        (is (= id (store-registry-intern (copy-seq "sr-stringly"))))))))
+
+(test store-registry-requires-a-system-directory
+  (let ((graph-db::*system-directory* nil)
+        (graph-db::*store-registry* nil))
+    (signals graph-db:system-directory-required
+      (store-registry-intern :sr-nodir))))
+
+(test open-graph-carries-its-store-id
+  "MAKE-GRAPH interns the graph-name and exposes the id on the graph;
+the open-store vector maps it back; CLOSE-GRAPH clears the vector slot
+but the registry keeps the assignment.  Nearest wrong implementation:
+a vector slot that survives close (a stale graph object would be
+returned for a closed store)."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let* ((g (make-graph :sr-open-store (namestring dir)
+                              :buffer-pool-size 1000))
+               (sid (graph-db::store-id g)))
+          (unwind-protect
+               (progn
+                 (is (integerp sid))
+                 (is (eq g (svref graph-db::*store-id->graph* sid))))
+            (close-graph g :snapshot-p nil))
+          (is (null (svref graph-db::*store-id->graph* sid)))
+          (is (= sid (store-registry-id-for :sr-open-store))
+              "the assignment outlives the open"))))))

--- a/tests/store-registry-tests.lisp
+++ b/tests/store-registry-tests.lisp
@@ -69,3 +69,48 @@ returned for a closed store)."
           (is (null (svref graph-db::*store-id->graph* sid)))
           (is (= sid (store-registry-id-for :sr-open-store))
               "the assignment outlives the open"))))))
+
+(test v8-ids-carry-the-store-tag
+  "Layout pin: version nibble 8, RFC variant, and the tag readable back
+from bytes 14-15.  Nearest wrong implementation: tag written but
+version left 5 (ID-STORE-TAG must return NIL for it)."
+  (let ((id (graph-db::gen-v8-uuid 2749)))
+    (is (= 16 (length id)))
+    (is (graph-db:uuid-v8-p id))
+    (is (= #b10 (ldb (byte 2 6) (aref id 8))) "RFC 9562 variant")
+    (is (= 2749 (graph-db:id-store-tag id)))))
+
+(test v5-ids-have-no-store-tag
+  "Legacy ids answer NIL, never a garbage tag read out of hash bytes."
+  (let ((id (graph-db::gen-v5-uuid graph-db::*vertex-namespace*)))
+    (is (not (graph-db:uuid-v8-p id)))
+    (is (null (graph-db:id-store-tag id)))))
+
+(test gen-ids-fall-back-to-v5-without-a-tag
+  "GEN-VERTEX-ID/GEN-EDGE-ID with no (or nil) tag are byte-layout v5 --
+the memory-graph/legacy path is unchanged (GH #169)."
+  (is (not (graph-db:uuid-v8-p (graph-db::gen-vertex-id))))
+  (is (not (graph-db:uuid-v8-p (graph-db::gen-edge-id nil)))))
+
+(test new-nodes-in-a-store-get-tagged-ids
+  "End to end: a vertex and an edge created in an open store carry ids
+whose tag is that store's id.  Nearest wrong implementation: generation
+still v5 everywhere (the whole point of the unit)."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :sr-tagged-store (namestring dir)
+                             :buffer-pool-size 1000)))
+          (unwind-protect
+               (let (v1 v2 e)
+                 (with-transaction ((graph-db::transaction-manager g))
+                   (setq v1 (graph-db:make-vertex :generic nil :graph g))
+                   (setq v2 (graph-db:make-vertex :generic nil :graph g))
+                   (setq e (graph-db:make-edge :generic (id v1) (id v2) 1.0 nil
+                                               :graph g)))
+                 (is (= (graph-db::store-id g)
+                        (graph-db:id-store-tag (id v1))))
+                 (is (= (graph-db::store-id g)
+                        (graph-db:id-store-tag (id e)))))
+            (close-graph g :snapshot-p nil)))))))

--- a/tests/store-resolver-tests.lisp
+++ b/tests/store-resolver-tests.lisp
@@ -1,0 +1,140 @@
+;;;; The tagged-id resolver and the detached-read semantics (GH #169).
+(in-package #:graph-db/test)
+
+(def-suite store-resolver-suite :in graph-db-suite
+  :description "O(1) v8 resolution; v5 scan; markers for the detached.")
+(in-suite store-resolver-suite)
+
+;; A typed edge for the cross-store traversal test.  :GENERIC edges are
+;; type-id 0, and MAP-EDGES' vertex-adjacency scan always excludes type 0
+;; (edge.lisp: "Generic, type-0 edges appear only in the untyped scan") --
+;; so TRAVERSE never sees a :GENERIC edge at all.  A real edge type is
+;; required to exercise TRAVERSE (task-3 correction to the brief, which
+;; used :GENERIC and would see zero edges regardless of the resolver).
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :rsv-store-1 *schema-node-metadata*) nil))
+
+(def-edge rsv-edge () () :rsv-store-1)
+
+(defmacro with-two-stores ((g1 g2 sys) &body body)
+  "Two open disk stores under one system directory."
+  (let ((d1 (gensym)) (d2 (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,d1)
+         (with-temp-directory (,d2)
+           (let ((graph-db::*system-directory* (namestring ,sys))
+                 (graph-db::*store-registry* nil))
+             (let ((,g1 (make-graph :rsv-store-1 (namestring ,d1)
+                                    :buffer-pool-size 1000))
+                   (,g2 (make-graph :rsv-store-2 (namestring ,d2)
+                                    :buffer-pool-size 1000)))
+               (unwind-protect (progn ,@body)
+                 (ignore-errors (close-graph ,g1 :snapshot-p nil))
+                 (ignore-errors (close-graph ,g2 :snapshot-p nil))
+                 (collect-garbage)))))))))
+
+(test v8-resolution-is-by-tag
+  "A v8 id resolves to its OWN open store without consulting the store
+it was found in.  Nearest wrong implementation: resolve everything via
+*GRAPH* (the pre-#169 assumption)."
+  (with-two-stores (g1 g2 sys)
+    (let (v)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v (graph-db:make-vertex :generic nil :graph g2)))
+      (multiple-value-bind (graph status sid)
+          (graph-db:resolve-node-graph (id v))
+        (is (eq g2 graph))
+        (is (eq :resolved status))
+        (is (= (graph-db::store-id g2) sid))))))
+
+(test v5-resolution-scans-open-stores
+  "A legacy v5 id resolves by trying each open store's vertex table --
+slower, correct, and the reason there is no flag day (GH #169)."
+  (with-two-stores (g1 g2 sys)
+    (let ((vid (graph-db::gen-vertex-id)))   ; untagged v5
+      (with-transaction ((graph-db::transaction-manager g2))
+        (graph-db:make-vertex :generic nil :id vid :graph g2))
+      (multiple-value-bind (graph status sid)
+          (graph-db:resolve-node-graph vid)
+        (declare (ignore sid))
+        (is (eq g2 graph))
+        (is (eq :resolved status))))))
+
+(test detached-store-yields-a-marker
+  "A v8 id whose store is REGISTERED but not OPEN is detached: known,
+findable, offline.  Incidental access gets the marker, never a raw NIL
+(indistinguishable from 'no such node') and never an error.  Nearest
+wrong implementation: return NIL (silent skipping, rejected by D8)."
+  (with-two-stores (g1 g2 sys)
+    (let (v)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v (graph-db:make-vertex :generic nil :graph g2)))
+      (close-graph g2 :snapshot-p nil)
+      (let ((r (graph-db:lookup-vertex-anywhere (id v))))
+        (is (graph-db:unresolved-node-p r))
+        (is (equalp (id v) (graph-db:unresolved-node-id r)))
+        (is (eq :rsv-store-2 (graph-db:unresolved-node-store-name r)))))))
+
+(test explicit-access-to-a-detached-store-signals
+  "The caller who ASKS for the detached store gets the error, per D8's
+explicit-versus-incidental split."
+  (with-two-stores (g1 g2 sys)
+    (let (v)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v (graph-db:make-vertex :generic nil :graph g2)))
+      (close-graph g2 :snapshot-p nil)
+      (signals graph-db:store-detached-error
+        (graph-db:lookup-vertex-anywhere (id v) :if-detached :error)))))
+
+(test unknown-tag-is-unknown-not-detached
+  "A v8 id with a tag the registry never assigned is :UNKNOWN -- the
+resolver must not fabricate a detached store out of it."
+  (with-two-stores (g1 g2 sys)
+    (let ((id (graph-db::gen-v8-uuid 4000)))
+      (multiple-value-bind (graph status sid)
+          (graph-db:resolve-node-graph id)
+        (declare (ignore sid))
+        (is (null graph))
+        (is (eq :unknown status))))))
+
+(test traversal-reaches-across-open-stores-and-marks-detached
+  "A cross-store edge: with both stores open, TRAVERSE surfaces the
+far-end vertex in its results (it is not walked further -- cross-store
+continuation is #170+ work); with the far store closed, the results
+carry the unresolved marker instead.  Nearest wrong implementation:
+LOOKUP-VERTEX in the local store only -- the far end silently vanishes
+from results in BOTH cases.
+
+CORRECTED (task-3), two brief defects:
+1. The brief's TRAVERSE calls omitted :EDGE-TYPE.  TRAVERSE's established
+   contract (tests/traverse-tests.lisp,
+   TRAVERSE-WITHOUT-EDGE-TYPE-RETURNS-NIL) is that with no :EDGE-TYPE
+   nothing is ever collected -- (TYPEP edge NIL) is always false.
+2. The brief used a :GENERIC edge (MAKE-EDGE :GENERIC ...), but generic
+   edges are type-id 0, and MAP-EDGES' vertex-adjacency scan always
+   excludes type 0 (edge.lisp: \"Generic, type-0 edges appear only in the
+   untyped scan\") -- TRAVERSE would see zero edges regardless of
+   :EDGE-TYPE.  RSV-EDGE (defined above) is a real registered type."
+  (with-two-stores (g1 g2 sys)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager g1))
+        (setq v1 (graph-db:make-vertex :generic nil :graph g1)))
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v2 (graph-db:make-vertex :generic nil :graph g2)))
+      (with-transaction ((graph-db::transaction-manager g1))
+        (make-rsv-edge :from v1 :to v2 :graph g1))
+      (let ((results (traverse v1 :graph g1 :direction :out
+                                :edge-type 'rsv-edge)))
+        (is (find-if (lambda (r)
+                       (and (graph-db::vertex-p r) (equalp (id v2) (id r))))
+                     results)
+            "open far store: the vertex itself is in the results"))
+      (close-graph g2 :snapshot-p nil)
+      (let ((results (traverse v1 :graph g1 :direction :out
+                                :edge-type 'rsv-edge)))
+        (is (find-if (lambda (r)
+                       (and (graph-db:unresolved-node-p r)
+                            (equalp (id v2)
+                                    (graph-db:unresolved-node-id r))))
+                     results)
+            "closed far store: the marker is in the results")))))

--- a/tests/store-resolver-tests.lisp
+++ b/tests/store-resolver-tests.lisp
@@ -181,3 +181,46 @@ CORRECTED (task-4), controller notes:
                                       (equalp (id e) (getf (cddr f) :id))))
                                forms)
                       "the dangling edge is IN the backup")))))))
+
+(test clean-backups-never-warn-dangling
+  "No-false-positive canary for DANGLING-EDGE-WARNING (review fix,
+GH #169): one graph, no cross-store edges anywhere -- a live-live
+edge, and an edge whose far endpoint is soft-deleted (but still in
+THIS graph's own vertex table) -- must never warn.  Pins the exact
+regression the risk names: filtering an endpoint out by DELETED-P, or
+treating ANY RESOLVE-NODE-GRAPH miss as dangling instead of only
+:DETACHED / :RESOLVED-elsewhere, would both turn this green.  Collects
+DANGLING-EDGE-WARNING specifically, not WARNING generally -- other
+machinery (e.g. spatial-index coarsening) may legitimately warn during
+backup."
+  (with-temp-directory (sys)
+    (with-temp-directory (d)
+      (with-temp-directory (bdir)
+        (let ((graph-db::*system-directory* (namestring sys))
+              (graph-db::*store-registry* nil))
+          (let ((g (make-graph :rsv-store-1 (namestring d)
+                                :buffer-pool-size 1000)))
+            (unwind-protect
+                 (let (v1 v2 v3)
+                   (with-transaction ((graph-db::transaction-manager g))
+                     (setq v1 (graph-db:make-vertex :generic nil :graph g))
+                     (setq v2 (graph-db:make-vertex :generic nil :graph g))
+                     (setq v3 (graph-db:make-vertex :generic nil :graph g))
+                     (graph-db:make-edge :generic (id v1) (id v2) 1.0 nil
+                                          :graph g)
+                     (graph-db:make-edge :generic (id v1) (id v3) 1.0 nil
+                                          :graph g))
+                   (with-transaction ((graph-db::transaction-manager g))
+                     (mark-deleted (lookup-vertex (id v3) :graph g)))
+                   (let ((file (merge-pathnames "clean.backup" bdir))
+                         (seen nil))
+                     (handler-bind ((graph-db:dangling-edge-warning
+                                      (lambda (w)
+                                        (push w seen)
+                                        (muffle-warning w))))
+                       (graph-db::backup g (namestring file)
+                                         :include-deleted-p t))
+                     (is (null seen)
+                         "a clean single-store backup must never warn")))
+              (ignore-errors (close-graph g :snapshot-p nil))
+              (collect-garbage))))))))

--- a/tests/store-resolver-tests.lisp
+++ b/tests/store-resolver-tests.lisp
@@ -138,3 +138,46 @@ CORRECTED (task-3), two brief defects:
                                     (graph-db:unresolved-node-id r))))
                      results)
             "closed far store: the marker is in the results")))))
+
+(test backup-includes-and-warns-on-a-dangling-cross-store-edge
+  "D12/sec.7: BACKUP writes the edge (connectivity survives) and signals
+DANGLING-EDGE-WARNING naming the offline endpoint.  Nearest wrong
+implementations: omit the edge silently, or refuse the backup.
+
+CORRECTED (task-4), controller notes:
+1. WITH-TRANSACTION takes the transaction manager, not :GRAPH.
+2. The substring-search assertion from the brief is replaced by
+   reading the backup file's forms back and matching a :E record's
+   :ID against E's id with EQUALP -- stronger than a printed-token
+   search, and avoids depending on STRING-ID's exact format."
+  (with-two-stores (g1 g2 sys)
+    (with-temp-directory (bdir)
+      (let (v1 v2 e)
+        (with-transaction ((graph-db::transaction-manager g1))
+          (setq v1 (graph-db:make-vertex :generic nil :graph g1)))
+        (with-transaction ((graph-db::transaction-manager g2))
+          (setq v2 (graph-db:make-vertex :generic nil :graph g2)))
+        (with-transaction ((graph-db::transaction-manager g1))
+          (setq e (graph-db:make-edge :generic (id v1) (id v2) 1.0 nil
+                                       :graph g1)))
+        (close-graph g2 :snapshot-p nil)
+        (let ((file (merge-pathnames "dangle.backup" bdir))
+              (warned nil))
+          (handler-bind ((graph-db:dangling-edge-warning
+                           (lambda (w)
+                             (setq warned w)
+                             (muffle-warning w))))
+            (graph-db::backup g1 (namestring file)))
+          (is-true warned "the backup must warn")
+          (is (equalp (id e) (graph-db:dangling-edge-id warned)))
+          (is-true (probe-file file))
+          (let* ((*readtable* graph-db::*restore-readtable*)
+                 (forms (with-open-file (in file)
+                          (loop for form = (read in nil :eof)
+                                until (eq form :eof)
+                                collect form))))
+            (is-true (find-if (lambda (f)
+                                 (and (eq :e (first f))
+                                      (equalp (id e) (getf (cddr f) :id))))
+                               forms)
+                      "the dangling edge is IN the backup")))))))

--- a/tests/store-resolver-tests.lisp
+++ b/tests/store-resolver-tests.lisp
@@ -182,6 +182,121 @@ CORRECTED (task-4), controller notes:
                                forms)
                       "the dangling edge is IN the backup")))))))
 
+(test traverse-gate-is-node-graph-not-tag
+  "TRAVERSE's same-store enqueue gate must trust NODE-GRAPH (stamped by
+every read), not a tag-vs-STORE-ID comparison: a store reopened under a
+DIFFERENT system directory gets a different registry id than the one
+baked into its own already-minted v8 ids, so the tag mismatches even
+though every vertex IS local.  The tag-based gate (pre-#209) truncates
+BFS after depth 1 here; the fix walks the whole chain.  Nearest wrong
+implementation: the reverted tag-equality gate (see the ablation notes
+in the fix-wave report)."
+  (with-temp-directory (sys1)
+    (with-temp-directory (d)
+      (let (v1id v2id v3id)
+        (let ((graph-db::*system-directory* (namestring sys1))
+              (graph-db::*store-registry* nil))
+          (let ((g (make-graph :rsv-store-1 (namestring d)
+                                :buffer-pool-size 1000)))
+            (unwind-protect
+                 (let (v1 v2 v3)
+                   (with-transaction ((graph-db::transaction-manager g))
+                     (setq v1 (graph-db:make-vertex :generic nil :graph g))
+                     (setq v2 (graph-db:make-vertex :generic nil :graph g))
+                     (setq v3 (graph-db:make-vertex :generic nil :graph g))
+                     (make-rsv-edge :from v1 :to v2 :graph g)
+                     (make-rsv-edge :from v2 :to v3 :graph g))
+                   (setq v1id (id v1) v2id (id v2) v3id (id v3)))
+              (ignore-errors (close-graph g :snapshot-p nil))
+              (collect-garbage))))
+        ;; Reopen under a DIFFERENT, otherwise-unrelated system directory.
+        ;; Consume id 1 with a dummy name first so :RSV-STORE-1 mints id 2
+        ;; here -- deliberately mismatching the tag (1) already baked into
+        ;; v1id/v2id/v3id, rather than relying on both registries handing
+        ;; out 1 by coincidence.
+        (with-temp-directory (sys2)
+          (let ((graph-db::*system-directory* (namestring sys2))
+                (graph-db::*store-registry* nil))
+            (graph-db::store-registry-intern "rsv-dummy-consumer")
+            (let ((g2 (open-graph :rsv-store-1 (namestring d)
+                                  :buffer-pool-size 1000)))
+              (unwind-protect
+                   (let* ((v1 (lookup-vertex v1id :graph g2))
+                          (results (traverse v1 :graph g2 :direction :out
+                                             :edge-type 'rsv-edge)))
+                     (is (find-if (lambda (r) (and (graph-db::vertex-p r)
+                                                    (equalp v2id (id r))))
+                                  results)
+                         "depth 1 (v2) is reached")
+                     (is (find-if (lambda (r) (and (graph-db::vertex-p r)
+                                                    (equalp v3id (id r))))
+                                  results)
+                         "depth 2 (v3) is reached -- fails under the tag gate"))
+                (ignore-errors (close-graph g2 :snapshot-p nil))
+                (collect-garbage)))))))))
+
+(test register-open-store-signals-on-slot-collision
+  "%REGISTER-OPEN-STORE must not silently overwrite an occupied
+open-store-vector slot: two system directories opened in the same image
+can each mint id 1 for their own first store.  Nearest wrong
+implementation: the pre-#209 unconditional (SETF SVREF ...), which would
+make RESOLVE-NODE-GRAPH answer id 1 with the wrong graph from then on."
+  (with-temp-directory (sys1)
+    (with-temp-directory (d1)
+      (let ((graph-db::*system-directory* (namestring sys1))
+            (graph-db::*store-registry* nil))
+        (let ((g1 (make-graph :rsv-collide-1 (namestring d1)
+                              :buffer-pool-size 1000)))
+          (unwind-protect
+               (with-temp-directory (sys2)
+                 (let ((graph-db::*system-directory* (namestring sys2))
+                       (graph-db::*store-registry* nil))
+                   ;; A hand-built second GRAPH avoids driving a full
+                   ;; MAKE-GRAPH into the collision mid-open (which would
+                   ;; leave heap/lhash files open with no clean unwind path).
+                   (let ((g2 (make-instance 'graph-db::graph
+                                           :graph-name :rsv-collide-2)))
+                     (signals error (graph-db::%register-open-store g2)))))
+            (ignore-errors (close-graph g1 :snapshot-p nil))
+            (collect-garbage)))))))
+
+(test resolve-node-graph-accepts-a-string-id
+  "RESOLVE-NODE-GRAPH accepts a 32-hex-digit string id, like LOOKUP-VERTEX
+does, and resolves it the same as the raw array (GH #209)."
+  (with-two-stores (g1 g2 sys)
+    g1
+    (let (v)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v (graph-db:make-vertex :generic nil :graph g2)))
+      (multiple-value-bind (graph status)
+          (graph-db:resolve-node-graph (string-id (id v)))
+        (is (eq g2 graph))
+        (is (eq :resolved status))))))
+
+(test reattach-after-reopen-resolves-to-the-new-graph
+  "The detached->reattached transition: once the store is OPEN again
+(a fresh GRAPH object, same directory), RESOLVE-NODE-GRAPH must answer
+:RESOLVED with the NEW graph, and LOOKUP-VERTEX-ANYWHERE must return the
+live vertex again -- not a marker, not the old (now-closed) graph."
+  (with-two-stores (g1 g2 sys)
+    g1
+    (let (v vid loc)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v (graph-db:make-vertex :generic nil :graph g2)))
+      (setq vid (id v))
+      (setq loc (namestring (graph-db::location g2)))
+      (close-graph g2 :snapshot-p nil)
+      (is (eq :detached (nth-value 1 (graph-db:resolve-node-graph vid))))
+      (let ((g2b (open-graph :rsv-store-2 loc :buffer-pool-size 1000)))
+        (unwind-protect
+             (multiple-value-bind (graph status)
+                 (graph-db:resolve-node-graph vid)
+               (is (eq :resolved status))
+               (is (eq g2b graph))
+               (is-true (graph-db::vertex-p
+                         (graph-db:lookup-vertex-anywhere vid))))
+          (ignore-errors (close-graph g2b :snapshot-p nil)))))))
+
 (test clean-backups-never-warn-dangling
   "No-false-positive canary for DANGLING-EDGE-WARNING (review fix,
 GH #169): one graph, no cross-store edges anywhere -- a live-live

--- a/tests/store-resolver-tests.lisp
+++ b/tests/store-resolver-tests.lisp
@@ -238,9 +238,10 @@ in the fix-wave report)."
 (test register-open-store-signals-on-slot-collision
   "%REGISTER-OPEN-STORE must not silently overwrite an occupied
 open-store-vector slot: two system directories opened in the same image
-can each mint id 1 for their own first store.  Nearest wrong
-implementation: the pre-#209 unconditional (SETF SVREF ...), which would
-make RESOLVE-NODE-GRAPH answer id 1 with the wrong graph from then on."
+can each mint id 1 for their own first store, and DIFFER by both name
+and location here.  Nearest wrong implementation: the pre-#209
+unconditional (SETF SVREF ...), which would make RESOLVE-NODE-GRAPH
+answer id 1 with the wrong graph from then on."
   (with-temp-directory (sys1)
     (with-temp-directory (d1)
       (let ((graph-db::*system-directory* (namestring sys1))
@@ -249,14 +250,49 @@ make RESOLVE-NODE-GRAPH answer id 1 with the wrong graph from then on."
                               :buffer-pool-size 1000)))
           (unwind-protect
                (with-temp-directory (sys2)
-                 (let ((graph-db::*system-directory* (namestring sys2))
-                       (graph-db::*store-registry* nil))
-                   ;; A hand-built second GRAPH avoids driving a full
-                   ;; MAKE-GRAPH into the collision mid-open (which would
-                   ;; leave heap/lhash files open with no clean unwind path).
-                   (let ((g2 (make-instance 'graph-db::graph
-                                           :graph-name :rsv-collide-2)))
-                     (signals error (graph-db::%register-open-store g2)))))
+                 (with-temp-directory (d2)
+                   (let ((graph-db::*system-directory* (namestring sys2))
+                         (graph-db::*store-registry* nil))
+                     ;; A hand-built second GRAPH avoids driving a full
+                     ;; MAKE-GRAPH into the collision mid-open (which would
+                     ;; leave heap/lhash files open with no clean unwind
+                     ;; path).  :LOCATION must be bound -- LOCATION is
+                     ;; unboundp otherwise, and reading an unbound slot
+                     ;; inside the guard would raise UNBOUND-SLOT instead
+                     ;; of the intended collision error.
+                     (let ((g2 (make-instance 'graph-db::graph
+                                             :graph-name :rsv-collide-2
+                                             :location d2)))
+                       (signals graph-db:store-id-collision-error
+                         (graph-db::%register-open-store g2))))))
+            (ignore-errors (close-graph g1 :snapshot-p nil))
+            (collect-garbage)))))))
+
+(test register-open-store-signals-on-same-name-different-location
+  "The hole the re-review found: comparing NAME ALONE is not enough --
+two DIFFERENT system directories whose first stores happen to share a
+NAME both mint id 1, and a name-only guard stays silent because the
+names match, so the slot is silently handed to the wrong-location
+store.  LOCATION is what actually distinguishes two stores that share a
+name (GH #169, #209)."
+  (with-temp-directory (sys1)
+    (with-temp-directory (d1)
+      (let ((graph-db::*system-directory* (namestring sys1))
+            (graph-db::*store-registry* nil))
+        (let ((g1 (make-graph :rsv-collide-same-name (namestring d1)
+                              :buffer-pool-size 1000)))
+          (unwind-protect
+               (with-temp-directory (sys2)
+                 (with-temp-directory (d2)
+                   (let ((graph-db::*system-directory* (namestring sys2))
+                         (graph-db::*store-registry* nil))
+                     ;; SAME name as G1, but a DIFFERENT location and a
+                     ;; different (fresh) registry -- also mints id 1.
+                     (let ((g2 (make-instance 'graph-db::graph
+                                             :graph-name :rsv-collide-same-name
+                                             :location d2)))
+                       (signals graph-db:store-id-collision-error
+                         (graph-db::%register-open-store g2))))))
             (ignore-errors (close-graph g1 :snapshot-p nil))
             (collect-garbage)))))))
 

--- a/traverse.lisp
+++ b/traverse.lisp
@@ -19,10 +19,15 @@
   (make-traversal (end-vertex traversal)
                   (copy-list (reverse-path traversal))))
 
-(defmethod update-traversal ((traversal traversal) (vertex vertex) (edge edge))
+;; END is normally a VERTEX, but LOOKUP-VERTEX-ANYWHERE can also hand back
+;; an UNRESOLVED-NODE marker (detached store) or NIL (unknown store); the
+;; specializer is widened to T so those still land in a traversal object
+;; for the result table, rather than hitting NO-APPLICABLE-METHOD
+;; (GH #169).
+(defmethod update-traversal ((traversal traversal) end (edge edge))
   (let ((new-traversal
          (make-instance 'traversal
-                        :end-vertex vertex
+                        :end-vertex end
                         :path (copy-list (reverse-path traversal)))))
     (push edge (reverse-path new-traversal))
     new-traversal))
@@ -50,14 +55,28 @@
                         (> (depth traversal) max-depth))
              (when (or (eql direction :out) (eql direction :both))
                (map-edges (lambda (edge)
-                            (let* ((to-vertex (lookup-vertex (to edge)))
+                            (let* ((to-vertex
+                                    (or (lookup-vertex (to edge))
+                                        (lookup-vertex-anywhere (to edge))))
                                    (new-traversal
                                     (update-traversal traversal
                                                       to-vertex
                                                       edge)))
-                              (unless (gethash to-vertex memory)
-                                (setf (gethash to-vertex memory) t)
-                                (enqueue queue new-traversal))
+                              ;; Only a same-store vertex is walked further; a
+                              ;; detached-store marker or a resolved
+                              ;; cross-store vertex still lands in RESULTS
+                              ;; below, but its adjacency lives in another
+                              ;; store's MAP-EDGES -- cross-store
+                              ;; continuation is future work (GH #169 ->
+                              ;; #170+).
+                              (when (and to-vertex (vertex-p to-vertex)
+                                         (let ((tag (id-store-tag
+                                                     (id to-vertex))))
+                                           (or (null tag)
+                                               (eql tag (store-id graph)))))
+                                (unless (gethash to-vertex memory)
+                                  (setf (gethash to-vertex memory) t)
+                                  (enqueue queue new-traversal)))
                               (when (typep edge edge-type)
                                 (setf (gethash to-vertex result-table)
                                       new-traversal))))
@@ -66,14 +85,22 @@
                           :direction :out))
              (when (or (eql direction :in) (eql direction :both))
                (map-edges (lambda (edge)
-                            (let* ((from-vertex (lookup-vertex (from edge)))
+                            (let* ((from-vertex
+                                    (or (lookup-vertex (from edge))
+                                        (lookup-vertex-anywhere (from edge))))
                                    (new-traversal
                                     (update-traversal traversal
                                                       from-vertex
                                                       edge)))
-                              (unless (gethash from-vertex memory)
-                                (setf (gethash from-vertex memory) t)
-                                (enqueue queue new-traversal))
+                              ;; See the :OUT branch above (GH #169 -> #170+).
+                              (when (and from-vertex (vertex-p from-vertex)
+                                         (let ((tag (id-store-tag
+                                                     (id from-vertex))))
+                                           (or (null tag)
+                                               (eql tag (store-id graph)))))
+                                (unless (gethash from-vertex memory)
+                                  (setf (gethash from-vertex memory) t)
+                                  (enqueue queue new-traversal)))
                               (when (typep edge edge-type)
                                 (setf (gethash from-vertex result-table)
                                       new-traversal))))

--- a/traverse.lisp
+++ b/traverse.lisp
@@ -68,12 +68,15 @@
                               ;; below, but its adjacency lives in another
                               ;; store's MAP-EDGES -- cross-store
                               ;; continuation is future work (GH #169 ->
-                              ;; #170+).
+                              ;; #170+). Gate on NODE-GRAPH (stamped by every
+                              ;; read, LOOKUP-VERTEX or LOOKUP-VERTEX-ANYWHERE
+                              ;; alike), not the id's tag: an untagged-reopen
+                              ;; graph's own vertices and a peer's tagged ids
+                              ;; landing in OUR table both have tags that
+                              ;; disagree with STORE-ID, and both must still
+                              ;; be walked (GH #169, #209).
                               (when (and to-vertex (vertex-p to-vertex)
-                                         (let ((tag (id-store-tag
-                                                     (id to-vertex))))
-                                           (or (null tag)
-                                               (eql tag (store-id graph)))))
+                                         (eq (node-graph to-vertex) graph))
                                 (unless (gethash to-vertex memory)
                                   (setf (gethash to-vertex memory) t)
                                   (enqueue queue new-traversal)))
@@ -92,12 +95,10 @@
                                     (update-traversal traversal
                                                       from-vertex
                                                       edge)))
-                              ;; See the :OUT branch above (GH #169 -> #170+).
+                              ;; See the :OUT branch above (GH #169, #209 ->
+                              ;; #170+).
                               (when (and from-vertex (vertex-p from-vertex)
-                                         (let ((tag (id-store-tag
-                                                     (id from-vertex))))
-                                           (or (null tag)
-                                               (eql tag (store-id graph)))))
+                                         (eq (node-graph from-vertex) graph))
                                 (unless (gethash from-vertex memory)
                                   (setf (gethash from-vertex memory) t)
                                   (enqueue queue new-traversal)))

--- a/vertex.lisp
+++ b/vertex.lisp
@@ -15,7 +15,7 @@
 
 (defun %make-vertex (&key id type-id revision deleted-p data-pointer data bytes
                      written-p heap-written-p type-idx-written-p views-written-p
-                     commit-epoch prev-pointer (class 'vertex))
+                     commit-epoch prev-pointer (class 'vertex) graph)
   ;; ECL ONLY: construct the target CLASS directly, because ECL's CHANGE-CLASS
   ;; retains memory on every call -- a base+change-class per node read leaked
   ;; ~unboundedly (#47).  This gives up the node buffer pool on ECL (a perf
@@ -26,8 +26,15 @@
   ;; persistent-slot init leaves the (empty) data alist alone.
   (let ((vertex #+ecl (let ((*initializing-node* t)) (make-instance class))
                 #-ecl (get-vertex-buffer)))
+    ;; GET-VERTEX-BUFFER may hand back a pool-warmed instance that already
+    ;; carries an untagged v5 id (MAKE-VERTEX-BUFFER has no graph to tag
+    ;; with) -- the +NULL-KEY+ check alone would never fire and every
+    ;; tagged store would silently get untagged ids.  A known store tag
+    ;; always wins and mints fresh, even over a pooled id (GH #169).
     (cond (id
            (setf (id vertex) id))
+          ((and graph (store-id graph))
+           (setf (id vertex) (gen-vertex-id (store-id graph))))
           ((equalp +null-key+ (id vertex))
            (setf (id vertex) (gen-vertex-id))))
     (when type-id (setf (type-id vertex) type-id))
@@ -143,7 +150,8 @@ the id on a duplicate-key collision."
                                 :deleted-p deleted-p
                                 :written-p nil
                                 :bytes bytes
-                                :data data)))
+                                :data data
+                                :graph graph)))
           (setf (bytes v) bytes)
           ;; Stamped from birth: the node is live for the whole creating
           ;; transaction, long before commit stamps it (GH #53).
@@ -155,7 +163,8 @@ the id on a duplicate-key collision."
                   (let ((*print-pretty* nil))
                     (log:error "VERTEX: Duplicate key error: ~A. Retrying MAKE-VERTEX" (id v))
                     (make-vertex type-id data
-                                 :id (gen-vertex-id)
+                                 :id (gen-vertex-id
+                                      (and graph (store-id graph)))
                                  :revision revision
                                  :deleted-p deleted-p :graph graph))
                   (error c)))))


### PR DESCRIPTION
Fixes #169 (namespaces unit 4; spec §5, §7; decisions D5, D8).

Node ids were already global, but nothing could map an id to its store short
of asking every open one — and a read into an offline store had no honest
answer. This unit builds the resolver and the answer.

## What changed

- **Store registry** (`store-registry.lisp`, new): graph-name → stable numeric
  store-id (1..4095, never reused), persisted append-only as
  `store-registry.log` in the system directory under the same
  flock/read-decide-append/torn-tail discipline as the type registry
  (#186/#191 idioms). Graphs opened without a system directory stay untagged.
- **Tagged ids**: a tagged store mints UUIDv8 (RFC 9562 vendor layout) —
  version 8 nibble, RFC variant, 12-bit store tag in the low nibble of byte 14
  plus byte 15, 110 random bits. Existing v5 ids are untouched and keep
  working; no flag day. Along the way this fixed a would-be silent no-op: the
  buffer pool pre-warms node instances with v5 ids, so tagging had to win over
  a pooled id, not just a null one.
- **Resolver**: `resolve-node-graph` — O(1) open-store-vector index for v8, a
  per-open-store scan for v5; `:resolved` / `:detached` (registered store, not
  open) / `:unknown`. The open-store vector refuses to hand one slot to two
  different stores (`store-id-collision-error`, name+location discriminant —
  the whole-branch review's catch, sharpened once more by its re-review).
- **D8 semantics**: `lookup-vertex-anywhere` returns the vertex, an
  `unresolved-node` marker for a detached store (never a raw NIL), or signals
  `store-detached-error` under `:if-detached :error`. `traverse` surfaces
  cross-store endpoints and markers in results without walking past them —
  gated on `node-graph` identity, not tag equality, so peer-replicated
  device-minted ids and system-directory changes cannot silently truncate a
  walk (#209). `active-edge-p` resolves cross-store endpoints for liveness,
  with two documented scoped gaps tracked as #208.
- **Backup** includes a dangling cross-store edge and warns
  (`dangling-edge-warning`, per offending endpoint); a clean backup never
  warns, pinned by a failing-capable handler-bind canary.
- Docs: CHANGELOG, manual (id format, ch.17 sections, API reference, backup
  note), spec §5.3/§7 Built-notes.

Out of scope, tracked: §5.4 store-occupancy set; #208 (active-edge-p v5 scan,
unknown-tag compaction); #209 (cross-system tag trust boundaries); Prolog
surfaces keep pre-existing per-graph endpoint behavior (recorded on #208).

## Verification

- Real gate `(asdf:test-system :graph-db)` on SBCL: **4073 checks — 4063 pass
  / 10 skip / 0 fail** (baseline 4023/4013/10/0; the 50 new checks account
  for the entire delta; the whole-branch reviewer derived the same expected
  total independently). ECL skipped per the standing demotion; the guard's
  pathname-EQUAL is flagged for the ECL catch-up pass.
- Every guard ablation-tested with recorded output, including: tag-gate
  reversion truncating BFS, name-only collision guard missing the same-name
  hole, version-nibble mis-stamp, dropped warn calls, silent-skip detached
  reads.
- Five per-task reviews plus a whole-branch review (two fix waves, each
  re-reviewed) — the whole-branch pass caught the traverse tag-gate defect
  and the vector collision, both fixed on-branch.

Unblocks #170 (detach quiescence + shadow bulk load), which was resequenced
behind this unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95