### PR TITLE
Detach quiescence and shadow bulk load (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,12 +70,17 @@ between releases; cutting a release renames it to the new version and dates it.
   `policy.dat` (`store-recovery-policy` / `set-store-recovery-policy`,
   default `:authored`) records whether a crash mid-load can simply be
   repaired by redoing it (`:derivable`) or whether its writes are the
-  only durable record (`:authored`). `open-shadow-graph :fast-load t`
-  suppresses the `.txn` file and replication log for the shadow's
-  transactions, but only when the shadow's copied policy says
-  `:derivable`; otherwise it signals `fast-load-requires-derivable`
-  rather than silently keeping the store's only record on an
-  unsuppressed WAL. **`presize-vector-segment`** turns a bulk load's
+  only durable record (`:authored`). `make-graph :recovery-policy`
+  writes `policy.dat` at creation; `open-graph :recovery-policy` is
+  only a hint once the file exists — a disagreeing value signals
+  `recovery-policy-mismatch-warning` (naming the location, the
+  requested policy and the on-disk one) rather than overwriting it.
+  `open-shadow-graph :fast-load t` suppresses the `.txn` file and
+  replication log for the shadow's transactions, but only when the
+  shadow's copied policy says `:derivable`; otherwise it signals
+  `fast-load-requires-derivable` rather than silently keeping the
+  store's only record on an unsuppressed WAL.
+  **`presize-vector-segment`** turns a bulk load's
   vector-segment capacity hazard into an upfront allocation instead of a
   mid-apply failure discovered after some writes are already durable;
   `open-shadow-graph :expected-vectors n` applies it to every segment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,59 @@ between releases; cutting a release renames it to the new version and dates it.
   `dangling-edge-warning` naming the edge, the missing endpoint and its
   store; a backup with no cross-store gaps never warns. (#169)
 
+- **Detach a store, bulk-load a shadow copy, and swap it in — all in-process,
+  with only two brief unavailable windows.** `detach-store` quiesces a
+  graph (refuses new transactions and read pins, drains in-flight ones),
+  leases a range of its system clock's epoch space via
+  `clock-lease-epochs`, journals `:detach`, closes it durably, and
+  returns a `store-detachment` handle; `reattach-store` reopens it and
+  rejoins the ambient `*system-clock*`. `shadow-store` takes a
+  consistent copy for a bulk load while the store keeps serving reads:
+  quiesce, close, recursive sparse-preserving copy to
+  `<location>-shadow/` (reservations are unwritten holes, so an empty
+  multi-gigabyte store copies in seconds, not by materializing every
+  reserved byte), reopen the live store and resume service — left
+  **read-only** (Kevin's ruling: a write during the shadow window signals
+  `store-not-accepting-error` with reason `:shadow-load` rather than
+  being silently dropped) until the caller calls `swap-in-shadow` or
+  `abandon-shadow`. A copy failure reopens the original store and
+  restores full service before re-signalling. `open-shadow-graph` opens
+  the copy as an unregistered graph, under the live store's own name and
+  store-id (so ids minted there resolve back to the live store), against
+  a leased `(start . end)` epoch range persisted in `lease.dat`; its
+  allocation cursor is always derived fresh from the shadow's own
+  highest committed transaction id, never from a separately persisted
+  cursor, and an already-exhausted range signals
+  `epoch-lease-exhausted` immediately rather than wrapping or
+  colliding. `swap-in-shadow` promotes the shadow: quiesce, close,
+  rename the live directory to `<location>-retired-<epoch>` **first**,
+  then rename the shadow into the live location — that second rename,
+  not the best-effort `:swap` journal record after it, is what "the
+  swap happened" means (a crash between the two renames is out of scope
+  here, tracked as #171/#212) — and reopens the new generation.
+  `discard-shadow` deletes a shadow tree (hard-gated on a `-shadow`
+  suffix) and `abandon-shadow` combines that with restoring the live
+  store to full service.
+
+  **Recovery policy licenses a fast, non-transactional load.** A store's
+  `policy.dat` (`store-recovery-policy` / `set-store-recovery-policy`,
+  default `:authored`) records whether a crash mid-load can simply be
+  repaired by redoing it (`:derivable`) or whether its writes are the
+  only durable record (`:authored`). `open-shadow-graph :fast-load t`
+  suppresses the `.txn` file and replication log for the shadow's
+  transactions, but only when the shadow's copied policy says
+  `:derivable`; otherwise it signals `fast-load-requires-derivable`
+  rather than silently keeping the store's only record on an
+  unsuppressed WAL. **`presize-vector-segment`** turns a bulk load's
+  vector-segment capacity hazard into an upfront allocation instead of a
+  mid-apply failure discovered after some writes are already durable;
+  `open-shadow-graph :expected-vectors n` applies it to every segment
+  the shadow's graph object carries.
+
+  V1 ships in-process only — no separate loader process — with the
+  epoch lease already shaped to carry that later without a redesign.
+  (#170)
+
 - Defining one class name in two stores with *different* slot sets now
   signals `divergent-node-type-redefinition` (a `style-warning`): both
   definitions name one CLOS class, so the last one loaded determines the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This is an ASDF system loaded through Quicklisp; there is no separate build step
 (in-package :graph-db)
 ```
 
-Dependencies (bordeaux-threads, alexandria, cffi, osicat, uuid, cl-store, hunchentoot, ningle, clack, log4cl, usocket, etc.) must be resolvable by Quicklisp/ASDF. `osicat` and `cffi` mean a working C toolchain is required (the mmap layer binds `mmap`/`munmap`).
+Dependencies (bordeaux-threads, alexandria, cffi, uuid, cl-store, hunchentoot, ningle, clack, log4cl, usocket, etc.) must be resolvable by Quicklisp/ASDF. `cffi` means a working C toolchain is required (the mmap layer binds `mmap`/`munmap`). `posix.lisp` hand-rolls the POSIX calls the embeddable core needs via raw CFFI, replacing an earlier `osicat` dependency there — `osicat` ships a C grovel/wrapper that complicated cross-compilation, so it survives only in the ad-hoc `test-lhash.lisp` REPL exercise, not the loaded system.
 
 **Component load order matters.** `graph-db.asd` encodes a strict dependency chain from the storage primitives up to the query/REST layers; if you add a file, place it in the right position and declare its `:depends-on`.
 
@@ -69,7 +69,7 @@ Tests write scratch databases under `/var/tmp/`; clean those up between runs if 
 
 The system is layered. Lower layers know nothing of graph semantics; higher layers build on them.
 
-1. **Storage primitives** — `mmap.lisp` (CFFI/osicat memory-mapped files, with SEGV-retry `:around` methods on `set-byte`/`get-byte`), `allocator.lisp` (binned heap allocator over an mmap'd region), `buffer-pool.lisp`, `serialize.lisp` (custom binary (de)serialization; type tag bytes are defined in `globals.lisp`), `pcons.lisp`/`pmem.lisp` (persistent cons cells).
+1. **Storage primitives** — `mmap.lisp` (CFFI memory-mapped files, with SEGV-retry `:around` methods on `set-byte`/`get-byte`), `posix.lisp` (hand-rolled CFFI bindings for the POSIX calls the embeddable core needs, replacing `osicat` there), `allocator.lisp` (binned heap allocator over an mmap'd region), `buffer-pool.lisp`, `serialize.lisp` (custom binary (de)serialization; type tag bytes are defined in `globals.lisp`), `pcons.lisp`/`pmem.lisp` (persistent cons cells).
 2. **On-disk collections** — `linear-hash.lisp` (linear hashing, the main key→offset table), `skip-list.lisp` + `skip-list-cursors.lisp`, `index-list.lisp`.
 3. **Graph indexes** — `ve-index.lisp` (vertex↔edge adjacency, in/out), `vev-index.lisp` (vertex-edge-vertex), `type-index.lisp` (nodes by type). A graph keeps separate `ve-index-in`, `ve-index-out`, and `vev-index` instances.
 4. **Graph model** — `graph-class.lisp`/`graph.lisp` (the `graph`/`master-graph`/`slave-graph` classes and `make-graph`/`open-graph`/`close-graph`), `schema.lisp` (node-type registry, per-class rw-locks), `node-class.lisp` + `primitive-node.lisp` + `vertex.lisp` + `edge.lisp` (the MOP-based persistent object model), `views.lisp` (map/map-reduce indexes), `gc.lisp`.

--- a/docs/superpowers/plans/2026-08-22-detach-shadow-170.md
+++ b/docs/superpowers/plans/2026-08-22-detach-shadow-170.md
@@ -1,0 +1,528 @@
+# Detach Quiescence and Shadow Bulk Load (#170) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A store can be taken out of service without stopping the system
+(detach = refuse + drain + close + journal, over the existing pin
+machinery); a bulk load builds a shadow generation and swaps it in, so the
+store is offline only for two brief windows (the consistent copy and the
+swap), a killed loader leaves the live generation byte-identical, a
+derivable store may load without WAL, and a load that would exceed
+vector-segment capacity fails before writing anything.
+
+**Architecture:** Six layers. (1) **Quiescence**: transaction-manager
+gains an `accepting-p` flag checked at the two choke points —
+`create-transaction` (via `call-with-transaction`) and `pin-read-epoch` —
+plus `%quiesce-transaction-manager` which flips it and waits for
+`reap-safe-floor` to report nothing active. (2) **Detach**:
+`detach-store` quiesces, leases an epoch range from the image clock
+(`clock-lease-epochs`), journals `:detach` with the range, closes the
+graph, and returns a `store-detachment` handle. `reattach-store` reopens
+and re-attaches to the clock (which journals `:attach`). #169's machinery
+makes the closed store honestly `:detached` to every reader for free.
+(3) **Shadow**: `shadow-store` makes a consistent copy — v1 consistency
+window is quiesce → `close-graph` → file copy → `open-graph` + clock
+reattach, seconds of unavailability, exactly the "copies in seconds"
+budget — and leaves the reopened live store in a **read-only window**
+(ruled by Kevin, 2026-08-22: the spec promises "readers continue" and
+says nothing about writers, and a write accepted against the doomed
+generation would be silently discarded at swap — so `accepting-p` goes
+`:read-only`: pins and reads flow, new write transactions signal
+`store-not-accepting-error` with reason `:shadow-load`, until
+`swap-in-shadow` replaces the generation or `abandon-shadow` restores
+full service). Then `open-shadow-graph` opens the copy WITHOUT
+registering it
+(`*graphs*`, open-store vector, and `.dirty`-independent: it is a private
+graph only the loader holds), with the SAME graph-name (schema metadata
+applies) and the same store-id set directly (so minted v8 ids carry the
+live store's tag), transaction ids drawn from the lease, and the lease
+persisted as `lease.dat` in the shadow directory (the out-of-process
+survival requirement from the #170/#182 comment). `discard-shadow`
+deletes the shadow directory. (4) **Swap**: `swap-in-shadow` quiesces and
+closes the live store, renames live → `<name>.retired-<epoch>`, shadow →
+live, journals `:swap`, reopens and reattaches. (5) **Fast path**: a
+persisted per-store `recovery-policy` (`policy.dat`; absent = `:authored`)
+licenses `:fast-load t` on `open-shadow-graph`, which suppresses WAL
+persistence (`persist-transaction` becomes a no-op on that graph) — sound
+for a shadow because a crashed load is discarded and redone, and gated on
+`:derivable` because only a derivable store's source material is
+guaranteed re-runnable. (6) **Presize**: `presize-vector-segment` grows a
+segment to capacity ≥ N upfront under its write lock, so allocation
+failure precedes any node write; `open-shadow-graph :expected-vectors N`
+presizes.
+
+Out of scope, stated: out-of-process detach (the lease + `lease.dat` +
+journal records accommodate it later, per the issue's #182 comment);
+cross-store traversal continuation; #171's restore/cascade semantics.
+
+**Tech Stack:** Common Lisp (SBCL primary), FiveAM, uiop for file copy.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-namespaces-design.md` §8
+(D12), GH #170 including its #182-constraint comment, and the acceptance
+list in the issue.
+
+## Global Constraints
+
+- Lisp: spaces only, never tabs; hard 80-column limit (96 is a defect).
+  Comments terse: invariant + `(GH #170)`.
+- Every SBCL run: from the worktree, FIRST
+  `--eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))'`,
+  and `--dynamic-space-size 16384`.
+- **The merge gate is `(asdf:test-system :graph-db)`, controller-run.**
+  Implementers run focused suites only and report expected gate deltas.
+  Branch baseline (post-#210, 11afe7d): 4073 checks / 4063 pass /
+  10 skip / 0 fail.
+- Test-form conventions that are LAW in this codebase (every prior unit
+  tripped on one): `with-transaction` takes the transaction manager —
+  `(with-transaction ((transaction-manager g)) ...)`; `:generic`
+  (type-0) edges are invisible to typed adjacency scans and `traverse`
+  needs `:edge-type`; tests binding `*system-directory*` must also
+  rebind `graph-db::*store-registry*` (and now `*type-registry*` where
+  types are minted) to nil per test; `make-vertex` is
+  `(make-vertex type data &key graph id ...)`, `make-edge` is
+  `(make-edge type from to weight data &key graph id ...)`.
+- Ablate every guard; each test names its nearest wrong implementation.
+- ECL demoted: verify on SBCL only, say so.
+- Host safety: live `ma-dev-server` on this host — NEVER
+  `pkill`/`killall`/`pgrep`; kill only a PID you started; one SBCL at a
+  time; never touch `/data0`. Never end a turn waiting on a background
+  run — bounded foreground stretches
+  (`timeout 570 bash -c 'while kill -0 <PID> 2>/dev/null; do sleep 15; done'`).
+- Worktree `.worktrees/170-detach-shadow`, branch `170-detach-shadow` off
+  `experiment` (11afe7d). PR against `experiment`. Pushing explicit-only.
+- PUBLIC repo: domain-neutral text everywhere.
+
+## Contract-first note to implementers
+
+Unlike earlier plans, several steps here say "read X and adapt" instead
+of verbatim code: this unit hooks deep machinery (transaction creation,
+txn-id allocation, open/close internals) where every prior unit's
+verbatim code needed correction against the real source. The CONTRACTS
+(names, signatures, semantics, tests) are fixed; the splice points you
+verify against the code. When the code contradicts a contract, report
+NEEDS_CONTEXT or flag a substantive deviation — do not silently improvise
+a different interface.
+
+---
+
+### Task 1: Quiescence, detach, reattach
+
+**Files:**
+- Modify: `transactions.lisp` (transaction-manager `accepting-p` slot;
+  refusal checks in `create-transaction` and `pin-read-epoch`;
+  `%quiesce-transaction-manager`; `detach-store`; `reattach-store`;
+  conditions)
+- Modify: `package.lisp` (exports)
+- Create: `tests/detach-tests.lisp` (+ .asd entry after
+  `store-resolver-tests`)
+
+**Interfaces (produced; Tasks 2–4 consume):**
+
+```lisp
+(define-condition store-not-accepting-error (error) (name reason))
+;; reason :detaching | :swapping | :shadow-load; readers
+;; store-not-accepting-name / store-not-accepting-reason.  Signaled by
+;; NEW transactions on any non-T accepting state, and by NEW read pins
+;; only under FULL quiesce (:detaching/:swapping) -- :read-only
+;; (reason :shadow-load) refuses transactions but ADMITS pins/reads.
+;; ACCEPTING-P states: T (all), :read-only (pins yes, txns no),
+;; :detaching/:swapping (nothing new).
+
+(define-condition detach-drain-timeout (error) (name seconds))
+;; readers detach-timeout-name / detach-timeout-seconds.  Quiesce wave
+;; failed to drain in time; ACCEPTING-P is restored to T before this
+;; is signaled (the store resumes service -- a failed detach must not
+;; strand it half-dead).
+
+(defstruct store-detachment
+  graph-name location store-id lease-start lease-end)
+
+(defun %quiesce-transaction-manager (tm reason timeout)
+  ;; Flip ACCEPTING-P to REASON (a keyword; NIL/T semantics: T =
+  ;; accepting).  Wait in short sleeps until REAP-SAFE-FLOOR is NIL
+  ;; (no active txns, no read pins) or TIMEOUT seconds pass.  On
+  ;; timeout: restore ACCEPTING-P to T and signal DETACH-DRAIN-TIMEOUT.
+  ;; On success return T with ACCEPTING-P left at REASON.
+  )
+
+(defun detach-store (graph &key (lease-epochs 1000000) (timeout 60))
+  ;; Requires (graph-system-clock graph) non-nil -- detach without an
+  ;; image clock has no lease to hand over; signal a plain error naming
+  ;; the requirement.  Steps: quiesce (:detaching, TIMEOUT);
+  ;; CLOCK-LEASE-EPOCHS for LEASE-EPOCHS; JOURNAL-APPEND :detach with
+  ;; :store name :lease-start s :lease-end e; CLOSE-GRAPH (snapshot-p
+  ;; t default); return the STORE-DETACHMENT handle.
+  )
+
+(defun reattach-store (detachment &key (buffer-pool-size nil bps-p))
+  ;; OPEN-GRAPH at the handle's location/name (pass buffer-pool-size
+  ;; through when supplied), ATTACH-TO-SYSTEM-CLOCK to the image clock
+  ;; (which journals :attach), return the new graph.
+  )
+```
+
+- [ ] **Step 1: Write the failing tests** (`tests/detach-tests.lisp`,
+  suite `detach-suite :in graph-db-suite`). Fixture: adapt
+  `with-two-stores` from `tests/store-resolver-tests.lisp` — but detach
+  needs the image CLOCK too: build `with-clocked-store` opening ONE
+  disk store under a temp system directory with
+  `open-system-clock` + `attach-to-system-clock` (read
+  `tests/system-clock-tests.lisp`'s `two-stores-on-one-clock-...` for
+  the exact wiring and reuse its idiom), rebinding `*system-directory*`,
+  `*store-registry*` and closing clock+graph in the unwind. Tests:
+
+```lisp
+(test detach-refuses-new-transactions-and-pins
+  "During and after quiesce, a NEW transaction and a NEW read pin both
+signal STORE-NOT-ACCEPTING-ERROR.  Nearest wrong implementation: close
+without refusing -- the segfault-shaped hazard the spec names."
+  ;; open clocked store; write one vertex; DETACH-STORE.
+  ;; After detach the graph object is closed; assert:
+  ;;   (signals store-not-accepting-error
+  ;;     (with-transaction ((transaction-manager g)) ...))
+  ;;   (signals store-not-accepting-error
+  ;;     (pin-read-epoch (transaction-manager g)))
+  )
+
+(test detach-drains-in-flight-readers-first
+  "A pinned reader taken BEFORE detach holds the drain; detach completes
+only after the pin is released.  Nearest wrong implementation: skip the
+drain (close underneath the reader).  Mechanism: take a pin, start
+DETACH-STORE in a second thread (bordeaux-threads, like the
+concurrency tests), assert it has NOT completed while the pin is held
+(sleep + flag), release the pin, join, assert detached."
+  )
+
+(test detach-timeout-restores-service
+  "A drain that cannot complete times out, signals
+DETACH-DRAIN-TIMEOUT, and the store ACCEPTS transactions again --
+a failed detach must not strand the store half-dead.  Hold a pin,
+call DETACH-STORE :timeout 1, expect the condition, then a
+with-transaction write must succeed."
+  )
+
+(test detach-journals-and-leases
+  "The clock journal records :detach with the lease range; the clock's
+next epoch is past LEASE-END (CLOCK-LEASE-EPOCHS semantics).  Read
+JOURNAL-RECORDS, find the :detach record, assert :lease-start/-end
+present and (>= (clock-current-epoch clock) lease-end)."
+  )
+
+(test detached-store-is-detached-to-the-resolver
+  "#169 integration: after DETACH-STORE, RESOLVE-NODE-GRAPH on a node
+id minted there reports :DETACHED and LOOKUP-VERTEX-ANYWHERE returns
+the marker."
+  )
+
+(test reattach-restores-service-and-journals
+  "REATTACH-STORE reopens, the same node reads back, a new write
+succeeds, and the journal carries the :attach record after the
+:detach one."
+  )
+```
+
+Write real assertions; the sketches above fix the scenario and the
+condition names, not the exact forms.
+
+- [ ] **Step 2: RED** (skeleton-first allowed as in every prior unit;
+  behavioral RED recorded per test).
+
+- [ ] **Step 3: Implement.** Splice points, verified this session:
+  - `call-with-transaction` (transactions.lisp:2863) calls
+    `create-transaction` — put the accepting check inside
+    `create-transaction` under the tm lock (or at its entry), signaling
+    `store-not-accepting-error` with the tm's graph name. Find where
+    `create-transaction` is defined and whether recovery/replication
+    paths also call it — the check must NOT break
+    recovery-transaction replay on open (those run before detach could
+    ever have flipped the flag, but confirm and say so).
+  - `pin-read-epoch` (transactions.lisp:652): check `accepting-p`
+    before registering; `with-read-pin` (graph-class.lisp:244) then
+    propagates the signal to `map-vertices`/`map-edges` for free.
+  - `accepting-p` initform `t`; readers treat any non-`t` value as the
+    refusal reason keyword.
+  - Drain condition: `reap-safe-floor` nil under the tm lock — but note
+    `minimum-start-transaction-id` semantics (read it): confirm nil
+    means "no active transactions".
+  - `clock-lease-epochs` is system-clock.lisp:289; `journal-append`
+    kinds already include `:detach`/`:attach`/`:swap`/`:retire`.
+  - `attach-to-system-clock` (transactions.lisp ~2990) already refuses
+    with active transactions and journals `:attach` — `reattach-store`
+    composes `open-graph` + it; do not reimplement.
+
+- [ ] **Step 4: Focused suite green; count checks; also run
+  `system-clock-suite` (journal interplay) and one concurrency-adjacent
+  canary you judge cheapest.**
+
+- [ ] **Step 5: Ablations — run (a) and (b).** (a) Remove the
+  `pin-read-epoch` check: `detach-refuses-...` fails its pin half.
+  (b) Make `%quiesce-transaction-manager` return immediately (no
+  drain): `detach-drains-in-flight-readers-first` fails. Revert, green.
+
+- [ ] **Step 6: Commit**
+  `feat(detach): quiescence protocol over the pin machinery (#170)`
+
+---
+
+### Task 2: Shadow generation
+
+**Files:**
+- Create: `shadow-store.lisp` (+ .asd entry — needs `graph`,
+  `transactions`; place near `backup` in the chain and declare
+  `:depends-on` accordingly, reporting the position)
+- Modify: `graph-class.lisp` (graph slot `shadow-p`, initform nil;
+  graph slot `epoch-lease`, initform nil — a `(next . end)` cons or
+  small struct), `transactions.lisp` (txn-id allocation consults the
+  lease first — find the allocation point: the function that yields the
+  next transaction id when a system clock is attached vs the per-store
+  counter; add the lease branch BEFORE both, erroring past `end` with a
+  named condition `epoch-lease-exhausted`), `graph.lisp`/`open-graph`
+  (a `:shadow-p` keyword that skips `*graphs*` registration,
+  `%register-open-store`, and replication start), `package.lisp`
+- Modify: `tests/detach-tests.lisp` (append)
+
+**Interfaces (produced):**
+
+```lisp
+(defun shadow-store (graph &key (timeout 60))
+  ;; Consistent copy of GRAPH's directory: quiesce (:swapping, TIMEOUT)
+  ;; -> CLOSE-GRAPH -> copy directory tree to "<location>-shadow/"
+  ;; (uiop:collect-sub*directories / copy-file loop; NO shell-outs) ->
+  ;; reopen via OPEN-GRAPH + ATTACH-TO-SYSTEM-CLOCK (service resumes)
+  ;; -> set the reopened graph's ACCEPTING-P to :READ-ONLY (reason
+  ;; :shadow-load: reads and pins flow, new writes signal -- Kevin's
+  ;; ruling; no write is ever silently discarded at swap)
+  ;; -> return (values shadow-location reopened-graph).  The live store
+  ;; is fully unavailable only for close+copy+reopen -- seconds
+  ;; (spec sec.8) -- and write-unavailable until swap or abandon.
+  )
+
+(defun abandon-shadow (graph shadow-location)
+  ;; The lifecycle exit that is not a swap: DISCARD-SHADOW the
+  ;; directory, restore GRAPH's ACCEPTING-P to T (full service).
+  )
+
+(defun open-shadow-graph (shadow-location graph-name
+                          &key lease fast-load expected-vectors
+                               (buffer-pool-size nil))
+  ;; OPEN-GRAPH :shadow-p t -- unregistered (not in *graphs*, not in
+  ;; the open-store vector, no replication), SAME graph-name so schema
+  ;; metadata instantiates, store-id set directly from
+  ;; STORE-REGISTRY-INTERN so minted v8 ids carry the LIVE store's tag.
+  ;; LEASE is (start . end) from the STORE-DETACHMENT (or DETACH-STORE
+  ;; was never called and the caller passes one from
+  ;; CLOCK-LEASE-EPOCHS); persist it as lease.dat in the shadow dir
+  ;; ((:lease-start s :lease-end e) printed readably, *read-eval* nil
+  ;; on read) and install it as the graph's epoch-lease so transaction
+  ;; ids come from the lease.  FAST-LOAD and EXPECTED-VECTORS are
+  ;; Task 4/5 hooks -- accept and stash them now (fast-load errors
+  ;; :not-implemented until Task 4? NO: accept the keyword, signal a
+  ;; clear "arrives in a later task" error so Task 4 replaces it).
+  )
+
+(defun discard-shadow (shadow-location)
+  ;; Close if somehow open (it never registers, so just delete);
+  ;; UIOP:DELETE-DIRECTORY-TREE with :validate confining the path to
+  ;; one that ENDS in "-shadow" -- refuse anything else (this function
+  ;; deletes trees; the guard is the whole safety story).
+  )
+```
+
+- [ ] **Step 1: Tests** (append to detach-tests):
+
+```lisp
+(test shadow-copy-is-consistent-and-reads-resume
+  ;; write 3 nodes; SHADOW-STORE; assert the live graph serves READS
+  ;; (map-vertices under a pin) afterward; OPEN-SHADOW-GRAPH with a
+  ;; lease from CLOCK-LEASE-EPOCHS; assert the 3 nodes are present in
+  ;; the shadow.
+
+(test live-store-is-read-only-during-the-shadow-window
+  ;; Kevin's ruling: after SHADOW-STORE, a new write transaction on the
+  ;; live graph signals STORE-NOT-ACCEPTING-ERROR with reason
+  ;; :shadow-load, while PIN-READ-EPOCH succeeds; ABANDON-SHADOW
+  ;; deletes the shadow dir and a write then succeeds.  Nearest wrong
+  ;; implementation: writes allowed and silently discarded at swap.
+
+(test shadow-is-unregistered
+  ;; while the shadow is open: *graphs* has no second entry, the
+  ;; open-store vector still maps the store-id to the LIVE graph, and
+  ;; RESOLVE-NODE-GRAPH on a shadow-minted id resolves to the LIVE
+  ;; graph (same tag).  Nearest wrong implementation: plain OPEN-GRAPH
+  ;; (clobbers *graphs*, trips the #209 collision guard).
+
+(test shadow-writes-draw-from-the-lease
+  ;; a node written in the shadow has commit-epoch/transaction id
+  ;; within [lease-start, lease-end); exhausting a tiny lease (e.g. 3
+  ;; epochs) signals EPOCH-LEASE-EXHAUSTED.  Nearest wrong
+  ;; implementation: shadow ids from the store's own counter --
+  ;; colliding with the live store's post-copy writes.
+
+(test lease-survives-in-the-shadow-directory
+  ;; lease.dat exists in the shadow dir and reads back the exact range
+  ;; (the out-of-process survival requirement, GH #170 comment).
+
+(test discard-shadow-refuses-non-shadow-paths
+  ;; (signals error (discard-shadow <the live store's directory>)) --
+  ;; the -shadow suffix guard.  THE deletion-safety test.
+```
+
+- [ ] **Step 2: RED. Step 3: Implement** (splice notes: find the txn-id
+  allocation point by reading how `attach-to-system-clock`'s clock is
+  consulted — grep `clock-next-epoch` in transactions.lisp; the lease
+  branch goes where the clock branch is chosen, BEFORE it). Copying:
+  plain recursive file copy; the store is closed, so no mmap hazards.
+- [ ] **Step 4: Focused green + counts. Step 5: Ablations** — (a)
+  registration NOT skipped (drop :shadow-p handling): the
+  unregistered test fails (collision guard fires or vector clobbered);
+  (b) lease branch removed: the lease test fails. Revert, green.
+- [ ] **Step 6: Commit**
+  `feat(shadow): shadow generations with leased epochs (#170)`
+
+---
+
+### Task 3: The swap, and the acceptance scenarios
+
+**Files:** `shadow-store.lisp` (swap), `tests/detach-tests.lisp`,
+`package.lisp`.
+
+**Interfaces:**
+
+```lisp
+(defun swap-in-shadow (graph shadow-location &key (timeout 60))
+  ;; GRAPH is the live, open store.  Quiesce (:swapping) -> CLOSE-GRAPH
+  ;; -> rename live dir to "<location>-retired-<epoch>" -> rename
+  ;; shadow dir to the live location -> JOURNAL-APPEND :swap with
+  ;; :store name :retired <retired-path> -> OPEN-GRAPH at the live
+  ;; location + ATTACH-TO-SYSTEM-CLOCK -> return (values new-graph
+  ;; retired-path).  Any failure BEFORE the first rename leaves the
+  ;; live store intact (reopen it and signal); between the renames is
+  ;; the unavoidable window -- order them so the live data always
+  ;; exists under SOME name (rename live away FIRST, then shadow in;
+  ;; a crash between leaves live at the retired path, recoverable by
+  ;; hand -- state this in the docstring, it is #171's territory).
+```
+
+- [ ] **Tests:**
+
+```lisp
+(test swap-in-shadow-end-to-end
+  ;; THE acceptance scenario: open clocked store with data A; SHADOW-
+  ;; STORE; OPEN-SHADOW-GRAPH; bulk-write data B into the shadow
+  ;; (plain transactions); MEANWHILE the live store serves a READ and
+  ;; REFUSES a write with reason :shadow-load (the ruled read-only
+  ;; window -- "offline only for the swap" means read service);
+  ;; SWAP-IN-SHADOW; assert: new graph serves A+B AND accepts a fresh
+  ;; write (full service restored); retired dir exists (the old
+  ;; generation is kept, not deleted); journal carries :swap and
+  ;; :attach.
+
+(test killed-loader-leaves-live-byte-identical
+  ;; (use ABANDON-SHADOW as the discard path -- it must also restore
+  ;; write service, asserted at the end)
+  ;; hash every file in the live directory (sha or byte-compare);
+  ;; SHADOW-STORE (copy window); open shadow, write garbage into it,
+  ;; simulate the kill by just NOT swapping (close nothing -- abandon
+  ;; the object) and DISCARD-SHADOW; byte-compare the live directory
+  ;; against the pre-shadow state EXCLUDING files the reopen itself
+  ;; legitimately touches (.dirty, txn dir, replication log) -- derive
+  ;; the exclusion list from what a bare close/open round-trip changes
+  ;; (measure it in the test first!), then assert everything else
+  ;; identical.  Nearest wrong implementation: loader writes into the
+  ;; live mmaps (any shared-file bug) -- heap.dat diverges.
+
+(test swap-failure-before-rename-restores-service
+  ;; force a failure before the first rename (e.g. shadow-location
+  ;; does not exist); the live store must still be OPEN-or-reopened
+  ;; and serving.
+```
+
+- [ ] RED → implement → focused green → ablation (skip the quiesce in
+  swap: the end-to-end test with a held pin... add the pin-held variant
+  inline — a pin held across SWAP-IN-SHADOW must delay it, same
+  mechanism as Task 1's drain test) → commit
+  `feat(swap): atomic generation swap with retirement (#170)`
+
+---
+
+### Task 4: Recovery policy and the WAL-suppressed fast path
+
+**Files:** `shadow-store.lisp` or `graph.lisp` (policy read/write),
+`transactions.lisp` (`persist-transaction` no-op branch),
+`graph-class.lisp` (slot `wal-suppressed-p`), `package.lisp`, tests.
+
+**Contracts:** `store-recovery-policy (location)` → `:derivable` /
+`:authored` (reads `policy.dat`, absent = `:authored`);
+`(setf-able via) set-store-recovery-policy (location policy)`;
+`make-graph`/`open-graph` gain `:recovery-policy` (persisted at create;
+open reads the file). `open-shadow-graph :fast-load t` requires the
+policy `:derivable` (else `error 'fast-load-requires-derivable`) and
+sets `wal-suppressed-p`; `persist-transaction` returns without writing
+the .txn file or the replication log when the transaction's graph has
+`wal-suppressed-p` (find how the transaction reaches its graph — the
+`graph` accessor on tx exists per `transaction-prepare-pathname`).
+Tests: fast load leaves the shadow's txn directory EMPTY of .txn files
+while the data reads back; `:fast-load t` on an `:authored` store
+signals; a NORMAL (non-shadow) graph is never WAL-suppressed (assert
+the slot's initform path — nearest wrong implementation: a dynamic
+variable that leaks suppression to other graphs). Ablation: drop the
+policy gate — the authored-refusal test fails. Commit
+`feat(load): recovery policy licenses the WAL-free fast path (#170)`.
+
+---
+
+### Task 5: Vector-segment presize
+
+**Files:** `segment.lisp` (`presize-vector-segment`),
+`shadow-store.lisp` (wire `:expected-vectors`), `package.lisp`, tests
+(append; if the graph↔segment wiring lives elsewhere — grep
+`create-vector-segment` callers — put the wiring where the graph's
+segments are opened and REPORT the location).
+
+**Contract:** `presize-vector-segment (segment n)` — under the
+segment's write lock, grow (the existing doubling path, segment.lisp
+~490) until `segment-capacity ≥ n`; any allocation failure surfaces
+HERE, before a single node is written. `open-shadow-graph
+:expected-vectors n` presizes each of the shadow's segments (or its
+one segment — match reality). Tests: presize to 10000 → capacity ≥
+10000 and a subsequent `segment-put` burst triggers NO grow (peek the
+capacity before/after); presize failure (simulate: an absurd N whose
+file size cannot be reserved — if not reliably simulable on this host,
+test instead that presize on a too-large-for-uint N signals cleanly
+and REPORT the substitution). Ablation: make presize a no-op — the
+no-grow assertion fails. Commit
+`feat(segment): presize turns mid-apply capacity failure upfront (#170)`.
+
+---
+
+### Task 6: Documentation
+
+CHANGELOG (`### Added`, model = the #169 entry); manual — new Chapter 17
+section "Detach, shadow load, and the swap" (the lifecycle, the two
+brief windows, the discard guarantee, policy + fast path, presize) plus
+API-reference entries for `detach-store`, `reattach-store`,
+`shadow-store`, `open-shadow-graph`, `swap-in-shadow`,
+`discard-shadow`, `store-recovery-policy`, `presize-vector-segment` and
+the three conditions; spec §8 gets the "**Built (#170):**" note naming
+the two-window v1 consistency choice and the out-of-process deferral.
+Domain-neutral; 80-col. Commit
+`docs: detach quiescence and shadow bulk load (#170)`.
+
+Whole-branch review + PR are the controller's.
+
+---
+
+## Self-Review
+
+- Acceptance list coverage: bulk-load while serving (T3 end-to-end),
+  offline only for the windows (T2/T3 tests assert service resumes),
+  killed loader byte-identity (T3), capacity fails upfront (T5), suite
+  green (gate). Recovery-policy licensing (scope narrative) is T4.
+- The one deliberate narrowing vs the spec's prose: v1's consistent
+  copy uses a second brief window (close-copy-reopen) rather than
+  copying under a live mmap — stated in the architecture, tested as
+  "service resumes", and recorded for the spec note in T6.
+- The riskiest splice is the txn-id lease branch (T2); it is
+  contract-first with an explicit NEEDS_CONTEXT instruction.
+- The read-only shadow window is Kevin's explicit ruling (2026-08-22),
+  pinned by its own test; no write is ever silently discarded.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -374,6 +374,34 @@ failure into an upfront allocation.
 existed to stop a live server holding the store. The epoch lease still accommodates
 out-of-process later without redesign.
 
+**Built (#170):** `detach-store`/`reattach-store` (quiesce, lease via
+`clock-lease-epochs`, journal `:detach`, close/reopen against the
+ambient system clock) and `shadow-store`/`open-shadow-graph`/
+`swap-in-shadow`/`discard-shadow`/`abandon-shadow` for the bulk-load
+generation. V1's consistent copy is **two brief windows, not one**:
+close-copy-reopen for the shadow (a sparse-preserving directory copy,
+seconds not minutes) and a second close-rename-rename-reopen for the
+swap — chosen over copying under a live mmap as materially safer for a
+first cut, at the cost of a second short outage instead of zero. The
+live store is deliberately left **read-only, not fully unavailable**,
+between shadow and swap: reads and pins keep flowing and a write
+signals `store-not-accepting-error` (Kevin's ruling, 2026-08-22) — no
+write is ever silently dropped at swap time. Out-of-process detach
+stays deferred, as anticipated above; `lease.dat` already persists
+everything a second process would need to resume a shadow's
+allocation, so nothing built here blocks it later. Swap completion is
+defined as the second of the two renames, not the best-effort `:swap`
+journal record after it, which surfaced its own gap: recovering a
+post-completion failure must reopen the *new* generation and warn
+(`swap-recovered-warning`) rather than re-signal, or the caller would
+wrongly conclude the swap never happened. A crash between the two
+renames, and a swap that lands without its journal record, are not
+handled here — filed as #171 and #212 respectively. `:expected-vectors`
+presizing applies one N uniformly to every vector segment a shadow
+carries: never under-provisions, but can over-allocate on a store with
+several `:vector-index` owner classes of different sizes — no per-owner
+knob in v1.
+
 ## 9. Restore
 
 ### 9.1 The system journal

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3254,7 +3254,7 @@ by the lock.
 *** Epoch leases for a detached store
 
 ~clock-lease-epochs~ reserves a contiguous range on the clock for a store
-that is about to go offline (a detach, per spec §8 — not yet built; see
+that is about to go offline (a detach, per spec §8; see
 ~docs/superpowers/specs/2026-08-20-namespaces-design.md~ §6): the range
 is skipped so the clock never hands the same epochs to anyone else, and
 the detached store can allocate from its own leased range with no further
@@ -3267,9 +3267,10 @@ coordination while it is disconnected.
 #+END_SRC
 
 Epoch ids are 64-bit, so a lease large enough for any realistic bulk load
-still leaves exhaustion unreachable. As of GH #168, this is a primitive
-with no caller yet — #170's shadow-generation swap is the first thing
-that will call it, to hand a detached bulk load its own private range.
+still leaves exhaustion unreachable. **Built (#170):** ~detach-store~ and
+the shadow-generation bulk-load-and-swap both call this, to hand a
+detached store, or a shadow copy opened for loading, its own private
+range. See "Detach, shadow load, and the swap" below.
 
 *** The lifecycle journal
 
@@ -3279,13 +3280,14 @@ directory. ~journal-append~ writes one record — kind ~:create~, ~:detach~
 (with its lease range), ~:swap~, ~:attach~, or ~:retire~, plus whatever
 else the caller supplies — and ~journal-records~ reads every record back,
 oldest first. ~attach-to-system-clock~ already appends an ~:attach~
-record on every attach; the other four kinds are for #170 and #171 to
-write as they build detach, swap and restore on top of this.
+record on every attach; **built (#170):** ~detach-store~ appends
+~:detach~ and ~swap-in-shadow~ appends ~:swap~; ~:retire~ is left for
+#171's restore work.
 
 **The journal is read with ~*read-eval*~ bound to ~nil~: it is data, and
 is never evaluated.** This is load-bearing, not a stylistic default —
-#170's shadow swap and #171's restore both plan to trust journal contents
-without re-checking them, so a record must never be able to execute code
+#170's shadow swap trusts journal contents without re-checking them, and
+#171's restore plans to as well, so a record must never be able to execute code
 just by being read back.
 
 **Hardened (#191):** ~journal-records~ returns two values, the record
@@ -3302,6 +3304,166 @@ clock holds the directory lock;** a stale/closed clock's read stays
 tolerant (warns, returns the torn-tail flag) but leaves the file
 untouched, so the next reader that owns the lock is the one that
 truncates it (GH #182, #191).
+
+*** Detach, shadow load, and the swap
+
+GH #170 turns the primitives above — quiescence, epoch leases, the
+lifecycle journal — into three complete operations: detaching a store
+cleanly, bulk-loading a consistent copy of it while it keeps serving
+reads, and swapping that copy in. All three run *in the same process*
+as the live store; the separate-loader-process pattern this replaces
+existed only to stop a live server from holding the store's mmaps open,
+and the epoch lease is already shaped to support that pattern later
+without a redesign, should it be needed.
+
+**A store accepts work in one of four states,** tracked by its
+transaction manager's ~accepting-p~: ~t~ (everything — the normal
+case), ~:read-only~ (reads and pins flow, a new transaction signals
+~store-not-accepting-error~ with reason ~:shadow-load~), or
+~:detaching~/~:swapping~ (nothing new — a full drain is in progress).
+Every transition goes through the same quiesce-and-wait: flip the
+flag, then poll ~reap-safe-floor~ until no transaction and no read pin
+remains that could observe a version out from under the coming close.
+A quiesce that cannot drain within its timeout restores ~accepting-p~
+to ~t~ and signals ~detach-drain-timeout~ — a failed detach must never
+strand a store half-dead.
+
+**Detaching a store: ~detach-store~ / ~reattach-store~.**
+~detach-store~ quiesces the graph (reason ~:detaching~), leases a range
+of the system clock's epoch space via ~clock-lease-epochs~, journals
+~:detach~, and ~close-graph~'s it durably, returning a
+~store-detachment~ handle (graph name, location, store-id, and the
+leased range). ~reattach-store~ reopens it at its recorded location and
+rejoins it to the image clock — it reads the ambient ~*system-clock*~
+rather than taking one as an argument, the same convention
+~make-graph~/~open-graph~'s own ~:system-clock~ default follows. Both
+require the graph already be attached to a system clock: a detach with
+no lease to hand over has nothing to reattach against.
+
+**Two brief unavailable windows, not one long one.** ~shadow-store~
+takes a consistent copy of a live store *while it keeps serving reads*:
+quiesce (reason ~:swapping~) → ~close-graph~ → a recursive,
+sparse-preserving copy of the store's directory to
+~<location>-shadow/~ → reopen the original store and resume service.
+That close-copy-reopen window is seconds, not the length of the load —
+this is v1's deliberate choice of a **second brief window** over
+copying under a live mmap, which was ruled out as materially riskier
+for a first cut. The reopened store's ~accepting-p~ comes back
+~:read-only~, not ~t~: this is Kevin's explicit ruling (2026-08-22) —
+reads and pins keep flowing, but a write during the shadow window
+signals ~store-not-accepting-error~ rather than being silently
+accepted and then lost at swap time. Service is fully restored only by
+~swap-in-shadow~ or ~abandon-shadow~. If the copy (or the reopen
+itself) fails, the *original* store is reopened and restored to full
+service before the failure is re-signalled — a failed shadow attempt
+must never leave the live store stranded closed; if that recovery
+reopen also fails, ~shadow-recovery-failed~ is signalled instead,
+carrying both conditions.
+
+The copy is sparse-preserving because a fresh store already reserves
+several gigabytes of mostly-zero mmap regions — a byte-for-byte copy
+would materialize every one of those unwritten reservations. The
+copier walks each file in fixed-size chunks and re-creates only the
+holes: an all-zero chunk is skipped via a bare seek on the (already
+zero) destination file rather than written, so an empty multi-gigabyte
+store copies in seconds. This is why "copies in seconds against a load
+measured in tens of minutes" (spec §8) holds in practice, not just in
+principle.
+
+**Loading: ~open-shadow-graph~.** Opens the shadow directory as a
+graph under the *live* store's own name — so its schema metadata
+instantiates identically — but unregistered: it never enters
+~*graphs*~ or the open-store vector, and never replicates. Its
+store-id is interned straight from the live store's registry entry, so
+every node id the load mints resolves back to the live store once
+swapped in. Its epoch range comes from ~:lease (start . end)~ — a
+~store-detachment~'s range if there was a ~detach-store~, or a direct
+~clock-lease-epochs~ call if not — and is persisted to ~lease.dat~ in
+the shadow directory so it survives a crash or restart of the loading
+process. The allocation cursor itself is never taken from that lease
+or file: it is derived fresh on every open as
+~(max lease-start (1+ load-highest-transaction-id))~, because the
+shadow's own committed transactions are the only truth about what it
+has already allocated that cannot go stale. A range already exhausted
+before this open — the derived cursor at or past the lease's end —
+signals ~epoch-lease-exhausted~ immediately, rather than wrapping,
+reusing an id, or deferring the failure to the load's first write.
+
+**The fast path needs an explicit opt-in.** A store's recovery policy
+(~store-recovery-policy~ / ~set-store-recovery-policy~, persisted in
+~policy.dat~, default ~:authored~) records whether a crash mid-load can
+simply be repaired by redoing the load (~:derivable~) or whether the
+load is the only durable record of its own writes (~:authored~, the
+implicit policy of every store predating this feature). Passing
+~open-shadow-graph :fast-load t~ suppresses the ~.txn~ WAL file and
+replication log for every transaction committed against the shadow —
+safe only because a crashed derivable load is simply discarded and
+redone, never recovered from a log that was never written. Requesting
+it against a shadow whose (copied) policy is ~:authored~ signals
+~fast-load-requires-derivable~ instead of silently keeping the WAL
+suppressed and quietly risking data no one intended to make
+disposable.
+
+**Presizing avoids a mid-load capacity surprise.** A vector-segment
+capacity failure discovered inside an ordinary transaction leaves a
+persisted node with no segment entry — invisible to retrieval, with
+~store-count~ still reporting it as present. ~presize-vector-segment~
+grows a segment up front to at least N entries, so a bulk load that
+knows its row count ahead of time turns that failure into an upfront
+allocation instead. ~open-shadow-graph :expected-vectors n~ applies
+this to *every* vector segment the shadow's graph object already
+carries (populated by ~open-graph~'s own vector-segment restore, which
+runs before ~:expected-vectors~ gets control) — one ~n~ for every
+segment, regardless of how many distinct ~:vector-index~ owner classes
+share the store. This never under-provisions a segment, but on a
+multi-owner store it can over-allocate the smaller ones; there is no
+per-owner sizing knob in v1.
+
+**Swapping the shadow in: ~swap-in-shadow~.** Validates
+~shadow-location~ — it must exist and carry no ~.dirty~ marker, i.e.
+it must already be closed — *before* touching the live store at all: a
+typo'd path or a still-open shadow costs one ~probe-file~, not a
+read-and-write outage. It then quiesces the live store (reason
+~:swapping~), closes it, and performs the promotion as two POSIX
+renames: the live directory is renamed to
+~<location>-retired-<epoch>~ **first**, then the shadow directory is
+renamed into the live location. That second rename — not the ~:swap~
+journal record appended just after it — is what "the swap happened"
+means: the data exists under some name throughout, and once the second
+rename lands, the live location holds the new generation no matter
+what happens next. The journal append is consequently best-effort:
+if it is what fails, the swap still succeeded, and ~swap-in-shadow~
+recovers by reopening the *new* generation and signalling
+~swap-recovered-warning~ (a warning, not an error) rather than
+re-signalling — re-signalling here would wrongly tell the caller the
+swap never happened. A failure *before* both renames complete instead
+reopens the *old* store, restores full service, and re-signals the
+original error, mirroring ~shadow-store~'s own recovery. A crash
+*between* the two renames is not recovered by this function at all —
+the live data sits at the retired path and the live location may be
+missing or half-replaced, needing manual recovery; that window, and
+the possibility of a missing ~:swap~ journal record after a completed
+swap, are tracked as GH #171 and #212. Either recovery reopen itself
+failing signals ~shadow-recovery-failed~, same as ~shadow-store~.
+~swap-in-shadow~ returns ~(values new-graph retired-path)~; the retired
+directory is kept, not deleted, on success.
+
+**Ending the lifecycle without a swap: ~discard-shadow~ /
+~abandon-shadow~.** A shadow never registers anywhere, so there is
+nothing to unregister before deleting it — ~discard-shadow~ just
+removes the tree, hard-gated on the directory name ending in
+~-shadow~ (the entire safety story for a function that deletes
+directory trees). ~abandon-shadow~ is the ordinary way to walk away
+from a shadow that will not be swapped in: it discards the shadow and
+restores the live store's ~accepting-p~ to ~t~ in one call.
+
+**What v1 deliberately does not do.** Out-of-process detach — a
+separate loader process, rather than this process performing the load
+itself — is deferred; ~lease.dat~ already carries everything a second
+process would need to resume a shadow's allocation across a restart,
+so nothing here blocks it. Restoring *across* a swap (rewinding a
+retired generation, or rebuilding a derivable one) is GH #171's
+territory, not this one's.
 
 *** Cross-image effects: a peer sync can advance the clock
 
@@ -4416,6 +4578,52 @@ This chapter provides a categorized reference for the most important exported sy
 
 - ~peer-check-type-registry-agreement (table &optional registry)~ ::
   Signals ~peer-type-registry-conflict-error~, naming every conflicting symbol, unless the hub's ~table~ agrees with this image's registry about every type-id the two share. Run by ~peer-sync~ at the handshake; a disagreement is an operator event, not something a handshake may reconcile.
+
+**** Detach, Shadow Load, and the Swap (see Chapter 17)
+- ~detach-store (graph &key lease-epochs timeout)~ ::
+  Quiesces ~graph~ (no new transactions or read pins), leases ~lease-epochs~ of its system clock's epoch space, journals ~:detach~, and closes it durably. Returns a ~store-detachment~ handle for ~reattach-store~. Requires ~graph~ be attached to a system clock. Propagates ~detach-drain-timeout~ unchanged if the quiesce cannot drain within ~timeout~ seconds, leaving ~graph~ open and accepting again.
+
+- ~reattach-store (detachment &key buffer-pool-size)~ ::
+  Reopens the store ~detachment~ names at its recorded location and rejoins it to the image clock. Reads the ambient ~*system-clock*~ rather than taking one as an argument. Returns the new graph.
+
+- ~shadow-store (graph &key timeout)~ ::
+  Takes a consistent shadow copy of ~graph~'s store: quiesce, close, sparse-preserving recursive copy to ~<location>-shadow/~, reopen ~graph~'s own store and resume service — left ~:read-only~ (a write signals ~store-not-accepting-error~ with reason ~:shadow-load~) until a caller calls ~swap-in-shadow~ or ~abandon-shadow~. A copy or reopen failure reopens the original store and restores full service before re-signalling; if that recovery also fails, signals ~shadow-recovery-failed~. Returns ~(values shadow-location reopened-graph)~.
+
+- ~open-shadow-graph (shadow-location graph-name &key lease fast-load expected-vectors buffer-pool-size)~ ::
+  Opens ~shadow-location~ as an *unregistered* graph under ~graph-name~ (the live store's own name), for a bulk load. ~:lease (start . end)~ — from a ~store-detachment~ or a direct ~clock-lease-epochs~ call — is persisted to ~lease.dat~; when omitted, an existing ~lease.dat~ supplies it. The allocation cursor is always derived fresh from the shadow's own highest committed transaction id, never persisted; a range already exhausted signals ~epoch-lease-exhausted~. ~:fast-load t~ suppresses the WAL and replication log for the shadow's transactions, but only when the shadow's copied recovery policy is ~:derivable~ — otherwise signals ~fast-load-requires-derivable~. ~:expected-vectors n~ presizes every vector segment the shadow's graph object carries via ~presize-vector-segment~ (one ~n~ applied uniformly; a no-op when there are no segments yet).
+
+- ~swap-in-shadow (graph shadow-location &key timeout)~ ::
+  Promotes ~shadow-location~ (which must already be a closed shadow) into ~graph~'s place: validate first, quiesce, close, rename the live directory to ~<location>-retired-<epoch>~, rename the shadow into the live location, journal ~:swap~ (best-effort), reopen. Returns ~(values new-graph retired-path)~; the retired directory is kept. A failure before both renames complete reopens the old store and re-signals; a failure after they complete reopens the new generation and signals ~swap-recovered-warning~ instead of re-signalling, since the swap already succeeded. Either recovery reopen itself failing signals ~shadow-recovery-failed~. A crash *between* the two renames is not recovered here (GH #171/#212).
+
+- ~discard-shadow (shadow-location)~ ::
+  Deletes ~shadow-location~'s tree. Hard-gated on the directory name ending in ~-shadow~ — the entire safety story for a function that deletes directory trees.
+
+- ~abandon-shadow (graph shadow-location)~ ::
+  The lifecycle exit that is not a swap: ~discard-shadow~s the directory and restores ~graph~'s ~accepting-p~ to ~t~ (full service).
+
+- ~store-recovery-policy (location)~ / ~set-store-recovery-policy (location policy)~ ::
+  Read/write a store's ~policy.dat~: ~:derivable~ (rebuildable, so a crash may discard it — licenses ~open-shadow-graph~'s ~:fast-load~) or ~:authored~ (the only durable record of its writes — the default, including for a store predating this feature).
+
+- ~presize-vector-segment (segment n)~ ::
+  Grows ~segment~ under its write lock until its capacity is at least ~n~; a no-op if already there. Turns a mid-apply ~vector-segment-capacity-exhausted~ failure into an upfront one for a load that knows its row count ahead of time.
+
+- ~store-not-accepting-error~ (condition) ::
+  Signalled by a new transaction or pin against a store whose ~accepting-p~ is not ~t~. Readers: ~store-not-accepting-name~, ~-reason~ — ~:read-only~ reports as ~:shadow-load~; ~:detaching~/~:swapping~ report as themselves.
+
+- ~detach-drain-timeout~ (condition) ::
+  Signalled by ~detach-store~/~shadow-store~/~swap-in-shadow~'s quiesce when the in-flight transactions and pins do not drain within their timeout. ~accepting-p~ is restored to ~t~ before this is signalled. Readers: ~detach-timeout-name~, ~-seconds~.
+
+- ~epoch-lease-exhausted~ (condition) ::
+  Signalled by ~open-shadow-graph~ when the shadow's derived allocation cursor is already at or past its leased range's end. Readers: ~epoch-lease-exhausted-name~, ~-end~.
+
+- ~fast-load-requires-derivable~ (condition) ::
+  Signalled by ~open-shadow-graph :fast-load t~ when the source store's recovery policy is not ~:derivable~. Readers: ~fast-load-requires-derivable-location~, ~-policy~.
+
+- ~swap-recovered-warning~ (warning) ::
+  Signalled by ~swap-in-shadow~ when both renames completed but something after them (typically the ~:swap~ journal append, GH #212) failed; the swap itself succeeded and the new generation is reopened and returned normally. Reader: ~swap-recovered-warning-original~.
+
+- ~shadow-recovery-failed~ (condition) ::
+  Signalled by ~shadow-store~ or ~swap-in-shadow~ when *both* the original operation and its recovery reopen failed — the store may be left closed and needs a manual ~open-graph~. Readers: ~shadow-recovery-failed-original~, ~-recovery~.
 
 **** MVCC / Versioning
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3316,10 +3316,17 @@ existed only to stop a live server from holding the store's mmaps open,
 and the epoch lease is already shaped to support that pattern later
 without a redesign, should it be needed.
 
-**A store accepts work in one of four states,** tracked by its
+**A store accepts work in one of five states,** tracked by its
 transaction manager's ~accepting-p~: ~t~ (everything — the normal
 case), ~:read-only~ (reads and pins flow, a new transaction signals
-~store-not-accepting-error~ with reason ~:shadow-load~), or
+~store-not-accepting-error~ with reason ~:shadow-load~), ~:opening~
+(the same admit-pins/refuse-transactions shape as ~:read-only~, but for
+~open-graph~'s own mid-open window — GH #170 review round 3: every
+transaction manager starts here, before the graph is published to
+~*graphs*~, so a racing name-lookup writer gets a loud
+~store-not-accepting-error~ reason ~:opening~ instead of colliding with
+a still-running rebuild or crash recovery; ~open-graph~ flips to the
+caller's requested end state only once fully open), or
 ~:detaching~/~:swapping~ (nothing new — a full drain is in progress).
 Every transition goes through the same quiesce-and-wait: flip the
 flag, then poll ~reap-safe-floor~ until no transaction and no read pin
@@ -4401,7 +4408,7 @@ This chapter provides a categorized reference for the most important exported sy
   Creates a new, empty graph database at the specified ~location~. The ~name~ must be a keyword and should match the graph name used in your schema definitions. ~:index-backend~ (~:skip-list~, the default, or ~:bplus-tree~) selects the ordered-index engine for this graph's views/unique/spatial indexes; it defaults to the global ~*index-backend*~. Returns a `graph` object. See Chapter 3, "Ordered indexes and pluggable backends."
 
 - ~open-graph (name location &key index-backend initial-accepting-state ... )~ ::
-  Opens an existing graph database from ~location~. Fails if the database was not closed cleanly (i.e., if the ~.dirty~ file exists). ~:index-backend~ governs only *new* indexes created after open; each existing index reopens on the backend it was written with (its persisted tag). ~:initial-accepting-state~ (default ~t~, GH #170) sets the fresh transaction manager's ~accepting-p~ at construction, before the graph is registered anywhere — used by ~shadow-store~'s reopen to come up ~:read-only~ from the start rather than briefly writable then flipped. Returns a `graph` object.
+  Opens an existing graph database from ~location~. Fails if the database was not closed cleanly (i.e., if the ~.dirty~ file exists). ~:index-backend~ governs only *new* indexes created after open; each existing index reopens on the backend it was written with (its persisted tag). ~:initial-accepting-state~ (default ~t~, GH #170) is the state the graph is left in once this call returns — used by ~shadow-store~'s reopen to come back ~:read-only~. The transaction manager itself always starts at ~:opening~ (review round 3), before the graph is registered anywhere, for the duration of ~open-graph~'s own internal rebuild/recovery steps; it flips to ~:initial-accepting-state~ only at the very end, once the graph is fully open. Returns a `graph` object.
 
 - ~make-memory-graph (name location &key lazy peer-role origin-id peer-host ... )~ ::
   Like ~make-graph~, but constructs an *in-memory* graph (Chapter 15): the graph lives as live Lisp objects in RAM, with the same schema/transaction/query API. ~location~ still holds the durable journal, checkpoint image, schema and peer state. Pass ~:lazy t~ for fault-on-access materialization (near-instant open); accepts the same peer arguments as ~make-graph~ for an in-memory peer device.
@@ -4641,7 +4648,7 @@ This chapter provides a categorized reference for the most important exported sy
   Grows ~segment~ under its write lock until its capacity is at least ~n~; a no-op if already there. Turns a mid-apply ~vector-segment-capacity-exhausted~ failure into an upfront one for a load that knows its row count ahead of time.
 
 - ~store-not-accepting-error~ (condition) ::
-  Signalled by a new transaction or pin against a store whose ~accepting-p~ is not ~t~. Readers: ~store-not-accepting-name~, ~-reason~ — ~:read-only~ reports as ~:shadow-load~; ~:detaching~/~:swapping~ report as themselves.
+  Signalled by a new transaction or pin against a store whose ~accepting-p~ is not ~t~. Readers: ~store-not-accepting-name~, ~-reason~ — ~:read-only~ reports as ~:shadow-load~; ~:opening~ (~open-graph~'s own mid-open window, GH #170 review round 3) and ~:detaching~/~:swapping~ report as themselves.
 
 - ~detach-drain-timeout~ (condition) ::
   Signalled by ~detach-store~/~shadow-store~/~swap-in-shadow~'s quiesce when the in-flight transactions and pins do not drain within their timeout. ~accepting-p~ is restored to whatever it was *before* the quiesce call, not hardcoded ~t~ — a timeout during ~shadow-store~'s ~:read-only~ window leaves the store ~:read-only~ (GH #170, review finding C1). Readers: ~detach-timeout-name~, ~-seconds~.

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3325,8 +3325,11 @@ Every transition goes through the same quiesce-and-wait: flip the
 flag, then poll ~reap-safe-floor~ until no transaction and no read pin
 remains that could observe a version out from under the coming close.
 A quiesce that cannot drain within its timeout restores ~accepting-p~
-to ~t~ and signals ~detach-drain-timeout~ — a failed detach must never
-strand a store half-dead.
+to whatever it was *before* this quiesce call — not hardcoded ~t~ —
+and signals ~detach-drain-timeout~: a timeout during ~shadow-store~'s
+~:read-only~ window must leave the store ~:read-only~, not silently
+lift the shadow-window guard and let a write land in the doomed
+generation (GH #170, review finding C1).
 
 **Detaching a store: ~detach-store~ / ~reattach-store~.**
 ~detach-store~ quiesces the graph (reason ~:detaching~), leases a range
@@ -3467,13 +3470,27 @@ directory trees). ~abandon-shadow~ is the ordinary way to walk away
 from a shadow that will not be swapped in: it discards the shadow and
 restores the live store's ~accepting-p~ to ~t~ in one call.
 
-**What v1 deliberately does not do.** Out-of-process detach — a
-separate loader process, rather than this process performing the load
-itself — is deferred; ~lease.dat~ already carries everything a second
+**What v1 deliberately does not do.** ~detach-store~, ~shadow-store~
+and ~swap-in-shadow~ all refuse a ~master-graph~/~slave-graph~/
+~peer-graph~ outright, signalling ~detach-unsupported-graph-error~:
+every reopen these three perform uses ~open-graph~'s plain default
+arguments, which would silently drop a replicated or peer graph's
+replication/peer configuration on the reopened generation. Threading
+the full ~open-graph~ argument set through detachment and shadowing is
+follow-on work, not this pass's. Out-of-process detach — a separate
+loader process, rather than this process performing the load itself —
+is deferred too; ~lease.dat~ already carries everything a second
 process would need to resume a shadow's allocation across a restart,
 so nothing here blocks it. Restoring *across* a swap (rewinding a
 retired generation, or rebuilding a derivable one) is GH #171's
 territory, not this one's.
+
+**Do not name a real, non-shadow store with a ~-shadow~ suffix.**
+~shadow-store~ derives its copy's directory name by appending
+~-shadow~ to the live location, and ~discard-shadow~'s entire deletion
+safety story is gating on that same suffix. A real store that happens
+to already end in ~-shadow~ would be indistinguishable from an actual
+shadow to that guard.
 
 *** Cross-image effects: a peer sync can advance the clock
 
@@ -4383,8 +4400,8 @@ This chapter provides a categorized reference for the most important exported sy
 - ~make-graph (name location &key index-backend ... )~ ::
   Creates a new, empty graph database at the specified ~location~. The ~name~ must be a keyword and should match the graph name used in your schema definitions. ~:index-backend~ (~:skip-list~, the default, or ~:bplus-tree~) selects the ordered-index engine for this graph's views/unique/spatial indexes; it defaults to the global ~*index-backend*~. Returns a `graph` object. See Chapter 3, "Ordered indexes and pluggable backends."
 
-- ~open-graph (name location &key index-backend ... )~ ::
-  Opens an existing graph database from ~location~. Fails if the database was not closed cleanly (i.e., if the ~.dirty~ file exists). ~:index-backend~ governs only *new* indexes created after open; each existing index reopens on the backend it was written with (its persisted tag). Returns a `graph` object.
+- ~open-graph (name location &key index-backend initial-accepting-state ... )~ ::
+  Opens an existing graph database from ~location~. Fails if the database was not closed cleanly (i.e., if the ~.dirty~ file exists). ~:index-backend~ governs only *new* indexes created after open; each existing index reopens on the backend it was written with (its persisted tag). ~:initial-accepting-state~ (default ~t~, GH #170) sets the fresh transaction manager's ~accepting-p~ at construction, before the graph is registered anywhere — used by ~shadow-store~'s reopen to come up ~:read-only~ from the start rather than briefly writable then flipped. Returns a `graph` object.
 
 - ~make-memory-graph (name location &key lazy peer-role origin-id peer-host ... )~ ::
   Like ~make-graph~, but constructs an *in-memory* graph (Chapter 15): the graph lives as live Lisp objects in RAM, with the same schema/transaction/query API. ~location~ still holds the durable journal, checkpoint image, schema and peer state. Pass ~:lazy t~ for fault-on-access materialization (near-instant open); accepts the same peer arguments as ~make-graph~ for an in-memory peer device.
@@ -4591,19 +4608,19 @@ This chapter provides a categorized reference for the most important exported sy
 
 **** Detach, Shadow Load, and the Swap (see Chapter 17)
 - ~detach-store (graph &key lease-epochs timeout)~ ::
-  Quiesces ~graph~ (no new transactions or read pins), leases ~lease-epochs~ of its system clock's epoch space, journals ~:detach~, and closes it durably. Returns a ~store-detachment~ handle for ~reattach-store~. Requires ~graph~ be attached to a system clock. Propagates ~detach-drain-timeout~ unchanged if the quiesce cannot drain within ~timeout~ seconds, leaving ~graph~ open and accepting again.
+  Quiesces ~graph~ (no new transactions or read pins), leases ~lease-epochs~ of its system clock's epoch space, journals ~:detach~, and closes it durably. Returns a ~store-detachment~ handle for ~reattach-store~. Requires ~graph~ be attached to a system clock. Propagates ~detach-drain-timeout~ unchanged if the quiesce cannot drain within ~timeout~ seconds, leaving ~graph~ open and accepting again. Refuses a ~master-graph~/~slave-graph~/~peer-graph~ with ~detach-unsupported-graph-error~ (v1 scope). A failure between a successful quiesce and the durable close restores ~accepting-p~ to its pre-quiesce state before re-signalling.
 
 - ~reattach-store (detachment &key buffer-pool-size)~ ::
   Reopens the store ~detachment~ names at its recorded location and rejoins it to the image clock. Reads the ambient ~*system-clock*~ rather than taking one as an argument. Returns the new graph.
 
 - ~shadow-store (graph &key timeout)~ ::
-  Takes a consistent shadow copy of ~graph~'s store: quiesce, close, sparse-preserving recursive copy to ~<location>-shadow/~, reopen ~graph~'s own store and resume service — left ~:read-only~ (a write signals ~store-not-accepting-error~ with reason ~:shadow-load~) until a caller calls ~swap-in-shadow~ or ~abandon-shadow~. A copy or reopen failure reopens the original store and restores full service before re-signalling; if that recovery also fails, signals ~shadow-recovery-failed~. Returns ~(values shadow-location reopened-graph)~.
+  Takes a consistent shadow copy of ~graph~'s store: quiesce, close, sparse-preserving recursive copy to ~<location>-shadow/~, reopen ~graph~'s own store and resume service — left ~:read-only~ (a write signals ~store-not-accepting-error~ with reason ~:shadow-load~) until a caller calls ~swap-in-shadow~ or ~abandon-shadow~. A copy or reopen failure reopens the original store and restores full service before re-signalling; if that recovery also fails, signals ~shadow-recovery-failed~. Returns ~(values shadow-location reopened-graph)~. A pre-existing ~<location>-shadow/~ is discarded before the copy, never merged with. Refuses a ~master-graph~/~slave-graph~/~peer-graph~ with ~detach-unsupported-graph-error~ (v1 scope).
 
 - ~open-shadow-graph (shadow-location graph-name &key lease fast-load expected-vectors buffer-pool-size)~ ::
-  Opens ~shadow-location~ as an *unregistered* graph under ~graph-name~ (the live store's own name), for a bulk load. ~:lease (start . end)~ — from a ~store-detachment~ or a direct ~clock-lease-epochs~ call — is persisted to ~lease.dat~; when omitted, an existing ~lease.dat~ supplies it. The allocation cursor is always derived fresh from the shadow's own highest committed transaction id, never persisted; a range already exhausted signals ~epoch-lease-exhausted~. ~:fast-load t~ suppresses the WAL and replication log for the shadow's transactions, but only when the shadow's copied recovery policy is ~:derivable~ — otherwise signals ~fast-load-requires-derivable~. ~:expected-vectors n~ presizes every vector segment the shadow's graph object carries via ~presize-vector-segment~ (one ~n~ applied uniformly; a no-op when there are no segments yet).
+  Opens ~shadow-location~ as an *unregistered* graph under ~graph-name~ (the live store's own name), for a bulk load. ~:lease (start . end)~ — from a ~store-detachment~ or a direct ~clock-lease-epochs~ call — is persisted to ~lease.dat~; when omitted, an existing ~lease.dat~ supplies it. The allocation cursor is always derived fresh from the shadow's own highest committed transaction id, never persisted; a range already exhausted signals ~epoch-lease-exhausted~. ~:fast-load t~ suppresses the WAL and replication log for the shadow's transactions, but only when the shadow's copied recovery policy is ~:derivable~ — otherwise signals ~fast-load-requires-derivable~. ~:expected-vectors n~ presizes every vector segment the shadow's graph object carries via ~presize-vector-segment~ (one ~n~ applied uniformly; a no-op when there are no segments yet). The lease and ~:expected-vectors~ are validated before ~open-graph~ runs; every check after it runs under an unwind-protect that closes the graph on error, so a failed open (e.g. an exhausted lease) never leaks an open handle that would make a retry fail on a stale ~.dirty~ marker.
 
 - ~swap-in-shadow (graph shadow-location &key timeout)~ ::
-  Promotes ~shadow-location~ (which must already be a closed shadow) into ~graph~'s place: validate first, quiesce, close, rename the live directory to ~<location>-retired-<epoch>~, rename the shadow into the live location, journal ~:swap~ (best-effort), reopen. Returns ~(values new-graph retired-path)~; the retired directory is kept. A failure before both renames complete reopens the old store and re-signals; a failure after they complete reopens the new generation and signals ~swap-recovered-warning~ instead of re-signalling, since the swap already succeeded. Either recovery reopen itself failing signals ~shadow-recovery-failed~. A crash *between* the two renames is not recovered here (GH #171/#212).
+  Promotes ~shadow-location~ (which must already be a closed shadow) into ~graph~'s place: validate first, quiesce, close, rename the live directory to ~<location>-retired-<epoch>~, rename the shadow into the live location, journal ~:swap~ (best-effort), reopen. Returns ~(values new-graph retired-path)~; the retired directory is kept. A failure before both renames complete reopens the old store and re-signals; a failure after they complete reopens the new generation and signals ~swap-recovered-warning~ instead of re-signalling, since the swap already succeeded. Either recovery reopen itself failing signals ~shadow-recovery-failed~. A crash *between* the two renames is not recovered here (GH #171/#212). The promoted generation's copied-in ~lease.dat~ is deleted right after the second rename. Refuses a ~master-graph~/~slave-graph~/~peer-graph~ with ~detach-unsupported-graph-error~ (v1 scope).
 
 - ~discard-shadow (shadow-location)~ ::
   Deletes ~shadow-location~'s tree. Hard-gated on the directory name ending in ~-shadow~ — the entire safety story for a function that deletes directory trees.
@@ -4627,7 +4644,10 @@ This chapter provides a categorized reference for the most important exported sy
   Signalled by a new transaction or pin against a store whose ~accepting-p~ is not ~t~. Readers: ~store-not-accepting-name~, ~-reason~ — ~:read-only~ reports as ~:shadow-load~; ~:detaching~/~:swapping~ report as themselves.
 
 - ~detach-drain-timeout~ (condition) ::
-  Signalled by ~detach-store~/~shadow-store~/~swap-in-shadow~'s quiesce when the in-flight transactions and pins do not drain within their timeout. ~accepting-p~ is restored to ~t~ before this is signalled. Readers: ~detach-timeout-name~, ~-seconds~.
+  Signalled by ~detach-store~/~shadow-store~/~swap-in-shadow~'s quiesce when the in-flight transactions and pins do not drain within their timeout. ~accepting-p~ is restored to whatever it was *before* the quiesce call, not hardcoded ~t~ — a timeout during ~shadow-store~'s ~:read-only~ window leaves the store ~:read-only~ (GH #170, review finding C1). Readers: ~detach-timeout-name~, ~-seconds~.
+
+- ~detach-unsupported-graph-error~ (condition) ::
+  Signalled by ~detach-store~/~shadow-store~/~swap-in-shadow~ when ~graph~ is a ~master-graph~, ~slave-graph~ or ~peer-graph~ — v1 scope only covers plain clocked stores, since the reopen paths use ~open-graph~'s plain default arguments and would silently drop replication/peer configuration. Readers: ~detach-unsupported-graph-error-graph~, ~-operation~.
 
 - ~epoch-lease-exhausted~ (condition) ::
   Signalled by ~open-shadow-graph~ when the shadow's derived allocation cursor is already at or past its leased range's end. Readers: ~epoch-lease-exhausted-name~, ~-end~.

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3404,6 +3404,16 @@ it against a shadow whose (copied) policy is ~:authored~ signals
 suppressed and quietly risking data no one intended to make
 disposable.
 
+A store's policy is ordinarily set once, at creation: ~make-graph
+:recovery-policy :derivable~ (or ~:authored~) writes ~policy.dat~
+immediately. ~open-graph~ also accepts ~:recovery-policy~, but there it
+is only a hint — once ~policy.dat~ exists it is authoritative, and an
+~:recovery-policy~ that disagrees with it merely signals
+~recovery-policy-mismatch-warning~ (a warning, not an error) rather
+than rewriting the file out from under whatever set it; ~open-graph~'s
+~:recovery-policy~ is only ever persisted for a location with no
+~policy.dat~ yet (i.e. one being created via ~open-graph~ itself).
+
 **Presizing avoids a mid-load capacity surprise.** A vector-segment
 capacity failure discovered inside an ordinary transaction leaves a
 persisted node with no segment entry — invisible to retrieval, with
@@ -4603,6 +4613,12 @@ This chapter provides a categorized reference for the most important exported sy
 
 - ~store-recovery-policy (location)~ / ~set-store-recovery-policy (location policy)~ ::
   Read/write a store's ~policy.dat~: ~:derivable~ (rebuildable, so a crash may discard it — licenses ~open-shadow-graph~'s ~:fast-load~) or ~:authored~ (the only durable record of its writes — the default, including for a store predating this feature).
+
+- ~make-graph ( ... :recovery-policy policy)~ / ~open-graph ( ... :recovery-policy policy)~ ::
+  ~make-graph~'s ~:recovery-policy~ sets a new store's ~policy.dat~ at creation. ~open-graph~'s ~:recovery-policy~ is only a hint — ~policy.dat~, once present, is authoritative; a disagreeing value signals ~recovery-policy-mismatch-warning~ rather than overwriting the file, and is itself persisted only when ~open-graph~ is the call creating the store (no ~policy.dat~ yet).
+
+- ~recovery-policy-mismatch-warning~ (condition) ::
+  Signalled by ~open-graph~ when its ~:recovery-policy~ argument disagrees with an existing ~policy.dat~; the file wins regardless. Readers: ~recovery-policy-mismatch-warning-location~, ~-requested~, ~-on-disk~.
 
 - ~presize-vector-segment (segment n)~ ::
   Grows ~segment~ under its write lock until its capacity is at least ~n~; a no-op if already there. Turns a mid-apply ~vector-segment-capacity-exhausted~ failure into an upfront one for a load that knows its row count ahead of time.

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -229,9 +229,12 @@ received an UNRESOLVED-NODE marker instead (GH #169, D8)."
    ;; never starts replication.  EPOCH-LEASE: an EPOCH-LEASE struct
    ;; (below) when this store mints txn ids from a leased range instead
    ;; of its clock/counter; NIL is the default (pre-#170 behaviour).
-   (shadow-p :accessor graph-shadow-p :initarg :shadow-p :initform nil)
-   (epoch-lease :accessor graph-epoch-lease :initarg :epoch-lease
-               :initform nil)))
+   ;; Both are always set post-construction via SETF (OPEN-GRAPH,
+   ;; OPEN-SHADOW-GRAPH) rather than at MAKE-INSTANCE, so neither takes
+   ;; an :INITARG -- one would be dead weight the constructor never
+   ;; receives.
+   (shadow-p :accessor graph-shadow-p :initform nil)
+   (epoch-lease :accessor graph-epoch-lease :initform nil)))
 
 (defstruct epoch-lease
   "A shadow store's leased txn-id range [START, END) (GH #170).  NEXT is

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -223,7 +223,21 @@ received an UNRESOLVED-NODE marker instead (GH #169, D8)."
    ;; The image-level epoch clock (GH #168), or NIL for this store's own
    ;; counter.  NIL is the pre-#168 behaviour and the default.
    (system-clock :accessor graph-system-clock :initarg :system-clock
-                 :initform nil)))
+                 :initform nil)
+   ;; Shadow generations (GH #170).  SHADOW-P: T on a graph opened via
+   ;; OPEN-SHADOW-GRAPH -- never registered in *GRAPHS*/open-store vector,
+   ;; never starts replication.  EPOCH-LEASE: an EPOCH-LEASE struct
+   ;; (below) when this store mints txn ids from a leased range instead
+   ;; of its clock/counter; NIL is the default (pre-#170 behaviour).
+   (shadow-p :accessor graph-shadow-p :initarg :shadow-p :initform nil)
+   (epoch-lease :accessor graph-epoch-lease :initarg :epoch-lease
+               :initform nil)))
+
+(defstruct epoch-lease
+  "A shadow store's leased txn-id range [START, END) (GH #170).  NEXT is
+the next id to hand out; ids past END are refused -- see
+EPOCH-LEASE-EXHAUSTED in transactions.lisp."
+  start next end)
 
 (defmethod print-object ((graph graph) stream)
   (print-unreadable-object (graph stream :type t :identity t)

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -234,7 +234,14 @@ received an UNRESOLVED-NODE marker instead (GH #169, D8)."
    ;; an :INITARG -- one would be dead weight the constructor never
    ;; receives.
    (shadow-p :accessor graph-shadow-p :initform nil)
-   (epoch-lease :accessor graph-epoch-lease :initform nil)))
+   (epoch-lease :accessor graph-epoch-lease :initform nil)
+   ;; WAL-suppressed fast path (GH #170 Task 4).  T only on a shadow opened
+   ;; via OPEN-SHADOW-GRAPH :FAST-LOAD T against a :DERIVABLE-policy source;
+   ;; PERSIST-TRANSACTION's callers skip the .txn file and replication log
+   ;; entirely when this is set.  Per-graph slot, not a dynamic variable --
+   ;; a special would leak suppression to any OTHER graph committing on the
+   ;; same thread.  NIL by default: an ordinary graph is never suppressed.
+   (wal-suppressed-p :accessor wal-suppressed-p :initform nil)))
 
 (defstruct epoch-lease
   "A shadow store's leased txn-id range [START, END) (GH #170).  NEXT is

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -530,6 +530,7 @@ cl-temporal-extent."
                (:file "keyword-alias-tests")      ; GH #190
                (:file "store-registry-tests")     ; GH #169
                (:file "store-resolver-tests")     ; GH #169
+               (:file "detach-tests")             ; GH #170
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -105,6 +105,11 @@
                (:file "transactions" :depends-on ("graph-class" "type-index" "vev-index" "ve-index" "edge" "vertex" "gc" "spatial-index" "posix" "system-clock"))
                (:file "transaction-restore" :depends-on ("transactions"))
                (:file "transaction-log-streaming" :depends-on ("transactions"))
+               ;; Shadow generations (GH #170): quiesce/copy/reopen a store
+               ;; (GRAPH) under a leased epoch range (TRANSACTIONS).  Placed
+               ;; just before BACKUP, which it does not depend on -- it needs
+               ;; only the graph and transaction layers.
+               (:file "shadow-store" :depends-on ("graph" "transactions"))
                (:file "backup" :depends-on ("edge" "type-seeding"))
                (:file "replication" :depends-on ("backup"))
                (:file "txn-log" :depends-on ("replication"))

--- a/graph.lisp
+++ b/graph.lisp
@@ -522,6 +522,23 @@ to disk and remove it."
         (install-unique-tuple-constraints graph))
       graph)))
 
+(define-condition recovery-policy-mismatch-warning (warning)
+  ;; A named class rather than a bare STRING WARN, so a caller (or a test)
+  ;; can HANDLER-BIND on it specifically instead of on every CL:WARNING
+  ;; OPEN-GRAPH might ever signal (GH #170 Task 4, fix round 1).
+  ((location :initarg :location
+             :reader recovery-policy-mismatch-warning-location)
+   (requested :initarg :requested
+              :reader recovery-policy-mismatch-warning-requested)
+   (on-disk :initarg :on-disk
+            :reader recovery-policy-mismatch-warning-on-disk))
+  (:report (lambda (c s)
+             (format s "OPEN-GRAPH ~A: :RECOVERY-POLICY ~S disagrees with ~
+policy.dat's ~S; the file wins."
+                     (recovery-policy-mismatch-warning-location c)
+                     (recovery-policy-mismatch-warning-requested c)
+                     (recovery-policy-mismatch-warning-on-disk c)))))
+
 (defun open-graph (name location &key master-p slave-p master-host replication-port
                    replication-key package (buffer-pool-p t) (gc-heap-p t)
                    (buffer-pool-size 100000)
@@ -567,9 +584,10 @@ started.
 
 :RECOVERY-POLICY (GH #170) is only a HINT here, unlike MAKE-GRAPH: if
 LOCATION already carries a policy.dat, that file is authoritative --
-this keyword is ignored (a value that disagrees with the file WARNs,
-but the file wins) rather than silently rewritten out from under
-whatever wrote it.  It is persisted only when LOCATION is being
+this keyword is ignored (a value that disagrees with the file signals
+RECOVERY-POLICY-MISMATCH-WARNING, a WARNING, but the file still wins)
+rather than silently rewritten out from under whatever wrote it.  It
+is persisted only when LOCATION is being
 created-on-open (no schema.dat yet, the same condition INIT-SCHEMA
 below branches on) -- a genuine reopen of an existing graph with no
 policy.dat leaves it absent (STORE-RECOVERY-POLICY's :AUTHORED
@@ -655,8 +673,9 @@ default), it does not retroactively opt that graph in."
           (if (probe-file (%policy-file path))
               (let ((on-disk (store-recovery-policy path)))
                 (when (and recovery-policy (not (eq recovery-policy on-disk)))
-                  (warn "OPEN-GRAPH ~A: :RECOVERY-POLICY ~S disagrees with ~
-policy.dat's ~S; the file wins." path recovery-policy on-disk)))
+                  (warn 'recovery-policy-mismatch-warning
+                        :location path :requested recovery-policy
+                        :on-disk on-disk)))
               (when (and recovery-policy creating-on-open-p)
                 (set-store-recovery-policy path recovery-policy))))
         (setf (schema-lock (schema graph)) (make-recursive-lock))

--- a/graph.lisp
+++ b/graph.lisp
@@ -503,6 +503,13 @@ to disk and remove it."
               (applied-op-ids graph)
               (make-lhash :location (format nil "~A/applied-ops/" path)
                           :buckets 8)))
+      ;; Unlike OPEN-GRAPH, this TM does not need :OPENING (review round
+      ;; 3): MAKE-GRAPH's *GRAPHS* registration above already runs before
+      ;; this construction, same as before I4, and there is no RECOVER-
+      ;; TRANSACTIONS/rebuild step here for a racing writer to collide
+      ;; with -- a write against the still-unbound TRANSACTION-MANAGER
+      ;; slot in that window signals a loud unbound-slot error, the same
+      ;; acceptable pre-#170 behaviour (GH #170).
       (setf (transaction-manager graph)
             (make-instance 'transaction-manager
                            :graph graph))
@@ -594,13 +601,18 @@ below branches on) -- a genuine reopen of an existing graph with no
 policy.dat leaves it absent (STORE-RECOVERY-POLICY's :AUTHORED
 default), it does not retroactively opt that graph in.
 
-:INITIAL-ACCEPTING-STATE (GH #170, review finding I4) sets the fresh
-TRANSACTION-MANAGER's ACCEPTING-P at construction, BEFORE the graph is
-registered in *GRAPHS* -- so a caller that wants the reopened graph to
-come up in a non-accepting window (e.g. SHADOW-STORE's :READ-ONLY) never
-publishes it writable-then-flips, which would let a racing writer land a
-commit in the doomed generation during the gap.  Defaults to T (ordinary
-opens are immediately fully accepting, as before)."
+:INITIAL-ACCEPTING-STATE (GH #170, review finding I4) is the state this
+call leaves the graph in once it returns -- e.g. SHADOW-STORE's reopen
+passes :READ-ONLY so the returned graph never briefly comes up fully
+writable.  The fresh TRANSACTION-MANAGER itself always starts at
+:OPENING (review round 3), not this value directly: :OPENING is what is
+in force, before the graph is registered in *GRAPHS*, for every
+rebuild/recovery step this call runs internally, refusing a racing
+external writer with STORE-NOT-ACCEPTING-ERROR reason :OPENING while
+still admitting the read pins those internal steps themselves take.
+Only once GRAPH-OPEN-P is T, at the very end, does ACCEPTING-P flip to
+INITIAL-ACCEPTING-STATE.  Defaults to T (ordinary opens end up fully
+accepting, as before)."
   (unless *system-directory*
     (error 'system-directory-required :operation 'open-graph))
   (when (and peer-role (or master-p slave-p))
@@ -736,15 +748,24 @@ opens are immediately fully accepting, as before)."
         (restore-vector-segments graph)
         (with-open-file (out dirty-file :direction :output)
           (format out "~S" (get-universal-time)))
-        ;; The TM must exist -- with ACCEPTING-P already at its final
-        ;; INITIAL-ACCEPTING-STATE -- BEFORE this graph is published to
-        ;; *GRAPHS*/the open-store vector below: publishing writable then
-        ;; flipping after would let a racing writer land a commit in a
-        ;; generation meant to come up non-accepting (GH #170, I4).
+        ;; The TM must exist BEFORE this graph is published to *GRAPHS*/
+        ;; the open-store vector below (GH #170, I4) -- but it starts at
+        ;; :OPENING, not INITIAL-ACCEPTING-STATE directly (review round
+        ;; 3): publication happens before RECOVER-TRANSACTIONS and every
+        ;; rebuild step below it, so a racing name-lookup writer could
+        ;; otherwise pin AND commit against a mid-recovery graph.
+        ;; :OPENING admits pins (every rebuild/recovery scan below runs
+        ;; under WITH-READ-PIN) but refuses new transactions with reason
+        ;; :OPENING -- RECOVER-TRANSACTIONS itself creates none: it
+        ;; applies RECOVERY-TRANSACTION instances directly via APPLY-
+        ;; TRANSACTION, bypassing CREATE-TRANSACTION entirely, and its
+        ;; CALL-WITH-TRANSACTION-LOCK method is a no-op ("No locking
+        ;; during recovery").  The flip to INITIAL-ACCEPTING-STATE runs
+        ;; at the very end of this function, once GRAPH-OPEN-P is T.
         (setf (transaction-manager graph)
               (make-instance 'transaction-manager
                              :graph graph
-                             :accepting-p initial-accepting-state))
+                             :accepting-p :opening))
         (setf (graph-shadow-p graph) shadow-p)
         (if shadow-p
             ;; Unregistered: STORE-ID still comes from the registry (v8 ids
@@ -775,12 +796,29 @@ opens are immediately fully accepting, as before)."
           ;; Reproduces TRANSACTION-MANAGER's own INITIALIZE-INSTANCE
           ;; :AFTER formula verbatim; safe mid-open, no concurrency yet
           ;; (GH #170, review round 2).
+          ;;
+          ;; The SAME :AFTER method also derives REPLICATION-LOG-FILE
+          ;; from that (then pre-recovery) counter value -- re-seeding
+          ;; TX-ID-COUNTER alone left the log file's own NAME advertising
+          ;; the stale, lower minimum id it would actually contain, a
+          ;; range gap for APPLICABLE-REPLICATION-LOGS (transaction-log-
+          ;; streaming.lisp derives ranges from filenames) on every
+          ;; master/peer crash-recovery open.  Re-derive it too, from the
+          ;; now-current counter, with the exact same expression (GH
+          ;; #170, review round 3).
           (when crash-recovery-p
-            (setf (tx-id-counter (transaction-manager graph))
-                  (1+ (max (load-highest-transaction-id graph)
-                           (if (peer-graph-p graph)
-                               (load-peer-pull-cursor graph)
-                               0)))))
+            (let ((tm (transaction-manager graph)))
+              (setf (tx-id-counter tm)
+                    (1+ (max (load-highest-transaction-id graph)
+                             (if (peer-graph-p graph)
+                                 (load-peer-pull-cursor graph)
+                                 0))))
+              (setf (replication-log-file tm)
+                    (make-pathname :name (format nil "replication-~16,'0X"
+                                                 (tx-id-counter tm))
+                                   :type "log"
+                                   :defaults
+                                   (persistent-transaction-directory graph)))))
           ;; The spatial index restored above came from a sidecar written at the
           ;; last CLEAN close -- it predates the writes just replayed, and its
           ;; histogram cannot be repaired by replay, because replay's idempotent
@@ -844,6 +882,11 @@ opens are immediately fully accepting, as before)."
       (unless shadow-p
         (start-replication graph :package package))
       (setf (graph-open-p graph) t)
+      ;; Flip from :OPENING to the caller's requested state now that
+      ;; GRAPH-OPEN-P is T and every rebuild/recovery step above has run
+      ;; -- the mid-open window closes here, last, not at construction
+      ;; (GH #170, review round 3).
+      (%set-accepting-p (transaction-manager graph) initial-accepting-state)
       graph)))
 
 (defmethod close-graph ((graph graph) &key (snapshot-p t))

--- a/graph.lisp
+++ b/graph.lisp
@@ -528,7 +528,8 @@ to disk and remove it."
                    ;; for a pre-v3 graph, the ones its migration re-derives.
                    (spatial-precision 7)
                    (spatial-max-cells +spatial-insert-max-cells+)
-                   (system-clock *system-clock*))
+                   (system-clock *system-clock*)
+                   shadow-p)
   "Open the existing graph named NAME whose files live under directory
 LOCATION, register it, and return it.  Use this to reopen a graph created
 earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's, including
@@ -544,7 +545,14 @@ reconciled against their declarative definitions and kept as-is unless changed
 Always CLOSE-GRAPH when finished.
 
 *SYSTEM-DIRECTORY* must be set: reopening replays the schema and may assign
-ids to types added since (GH #186)."
+ids to types added since (GH #186).
+
+:SHADOW-P T opens an unregistered shadow generation (GH #170,
+OPEN-SHADOW-GRAPH): the graph is never placed in *GRAPHS*, never
+published to the open-store vector (%REGISTER-OPEN-STORE is skipped;
+STORE-ID is still interned from the registry, directly, so v8 ids
+minted here carry the live store's tag), and replication is never
+started."
   (unless *system-directory*
     (error 'system-directory-required :operation 'open-graph))
   (when (and peer-role (or master-p slave-p))
@@ -666,8 +674,17 @@ ids to types added since (GH #186)."
         (restore-vector-segments graph)
         (with-open-file (out dirty-file :direction :output)
           (format out "~S" (get-universal-time)))
-        (setf (gethash name *graphs*) graph)
-        (%register-open-store graph)
+        (setf (graph-shadow-p graph) shadow-p)
+        (if shadow-p
+            ;; Unregistered: STORE-ID still comes from the registry (v8 ids
+            ;; minted here must carry the live store's tag) but never
+            ;; publishes to the open-store vector -- RESOLVE-NODE-GRAPH must
+            ;; keep resolving that tag to the LIVE graph (GH #170).
+            (when *system-directory*
+              (setf (store-id graph) (store-registry-intern name)))
+            (progn
+              (setf (gethash name *graphs*) graph)
+              (%register-open-store graph)))
         (when gc-heap-p
           (gc-heap graph))
         ;; A non-empty WAL tail means this open is a CRASH RECOVERY: the .txn files
@@ -736,7 +753,8 @@ ids to types added since (GH #186)."
         (attach-to-system-clock graph system-clock))
       (ensure-directories-exist (persistent-transaction-directory graph))
       (init-replication-log graph)
-      (start-replication graph :package package)
+      (unless shadow-p
+        (start-replication graph :package package))
       (setf (graph-open-p graph) t)
       graph)))
 
@@ -755,7 +773,11 @@ a snapshot failure does NOT abort the close (GH #120)."
   (let ((snapshot-problem nil))
     (when (graph-open-p graph)
       (stop-replication graph)
-      (remhash (graph-name graph) *graphs*)
+      ;; Guard by identity, not name alone: a shadow (GH #170) shares its
+      ;; live store's GRAPH-NAME but was never the one *GRAPHS* maps that
+      ;; name to, so closing it must not evict the live graph's entry.
+      (when (eq graph (gethash (graph-name graph) *graphs*))
+        (remhash (graph-name graph) *graphs*))
       (%unregister-open-store graph)
       ;; Unique constraints (#6): persist the on-disk unique skip-lists' roots
       ;; while the heap is still open, so OPEN can reopen them without a scan.

--- a/graph.lisp
+++ b/graph.lisp
@@ -557,7 +557,8 @@ policy.dat's ~S; the file wins."
                    (spatial-precision 7)
                    (spatial-max-cells +spatial-insert-max-cells+)
                    (system-clock *system-clock*)
-                   shadow-p recovery-policy)
+                   shadow-p recovery-policy
+                   (initial-accepting-state t))
   "Open the existing graph named NAME whose files live under directory
 LOCATION, register it, and return it.  Use this to reopen a graph created
 earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's, including
@@ -591,7 +592,15 @@ is persisted only when LOCATION is being
 created-on-open (no schema.dat yet, the same condition INIT-SCHEMA
 below branches on) -- a genuine reopen of an existing graph with no
 policy.dat leaves it absent (STORE-RECOVERY-POLICY's :AUTHORED
-default), it does not retroactively opt that graph in."
+default), it does not retroactively opt that graph in.
+
+:INITIAL-ACCEPTING-STATE (GH #170, review finding I4) sets the fresh
+TRANSACTION-MANAGER's ACCEPTING-P at construction, BEFORE the graph is
+registered in *GRAPHS* -- so a caller that wants the reopened graph to
+come up in a non-accepting window (e.g. SHADOW-STORE's :READ-ONLY) never
+publishes it writable-then-flips, which would let a racing writer land a
+commit in the doomed generation during the gap.  Defaults to T (ordinary
+opens are immediately fully accepting, as before)."
   (unless *system-directory*
     (error 'system-directory-required :operation 'open-graph))
   (when (and peer-role (or master-p slave-p))
@@ -727,6 +736,15 @@ default), it does not retroactively opt that graph in."
         (restore-vector-segments graph)
         (with-open-file (out dirty-file :direction :output)
           (format out "~S" (get-universal-time)))
+        ;; The TM must exist -- with ACCEPTING-P already at its final
+        ;; INITIAL-ACCEPTING-STATE -- BEFORE this graph is published to
+        ;; *GRAPHS*/the open-store vector below: publishing writable then
+        ;; flipping after would let a racing writer land a commit in a
+        ;; generation meant to come up non-accepting (GH #170, I4).
+        (setf (transaction-manager graph)
+              (make-instance 'transaction-manager
+                             :graph graph
+                             :accepting-p initial-accepting-state))
         (setf (graph-shadow-p graph) shadow-p)
         (if shadow-p
             ;; Unregistered: STORE-ID still comes from the registry (v8 ids
@@ -799,9 +817,8 @@ default), it does not retroactively opt that graph in."
                 (if (probe-file (format nil "~Astruct.dat" loc))
                     (open-lhash loc)
                     (make-lhash :location loc :buckets 8)))))
-      (setf (transaction-manager graph)
-            (make-instance 'transaction-manager
-                           :graph graph))
+      ;; TRANSACTION-MANAGER is already installed -- see above, before the
+      ;; *GRAPHS* registration (GH #170, I4).
       (when system-clock
         (attach-to-system-clock graph system-clock))
       (ensure-directories-exist (persistent-transaction-directory graph))

--- a/graph.lisp
+++ b/graph.lisp
@@ -763,6 +763,24 @@ opens are immediately fully accepting, as before)."
         ;; applied.  Capture that BEFORE the replay marks/consumes them.
         (let ((crash-recovery-p (and (recovery-transaction-files graph) t)))
           (recover-transactions graph)
+          ;; RE-SEED: the TM was constructed (GH #170, I4) BEFORE this
+          ;; replay ran, so its TX-ID-COUNTER was seeded from the
+          ;; PRE-recovery highest-transaction-id.  Each replayed write
+          ;; goes through APPLY-TRANSACTION, which persists a higher
+          ;; watermark to disk for every recovered .txn file -- but never
+          ;; touches TX-ID-COUNTER itself (recovery ids come from the
+          ;; .txn filename, not the counter).  Without this, the first
+          ;; post-open transaction mints an id from the stale counter,
+          ;; colliding with an id a replayed transaction already used.
+          ;; Reproduces TRANSACTION-MANAGER's own INITIALIZE-INSTANCE
+          ;; :AFTER formula verbatim; safe mid-open, no concurrency yet
+          ;; (GH #170, review round 2).
+          (when crash-recovery-p
+            (setf (tx-id-counter (transaction-manager graph))
+                  (1+ (max (load-highest-transaction-id graph)
+                           (if (peer-graph-p graph)
+                               (load-peer-pull-cursor graph)
+                               0)))))
           ;; The spatial index restored above came from a sidecar written at the
           ;; last CLEAN close -- it predates the writes just replayed, and its
           ;; histogram cannot be repaired by replay, because replay's idempotent

--- a/graph.lisp
+++ b/graph.lisp
@@ -307,7 +307,8 @@ debugging an unexpectedly empty result, check the declaration before the data."
                                    reference-classes (peer-schema-version '(1 0))
                                    (index-backend *index-backend*)
                                    spatial-index-backend
-                                   (system-clock *system-clock*))
+                                   (system-clock *system-clock*)
+                                   recovery-policy)
   "Create a brand-new graph named NAME with its on-disk files under the
 directory LOCATION, register it (so LOOKUP-GRAPH and *GRAPH* can find it), and
 return it.  The directory is created if necessary and must not already contain
@@ -364,6 +365,12 @@ Keyword arguments:
                           store's own counter -- the pre-#168 behaviour.
                           Attaching raises the clock above this store's
                           persisted highest id.
+  :RECOVERY-POLICY       :DERIVABLE or :AUTHORED, persisted to policy.dat
+                          (GH #170); NIL (default) writes nothing, so an
+                          absent file -- STORE-RECOVERY-POLICY's :AUTHORED
+                          default -- is what a plain MAKE-GRAPH call gets.
+                          OPEN-SHADOW-GRAPH :FAST-LOAD gates on this via the
+                          shadow's copied policy.dat.
 
 GRAPH-DB:*SYSTEM-DIRECTORY* must be set before calling this: type-ids are
 assigned from the registry that lives there, so that one symbol names one id
@@ -395,6 +402,10 @@ to disk and remove it."
          (dirty-file (format nil "~A/.dirty" location)))
     (unless (probe-file path)
       (error "Unable to open graph location ~A" path))
+    ;; GH #170 Task 4: persisted once, at create, before anything else
+    ;; touches LOCATION -- SET-STORE-RECOVERY-POLICY validates the value.
+    (when recovery-policy
+      (set-store-recovery-policy path recovery-policy))
     (when buffer-pool-p
       (ensure-buffer-pool buffer-pool-size))
     (let* ((heap (create-memory
@@ -529,7 +540,7 @@ to disk and remove it."
                    (spatial-precision 7)
                    (spatial-max-cells +spatial-insert-max-cells+)
                    (system-clock *system-clock*)
-                   shadow-p)
+                   shadow-p recovery-policy)
   "Open the existing graph named NAME whose files live under directory
 LOCATION, register it, and return it.  Use this to reopen a graph created
 earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's, including
@@ -552,7 +563,17 @@ OPEN-SHADOW-GRAPH): the graph is never placed in *GRAPHS*, never
 published to the open-store vector (%REGISTER-OPEN-STORE is skipped;
 STORE-ID is still interned from the registry, directly, so v8 ids
 minted here carry the live store's tag), and replication is never
-started."
+started.
+
+:RECOVERY-POLICY (GH #170) is only a HINT here, unlike MAKE-GRAPH: if
+LOCATION already carries a policy.dat, that file is authoritative --
+this keyword is ignored (a value that disagrees with the file WARNs,
+but the file wins) rather than silently rewritten out from under
+whatever wrote it.  It is persisted only when LOCATION is being
+created-on-open (no schema.dat yet, the same condition INIT-SCHEMA
+below branches on) -- a genuine reopen of an existing graph with no
+policy.dat leaves it absent (STORE-RECOVERY-POLICY's :AUTHORED
+default), it does not retroactively opt that graph in."
   (unless *system-directory*
     (error 'system-directory-required :operation 'open-graph))
   (when (and peer-role (or master-p slave-p))
@@ -616,15 +637,28 @@ started."
               (open-type-index (format nil "~A/edge-index.dat" path) heap))
         ;; (MVCC: no lhash value-finalizer; read paths materialize node bytes
         ;; under a read pin -- see ENSURE-NODE-BYTES.)
-        (if (probe-file schema-file)
-            (progn
-              (setf (schema graph)
-                    (cl-store:restore schema-file))
-              ;; Locks aren't persisted; rebuild the per-class rw-locks for the
-              ;; restored types (otherwise schema-class-locks is nil and
-              ;; def-vertex/def-edge and with-*-locked-class fail -- issue #32).
-              (restore-schema-locks (schema graph)))
-            (init-schema graph))
+        (let ((creating-on-open-p (not (probe-file schema-file))))
+          (if creating-on-open-p
+              (init-schema graph)
+              (progn
+                (setf (schema graph)
+                      (cl-store:restore schema-file))
+                ;; Locks aren't persisted; rebuild the per-class rw-locks for
+                ;; the restored types (otherwise schema-class-locks is nil and
+                ;; def-vertex/def-edge and with-*-locked-class fail -- #32).
+                (restore-schema-locks (schema graph))))
+          ;; GH #170 Task 4: policy.dat is authoritative once it exists --
+          ;; a supplied :RECOVERY-POLICY that disagrees only WARNS, never
+          ;; overwrites it.  Absent, it is persisted only on the same
+          ;; creating-on-open branch MAKE-GRAPH's create path corresponds
+          ;; to; a genuine reopen with no file leaves it absent (:AUTHORED).
+          (if (probe-file (%policy-file path))
+              (let ((on-disk (store-recovery-policy path)))
+                (when (and recovery-policy (not (eq recovery-policy on-disk)))
+                  (warn "OPEN-GRAPH ~A: :RECOVERY-POLICY ~S disagrees with ~
+policy.dat's ~S; the file wins." path recovery-policy on-disk)))
+              (when (and recovery-policy creating-on-open-p)
+                (set-store-recovery-policy path recovery-policy))))
         (setf (schema-lock (schema graph)) (make-recursive-lock))
         ;; MVCC: optional override of the persisted graph-wide keep-revisions.
         (when keep-revisions

--- a/package.lisp
+++ b/package.lisp
@@ -63,6 +63,9 @@
            #:reattach-store
            #:pin-read-epoch
            #:unpin-read-epoch
+           #:detach-unsupported-graph-error
+           #:detach-unsupported-graph-error-graph
+           #:detach-unsupported-graph-error-operation
            ;; Shadow generations (GH #170).
            #:shadow-store
            #:abandon-shadow

--- a/package.lisp
+++ b/package.lisp
@@ -45,6 +45,24 @@
            #:journal-torn-position
            #:graph-system-clock
            #:attach-to-system-clock
+           ;; Detach quiescence protocol (GH #170).
+           #:accepting-p
+           #:store-not-accepting-error
+           #:store-not-accepting-name
+           #:store-not-accepting-reason
+           #:detach-drain-timeout
+           #:detach-timeout-name
+           #:detach-timeout-seconds
+           #:store-detachment
+           #:store-detachment-graph-name
+           #:store-detachment-location
+           #:store-detachment-store-id
+           #:store-detachment-lease-start
+           #:store-detachment-lease-end
+           #:detach-store
+           #:reattach-store
+           #:pin-read-epoch
+           #:unpin-read-epoch
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -71,6 +71,9 @@
            #:swap-in-shadow
            #:swap-recovered-warning
            #:swap-recovered-warning-original
+           #:shadow-recovery-failed
+           #:shadow-recovery-failed-original
+           #:shadow-recovery-failed-recovery
            #:graph-shadow-p
            #:graph-epoch-lease
            #:epoch-lease

--- a/package.lisp
+++ b/package.lisp
@@ -63,6 +63,20 @@
            #:reattach-store
            #:pin-read-epoch
            #:unpin-read-epoch
+           ;; Shadow generations (GH #170).
+           #:shadow-store
+           #:abandon-shadow
+           #:open-shadow-graph
+           #:discard-shadow
+           #:graph-shadow-p
+           #:graph-epoch-lease
+           #:epoch-lease
+           #:epoch-lease-start
+           #:epoch-lease-next
+           #:epoch-lease-end
+           #:epoch-lease-exhausted
+           #:epoch-lease-exhausted-name
+           #:epoch-lease-exhausted-end
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -69,6 +69,8 @@
            #:open-shadow-graph
            #:discard-shadow
            #:swap-in-shadow
+           #:swap-recovered-warning
+           #:swap-recovered-warning-original
            #:graph-shadow-p
            #:graph-epoch-lease
            #:epoch-lease

--- a/package.lisp
+++ b/package.lisp
@@ -87,6 +87,10 @@
            #:fast-load-requires-derivable-location
            #:fast-load-requires-derivable-policy
            #:wal-suppressed-p
+           #:recovery-policy-mismatch-warning
+           #:recovery-policy-mismatch-warning-location
+           #:recovery-policy-mismatch-warning-requested
+           #:recovery-policy-mismatch-warning-on-disk
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -80,6 +80,13 @@
            #:epoch-lease-exhausted
            #:epoch-lease-exhausted-name
            #:epoch-lease-exhausted-end
+           ;; Recovery policy + WAL-suppressed fast path (GH #170 Task 4).
+           #:store-recovery-policy
+           #:set-store-recovery-policy
+           #:fast-load-requires-derivable
+           #:fast-load-requires-derivable-location
+           #:fast-load-requires-derivable-policy
+           #:wal-suppressed-p
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -176,6 +176,9 @@
            #:rebuild-vector-segment-batched
            #:segment-scan
            #:segment-score-subset
+           ;; Presize a segment's capacity up front (GH #170 Task 5) -- turns
+           ;; a mid-apply VECTOR-SEGMENT-CAPACITY-EXHAUSTED into an upfront one.
+           #:presize-vector-segment
            ;; Signalled pre-durability when a commit would grow a segment past
            ;; its mmap reservation.  Exported so a caller can tell "reopen the
            ;; graph / raise the reservation and retry" apart from a genuine data

--- a/package.lisp
+++ b/package.lisp
@@ -68,6 +68,7 @@
            #:abandon-shadow
            #:open-shadow-graph
            #:discard-shadow
+           #:swap-in-shadow
            #:graph-shadow-p
            #:graph-epoch-lease
            #:epoch-lease

--- a/segment.lisp
+++ b/segment.lisp
@@ -522,6 +522,23 @@ for segments."
     (serialize-uint64 mmap new-cap 32)         ; capacity := new-cap
     old-cap))                                  ; first fresh slot index
 
+(defun presize-vector-segment (segment n)
+  "Grow SEGMENT under its write lock, via the same doubling path SEGMENT-PUT
+uses (%SEG-GROW), until SEGMENT-CAPACITY >= N.  A no-op if already there.
+
+The point: turn a mid-apply capacity failure into an upfront one.  A
+transaction that would otherwise discover VECTOR-SEGMENT-CAPACITY-EXHAUSTED
+partway through applying its writes (some already durable) instead hits that
+same condition HERE, before any node write, when called ahead of the load
+that will need the room (GH #170 Task 5).
+
+Takes the segment's WRITE lock, same as SEGMENT-PUT/SEGMENT-REMOVE -- %SEG-
+GROW is lock-free by convention and assumes the caller already holds it."
+  (with-write-lock ((segment-lock segment))
+    (loop while (< (segment-capacity segment) n)
+          do (%seg-grow segment)))
+  segment)
+
 (defun %seg-claim-slot (segment)
   "Return a slot index to write a NEW id into: the free-list head if any, else
 the next slot past live-count, growing the segment first if capacity is

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -311,12 +311,18 @@ that copy is the gate input, not a fresh read of the live store).
 :AUTHORED (including the no-policy-file default) signals
 FAST-LOAD-REQUIRES-DERIVABLE instead of silently keeping the WAL.
 
-EXPECTED-VECTORS is a Task 5 hook: accepted here, but using it signals
-a clear \"arrives in a later task\" error rather than silently doing
-nothing."
-  (when expected-vectors
-    (error "OPEN-SHADOW-GRAPH :EXPECTED-VECTORS is a Task 5 hook and is ~
-not implemented yet (GH #170)."))
+EXPECTED-VECTORS (GH #170 Task 5), when given, presizes every vector
+segment the shadow's graph object carries -- PRESIZE-VECTOR-SEGMENT on
+each value of (VECTOR-SEGMENTS GRAPH), which OPEN-GRAPH has already
+populated (RESTORE-VECTOR-SEGMENTS runs inside it, before this function
+gets control) by opening or rebuilding whatever segment files the copy
+carries.  A shadow whose graph declares no :VECTOR-INDEX slot, or one
+whose owners have no live nodes yet, has an EMPTY vector-segments table
+-- :EXPECTED-VECTORS is then a clean no-op, not an error: there is
+nothing to presize, which is not a failure of the hook.  Any allocation
+failure inside PRESIZE-VECTOR-SEGMENT (VECTOR-SEGMENT-CAPACITY-
+EXHAUSTED) propagates unchanged, before OPEN-SHADOW-GRAPH sets up the
+epoch lease below."
   (when fast-load
     (let ((policy (store-recovery-policy shadow-location)))
       (unless (eq policy :derivable)
@@ -333,6 +339,15 @@ not implemented yet (GH #170)."))
                             open-args))))
       (when fast-load
         (setf (wal-suppressed-p graph) t))
+      ;; Presize whatever segments this shadow actually carries (GH #170 Task
+      ;; 5).  An empty VECTOR-SEGMENTS table (no :VECTOR-INDEX owner has data
+      ;; yet) makes this loop a no-op, by design -- see the docstring.
+      (when expected-vectors
+        (check-type expected-vectors (integer 0))
+        (maphash (lambda (key segment)
+                   (declare (ignore key))
+                   (presize-vector-segment segment expected-vectors))
+                 (vector-segments graph)))
       (let* ((persisted (and (null lease) (%read-lease location)))
              (start (if lease (car lease) (getf persisted :lease-start)))
              (end (if lease (cdr lease) (getf persisted :lease-end))))

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -171,10 +171,12 @@ durable state: NEXT = (MAX START (1+ LOAD-HIGHEST-TRANSACTION-ID)).  The
 shadow's own committed transaction ids are the truth about what it has
 already allocated; persisting a separate mutable cursor would need an
 fsync on the bulk-load hot path AND would go stale the moment a crash
-lost the last update.  If the derived NEXT is already past END, the
-lease was fully consumed before this open -- EPOCH-LEASE-EXHAUSTED is
-signalled immediately rather than quietly wrapping or reusing an id
-(GH #170, fix round 1).
+lost the last update.  If the derived NEXT is already AT OR PAST END
+(the range is half-open [START,END), so NEXT = END means fully
+consumed, not merely at the boundary), the lease was used up before
+this open -- EPOCH-LEASE-EXHAUSTED is signalled immediately rather than
+quietly wrapping, reusing an id, or deferring the failure to the first
+write (GH #170, fix round 2).
 
 FAST-LOAD and EXPECTED-VECTORS are Task 4/5 hooks: accepted here, but
 using either signals a clear \"arrives in a later task\" error rather
@@ -205,7 +207,10 @@ given and ~A has no lease.dat." location))
         ;; round 1).  LOAD-HIGHEST-TRANSACTION-ID is 0 on a shadow that has
         ;; never committed a write, so NEXT starts at START there.
         (let ((next (max start (1+ (load-highest-transaction-id graph)))))
-          (when (> next end)
+          ;; Half-open [start,end): NEXT == END means fully consumed, not
+          ;; just "at the boundary" -- TM-NEXT-EPOCH's own runtime check
+          ;; uses >= for the same reason (GH #170, fix round 2).
+          (when (>= next end)
             (error 'epoch-lease-exhausted :name graph-name :end end))
           (setf (graph-epoch-lease graph)
                 (make-epoch-lease :start start :next next :end end)))

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -1,0 +1,166 @@
+(in-package :graph-db)
+
+;;; Shadow generations (GH #170).  A shadow is a consistent, unregistered
+;;; copy of a live store's directory, opened for a bulk load under its own
+;;; leased epoch range while the live store stays read-only.  See
+;;; docs/superpowers/specs/2026-08-20-namespaces-design.md sec.8.
+
+(defun %shadow-location (location)
+  "LOCATION's shadow sibling: same parent, directory name suffixed
+\"-shadow\" (GH #170)."
+  (let* ((dir (uiop:ensure-directory-pathname location))
+         (trimmed (string-right-trim "/" (namestring dir))))
+    (uiop:ensure-directory-pathname (concatenate 'string trimmed "-shadow"))))
+
+(defun %copy-directory-tree (source destination)
+  "Plain recursive file copy, SOURCE to DESTINATION.  Called only while
+the store is closed, so there are no mmap hazards.  NO shell-outs --
+UIOP:COLLECT-SUB*DIRECTORIES walks SOURCE and UIOP:COPY-FILE moves each
+file (GH #170)."
+  (let ((source (uiop:ensure-directory-pathname source))
+        (destination (uiop:ensure-directory-pathname destination)))
+    (ensure-directories-exist destination)
+    (uiop:collect-sub*directories
+     source t t
+     (lambda (dir)
+       (ensure-directories-exist
+        (merge-pathnames (uiop:enough-pathname dir source) destination))
+       (dolist (file (uiop:directory-files dir))
+         (uiop:copy-file
+          file
+          (merge-pathnames (uiop:enough-pathname file source) destination)))))
+    destination))
+
+(defun %shadow-suffix-p (path)
+  "True when PATH's directory name ends in \"-shadow\" -- the entire
+safety story for DISCARD-SHADOW, which deletes trees (GH #170)."
+  (let ((trimmed (string-right-trim
+                  "/" (namestring (uiop:ensure-directory-pathname path)))))
+    (and (>= (length trimmed) 7)
+         (string= "-shadow" trimmed :start2 (- (length trimmed) 7)))))
+
+(defun shadow-store (graph &key (timeout 60))
+  "Take a consistent shadow copy of GRAPH's store: quiesce (reason
+:SWAPPING, TIMEOUT seconds to drain) -> CLOSE-GRAPH -> recursive file
+copy to \"<location>-shadow/\" -> reopen GRAPH's own store and
+ATTACH-TO-SYSTEM-CLOCK (service resumes) -> set the reopened graph's
+ACCEPTING-P to :READ-ONLY (Kevin's ruling: reads and pins keep flowing;
+a new write signals STORE-NOT-ACCEPTING-ERROR reason :SHADOW-LOAD, so no
+write is ever silently discarded at swap).
+
+Requires GRAPH be attached to a system clock -- the reopen needs it to
+resume service and the shadow's own lease (see OPEN-SHADOW-GRAPH) is
+drawn from the same clock.
+
+Returns (values SHADOW-LOCATION REOPENED-GRAPH).  The live store is
+fully unavailable only for close+copy+reopen -- seconds -- and
+write-unavailable until a caller swaps it in or calls ABANDON-SHADOW
+(GH #170)."
+  (let* ((tm (transaction-manager graph))
+         (name (graph-name graph))
+         (location (location graph))
+         (clock (graph-system-clock graph)))
+    (unless clock
+      (error "SHADOW-STORE requires GRAPH to be attached to a system ~
+clock (GRAPH-SYSTEM-CLOCK is NIL) -- the shadow window resumes service ~
+via ATTACH-TO-SYSTEM-CLOCK, which needs one."))
+    (%quiesce-transaction-manager tm :swapping timeout)
+    (let ((*graph* graph)
+          (*quiesced-store-closing-p* t))
+      (close-graph graph :snapshot-p t))
+    (let ((shadow-location (%shadow-location location)))
+      (%copy-directory-tree location shadow-location)
+      (let ((reopened (open-graph name (namestring location)
+                                  :system-clock nil)))
+        (attach-to-system-clock reopened clock)
+        (%set-accepting-p (transaction-manager reopened) :read-only)
+        (values shadow-location reopened)))))
+
+(defun abandon-shadow (graph shadow-location)
+  "The lifecycle exit that is not a swap: DISCARD-SHADOW the directory
+and restore GRAPH's ACCEPTING-P to T (full service) (GH #170)."
+  (discard-shadow shadow-location)
+  (%set-accepting-p (transaction-manager graph) t)
+  graph)
+
+(defun %lease-file (shadow-location)
+  (merge-pathnames "lease.dat"
+                   (uiop:ensure-directory-pathname shadow-location)))
+
+(defun %persist-lease (shadow-location start end)
+  "Write (:LEASE-START START :LEASE-END END) readably to lease.dat, so
+the lease survives outside this process (GH #170)."
+  (with-open-file (out (%lease-file shadow-location)
+                       :direction :output :if-exists :supersede
+                       :if-does-not-exist :create)
+    (let ((*print-readably* nil) (*print-pretty* nil))
+      (prin1 (list :lease-start start :lease-end end) out))))
+
+(defun %read-lease (shadow-location)
+  "Read back lease.dat, or NIL if absent.  *READ-EVAL* NIL: this file
+may have been copied from anywhere and is untrusted input (GH #170)."
+  (let ((file (%lease-file shadow-location)))
+    (when (probe-file file)
+      (with-open-file (in file)
+        (let ((*read-eval* nil))
+          (read in nil nil))))))
+
+(defun open-shadow-graph (shadow-location graph-name
+                          &key lease fast-load expected-vectors
+                               (buffer-pool-size nil))
+  "OPEN-GRAPH :SHADOW-P T on SHADOW-LOCATION under GRAPH-NAME -- same
+name as the live store, so its schema metadata instantiates identically
+-- unregistered: not in *GRAPHS*, not in the open-store vector, no
+replication.  STORE-ID is interned directly from the store registry, so
+v8 node ids minted here carry the LIVE store's tag; RESOLVE-NODE-GRAPH
+therefore still resolves them to the live graph.
+
+LEASE is (START . END) -- from the STORE-DETACHMENT SHADOW-STORE's
+caller holds, or from a direct CLOCK-LEASE-EPOCHS call when there was no
+DETACH-STORE.  Installed as the graph's EPOCH-LEASE, so every
+transaction id minted against the returned graph comes from the lease,
+never the clock or a per-store counter (see TM-NEXT-EPOCH).  Persisted
+as lease.dat in SHADOW-LOCATION so it survives a crash/restart of this
+process; when LEASE is not given, the persisted lease.dat is read back
+instead (needed to reopen a shadow across a restart).
+
+FAST-LOAD and EXPECTED-VECTORS are Task 4/5 hooks: accepted here, but
+using either signals a clear \"arrives in a later task\" error rather
+than silently doing nothing."
+  (when fast-load
+    (error "OPEN-SHADOW-GRAPH :FAST-LOAD is a Task 4 hook and is not ~
+implemented yet (GH #170)."))
+  (when expected-vectors
+    (error "OPEN-SHADOW-GRAPH :EXPECTED-VECTORS is a Task 5 hook and is ~
+not implemented yet (GH #170)."))
+  (let* ((location
+          (uiop:ensure-directory-pathname shadow-location))
+         (open-args (list graph-name (namestring location)
+                          :shadow-p t :system-clock nil)))
+    (let ((graph (apply #'open-graph
+                        (if buffer-pool-size
+                            (append open-args
+                                   (list :buffer-pool-size buffer-pool-size))
+                            open-args))))
+      (let* ((persisted (and (null lease) (%read-lease location)))
+             (start (if lease (car lease) (getf persisted :lease-start)))
+             (end (if lease (cdr lease) (getf persisted :lease-end))))
+        (unless (and start end)
+          (error "OPEN-SHADOW-GRAPH needs :LEASE (start . end); none was ~
+given and ~A has no lease.dat." location))
+        (setf (graph-epoch-lease graph)
+              (make-epoch-lease :start start :next start :end end))
+        (%persist-lease location start end))
+      graph)))
+
+(defun discard-shadow (shadow-location)
+  "Delete SHADOW-LOCATION's tree.  A shadow never registers (*GRAPHS*,
+open-store vector), so there is nothing to close first -- just delete.
+Gated HARD on the path ending in \"-shadow\" via %SHADOW-SUFFIX-P: this
+function deletes directory trees, and that suffix check is the whole
+safety story (GH #170)."
+  (let ((dir (uiop:ensure-directory-pathname shadow-location)))
+    (uiop:delete-directory-tree
+     dir
+     :validate #'%shadow-suffix-p
+     :if-does-not-exist :ignore)))

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -217,6 +217,91 @@ given and ~A has no lease.dat." location))
         (%persist-lease location start end))
       graph)))
 
+(defun %require-closed-shadow (shadow-location)
+  "Signal a clear error unless SHADOW-LOCATION exists and carries no
+.dirty marker -- SWAP-IN-SHADOW requires the shadow be CLOSE-GRAPH'd
+before promotion (the contract: caller closes it, not this function).
+Renaming a directory a graph still has mmapped open would corrupt
+whatever ends up living at that name (GH #170)."
+  (let ((dir (uiop:ensure-directory-pathname shadow-location)))
+    (unless (probe-file dir)
+      (error "SWAP-IN-SHADOW: shadow location ~A does not exist." dir))
+    (when (probe-file (merge-pathnames ".dirty" dir))
+      (error "SWAP-IN-SHADOW: ~A still carries .dirty -- close the ~
+shadow (CLOSE-GRAPH) before swapping it in." dir))))
+
+(defun %trimmed-namestring (location)
+  "LOCATION (string or pathname) as a namestring with no trailing
+slash -- %POSIX-RENAME's two arguments must name the directories
+themselves, not \"dir/\" (GH #170)."
+  (string-right-trim "/" (namestring (uiop:ensure-directory-pathname
+                                      location))))
+
+(defun %swap-in-shadow-1 (name location shadow-location clock)
+  "The risky middle of SWAP-IN-SHADOW, run after the live store is
+already closed: validate, rename live away, rename shadow in, journal,
+reopen.  Split out so the caller's HANDLER-CASE recovery wrap reads
+cleanly (GH #170)."
+  (%require-closed-shadow shadow-location)
+  (let* ((live (%trimmed-namestring location))
+         (shadow (%trimmed-namestring shadow-location))
+         (retired-path (format nil "~A-retired-~D" live
+                               (clock-current-epoch clock))))
+    ;; Live renamed away FIRST: the data always exists under some name.
+    ;; A crash between these two renames is #171's territory (see the
+    ;; docstring) -- not recovered here.
+    (%posix-rename live retired-path)
+    (%posix-rename shadow live)
+    (journal-append clock :swap :store name :retired retired-path)
+    (let ((new-graph (open-graph name live :system-clock nil)))
+      (attach-to-system-clock new-graph clock)
+      (values new-graph retired-path))))
+
+(defun swap-in-shadow (graph shadow-location &key (timeout 60))
+  "Promote SHADOW-LOCATION into GRAPH's place: quiesce GRAPH (reason
+:SWAPPING, TIMEOUT seconds to drain) -> CLOSE-GRAPH -> rename the live
+directory to \"<location>-retired-<epoch>\" (EPOCH from
+CLOCK-CURRENT-EPOCH) -> rename SHADOW-LOCATION to the live location ->
+JOURNAL-APPEND :SWAP (:store name :retired retired-path) -> OPEN-GRAPH
+at the live location + ATTACH-TO-SYSTEM-CLOCK.  Returns (values
+NEW-GRAPH RETIRED-PATH); the retired directory is kept, not deleted.
+
+SHADOW-LOCATION must already be a CLOSED shadow (no .dirty marker) --
+this function does not close an open shadow handle for you.  That is
+the safer contract: a handle this function closes on your behalf is
+one more place a caller's pins/pending writes could be silently
+dropped, whereas requiring pre-closed just means CLOSE-GRAPH the
+shadow yourself first (GH #170).
+
+Requires GRAPH be attached to a system clock, same as SHADOW-STORE.
+Any failure BEFORE the first rename -- including SHADOW-LOCATION not
+existing or not being cleanly closed -- reopens the live store,
+restores ACCEPTING-P to T, and re-signals, mirroring SHADOW-STORE's
+copy-failure recovery (GH #170, fix round 1).  A failure BETWEEN the
+two renames is NOT recovered here: the live data sits at the retired
+path and the live location may be missing or half-replaced; manual
+recovery is required.  That crash window is GH #171's territory."
+  (let* ((tm (transaction-manager graph))
+         (name (graph-name graph))
+         (location (location graph))
+         (clock (graph-system-clock graph)))
+    (unless clock
+      (error "SWAP-IN-SHADOW requires GRAPH to be attached to a system ~
+clock (GRAPH-SYSTEM-CLOCK is NIL)."))
+    (%quiesce-transaction-manager tm :swapping timeout)
+    (let ((*graph* graph)
+          (*quiesced-store-closing-p* t))
+      (close-graph graph :snapshot-p t))
+    (handler-case
+        (%swap-in-shadow-1 name location shadow-location clock)
+      (error (original)
+        (handler-case
+            (%reopen-and-resume name location clock t)
+          (error (recovery)
+            (error 'shadow-recovery-failed
+                   :original original :recovery recovery)))
+        (error original)))))
+
 (defun discard-shadow (shadow-location)
   "Delete SHADOW-LOCATION's tree.  A shadow never registers (*GRAPHS*,
 open-store vector), so there is nothing to close first -- just delete.

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -222,7 +222,10 @@ given and ~A has no lease.dat." location))
 .dirty marker -- SWAP-IN-SHADOW requires the shadow be CLOSE-GRAPH'd
 before promotion (the contract: caller closes it, not this function).
 Renaming a directory a graph still has mmapped open would corrupt
-whatever ends up living at that name (GH #170)."
+whatever ends up living at that name.  Called BEFORE any quiesce or
+close of the live store (GH #170, fix round 1) -- a typo'd path or a
+still-open shadow must cost nothing more than this PROBE-FILE, not a
+live outage."
   (let ((dir (uiop:ensure-directory-pathname shadow-location)))
     (unless (probe-file dir)
       (error "SWAP-IN-SHADOW: shadow location ~A does not exist." dir))
@@ -237,12 +240,36 @@ themselves, not \"dir/\" (GH #170)."
   (string-right-trim "/" (namestring (uiop:ensure-directory-pathname
                                       location))))
 
-(defun %swap-in-shadow-1 (name location shadow-location clock)
+(define-condition swap-recovered-warning (warning)
+  ;; The renames + :SWAP journal record were durably complete before
+  ;; the follow-up OPEN-GRAPH/ATTACH-TO-SYSTEM-CLOCK failed -- the swap
+  ;; itself SUCCEEDED.  Recovering by reopening the NEW generation and
+  ;; returning it normally is correct; this warning exists so the
+  ;; caller can still notice the reopen hiccup (GH #170, fix round 1).
+  ((original :initarg :original :reader swap-recovered-warning-original))
+  (:report (lambda (c s)
+             (format s "SWAP-IN-SHADOW's renames and :SWAP journal ~
+record completed, but the follow-up reopen failed (~A); recovered by ~
+reopening the NEW generation instead -- the swap itself succeeded."
+                     (swap-recovered-warning-original c)))))
+
+(defun %swap-completed-p (progress)
+  "True when PROGRESS (see %SWAP-IN-SHADOW-1) marks the renames and
+:SWAP journal record already durably complete.  Pulled out as its own
+predicate so the discrimination SWAP-IN-SHADOW's failure handler makes
+-- recover onto the OLD store and resignal, vs. recover onto the NEW
+one and return -- is unit-testable on its own (GH #170, fix round 1)."
+  (and (aref progress 0) t))
+
+(defun %swap-in-shadow-1 (name location shadow-location clock progress)
   "The risky middle of SWAP-IN-SHADOW, run after the live store is
-already closed: validate, rename live away, rename shadow in, journal,
-reopen.  Split out so the caller's HANDLER-CASE recovery wrap reads
-cleanly (GH #170)."
-  (%require-closed-shadow shadow-location)
+already closed: rename live away, rename shadow in, journal, reopen.
+PROGRESS is a 2-element vector; element 0 is set true and element 1 set
+to RETIRED-PATH the instant both renames and the journal record are
+durably complete -- the caller's HANDLER-CASE uses it to discriminate a
+pre-completion failure (recover the OLD store) from a post-completion
+one (recover the NEW store; the swap already happened) (GH #170, fix
+round 1).  Split out so that HANDLER-CASE reads cleanly."
   (let* ((live (%trimmed-namestring location))
          (shadow (%trimmed-namestring shadow-location))
          (retired-path (format nil "~A-retired-~D" live
@@ -253,34 +280,55 @@ cleanly (GH #170)."
     (%posix-rename live retired-path)
     (%posix-rename shadow live)
     (journal-append clock :swap :store name :retired retired-path)
+    (setf (aref progress 0) t (aref progress 1) retired-path)
     (let ((new-graph (open-graph name live :system-clock nil)))
       (attach-to-system-clock new-graph clock)
       (values new-graph retired-path))))
 
 (defun swap-in-shadow (graph shadow-location &key (timeout 60))
-  "Promote SHADOW-LOCATION into GRAPH's place: quiesce GRAPH (reason
-:SWAPPING, TIMEOUT seconds to drain) -> CLOSE-GRAPH -> rename the live
-directory to \"<location>-retired-<epoch>\" (EPOCH from
-CLOCK-CURRENT-EPOCH) -> rename SHADOW-LOCATION to the live location ->
-JOURNAL-APPEND :SWAP (:store name :retired retired-path) -> OPEN-GRAPH
-at the live location + ATTACH-TO-SYSTEM-CLOCK.  Returns (values
-NEW-GRAPH RETIRED-PATH); the retired directory is kept, not deleted.
+  "Promote SHADOW-LOCATION into GRAPH's place: validate SHADOW-LOCATION
+(exists, no .dirty) -> quiesce GRAPH (reason :SWAPPING, TIMEOUT seconds
+to drain) -> CLOSE-GRAPH -> rename the live directory to
+\"<location>-retired-<epoch>\" (EPOCH from CLOCK-CURRENT-EPOCH) ->
+rename SHADOW-LOCATION to the live location -> JOURNAL-APPEND :SWAP
+(:store name :retired retired-path) -> OPEN-GRAPH at the live location
++ ATTACH-TO-SYSTEM-CLOCK.  Returns (values NEW-GRAPH RETIRED-PATH); the
+retired directory is kept, not deleted.
 
 SHADOW-LOCATION must already be a CLOSED shadow (no .dirty marker) --
-this function does not close an open shadow handle for you.  That is
-the safer contract: a handle this function closes on your behalf is
-one more place a caller's pins/pending writes could be silently
-dropped, whereas requiring pre-closed just means CLOSE-GRAPH the
-shadow yourself first (GH #170).
+this function does not close an open shadow handle for you (GH #170).
 
 Requires GRAPH be attached to a system clock, same as SHADOW-STORE.
-Any failure BEFORE the first rename -- including SHADOW-LOCATION not
-existing or not being cleanly closed -- reopens the live store,
-restores ACCEPTING-P to T, and re-signals, mirroring SHADOW-STORE's
-copy-failure recovery (GH #170, fix round 1).  A failure BETWEEN the
-two renames is NOT recovered here: the live data sits at the retired
-path and the live location may be missing or half-replaced; manual
-recovery is required.  That crash window is GH #171's territory."
+The SHADOW-LOCATION validation runs FIRST, before anything touches the
+live store: a typo'd path or a shadow that is still open must never
+cost a read-and-write outage, only a PROBE-FILE and an immediate
+signal -- GRAPH is untouched, ACCEPTING-P never leaves T (GH #170, fix
+round 1).
+
+Two further failure outcomes, discriminated by whether both renames
+and the :SWAP journal record had already completed (see
+%SWAP-IN-SHADOW-1's PROGRESS argument):
+
+- NOT YET COMPLETE (the copy/rename/journal step itself failed): the
+  swap did not happen.  Reopen the OLD store, restore ACCEPTING-P to
+  T, and re-signal the original error, mirroring SHADOW-STORE's
+  copy-failure recovery.
+- ALREADY COMPLETE (only the follow-up OPEN-GRAPH/ATTACH-TO-SYSTEM-
+  CLOCK failed): the swap SUCCEEDED -- the live location already holds
+  the new generation's files.  Resignalling here would be a lie: the
+  caller would conclude the swap didn't happen and could, e.g., retry
+  it against a shadow location that no longer exists.  Instead: reopen
+  the NEW generation, signal SWAP-RECOVERED-WARNING (a WARNING, not an
+  ERROR) carrying the original condition, and RETURN (values NEW-GRAPH
+  RETIRED-PATH) normally (GH #170, fix round 1).
+
+Either recovery reopen itself failing is unchanged: SHADOW-RECOVERY-
+FAILED, carrying both conditions.
+
+A failure BETWEEN the two renames is NOT recovered here: the live data
+sits at the retired path and the live location may be missing or
+half-replaced; manual recovery is required.  That crash window is GH
+#171's territory."
   (let* ((tm (transaction-manager graph))
          (name (graph-name graph))
          (location (location graph))
@@ -288,19 +336,34 @@ recovery is required.  That crash window is GH #171's territory."
     (unless clock
       (error "SWAP-IN-SHADOW requires GRAPH to be attached to a system ~
 clock (GRAPH-SYSTEM-CLOCK is NIL)."))
+    ;; Validate BEFORE touching the live store at all (fix round 1).
+    (%require-closed-shadow shadow-location)
     (%quiesce-transaction-manager tm :swapping timeout)
     (let ((*graph* graph)
           (*quiesced-store-closing-p* t))
       (close-graph graph :snapshot-p t))
-    (handler-case
-        (%swap-in-shadow-1 name location shadow-location clock)
-      (error (original)
-        (handler-case
-            (%reopen-and-resume name location clock t)
-          (error (recovery)
-            (error 'shadow-recovery-failed
-                   :original original :recovery recovery)))
-        (error original)))))
+    (let ((progress (vector nil nil)))
+      (handler-case
+          (%swap-in-shadow-1 name location shadow-location clock progress)
+        (error (original)
+          (if (%swap-completed-p progress)
+              ;; Renames + journal already durable: the swap SUCCEEDED.
+              ;; Recover onto the NEW generation and return normally.
+              (handler-case
+                  (let ((recovered (%reopen-and-resume name location clock t)))
+                    (warn 'swap-recovered-warning :original original)
+                    (return-from swap-in-shadow
+                      (values recovered (aref progress 1))))
+                (error (recovery)
+                  (error 'shadow-recovery-failed
+                         :original original :recovery recovery)))
+              (progn
+                (handler-case
+                    (%reopen-and-resume name location clock t)
+                  (error (recovery)
+                    (error 'shadow-recovery-failed
+                           :original original :recovery recovery)))
+                (error original))))))))
 
 (defun discard-shadow (shadow-location)
   "Delete SHADOW-LOCATION's tree.  A shadow never registers (*GRAPHS*,

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -18,10 +18,21 @@ per-chunk overhead is negligible, small enough that a single dirty
 region near the end of an otherwise-empty multi-GB reservation doesn't
 force writing the whole file (GH #170).")
 
-(defun %all-zero-p (buffer count zero-buffer)
-  "True when the first COUNT octets of BUFFER are all zero, compared
-against a same-sized, once-allocated ZERO-BUFFER (GH #170)."
-  (not (mismatch buffer zero-buffer :end1 count :end2 count)))
+(defun %all-zero-p (buffer count)
+  "True when the first COUNT octets of BUFFER are all zero.
+
+A typed loop, not CL:MISMATCH -- MISMATCH has no fast-path transform for
+(SIMPLE-ARRAY (UNSIGNED-BYTE 8) (*)) in SBCL and falls back to boxed,
+per-element generic dispatch (~16ms/MB measured).  Each store reserves
+~12GB of mostly-zero mmap regions (see %COPY-DIRECTORY-TREE), so every
+shadow paid ~3+ minutes of pure CPU here -- the whole detach-suite's
+'hang' (GH #170).  This typed DOTIMES compiles to a tight bounds-checked
+loop (~0.8ms/MB measured, ~20x)."
+  (declare (type (simple-array (unsigned-byte 8) (*)) buffer)
+           (type fixnum count)
+           (optimize (speed 3)))
+  (dotimes (i count t)
+    (unless (zerop (aref buffer i)) (return nil))))
 
 (defun %copy-file-sparse (source destination)
   "Copy SOURCE to DESTINATION preserving holes: read in
@@ -40,8 +51,6 @@ DESTINATION to SOURCE's exact length with one extra byte written (GH
 #170)."
   (let* ((chunk-size *sparse-copy-chunk-size*)
          (buffer (make-array chunk-size :element-type '(unsigned-byte 8)))
-         (zero-buffer (make-array chunk-size :element-type '(unsigned-byte 8)
-                                  :initial-element 0))
          (length 0)
          (last-chunk-skipped-p nil))
     (with-open-file (in source :element-type '(unsigned-byte 8))
@@ -53,7 +62,7 @@ DESTINATION to SOURCE's exact length with one extra byte written (GH
           (let ((n (read-sequence buffer in)))
             (when (zerop n) (return))
             (cond
-              ((%all-zero-p buffer n zero-buffer)
+              ((%all-zero-p buffer n)
                ;; FILE-POSITION is a FUNCTION, not a SETF place: call it
                ;; with the new position as a second argument.
                (file-position out (+ (file-position out) n))

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -39,6 +39,30 @@ safety story for DISCARD-SHADOW, which deletes trees (GH #170)."
     (and (>= (length trimmed) 7)
          (string= "-shadow" trimmed :start2 (- (length trimmed) 7)))))
 
+(define-condition shadow-recovery-failed (error)
+  ;; The copy step failed AND the post-close recovery reopen also
+  ;; failed: the store may be stuck closed and needs a manual
+  ;; OPEN-GRAPH.  Both conditions are carried so neither is lost
+  ;; (GH #170, fix round 1).
+  ((original :initarg :original :reader shadow-recovery-failed-original)
+   (recovery :initarg :recovery :reader shadow-recovery-failed-recovery))
+  (:report (lambda (c s)
+             (format s "SHADOW-STORE failed (~A) and the recovery ~
+reopen ALSO failed (~A) -- the store is left closed; a manual ~
+OPEN-GRAPH is required."
+                     (shadow-recovery-failed-original c)
+                     (shadow-recovery-failed-recovery c)))))
+
+(defun %reopen-and-resume (name location clock reason)
+  "OPEN-GRAPH + ATTACH-TO-SYSTEM-CLOCK + %SET-ACCEPTING-P REASON --
+the resume sequence shared by SHADOW-STORE's happy path and its
+copy-failure recovery path (GH #170)."
+  (let ((reopened (open-graph name (namestring location)
+                              :system-clock nil)))
+    (attach-to-system-clock reopened clock)
+    (%set-accepting-p (transaction-manager reopened) reason)
+    reopened))
+
 (defun shadow-store (graph &key (timeout 60))
   "Take a consistent shadow copy of GRAPH's store: quiesce (reason
 :SWAPPING, TIMEOUT seconds to drain) -> CLOSE-GRAPH -> recursive file
@@ -52,10 +76,18 @@ Requires GRAPH be attached to a system clock -- the reopen needs it to
 resume service and the shadow's own lease (see OPEN-SHADOW-GRAPH) is
 drawn from the same clock.
 
-Returns (values SHADOW-LOCATION REOPENED-GRAPH).  The live store is
-fully unavailable only for close+copy+reopen -- seconds -- and
-write-unavailable until a caller swaps it in or calls ABANDON-SHADOW
-(GH #170)."
+Once CLOSE-GRAPH has run, the live store is durably closed; ANY error
+from the copy or the happy-path reopen itself triggers a recovery
+reopen (ACCEPTING-P restored to T, full service) BEFORE the original
+error is re-signalled -- a failed shadow attempt must not leave the
+live store stranded closed.  If recovery ALSO fails, SHADOW-RECOVERY-
+FAILED is signalled instead, carrying both conditions (GH #170, fix
+round 1).
+
+Returns (values SHADOW-LOCATION REOPENED-GRAPH) on success.  The live
+store is fully unavailable only for close+copy+reopen -- seconds --
+and write-unavailable until a caller swaps it in or calls
+ABANDON-SHADOW."
   (let* ((tm (transaction-manager graph))
          (name (graph-name graph))
          (location (location graph))
@@ -69,12 +101,19 @@ via ATTACH-TO-SYSTEM-CLOCK, which needs one."))
           (*quiesced-store-closing-p* t))
       (close-graph graph :snapshot-p t))
     (let ((shadow-location (%shadow-location location)))
-      (%copy-directory-tree location shadow-location)
-      (let ((reopened (open-graph name (namestring location)
-                                  :system-clock nil)))
-        (attach-to-system-clock reopened clock)
-        (%set-accepting-p (transaction-manager reopened) :read-only)
-        (values shadow-location reopened)))))
+      (handler-case
+          (progn
+            (%copy-directory-tree location shadow-location)
+            (let ((reopened (%reopen-and-resume name location clock
+                                                :read-only)))
+              (values shadow-location reopened)))
+        (error (original)
+          (handler-case
+              (%reopen-and-resume name location clock t)
+            (error (recovery)
+              (error 'shadow-recovery-failed
+                     :original original :recovery recovery)))
+          (error original))))))
 
 (defun abandon-shadow (graph shadow-location)
   "The lifecycle exit that is not a swap: DISCARD-SHADOW the directory
@@ -89,7 +128,11 @@ and restore GRAPH's ACCEPTING-P to T (full service) (GH #170)."
 
 (defun %persist-lease (shadow-location start end)
   "Write (:LEASE-START START :LEASE-END END) readably to lease.dat, so
-the lease survives outside this process (GH #170)."
+the RANGE survives outside this process.  Never NEXT -- see
+OPEN-SHADOW-GRAPH's resume story: the cursor is derived from the
+shadow's own durable highest-transaction-id on every open, not
+persisted here, so this file never needs an fsync on the per-write hot
+path (GH #170, fix round 1)."
   (with-open-file (out (%lease-file shadow-location)
                        :direction :output :if-exists :supersede
                        :if-does-not-exist :create)
@@ -117,12 +160,21 @@ therefore still resolves them to the live graph.
 
 LEASE is (START . END) -- from the STORE-DETACHMENT SHADOW-STORE's
 caller holds, or from a direct CLOCK-LEASE-EPOCHS call when there was no
-DETACH-STORE.  Installed as the graph's EPOCH-LEASE, so every
-transaction id minted against the returned graph comes from the lease,
-never the clock or a per-store counter (see TM-NEXT-EPOCH).  Persisted
-as lease.dat in SHADOW-LOCATION so it survives a crash/restart of this
-process; when LEASE is not given, the persisted lease.dat is read back
-instead (needed to reopen a shadow across a restart).
+DETACH-STORE.  The RANGE is persisted as lease.dat in SHADOW-LOCATION so
+it survives a crash/restart of this process; when LEASE is not given,
+the persisted lease.dat supplies it instead (needed to reopen a shadow
+across a restart).
+
+The CURSOR (where allocation resumes) is never taken from LEASE or from
+lease.dat -- it is derived fresh on every open from the shadow's own
+durable state: NEXT = (MAX START (1+ LOAD-HIGHEST-TRANSACTION-ID)).  The
+shadow's own committed transaction ids are the truth about what it has
+already allocated; persisting a separate mutable cursor would need an
+fsync on the bulk-load hot path AND would go stale the moment a crash
+lost the last update.  If the derived NEXT is already past END, the
+lease was fully consumed before this open -- EPOCH-LEASE-EXHAUSTED is
+signalled immediately rather than quietly wrapping or reusing an id
+(GH #170, fix round 1).
 
 FAST-LOAD and EXPECTED-VECTORS are Task 4/5 hooks: accepted here, but
 using either signals a clear \"arrives in a later task\" error rather
@@ -148,8 +200,15 @@ not implemented yet (GH #170)."))
         (unless (and start end)
           (error "OPEN-SHADOW-GRAPH needs :LEASE (start . end); none was ~
 given and ~A has no lease.dat." location))
-        (setf (graph-epoch-lease graph)
-              (make-epoch-lease :start start :next start :end end))
+        ;; Resume cursor: derived from the shadow's OWN durable state, not
+        ;; persisted -- see the docstring and %PERSIST-LEASE (GH #170, fix
+        ;; round 1).  LOAD-HIGHEST-TRANSACTION-ID is 0 on a shadow that has
+        ;; never committed a write, so NEXT starts at START there.
+        (let ((next (max start (1+ (load-highest-transaction-id graph)))))
+          (when (> next end)
+            (error 'epoch-lease-exhausted :name graph-name :end end))
+          (setf (graph-epoch-lease graph)
+                (make-epoch-lease :start start :next next :end end)))
         (%persist-lease location start end))
       graph)))
 

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -12,11 +12,78 @@
          (trimmed (string-right-trim "/" (namestring dir))))
     (uiop:ensure-directory-pathname (concatenate 'string trimmed "-shadow"))))
 
+(defparameter *sparse-copy-chunk-size* (* 1024 1024)
+  "Octets per read/write in %COPY-FILE-SPARSE.  1MB: big enough that the
+per-chunk overhead is negligible, small enough that a single dirty
+region near the end of an otherwise-empty multi-GB reservation doesn't
+force writing the whole file (GH #170).")
+
+(defun %all-zero-p (buffer count zero-buffer)
+  "True when the first COUNT octets of BUFFER are all zero, compared
+against a same-sized, once-allocated ZERO-BUFFER (GH #170)."
+  (not (mismatch buffer zero-buffer :end1 count :end2 count)))
+
+(defun %copy-file-sparse (source destination)
+  "Copy SOURCE to DESTINATION preserving holes: read in
+*SPARSE-COPY-CHUNK-SIZE* octet chunks; an all-zero chunk is never
+WRITE-SEQUENCEd, only skipped over via FILE-POSITION on the (freshly
+created, hence already-zero) output -- seeking past unwritten bytes on
+a fresh file leaves a hole instead of materializing them, which is the
+entire point (see %COPY-DIRECTORY-TREE's docstring for why this
+matters).  A bare seek never extends a file's on-disk length by itself
+though (that needs an actual write at or past the target offset), so if
+the copy ends in a skipped region DESTINATION would come up short --
+handled by writing SOURCE's final byte whenever the last chunk
+processed was skipped, which is a no-op when the last chunk was
+written (the write already reached the true end) and otherwise pins
+DESTINATION to SOURCE's exact length with one extra byte written (GH
+#170)."
+  (let* ((chunk-size *sparse-copy-chunk-size*)
+         (buffer (make-array chunk-size :element-type '(unsigned-byte 8)))
+         (zero-buffer (make-array chunk-size :element-type '(unsigned-byte 8)
+                                  :initial-element 0))
+         (length 0)
+         (last-chunk-skipped-p nil))
+    (with-open-file (in source :element-type '(unsigned-byte 8))
+      (setf length (file-length in))
+      (with-open-file (out destination :direction :output
+                           :element-type '(unsigned-byte 8)
+                           :if-exists :supersede :if-does-not-exist :create)
+        (loop
+          (let ((n (read-sequence buffer in)))
+            (when (zerop n) (return))
+            (cond
+              ((%all-zero-p buffer n zero-buffer)
+               ;; FILE-POSITION is a FUNCTION, not a SETF place: call it
+               ;; with the new position as a second argument.
+               (file-position out (+ (file-position out) n))
+               (setf last-chunk-skipped-p t))
+              (t
+               (write-sequence buffer out :end n)
+               (setf last-chunk-skipped-p nil)))))
+        ;; Pin the apparent LENGTH (see docstring): only needed when the
+        ;; copy ends in a hole -- if the last chunk was written, the
+        ;; write itself already put OUT at LENGTH.
+        (when (and last-chunk-skipped-p (plusp length))
+          (file-position out (1- length))
+          (write-byte 0 out))))
+    destination))
+
 (defun %copy-directory-tree (source destination)
-  "Plain recursive file copy, SOURCE to DESTINATION.  Called only while
-the store is closed, so there are no mmap hazards.  NO shell-outs --
-UIOP:COLLECT-SUB*DIRECTORIES walks SOURCE and UIOP:COPY-FILE moves each
-file (GH #170)."
+  "Recursive file copy, SOURCE to DESTINATION, preserving sparse holes
+via %COPY-FILE-SPARSE.  Called only while the store is closed, so there
+are no mmap hazards.  NO shell-outs -- UIOP:COLLECT-SUB*DIRECTORIES
+walks SOURCE.
+
+Load-bearing, not an optimization: a fresh, empty store already reserves
+twelve ~1000MB mmap regions (heap.dat, indexes.dat, and a table.dat +
+overflow.dat pair in each of the 5 lhash directories) that are almost
+entirely unwritten zero bytes -- ~12GB apparent for ~0MB of real data. A
+byte-for-byte copy (the previous UIOP:COPY-FILE implementation)
+materializes every one of those holes, writing the full 12GB to disk per
+shadow of an EMPTY store, worse for a store with real data in it. That
+breaks the spec's \"copies in seconds\" premise and can exhaust disk
+outright (GH #170)."
   (let ((source (uiop:ensure-directory-pathname source))
         (destination (uiop:ensure-directory-pathname destination)))
     (ensure-directories-exist destination)
@@ -26,7 +93,7 @@ file (GH #170)."
        (ensure-directories-exist
         (merge-pathnames (uiop:enough-pathname dir source) destination))
        (dolist (file (uiop:directory-files dir))
-         (uiop:copy-file
+         (%copy-file-sparse
           file
           (merge-pathnames (uiop:enough-pathname file source) destination)))))
     destination))

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -186,13 +186,17 @@ OPEN-GRAPH is required."
                      (shadow-recovery-failed-recovery c)))))
 
 (defun %reopen-and-resume (name location clock reason)
-  "OPEN-GRAPH + ATTACH-TO-SYSTEM-CLOCK + %SET-ACCEPTING-P REASON --
+  "OPEN-GRAPH :INITIAL-ACCEPTING-STATE REASON + ATTACH-TO-SYSTEM-CLOCK --
 the resume sequence shared by SHADOW-STORE's happy path and its
-copy-failure recovery path (GH #170)."
+copy-failure recovery path.  REASON is applied to the fresh transaction
+manager BEFORE the graph publishes to *GRAPHS*, not flipped after open
+-- a post-open flip would leave a window where the just-reopened graph
+is fully accepting and a racing writer could land a commit that belongs
+in the doomed generation (GH #170, review finding I4)."
   (let ((reopened (open-graph name (namestring location)
-                              :system-clock nil)))
+                              :system-clock nil
+                              :initial-accepting-state reason)))
     (attach-to-system-clock reopened clock)
-    (%set-accepting-p (transaction-manager reopened) reason)
     reopened))
 
 (defun shadow-store (graph &key (timeout 60))
@@ -219,7 +223,12 @@ round 1).
 Returns (values SHADOW-LOCATION REOPENED-GRAPH) on success.  The live
 store is fully unavailable only for close+copy+reopen -- seconds --
 and write-unavailable until a caller swaps it in or calls
-ABANDON-SHADOW."
+ABANDON-SHADOW.
+
+Refuses a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH with
+DETACH-UNSUPPORTED-GRAPH-ERROR -- v1 scope, see that condition's
+docstring (GH #170)."
+  (%check-detach-supported graph 'shadow-store)
   (let* ((tm (transaction-manager graph))
          (name (graph-name graph))
          (location (location graph))
@@ -235,6 +244,15 @@ via ATTACH-TO-SYSTEM-CLOCK, which needs one."))
     (let ((shadow-location (%shadow-location location)))
       (handler-case
           (progn
+            ;; A stale "<location>-shadow/" from a previous, never-cleaned
+            ;; SHADOW-STORE would otherwise MERGE (%COPY-DIRECTORY-TREE's
+            ;; per-file :SUPERSEDE never clears the destination first) --
+            ;; leftover .txn files there would then be replayed into the
+            ;; fresh shadow on its next open.  Deleted via the same
+            ;; %SHADOW-SUFFIX-P-validated path DISCARD-SHADOW uses (GH
+            ;; #170, review finding I2).
+            (when (probe-file shadow-location)
+              (discard-shadow shadow-location))
             (%copy-directory-tree location shadow-location)
             (let ((reopened (%reopen-and-resume name location clock
                                                 :read-only)))
@@ -331,52 +349,69 @@ whose owners have no live nodes yet, has an EMPTY vector-segments table
 nothing to presize, which is not a failure of the hook.  Any allocation
 failure inside PRESIZE-VECTOR-SEGMENT (VECTOR-SEGMENT-CAPACITY-
 EXHAUSTED) propagates unchanged, before OPEN-SHADOW-GRAPH sets up the
-epoch lease below."
+epoch lease below.
+
+The lease (LEASE or lease.dat) and EXPECTED-VECTORS are validated
+BEFORE OPEN-GRAPH runs, and every check made AFTER it (epoch-lease
+exhaustion, PRESIZE-VECTOR-SEGMENT) runs under an UNWIND-PROTECT that
+CLOSE-GRAPHs on any error -- an error exit used to leave the freshly
+opened graph's mmaps held and its .dirty marker set, which made a
+retried OPEN-SHADOW-GRAPH fail on \"not closed properly\" instead of
+just re-raising the original problem (GH #170, review finding M1)."
   (when fast-load
     (let ((policy (store-recovery-policy shadow-location)))
       (unless (eq policy :derivable)
         (error 'fast-load-requires-derivable
                :location shadow-location :policy policy))))
-  (let* ((location
-          (uiop:ensure-directory-pathname shadow-location))
-         (open-args (list graph-name (namestring location)
-                          :shadow-p t :system-clock nil)))
-    (let ((graph (apply #'open-graph
+  (when expected-vectors
+    (check-type expected-vectors (integer 0)))
+  (let* ((location (uiop:ensure-directory-pathname shadow-location))
+         (persisted (and (null lease) (%read-lease location)))
+         (start (if lease (car lease) (getf persisted :lease-start)))
+         (end (if lease (cdr lease) (getf persisted :lease-end))))
+    (unless (and start end)
+      (error "OPEN-SHADOW-GRAPH needs :LEASE (start . end); none was ~
+given and ~A has no lease.dat." location))
+    (let* ((open-args (list graph-name (namestring location)
+                            :shadow-p t :system-clock nil))
+           (graph (apply #'open-graph
                         (if buffer-pool-size
                             (append open-args
                                    (list :buffer-pool-size buffer-pool-size))
-                            open-args))))
-      (when fast-load
-        (setf (wal-suppressed-p graph) t))
-      ;; Presize whatever segments this shadow actually carries (GH #170 Task
-      ;; 5).  An empty VECTOR-SEGMENTS table (no :VECTOR-INDEX owner has data
-      ;; yet) makes this loop a no-op, by design -- see the docstring.
-      (when expected-vectors
-        (check-type expected-vectors (integer 0))
-        (maphash (lambda (key segment)
-                   (declare (ignore key))
-                   (presize-vector-segment segment expected-vectors))
-                 (vector-segments graph)))
-      (let* ((persisted (and (null lease) (%read-lease location)))
-             (start (if lease (car lease) (getf persisted :lease-start)))
-             (end (if lease (cdr lease) (getf persisted :lease-end))))
-        (unless (and start end)
-          (error "OPEN-SHADOW-GRAPH needs :LEASE (start . end); none was ~
-given and ~A has no lease.dat." location))
-        ;; Resume cursor: derived from the shadow's OWN durable state, not
-        ;; persisted -- see the docstring and %PERSIST-LEASE (GH #170, fix
-        ;; round 1).  LOAD-HIGHEST-TRANSACTION-ID is 0 on a shadow that has
-        ;; never committed a write, so NEXT starts at START there.
-        (let ((next (max start (1+ (load-highest-transaction-id graph)))))
-          ;; Half-open [start,end): NEXT == END means fully consumed, not
-          ;; just "at the boundary" -- TM-NEXT-EPOCH's own runtime check
-          ;; uses >= for the same reason (GH #170, fix round 2).
-          (when (>= next end)
-            (error 'epoch-lease-exhausted :name graph-name :end end))
-          (setf (graph-epoch-lease graph)
-                (make-epoch-lease :start start :next next :end end)))
-        (%persist-lease location start end))
-      graph)))
+                            open-args)))
+           (ok nil))
+      (unwind-protect
+          (progn
+            (when fast-load
+              (setf (wal-suppressed-p graph) t))
+            ;; Presize whatever segments this shadow actually carries (GH
+            ;; #170 Task 5).  An empty VECTOR-SEGMENTS table (no
+            ;; :VECTOR-INDEX owner has data yet) makes this loop a no-op,
+            ;; by design -- see the docstring.
+            (when expected-vectors
+              (maphash (lambda (key segment)
+                         (declare (ignore key))
+                         (presize-vector-segment segment expected-vectors))
+                       (vector-segments graph)))
+            ;; Resume cursor: derived from the shadow's OWN durable state,
+            ;; not persisted -- see the docstring and %PERSIST-LEASE (GH
+            ;; #170, fix round 1).  LOAD-HIGHEST-TRANSACTION-ID is 0 on a
+            ;; shadow that has never committed a write, so NEXT starts at
+            ;; START there.
+            (let ((next (max start (1+ (load-highest-transaction-id graph)))))
+              ;; Half-open [start,end): NEXT == END means fully consumed,
+              ;; not just "at the boundary" -- TM-NEXT-EPOCH's own runtime
+              ;; check uses >= for the same reason (GH #170, fix round 2).
+              (when (>= next end)
+                (error 'epoch-lease-exhausted :name graph-name :end end))
+              (setf (graph-epoch-lease graph)
+                    (make-epoch-lease :start start :next next :end end)))
+            (%persist-lease location start end)
+            (setf ok t)
+            graph)
+        (unless ok
+          (let ((*graph* graph))
+            (ignore-errors (close-graph graph :snapshot-p nil))))))))
 
 (defun %require-closed-shadow (shadow-location)
   "Signal a clear error unless SHADOW-LOCATION exists and carries no
@@ -453,6 +488,13 @@ NEW store).  Split out so that HANDLER-CASE reads cleanly."
     (%posix-rename shadow live)
     ;; Completion is THIS point, not the journal record below (#212).
     (setf (aref progress 0) t (aref progress 1) retired-path)
+    ;; The promoted generation's lease.dat (copied in from the shadow) has
+    ;; no meaning once this location is a plain, non-shadow live store --
+    ;; delete it so it cannot be mistaken for a live lease later (GH #170,
+    ;; review finding M2).
+    (ignore-errors
+     (delete-file (merge-pathnames "lease.dat"
+                                   (uiop:ensure-directory-pathname live))))
     (journal-append clock :swap :store name :retired retired-path)
     (let ((new-graph (open-graph name live :system-clock nil)))
       (attach-to-system-clock new-graph clock)
@@ -505,7 +547,12 @@ FAILED, carrying both conditions.
 A failure BETWEEN the two renames is NOT recovered here: the live data
 sits at the retired path and the live location may be missing or
 half-replaced; manual recovery is required.  That crash window is GH
-#171's territory."
+#171's territory.
+
+Refuses a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH with
+DETACH-UNSUPPORTED-GRAPH-ERROR -- v1 scope, see that condition's
+docstring (GH #170)."
+  (%check-detach-supported graph 'swap-in-shadow)
   (let* ((tm (transaction-manager graph))
          (name (graph-name graph))
          (location (location graph))
@@ -524,7 +571,8 @@ clock (GRAPH-SYSTEM-CLOCK is NIL)."))
           (%swap-in-shadow-1 name location shadow-location clock progress)
         (error (original)
           (if (%swap-completed-p progress)
-              ;; Renames + journal already durable: the swap SUCCEEDED.
+              ;; Renames already durable: the swap SUCCEEDED (the :SWAP
+              ;; journal record itself is best-effort, see above).
               ;; Recover onto the NEW generation and return normally.
               (handler-case
                   (let ((recovered (%reopen-and-resume name location clock t)))

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -241,35 +241,46 @@ themselves, not \"dir/\" (GH #170)."
                                       location))))
 
 (define-condition swap-recovered-warning (warning)
-  ;; The renames + :SWAP journal record were durably complete before
-  ;; the follow-up OPEN-GRAPH/ATTACH-TO-SYSTEM-CLOCK failed -- the swap
-  ;; itself SUCCEEDED.  Recovering by reopening the NEW generation and
-  ;; returning it normally is correct; this warning exists so the
-  ;; caller can still notice the reopen hiccup (GH #170, fix round 1).
+  ;; Both renames were durably complete before something after them
+  ;; failed -- the swap itself SUCCEEDED.  Recovering by reopening the
+  ;; NEW generation and returning it normally is correct; this warning
+  ;; exists so the caller can still notice the hiccup.  If ORIGINAL came
+  ;; from JOURNAL-APPEND itself, the :SWAP record may be missing from
+  ;; the clock's journal even though the swap happened -- #212/#171
+  ;; territory (GH #170, fix rounds 1-2).
   ((original :initarg :original :reader swap-recovered-warning-original))
   (:report (lambda (c s)
-             (format s "SWAP-IN-SHADOW's renames and :SWAP journal ~
-record completed, but the follow-up reopen failed (~A); recovered by ~
-reopening the NEW generation instead -- the swap itself succeeded."
+             (format s "SWAP-IN-SHADOW's renames completed, but ~
+something after them failed (~A); recovered by reopening the NEW ~
+generation instead -- the swap itself succeeded, though its :SWAP ~
+journal record may be missing (GH #212) if that is what failed."
                      (swap-recovered-warning-original c)))))
 
 (defun %swap-completed-p (progress)
-  "True when PROGRESS (see %SWAP-IN-SHADOW-1) marks the renames and
-:SWAP journal record already durably complete.  Pulled out as its own
-predicate so the discrimination SWAP-IN-SHADOW's failure handler makes
--- recover onto the OLD store and resignal, vs. recover onto the NEW
-one and return -- is unit-testable on its own (GH #170, fix round 1)."
+  "True when PROGRESS (see %SWAP-IN-SHADOW-1) marks BOTH RENAMES
+already durably complete -- NOT the :SWAP journal record, which is
+best-effort and can fail after the renames without undoing them (GH
+#170 fix round 2, #212).  Pulled out as its own predicate so the
+discrimination SWAP-IN-SHADOW's failure handler makes -- recover onto
+the OLD store and resignal, vs. recover onto the NEW one and return --
+is unit-testable on its own."
   (and (aref progress 0) t))
 
 (defun %swap-in-shadow-1 (name location shadow-location clock progress)
   "The risky middle of SWAP-IN-SHADOW, run after the live store is
 already closed: rename live away, rename shadow in, journal, reopen.
 PROGRESS is a 2-element vector; element 0 is set true and element 1 set
-to RETIRED-PATH the instant both renames and the journal record are
-durably complete -- the caller's HANDLER-CASE uses it to discriminate a
-pre-completion failure (recover the OLD store) from a post-completion
-one (recover the NEW store; the swap already happened) (GH #170, fix
-round 1).  Split out so that HANDLER-CASE reads cleanly."
+to RETIRED-PATH the instant BOTH RENAMES are durably complete -- that,
+not the journal record, is what \"the swap happened\" means (GH #170,
+fix round 2 / #212): the data is only ever un-findable under its old OR
+new name during the renames themselves, and once the second rename
+lands, the live location holds the new generation no matter what
+happens next.  JOURNAL-APPEND runs AFTER the flip and is therefore
+best-effort: a failure there still means the swap succeeded, just
+possibly without a :SWAP record (see SWAP-IN-SHADOW's docstring).  The
+caller's HANDLER-CASE uses PROGRESS to discriminate a pre-completion
+failure (recover the OLD store) from a post-completion one (recover the
+NEW store).  Split out so that HANDLER-CASE reads cleanly."
   (let* ((live (%trimmed-namestring location))
          (shadow (%trimmed-namestring shadow-location))
          (retired-path (format nil "~A-retired-~D" live
@@ -279,8 +290,9 @@ round 1).  Split out so that HANDLER-CASE reads cleanly."
     ;; docstring) -- not recovered here.
     (%posix-rename live retired-path)
     (%posix-rename shadow live)
-    (journal-append clock :swap :store name :retired retired-path)
+    ;; Completion is THIS point, not the journal record below (#212).
     (setf (aref progress 0) t (aref progress 1) retired-path)
+    (journal-append clock :swap :store name :retired retired-path)
     (let ((new-graph (open-graph name live :system-clock nil)))
       (attach-to-system-clock new-graph clock)
       (values new-graph retired-path))))
@@ -305,22 +317,26 @@ cost a read-and-write outage, only a PROBE-FILE and an immediate
 signal -- GRAPH is untouched, ACCEPTING-P never leaves T (GH #170, fix
 round 1).
 
-Two further failure outcomes, discriminated by whether both renames
-and the :SWAP journal record had already completed (see
-%SWAP-IN-SHADOW-1's PROGRESS argument):
+Two further failure outcomes, discriminated by whether BOTH RENAMES
+had already completed (see %SWAP-IN-SHADOW-1's PROGRESS argument) --
+completion is the second rename, NOT the :SWAP journal record after it
+(GH #170, fix round 2 / #212):
 
-- NOT YET COMPLETE (the copy/rename/journal step itself failed): the
-  swap did not happen.  Reopen the OLD store, restore ACCEPTING-P to
-  T, and re-signal the original error, mirroring SHADOW-STORE's
-  copy-failure recovery.
-- ALREADY COMPLETE (only the follow-up OPEN-GRAPH/ATTACH-TO-SYSTEM-
-  CLOCK failed): the swap SUCCEEDED -- the live location already holds
-  the new generation's files.  Resignalling here would be a lie: the
-  caller would conclude the swap didn't happen and could, e.g., retry
-  it against a shadow location that no longer exists.  Instead: reopen
-  the NEW generation, signal SWAP-RECOVERED-WARNING (a WARNING, not an
-  ERROR) carrying the original condition, and RETURN (values NEW-GRAPH
-  RETIRED-PATH) normally (GH #170, fix round 1).
+- NOT YET COMPLETE (a rename itself failed): the swap did not happen.
+  Reopen the OLD store, restore ACCEPTING-P to T, and re-signal the
+  original error, mirroring SHADOW-STORE's copy-failure recovery.
+- ALREADY COMPLETE (the renames landed; JOURNAL-APPEND, OPEN-GRAPH, or
+  ATTACH-TO-SYSTEM-CLOCK failed after them): the swap SUCCEEDED -- the
+  live location already holds the new generation's files.  Resignalling
+  here would be a lie: the caller would conclude the swap didn't happen
+  and could, e.g., retry it against a shadow location that no longer
+  exists.  Instead: reopen the NEW generation, signal
+  SWAP-RECOVERED-WARNING (a WARNING, not an ERROR) carrying the original
+  condition, and RETURN (values NEW-GRAPH RETIRED-PATH) normally.  The
+  :SWAP journal record itself is therefore best-effort once the renames
+  land: if JOURNAL-APPEND is what failed, the swap still succeeded but
+  its journal record may be missing -- a gap for a human or #171's
+  future recovery tooling to notice, tracked as #212.
 
 Either recovery reopen itself failing is unchanged: SHADOW-RECOVERY-
 FAILED, carrying both conditions.

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -98,6 +98,62 @@ outright (GH #170)."
           (merge-pathnames (uiop:enough-pathname file source) destination)))))
     destination))
 
+;;; Recovery policy (GH #170 Task 4).  A store's policy.dat records
+;;; whether its state is DERIVABLE (rebuildable from elsewhere -- a
+;;; shadow copied from a live store's data -- so a crash may discard it)
+;;; or AUTHORED (the only durable record of its writes -- the default,
+;;; and what every pre-#170 store implicitly is).  OPEN-SHADOW-GRAPH
+;;; :FAST-LOAD gates on this alone.
+
+(defun %policy-file (location)
+  (merge-pathnames "policy.dat" (uiop:ensure-directory-pathname location)))
+
+(defun store-recovery-policy (location)
+  "Read LOCATION's recovery policy from policy.dat: :DERIVABLE or
+:AUTHORED.  Absent file means :AUTHORED -- a store predating this
+feature, or one nobody ever opted in, must not be treated as
+derivable.  *READ-EVAL* NIL: untrusted input, same reasoning as
+%READ-LEASE.  A file present but not one of the two keywords is a
+hard error -- silently falling back to :AUTHORED would hide a corrupt
+gate input (GH #170)."
+  (let ((file (%policy-file location)))
+    (if (probe-file file)
+        (with-open-file (in file)
+          (let* ((*read-eval* nil)
+                 (value (read in nil nil)))
+            (unless (member value '(:derivable :authored))
+              (error "~A does not hold a valid recovery policy (expected ~
+:DERIVABLE or :AUTHORED, read ~S)." file value))
+            value))
+        :authored)))
+
+(defun set-store-recovery-policy (location policy)
+  "Write POLICY (:DERIVABLE or :AUTHORED) readably to LOCATION's
+policy.dat.  Errors on any other value -- this file is the sole gate
+input for OPEN-SHADOW-GRAPH's :FAST-LOAD, so a bad value must not
+silently authorize the WAL-free path (GH #170)."
+  (unless (member policy '(:derivable :authored))
+    (error "SET-STORE-RECOVERY-POLICY: POLICY must be :DERIVABLE or ~
+:AUTHORED, got ~S." policy))
+  (with-open-file (out (%policy-file location)
+                       :direction :output :if-exists :supersede
+                       :if-does-not-exist :create)
+    (let ((*print-readably* nil) (*print-pretty* nil))
+      (prin1 policy out)))
+  policy)
+
+(define-condition fast-load-requires-derivable (error)
+  ;; The whole safety story for :FAST-LOAD: an :AUTHORED store's shadow
+  ;; is the only durable record of anything written into it, so skipping
+  ;; the WAL there would silently discard data on a crash (GH #170).
+  ((location :initarg :location :reader fast-load-requires-derivable-location)
+   (policy :initarg :policy :reader fast-load-requires-derivable-policy))
+  (:report (lambda (c s)
+             (format s "OPEN-SHADOW-GRAPH :FAST-LOAD T requires the ~
+source store's recovery policy to be :DERIVABLE; ~A carries ~S."
+                     (fast-load-requires-derivable-location c)
+                     (fast-load-requires-derivable-policy c)))))
+
 (defun %shadow-suffix-p (path)
   "True when PATH's directory name ends in \"-shadow\" -- the entire
 safety story for DISCARD-SHADOW, which deletes trees (GH #170)."
@@ -245,15 +301,27 @@ this open -- EPOCH-LEASE-EXHAUSTED is signalled immediately rather than
 quietly wrapping, reusing an id, or deferring the failure to the first
 write (GH #170, fix round 2).
 
-FAST-LOAD and EXPECTED-VECTORS are Task 4/5 hooks: accepted here, but
-using either signals a clear \"arrives in a later task\" error rather
-than silently doing nothing."
-  (when fast-load
-    (error "OPEN-SHADOW-GRAPH :FAST-LOAD is a Task 4 hook and is not ~
-implemented yet (GH #170)."))
+FAST-LOAD (GH #170 Task 4): skip the .txn file and replication log for
+every transaction committed against the returned graph -- the shadow's
+heap/index writes are its only durable record until a later SWAP-IN-
+SHADOW or DISCARD-SHADOW, so this is only safe when the SOURCE store's
+recovery policy is :DERIVABLE (checked via STORE-RECOVERY-POLICY on
+SHADOW-LOCATION -- the shadow dir carries the copied policy.dat, so
+that copy is the gate input, not a fresh read of the live store).
+:AUTHORED (including the no-policy-file default) signals
+FAST-LOAD-REQUIRES-DERIVABLE instead of silently keeping the WAL.
+
+EXPECTED-VECTORS is a Task 5 hook: accepted here, but using it signals
+a clear \"arrives in a later task\" error rather than silently doing
+nothing."
   (when expected-vectors
     (error "OPEN-SHADOW-GRAPH :EXPECTED-VECTORS is a Task 5 hook and is ~
 not implemented yet (GH #170)."))
+  (when fast-load
+    (let ((policy (store-recovery-policy shadow-location)))
+      (unless (eq policy :derivable)
+        (error 'fast-load-requires-derivable
+               :location shadow-location :policy policy))))
   (let* ((location
           (uiop:ensure-directory-pathname shadow-location))
          (open-args (list graph-name (namestring location)
@@ -263,6 +331,8 @@ not implemented yet (GH #170)."))
                             (append open-args
                                    (list :buffer-pool-size buffer-pool-size))
                             open-args))))
+      (when fast-load
+        (setf (wal-suppressed-p graph) t))
       (let* ((persisted (and (null lease) (%read-lease location)))
              (start (if lease (car lease) (getf persisted :lease-start)))
              (end (if lease (cdr lease) (getf persisted :lease-end))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1,0 +1,155 @@
+;;;; The detach quiescence protocol (GH #170): a store refuses new
+;;;; transactions and read pins, drains what is already in flight, leases
+;;;; itself an epoch range from its system clock, journals the handoff,
+;;;; and closes durably -- then can be reopened and rejoined later.
+(in-package #:graph-db/test)
+
+(def-suite detach-suite :in graph-db-suite
+  :description "Quiescence, DETACH-STORE, and REATTACH-STORE.")
+(in-suite detach-suite)
+
+(defmacro with-clocked-store ((g clock sys) &body body)
+  "One disk store, under a fresh *SYSTEM-DIRECTORY*, attached to its own
+system clock -- the fixture DETACH-STORE / REATTACH-STORE need, adapted
+from TESTS/SYSTEM-CLOCK-TESTS.LISP's
+TWO-STORES-ON-ONE-CLOCK-GET-DISJOINT-ORDERED-EPOCHS."
+  (let ((cdir (gensym)) (ddir (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,cdir)
+         (with-temp-directory (,ddir)
+           (let ((graph-db::*system-directory* (namestring ,sys))
+                 (graph-db::*store-registry* nil))
+             (let ((,clock (open-system-clock (namestring ,cdir))))
+               (unwind-protect
+                    (let ((,g (make-graph :detach-store-1
+                                          (namestring ,ddir)
+                                          :buffer-pool-size 1000
+                                          :system-clock ,clock)))
+                      (unwind-protect (progn ,@body)
+                        (when (graph-db::graph-open-p ,g)
+                          (let ((graph-db:*graph* ,g))
+                            (ignore-errors
+                             (close-graph ,g :snapshot-p nil))))
+                        (collect-garbage)))
+                 (close-system-clock ,clock)))))))))
+
+(test detach-refuses-new-transactions-and-pins
+  "During and after quiesce, a NEW transaction and a NEW read pin both
+signal STORE-NOT-ACCEPTING-ERROR.  Nearest wrong implementation: close
+without refusing -- the segfault-shaped hazard the spec names."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let ((detachment (graph-db:detach-store g)))
+      (is (graph-db::store-detachment-p detachment))
+      (signals graph-db:store-not-accepting-error
+        (with-transaction ((graph-db::transaction-manager g))
+          (graph-db:make-vertex :generic nil :graph g)))
+      (signals graph-db:store-not-accepting-error
+        (graph-db:pin-read-epoch (graph-db::transaction-manager g))))))
+
+(test detach-drains-in-flight-readers-first
+  "A pinned reader taken BEFORE detach holds the drain; detach completes
+only after the pin is released.  Mechanism: take a pin, start
+DETACH-STORE in a second thread, assert it has NOT completed while the
+pin is held, release the pin, join, assert detached."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let* ((tm (graph-db::transaction-manager g))
+           (pin (graph-db:pin-read-epoch tm))
+           (done nil)
+           (result nil)
+           (thread (bt:make-thread
+                    (lambda ()
+                      (setq result (graph-db:detach-store g :timeout 5))
+                      (setq done t)))))
+      (unwind-protect
+           (progn
+             (sleep 0.3)
+             (is (not done) "detach must not complete while the pin holds")
+             (graph-db:unpin-read-epoch tm pin)
+             (bt:join-thread thread)
+             (is-true done)
+             (is (graph-db::store-detachment-p result))
+             (is (not (graph-db::graph-open-p g))))
+        (ignore-errors (bt:join-thread thread))))
+    clock))
+
+(test detach-timeout-restores-service
+  "A drain that cannot complete times out, signals
+DETACH-DRAIN-TIMEOUT, and the store ACCEPTS transactions again -- a
+failed detach must not strand the store half-dead."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let* ((tm (graph-db::transaction-manager g))
+           (pin (graph-db:pin-read-epoch tm)))
+      (unwind-protect
+           (signals graph-db:detach-drain-timeout
+             (graph-db:detach-store g :timeout 1))
+        (graph-db:unpin-read-epoch tm pin))
+      (is (eq t (graph-db:accepting-p tm)))
+      (with-transaction (tm)
+        (graph-db:make-vertex :generic nil :graph g)))))
+
+(test detach-journals-and-leases
+  "The clock journal records :detach with the lease range; the clock's
+next epoch is past LEASE-END (CLOCK-LEASE-EPOCHS semantics)."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (graph-db:detach-store g :lease-epochs 100)
+    (let* ((records (journal-records clock))
+           (record (find :detach records :key (lambda (r) (getf r :kind)))))
+      (is-true record)
+      (is-true (getf record :lease-start))
+      (is-true (getf record :lease-end))
+      (is (>= (clock-current-epoch clock) (getf record :lease-end))))))
+
+(test detached-store-is-detached-to-the-resolver
+  "#169 integration: after DETACH-STORE, RESOLVE-NODE-GRAPH on a node id
+minted there reports :DETACHED and LOOKUP-VERTEX-ANYWHERE returns the
+marker."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (let (v)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq v (graph-db:make-vertex :generic nil :graph g)))
+      (graph-db:detach-store g)
+      (is (eq :detached (nth-value 1 (graph-db:resolve-node-graph (id v)))))
+      (is (graph-db:unresolved-node-p
+           (graph-db:lookup-vertex-anywhere (id v)))))))
+
+(test reattach-restores-service-and-journals
+  "REATTACH-STORE reopens, the same node reads back, a new write
+succeeds, and the journal carries the :attach record after the :detach
+one."
+  (with-clocked-store (g clock sys)
+    sys
+    (let (v vid)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq v (graph-db:make-vertex :generic nil :graph g)))
+      (setq vid (id v))
+      (let ((detachment (graph-db:detach-store g))
+            (*system-clock* clock))
+        (let ((g2 (graph-db:reattach-store detachment)))
+          (unwind-protect
+               (progn
+                 (is (graph-db::vertex-p (lookup-vertex vid :graph g2)))
+                 (with-transaction ((graph-db::transaction-manager g2))
+                   (graph-db:make-vertex :generic nil :graph g2))
+                 (let* ((records (journal-records clock))
+                        (kinds (mapcar (lambda (r) (getf r :kind)) records))
+                        (detach-pos (position :detach kinds))
+                        (attach-pos (position :attach kinds
+                                              :from-end t)))
+                   (is-true detach-pos)
+                   (is-true attach-pos)
+                   (is (< detach-pos attach-pos))))
+            (let ((graph-db:*graph* g2))
+              (ignore-errors (close-graph g2 :snapshot-p nil)))))))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1449,3 +1449,84 @@ meaning once the location is a plain, non-shadow live store."
          (uiop:delete-directory-tree
           (uiop:ensure-directory-pathname retired-path)
           :validate t :if-does-not-exist :ignore))))))
+
+;;; Round 2 (GH #170 re-review): I4's TM-before-registration reorder
+;;; introduced a NEW critical -- the fresh TX-ID-COUNTER is seeded from
+;;; LOAD-HIGHEST-TRANSACTION-ID before RECOVER-TRANSACTIONS runs, but
+;;; recovery's APPLY-TRANSACTION persists a HIGHER watermark to disk
+;;; without ever touching TX-ID-COUNTER.  Engine-wide (any plain,
+;;; non-clocked store with a crash-recovery WAL tail), and invisible to
+;;; the gate before this: there was no crash-recovery test at all.
+
+(test crash-recovery-reseeds-the-tx-id-watermark
+  "A plain (non-clocked) on-disk graph: commit two transactions, the
+second with *DELETE-COMMITTED-TRANSACTION-FILES* NIL so its .txn file
+survives as .committed instead of being deleted, then close cleanly.
+Fabricate a crash: rename the survived .committed file back to .txn (a
+WAL tail RECOVER-TRANSACTIONS will replay -- idempotent via
+*ADD-TO-INDEXES-UNLESS-PRESENT-P*, the flag documented for exactly this
+case), and REWIND transaction-id.dat (via the same
+PERSIST-HIGHEST-TRANSACTION-ID writer) to the FIRST transaction's id --
+simulating a crash between FINALIZE-TX-PERSISTENCE (durable .txn) and
+APPLY-TRANSACTION (which would have advanced the persisted watermark).
+Plant then clear .dirty, mirroring RECOVERY-FROM-DIRTY-MARKER, and
+reopen (recovery runs). A transaction committed after that open must
+mint an id STRICTLY GREATER than the replayed transaction's id, not
+just past the stale pre-recovery watermark.
+
+ABLATION (recorded, not re-run here): removing OPEN-GRAPH's re-seed
+after RECOVER-TRANSACTIONS makes the final (> new-id id-b) assertion
+fail -- the new transaction mints ID-A+1, which is <= ID-B."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil)
+            (path (namestring dir))
+            id-a id-b)
+        (let ((g (make-graph :gh-170-round2-recovery path
+                             :buffer-pool-size 1000))
+              va vb)
+          ;; COMMIT-EPOCH is stamped at the END of the WITH-TRANSACTION
+          ;; body, not when the node is created -- read it only AFTER the
+          ;; block (same idiom as SHADOW-LEASE-RESUMES-FROM-ITS-OWN-
+          ;; WATERMARK above), or it is still the pre-commit default 0.
+          (with-transaction ((graph-db::transaction-manager g))
+            (setq va (graph-db:make-vertex :generic nil :graph g)))
+          (setq id-a (graph-db::commit-epoch va))
+          (let ((graph-db::*delete-committed-transaction-files* nil))
+            (with-transaction ((graph-db::transaction-manager g))
+              (setq vb (graph-db:make-vertex :generic nil :graph g)))
+            (setq id-b (graph-db::commit-epoch vb)))
+          (let ((graph-db:*graph* g))
+            (close-graph g :snapshot-p nil))
+          ;; Fabricate the crash shape.
+          (let* ((tx-dir (graph-db::persistent-transaction-directory g))
+                 (committed-files
+                  (directory (merge-pathnames "*.committed" tx-dir)))
+                 (dirty (format nil "~A/.dirty" path)))
+            (is (= 1 (length committed-files))
+                "sanity: exactly the second commit's .txn survived as ~
+.committed")
+            (rename-file (first committed-files)
+                         (make-pathname :type "txn"
+                                        :defaults (first committed-files)))
+            (graph-db::persist-highest-transaction-id id-a g)
+            (is (= id-a (graph-db::load-highest-transaction-id g))
+                "sanity: the watermark file is now stale")
+            (with-open-file (out dirty :direction :output
+                                :if-exists :supersede
+                                :if-does-not-exist :create)
+              (format out "~S" (get-universal-time)))
+            (delete-file dirty)))
+        (let ((g2 (open-graph :gh-170-round2-recovery path)))
+          (unwind-protect
+               (let (id-c vc)
+                 (with-transaction ((graph-db::transaction-manager g2))
+                   (setq vc (graph-db:make-vertex :generic nil :graph g2)))
+                 (setq id-c (graph-db::commit-epoch vc))
+                 (is (> id-c id-b)
+                     "a post-recovery transaction must mint an id past ~
+every replayed id, not just the pre-recovery watermark (got ~D, ~
+replayed id was ~D)" id-c id-b))
+            (let ((graph-db:*graph* g2))
+              (ignore-errors (close-graph g2 :snapshot-p nil)))))))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -199,3 +199,169 @@ what guarantees its absence on every run."
       (is (plusp refusals) "the hammer thread must see the refusal")
       (is (zerop (hash-table-count (graph-db::read-pins tm)))
           "no straggler pin admitted after drain success"))))
+
+;;; Shadow generations (GH #170 Task 2).
+
+(test shadow-copy-is-consistent-and-reads-resume
+  "SHADOW-STORE makes a consistent copy while the live store resumes
+serving reads once it reopens; OPEN-SHADOW-GRAPH sees the same data."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g)
+      (graph-db:make-vertex :generic nil :graph g)
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (progn
+             (is-true (probe-file shadow-location))
+             (let* ((tm2 (graph-db::transaction-manager g2))
+                    (pin (graph-db:pin-read-epoch tm2))
+                    (count nil))
+               (unwind-protect
+                    (setq count (length (graph-db:map-vertices
+                                         #'identity g2 :collect-p t)))
+                 (graph-db:unpin-read-epoch tm2 pin))
+               (is (= 3 count)))
+             (multiple-value-bind (start end)
+                 (graph-db:clock-lease-epochs clock 1000)
+               (let ((sg (graph-db:open-shadow-graph
+                          shadow-location :detach-store-1
+                          :lease (cons start end))))
+                 (unwind-protect
+                      (is (= 3 (length (graph-db:map-vertices
+                                       #'identity sg :collect-p t))))
+                   (let ((graph-db:*graph* sg))
+                     (ignore-errors (close-graph sg :snapshot-p nil)))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test live-store-is-read-only-during-the-shadow-window
+  "Kevin's ruling: after SHADOW-STORE a new write on the live graph
+signals STORE-NOT-ACCEPTING-ERROR reason :SHADOW-LOAD while
+PIN-READ-EPOCH keeps succeeding; ABANDON-SHADOW restores writes."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (let ((tm2 (graph-db::transaction-manager g2)))
+             (handler-case
+                 (progn
+                   (with-transaction (tm2)
+                     (graph-db:make-vertex :generic nil :graph g2))
+                   (fail "write must be refused during the shadow window"))
+               (graph-db:store-not-accepting-error (c)
+                 (is (eq :shadow-load
+                         (graph-db:store-not-accepting-reason c)))))
+             (let ((pin (graph-db:pin-read-epoch tm2)))
+               (graph-db:unpin-read-epoch tm2 pin))
+             (graph-db:abandon-shadow g2 shadow-location)
+             (is (not (probe-file shadow-location)))
+             (with-transaction (tm2)
+               (graph-db:make-vertex :generic nil :graph g2)))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test shadow-is-unregistered
+  "While a shadow is open: *GRAPHS* has no second entry, the open-store
+vector still maps the store-id to the LIVE graph, and RESOLVE-NODE-GRAPH
+on a shadow-minted id resolves to the LIVE graph."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 1000)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end))))
+               (unwind-protect
+                    (progn
+                      (is (= 1 (hash-table-count graph-db::*graphs*)))
+                      (is (eq g2 (gethash :detach-store-1 graph-db::*graphs*)))
+                      (is (eq g2 (svref graph-db::*store-id->graph*
+                                       (graph-db::store-id g2))))
+                      (let (vid)
+                        (with-transaction ((graph-db::transaction-manager sg))
+                          (setq vid (id (graph-db:make-vertex
+                                        :generic nil :graph sg))))
+                        (is (eq g2 (graph-db:resolve-node-graph vid)))))
+                 (let ((graph-db:*graph* sg))
+                   (ignore-errors (close-graph sg :snapshot-p nil))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test shadow-writes-draw-from-the-lease
+  "A node written in the shadow gets a transaction id within
+[lease-start, lease-end); exhausting a tiny lease signals
+EPOCH-LEASE-EXHAUSTED. Nearest wrong implementation: shadow ids from
+the store's own counter -- colliding with the live store's writes."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 3)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end))))
+               (unwind-protect
+                    (progn
+                      (let (v)
+                        (with-transaction ((graph-db::transaction-manager sg))
+                          (setq v (graph-db:make-vertex
+                                  :generic nil :graph sg)))
+                        (is (<= start (graph-db::commit-epoch v)))
+                        (is (< (graph-db::commit-epoch v) end)))
+                      (signals graph-db:epoch-lease-exhausted
+                        (dotimes (i 5)
+                          (with-transaction ((graph-db::transaction-manager sg))
+                            (graph-db:make-vertex :generic nil :graph sg)))))
+                 (let ((graph-db:*graph* sg))
+                   (ignore-errors (close-graph sg :snapshot-p nil))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test lease-survives-in-the-shadow-directory
+  "lease.dat exists in the shadow dir and reads back the exact range --
+the out-of-process survival requirement (GH #170 comment)."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 1000)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end))))
+               (let ((graph-db:*graph* sg))
+                 (ignore-errors (close-graph sg :snapshot-p nil))))
+             (let ((file (merge-pathnames
+                          "lease.dat"
+                          (uiop:ensure-directory-pathname shadow-location))))
+               (is-true (probe-file file))
+               (let (form)
+                 (with-open-file (in file)
+                   (let ((*read-eval* nil))
+                     (setq form (read in))))
+                 (is (= start (getf form :lease-start)))
+                 (is (= end (getf form :lease-end))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test discard-shadow-refuses-non-shadow-paths
+  "THE deletion-safety test: DISCARD-SHADOW refuses any path that does
+not end in \"-shadow\" -- it deletes trees, and this guard is the whole
+safety story."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (signals error (graph-db:discard-shadow (graph-db::location g)))
+    (is-true (probe-file (graph-db::location g)))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -357,6 +357,234 @@ the out-of-process survival requirement (GH #170 comment)."
         (let ((graph-db:*graph* g2))
           (ignore-errors (close-graph g2 :snapshot-p nil)))))))
 
+;;; Swap (GH #170 Task 3).
+
+(defun %directory-file-hashes (dir)
+  "Map of relative-path-string -> sha256 digest, every regular file
+under DIR.  Test-only byte-identity tool (GH #170)."
+  (let ((root (uiop:ensure-directory-pathname dir))
+        (table (make-hash-table :test 'equal)))
+    (uiop:collect-sub*directories
+     root t t
+     (lambda (subdir)
+       (dolist (file (uiop:directory-files subdir))
+         (setf (gethash (namestring (uiop:enough-pathname file root)) table)
+               (ironclad:digest-file :sha256 file)))))
+    table))
+
+(defun %directory-diff (before after)
+  "(values ONLY-BEFORE ONLY-AFTER CHANGED), relative-path lists, comparing
+two %DIRECTORY-FILE-HASHES tables (GH #170)."
+  (let (only-before only-after changed)
+    (maphash (lambda (k v)
+               (multiple-value-bind (v2 present) (gethash k after)
+                 (cond ((not present) (push k only-before))
+                       ((not (equalp v v2)) (push k changed)))))
+             before)
+    (maphash (lambda (k v)
+               (declare (ignore v))
+               (unless (nth-value 1 (gethash k before))
+                 (push k only-after)))
+             after)
+    (values only-before only-after changed)))
+
+(defun %measured-exclusions (before after)
+  "Derive an exclusion set for a REPEAT of the SAME round trip from a
+%DIRECTORY-DIFF of one sample round trip.  A bare top-level file (no
+\"/\") is excluded by its exact name (e.g. \".dirty\"); a file inside a
+subdirectory is excluded by DIRECTORY PREFIX instead of its literal
+name, because SNAPSHOT mints a fresh UUID'd filename under txn-log/ on
+every close -- an exact-name exclusion would never match twice (GH
+#170)."
+  (let (exclusions)
+    (multiple-value-bind (ob oa ch) (%directory-diff before after)
+      (dolist (path (append ob oa ch))
+        (let ((slash (position #\/ path :from-end t)))
+          (pushnew (if slash (subseq path 0 (1+ slash)) path)
+                   exclusions :test #'equal))))
+    exclusions))
+
+(defun %excluded-p (path exclusions)
+  "True when PATH is covered by EXCLUSIONS: an exact match for a
+top-level exclusion, or a prefix match for a directory exclusion (one
+ending in \"/\") (GH #170)."
+  (some (lambda (ex)
+          (if (find #\/ ex)
+              (and (<= (length ex) (length path))
+                   (string= ex path :end2 (length ex)))
+              (string= ex path)))
+        exclusions))
+
+(test swap-in-shadow-end-to-end
+  "THE acceptance scenario: data A on the live store; SHADOW-STORE;
+OPEN-SHADOW-GRAPH; write data B into the shadow; MEANWHILE the live
+store serves a read and refuses a write reason :SHADOW-LOAD; close the
+shadow; SWAP-IN-SHADOW; the new graph serves A+B and accepts a fresh
+write; the retired dir exists; the journal carries :SWAP and :ATTACH."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (multiple-value-bind (start end)
+          (graph-db:clock-lease-epochs clock 1000)
+        (let ((sg (graph-db:open-shadow-graph
+                   shadow-location :detach-store-1
+                   :lease (cons start end))))
+          (with-transaction ((graph-db::transaction-manager sg))
+            (graph-db:make-vertex :generic nil :graph sg))
+          (with-transaction ((graph-db::transaction-manager sg))
+            (graph-db:make-vertex :generic nil :graph sg))
+          ;; DURING the load: live serves a read, refuses a write.
+          (let ((tm2 (graph-db::transaction-manager g2)))
+            (let ((pin (graph-db:pin-read-epoch tm2)))
+              (graph-db:unpin-read-epoch tm2 pin))
+            (handler-case
+                (progn
+                  (with-transaction (tm2)
+                    (graph-db:make-vertex :generic nil :graph g2))
+                  (fail "write must be refused during the shadow window"))
+              (graph-db:store-not-accepting-error (c)
+                (is (eq :shadow-load (graph-db:store-not-accepting-reason c))))))
+          (let ((graph-db:*graph* sg))
+            (close-graph sg :snapshot-p nil))))
+      (multiple-value-bind (new-graph retired-path)
+          (graph-db:swap-in-shadow g2 shadow-location)
+        (setq g new-graph)
+        (is-true (probe-file retired-path))
+        (is (= 3 (length (graph-db:map-vertices
+                          #'identity new-graph :collect-p t))))
+        (with-transaction ((graph-db::transaction-manager new-graph))
+          (graph-db:make-vertex :generic nil :graph new-graph))
+        (let* ((records (journal-records clock))
+               (kinds (mapcar (lambda (r) (getf r :kind)) records)))
+          (is-true (member :swap kinds))
+          (is-true (member :attach kinds)))
+        (ignore-errors
+         (uiop:delete-directory-tree
+          (uiop:ensure-directory-pathname retired-path)
+          :validate t :if-does-not-exist :ignore))))))
+
+(test swap-failure-before-rename-restores-service
+  "A nonexistent shadow location fails SWAP-IN-SHADOW before the first
+rename; the live store is reopened (or was never closed) and still
+serves reads and writes."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let ((nonexistent (merge-pathnames
+                        "nope-shadow/"
+                        (uiop:ensure-directory-pathname
+                         (graph-db::location g)))))
+      (signals error (graph-db:swap-in-shadow g nonexistent))
+      (let* ((name (graph-db:graph-name g))
+             (g2 (graph-db:lookup-graph name))
+             (tm2 (graph-db::transaction-manager g2)))
+        (is-true g2)
+        (is (graph-db::graph-open-p g2))
+        (is (eq t (graph-db:accepting-p tm2)))
+        (let ((pin (graph-db:pin-read-epoch tm2)))
+          (graph-db:unpin-read-epoch tm2 pin))
+        (with-transaction (tm2)
+          (graph-db:make-vertex :generic nil :graph g2))
+        (setq g g2)))))
+
+(test killed-loader-leaves-live-byte-identical
+  "ABANDON-SHADOW is the discard path exercised here; it must also
+restore write service.  Nearest wrong implementation: the loader writes
+into the live mmaps -- heap.dat diverges.  The exclusion list (files a
+bare round trip legitimately touches, e.g. .dirty) is MEASURED here
+first, from a bare SHADOW-STORE/ABANDON-SHADOW round trip on this same
+store, not asserted."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let* ((location (graph-db::location g))
+           (snap0 (%directory-file-hashes location)))
+      ;; Measure: a bare round trip, no write into the shadow, so any
+      ;; diff on the live dir is purely the close+reopen the live store
+      ;; itself goes through.
+      (multiple-value-bind (shadow1 g1) (graph-db:shadow-store g)
+        (graph-db:abandon-shadow g1 shadow1)
+        (setq g g1))
+      (let* ((snap1 (%directory-file-hashes location))
+             (exclusions (%measured-exclusions snap0 snap1)))
+        (is (member ".dirty" exclusions :test #'equal)
+            "the bare round trip is expected to touch .dirty")
+        ;; Real scenario: shadow, write garbage, kill the loader (never
+        ;; close its handle), ABANDON-SHADOW.
+        (multiple-value-bind (shadow2 g2) (graph-db:shadow-store g)
+          (multiple-value-bind (start end)
+              (graph-db:clock-lease-epochs clock 1000)
+            (let ((sg (graph-db:open-shadow-graph
+                       shadow2 :detach-store-1 :lease (cons start end))))
+              (with-transaction ((graph-db::transaction-manager sg))
+                (graph-db:make-vertex :generic nil :graph sg))))
+          (graph-db:abandon-shadow g2 shadow2)
+          (setq g g2)
+          (is (not (probe-file shadow2)))
+          (let ((snap2 (%directory-file-hashes location)))
+            (multiple-value-bind (ob oa ch) (%directory-diff snap1 snap2)
+              (flet ((uncovered (paths)
+                       (remove-if (lambda (p) (%excluded-p p exclusions))
+                                  paths)))
+                (is (null (uncovered ob))
+                    "files disappeared beyond the measured exclusion list")
+                (is (null (uncovered oa))
+                    "files appeared beyond the measured exclusion list")
+                (is (null (uncovered ch))
+                    "file content changed beyond the measured exclusion list"))))
+          (with-transaction ((graph-db::transaction-manager g2))
+            (graph-db:make-vertex :generic nil :graph g2)))))))
+
+(test swap-in-shadow-drains-in-flight-readers-first
+  "A pin held on the LIVE store across SWAP-IN-SHADOW delays it, same
+drain mechanism as DETACH-DRAINS-IN-FLIGHT-READERS-FIRST -- confirms
+SWAP-IN-SHADOW really quiesces rather than closing straight away."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (multiple-value-bind (start end)
+          (graph-db:clock-lease-epochs clock 1000)
+        (let ((sg (graph-db:open-shadow-graph
+                   shadow-location :detach-store-1
+                   :lease (cons start end))))
+          (let ((graph-db:*graph* sg))
+            (close-graph sg :snapshot-p nil))))
+      (let* ((tm2 (graph-db::transaction-manager g2))
+             (pin (graph-db:pin-read-epoch tm2))
+             (done nil)
+             (result nil)
+             ;; SWAP-IN-SHADOW reopens (OPEN-GRAPH), which needs
+             ;; *SYSTEM-DIRECTORY*/*STORE-REGISTRY* -- dynamic bindings
+             ;; from WITH-CLOCKED-STORE's LET do not cross to a new
+             ;; thread, so re-bind explicitly here (GH #170).
+             (sysdir graph-db::*system-directory*)
+             (registry graph-db::*store-registry*)
+             (thread (bt:make-thread
+                      (lambda ()
+                        (let ((graph-db::*system-directory* sysdir)
+                              (graph-db::*store-registry* registry))
+                          (setq result (graph-db:swap-in-shadow
+                                       g2 shadow-location))
+                          (setq done t))))))
+        (unwind-protect
+             (progn
+               (sleep 0.3)
+               (is (not done)
+                   "swap-in-shadow must not complete while a live pin holds")
+               (graph-db:unpin-read-epoch tm2 pin)
+               (bt:join-thread thread)
+               (is-true done)
+               (with-transaction ((graph-db::transaction-manager result))
+                 (graph-db:make-vertex :generic nil :graph result))
+               (setq g result))
+          (ignore-errors (bt:join-thread thread)))))))
+
 (test discard-shadow-refuses-non-shadow-paths
   "THE deletion-safety test: DISCARD-SHADOW refuses any path that does
 not end in \"-shadow\" -- it deletes trees, and this guard is the whole

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -559,6 +559,77 @@ propagates."
             (uiop:ensure-directory-pathname retired)
             :validate t :if-does-not-exist :ignore)))))))
 
+;;; Fix round 2 / GH #212: completion is the SECOND RENAME, not the
+;;; :SWAP journal record after it -- a JOURNAL-APPEND failure must still
+;;; be classified as a completed swap.
+
+(test swap-in-shadow-1-progress-survives-a-journal-append-failure
+  "No reliable way was found to make the REAL system clock's
+JOURNAL-APPEND fail on just this one call without ALSO breaking the
+recovery path's own :ATTACH journal-append -- both go through the same
+CLOCK object, and ATTACH-TO-SYSTEM-CLOCK unconditionally re-journals on
+every call, so any injection that breaks one breaks the other, turning
+the intended \"recovered, warn, return\" case into a
+SHADOW-RECOVERY-FAILED case instead.  Concretely: by the time
+SWAP-IN-SHADOW runs in these tests, the clock's journal stream is
+ALREADY open (WITH-CLOCKED-STORE's MAKE-GRAPH triggers an initial
+:ATTACH record), so CHMOD'ing the clock's directory does nothing --
+POSIX permission checks happen at OPEN, not at each WRITE to an
+already-open descriptor -- and closing that shared stream directly
+leaves it broken for the recovery call too, not just the one under
+test.  So, per the coordinator's authorized fallback, this seam-tests
+%SWAP-IN-SHADOW-1 directly with a MOCK clock: a real SYSTEM-CLOCK
+struct (%MAKE-SYSTEM-CLOCK) whose LOCATION is a directory that does not
+exist, so JOURNAL-APPEND's internal OPEN fails deterministically the
+instant it tries to create the journal file there -- verified below to
+actually signal.  PROGRESS must already be complete when that
+propagates.  ABLATION: reverting the SETF to run AFTER JOURNAL-APPEND
+(the pre-fix-round-2 placement) makes this test fail, since PROGRESS
+would still be unset when the error propagates."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let ((name (graph-db:graph-name g))
+          (location (graph-db::location g))
+          (retired nil)
+          (mock-clock (graph-db::%make-system-clock
+                       :location "/nonexistent-dir-for-gh-170-212/"
+                       :counter 1)))
+      (unwind-protect
+           (progn
+             (let ((graph-db:*graph* g))
+               (close-graph g :snapshot-p nil))
+             (with-temp-directory (shadow-dir)
+               (let ((sg (make-graph name (namestring shadow-dir)
+                                    :buffer-pool-size 1000)))
+                 (with-transaction ((graph-db::transaction-manager sg))
+                   (graph-db:make-vertex :generic nil :graph sg))
+                 (let ((graph-db:*graph* sg))
+                   (close-graph sg :snapshot-p nil)))
+               (let ((progress (vector nil nil)))
+                 (signals error
+                   (graph-db::%swap-in-shadow-1
+                    name location shadow-dir mock-clock progress))
+                 (is-true (aref progress 0)
+                          "PROGRESS must be complete: both renames landed")
+                 (is-true (aref progress 1))
+                 (setq retired (aref progress 1))
+                 (is-true (probe-file retired)
+                          "the retired dir proves the first rename ran")
+                 ;; The renames really did land: the shadow's data is now
+                 ;; AT LOCATION, proving JOURNAL-APPEND -- not an earlier
+                 ;; step -- is what failed.
+                 (is-true (probe-file (merge-pathnames
+                                       "schema.dat"
+                                       (uiop:ensure-directory-pathname
+                                        location)))))))
+        (when (and retired (probe-file retired))
+          (ignore-errors
+           (uiop:delete-directory-tree
+            (uiop:ensure-directory-pathname retired)
+            :validate t :if-does-not-exist :ignore)))))))
+
 (test killed-loader-leaves-live-byte-identical
   "ABANDON-SHADOW is the discard path exercised here; it must also
 restore write service.  Nearest wrong implementation: the loader writes

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -153,3 +153,49 @@ one."
                    (is (< detach-pos attach-pos))))
             (let ((graph-db:*graph* g2))
               (ignore-errors (close-graph g2 :snapshot-p nil)))))))))
+
+(test pin-admission-is-atomic-with-quiesce
+  "Fix round 1, GH #170: PIN-READ-EPOCH's accepting-p check and
+%QUIESCE-TRANSACTION-MANAGER's flip must be one atomic operation --
+otherwise a racing PIN-READ-EPOCH can slip a registration in AFTER the
+drain has already reported success (i.e. after DETACH-STORE has begun
+tearing down mmaps).  One thread hammers PIN-READ-EPOCH/UNPIN-READ-EPOCH
+in a tight loop for the whole duration of a concurrent DETACH-STORE;
+after DETACH-STORE returns, the read-pins table must be EMPTY (no
+straggler survived the drain) and the hammer thread must have seen at
+least one refusal.
+
+This is a BEST-EFFORT race canary, not the proof -- the proof is the
+LOCK DISCIPLINE: %QUIESCE-TRANSACTION-MANAGER's flip takes TM-LOCK then
+READ-PINS-LOCK (see %SET-ACCEPTING-P); PIN-READ-EPOCH's check-and-
+register runs as one critical section under READ-PINS-LOCK alone.  No
+existing caller nests these two locks in the opposite order (see
+%SET-ACCEPTING-P's docstring), so the flip and a pin attempt can never
+interleave: either PIN-READ-EPOCH's critical section runs first (and
+registers before REASON is visible, correctly holding the drain open),
+or the flip's critical section runs first (and PIN-READ-EPOCH sees
+REASON and refuses) -- never a check that reads T followed by a
+registration that lands after the flip.  This test can only ever
+demonstrate the ABSENCE of the race on this run; the lock discipline is
+what guarantees its absence on every run."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let* ((tm (graph-db::transaction-manager g))
+           (stop nil)
+           (refusals 0)
+           (hammer (bt:make-thread
+                    (lambda ()
+                      (loop until stop do
+                        (handler-case
+                            (let ((tok (graph-db:pin-read-epoch tm)))
+                              (graph-db:unpin-read-epoch tm tok))
+                          (graph-db:store-not-accepting-error ()
+                            (incf refusals))))))))
+      (graph-db:detach-store g)
+      (setq stop t)
+      (bt:join-thread hammer)
+      (is (plusp refusals) "the hammer thread must see the refusal")
+      (is (zerop (hash-table-count (graph-db::read-pins tm)))
+          "no straggler pin admitted after drain success"))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -437,7 +437,8 @@ normally with a usable graph."
                         :expected-vectors 10000)))
                (unwind-protect
                     (progn
-                      (is (= 0 (hash-table-count (graph-db::vector-segments sg))))
+                      (is (= 0 (hash-table-count
+                                (graph-db::vector-segments sg))))
                       (is (= 1 (length (graph-db:map-vertices
                                         #'identity sg :collect-p t)))))
                  (let ((graph-db:*graph* sg))
@@ -533,7 +534,8 @@ write; the retired dir exists; the journal carries :SWAP and :ATTACH."
                     (graph-db:make-vertex :generic nil :graph g2))
                   (fail "write must be refused during the shadow window"))
               (graph-db:store-not-accepting-error (c)
-                (is (eq :shadow-load (graph-db:store-not-accepting-reason c))))))
+                (is (eq :shadow-load
+                        (graph-db:store-not-accepting-reason c))))))
           (let ((graph-db:*graph* sg))
             (close-graph sg :snapshot-p nil))))
       (multiple-value-bind (new-graph retired-path)
@@ -871,7 +873,8 @@ store, not asserted."
                 (is (null (uncovered oa))
                     "files appeared beyond the measured exclusion list")
                 (is (null (uncovered ch))
-                    "file content changed beyond the measured exclusion list"))))
+                    "file content changed beyond the measured ~
+exclusion list"))))
           (with-transaction ((graph-db::transaction-manager g2))
             (graph-db:make-vertex :generic nil :graph g2)))))))
 

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1001,6 +1001,51 @@ also refuses a bad value outright."
     (signals error
       (graph-db:store-recovery-policy (graph-db::location g)))))
 
+(test recovery-policy-mismatch-warns-but-file-wins
+  "Fix round 1 (GH #170 Task 4 review): OPEN-GRAPH's :RECOVERY-POLICY is
+only a HINT once policy.dat exists.  MAKE-GRAPH a store :DERIVABLE,
+close it, then OPEN-GRAPH the same location with a disagreeing
+:AUTHORED: RECOVERY-POLICY-MISMATCH-WARNING must fire (caught here via
+HANDLER-BIND + MUFFLE-WARNING rather than FIVEAM:SIGNALS, because
+SIGNALS' HANDLER-CASE would unwind OUT of OPEN-GRAPH mid-call instead of
+letting it finish and return the graph), and the effective policy stays
+the FILE's :DERIVABLE -- STORE-RECOVERY-POLICY reads :DERIVABLE
+afterward, not the disagreeing :AUTHORED that was passed.  There is no
+further graph-side observable: the graph object caches no policy slot
+of its own -- OPEN-SHADOW-GRAPH re-reads policy.dat fresh on every
+:FAST-LOAD call -- so the file check above IS the behavioral check.
+ABLATION (recorded, not re-run here): drop the WARN call in OPEN-GRAPH
+and FIRED stays NIL."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :detach-store-1 (namestring dir)
+                             :buffer-pool-size 1000
+                             :recovery-policy :derivable)))
+          (let ((graph-db:*graph* g))
+            (close-graph g :snapshot-p nil)))
+        (let (g2 fired)
+          (unwind-protect
+               (progn
+                 (handler-bind
+                     ((graph-db:recovery-policy-mismatch-warning
+                        (lambda (c) (setq fired c) (muffle-warning c))))
+                   (setq g2 (open-graph :detach-store-1 (namestring dir)
+                                        :buffer-pool-size 1000
+                                        :recovery-policy :authored)))
+                 (is-true fired
+                          "OPEN-GRAPH must warn on a disagreeing ~
+:RECOVERY-POLICY")
+                 (is (eq :derivable
+                         (graph-db:store-recovery-policy (namestring dir)))
+                     "the FILE's policy must remain in effect, not the ~
+disagreeing keyword")
+                 (is-true (graph-db::graph-open-p g2)))
+            (when g2
+              (let ((graph-db:*graph* g2))
+                (ignore-errors (close-graph g2 :snapshot-p nil))))))))))
+
 (test fast-load-on-authored-store-signals
   "OPEN-SHADOW-GRAPH :FAST-LOAD T against a shadow whose source store's
 recovery policy is :AUTHORED (the default -- no :RECOVERY-POLICY was

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1474,9 +1474,20 @@ reopen (recovery runs). A transaction committed after that open must
 mint an id STRICTLY GREATER than the replayed transaction's id, not
 just past the stale pre-recovery watermark.
 
+Also asserts the re-opened graph's REPLICATION-LOG-FILE name (parsed via
+the same PARSE-REPLICATION-LOG-NAME the replication streaming code uses)
+encodes the RE-SEEDED counter, not the rewound one -- round 3's fix: the
+constructor's INITIALIZE-INSTANCE :AFTER derives that filename from the
+SAME (then pre-recovery) counter value TX-ID-COUNTER was seeded from, so
+re-seeding TX-ID-COUNTER alone would still leave the file's name
+advertising a stale, lower minimum id than it will actually hold.
+
 ABLATION (recorded, not re-run here): removing OPEN-GRAPH's re-seed
 after RECOVER-TRANSACTIONS makes the final (> new-id id-b) assertion
-fail -- the new transaction mints ID-A+1, which is <= ID-B."
+fail -- the new transaction mints ID-A+1, which is <= ID-B.  ABLATION 2
+(recorded, not re-run here): keeping the TX-ID-COUNTER re-seed but
+dropping the REPLICATION-LOG-FILE re-derivation makes the filename
+assertion fail -- it would still encode ID-A+1."
   (with-temp-directory (sys)
     (with-temp-directory (dir)
       (let ((graph-db::*system-directory* (namestring sys))
@@ -1521,6 +1532,12 @@ fail -- the new transaction mints ID-A+1, which is <= ID-B."
         (let ((g2 (open-graph :gh-170-round2-recovery path)))
           (unwind-protect
                (let (id-c vc)
+                 (is (= (1+ id-b)
+                        (graph-db::parse-replication-log-name
+                         (graph-db::replication-log-file
+                          (graph-db::transaction-manager g2))))
+                     "the reopened graph's replication-log-file must ~
+encode the RE-SEEDED counter (~D), not the rewound one" (1+ id-b))
                  (with-transaction ((graph-db::transaction-manager g2))
                    (setq vc (graph-db:make-vertex :generic nil :graph g2)))
                  (setq id-c (graph-db::commit-epoch vc))
@@ -1530,3 +1547,55 @@ every replayed id, not just the pre-recovery watermark (got ~D, ~
 replayed id was ~D)" id-c id-b))
             (let ((graph-db:*graph* g2))
               (ignore-errors (close-graph g2 :snapshot-p nil)))))))))
+
+;;; Round 3 (GH #170 re-review): the publication window.  *GRAPHS*/
+;;; %REGISTER-OPEN-STORE registration happens BEFORE RECOVER-TRANSACTIONS
+;;; and every rebuild step in OPEN-GRAPH; a racing name-lookup writer
+;;; could otherwise pin AND commit against a mid-recovery graph.  Fixed
+;;; by starting every fresh transaction manager at :OPENING (admits
+;;; pins, refuses new transactions with reason :OPENING) and flipping to
+;;; the caller's requested :INITIAL-ACCEPTING-STATE only at the very end
+;;; of OPEN-GRAPH, once GRAPH-OPEN-P is T.
+
+(test open-graph-ends-fully-accepting-and-opening-refuses-transactions
+  "Two-part unit probe (a true concurrent race against OPEN-GRAPH's own
+internal window is disproportionate to test directly -- see the source-
+order comment below instead, which is the actual proof):
+
+1. An ordinary OPEN-GRAPH call ends with ACCEPTING-P T -- the :OPENING
+   window is entirely internal to OPEN-GRAPH and never observable by a
+   caller holding the returned graph.
+2. CREATE-TRANSACTION against a transaction manager hand-set to
+   :OPENING (the exact state every fresh TM starts OPEN-GRAPH in) signals
+   STORE-NOT-ACCEPTING-ERROR reason :OPENING -- the same generic
+   REASON-mirrors-the-flag behavior :DETACHING/:SWAPPING already get.
+3. PIN-READ-EPOCH under that SAME :OPENING state succeeds -- OPEN-
+   GRAPH's own rebuild/recovery scans run under WITH-READ-PIN and must
+   not be refused by the very state meant to protect them.
+
+The ORDERING PIN (the actual guarantee, not re-tested by a race here):
+in OPEN-GRAPH's source (graph.lisp), the TRANSACTION-MANAGER is
+constructed with :ACCEPTING-P :OPENING BEFORE the (SETF (GETHASH NAME
+*GRAPHS*) GRAPH) / %REGISTER-OPEN-STORE call, and %SET-ACCEPTING-P to
+INITIAL-ACCEPTING-STATE is the LAST form before OPEN-GRAPH returns,
+after (SETF (GRAPH-OPEN-P GRAPH) T) -- so no window exists where the
+graph is both externally reachable (via *GRAPHS*/LOOKUP-GRAPH) and
+willing to accept a new transaction before every rebuild/recovery step
+has completed."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (is (eq t (graph-db:accepting-p (graph-db::transaction-manager g))))
+    (let ((tm (graph-db::transaction-manager g)))
+      (graph-db::%set-accepting-p tm :opening)
+      (unwind-protect
+           (progn
+             (handler-case
+                 (progn
+                   (with-transaction (tm)
+                     (graph-db:make-vertex :generic nil :graph g))
+                   (fail "a transaction under :OPENING must be refused"))
+               (graph-db:store-not-accepting-error (c)
+                 (is (eq :opening (graph-db:store-not-accepting-reason c)))))
+             (let ((pin (graph-db:pin-read-epoch tm)))
+               (graph-db:unpin-read-epoch tm pin)))
+        (graph-db::%set-accepting-p tm t)))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -360,6 +360,91 @@ the out-of-process survival requirement (GH #170 comment)."
         (let ((graph-db:*graph* g2))
           (ignore-errors (close-graph g2 :snapshot-p nil)))))))
 
+;;; Vector-segment presize (GH #170 Task 5).
+;;;
+;;; A vertex on the DETACH-STORE-1 schema (same graph name WITH-CLOCKED-STORE
+;;; uses everywhere else in this file) carrying one :VECTOR-INDEX slot, so
+;;; OPEN-SHADOW-GRAPH's :EXPECTED-VECTORS wiring has a real segment to
+;;; presize.  Declared once at load time, like SI-DOC in
+;;; segment-integration-tests.lisp.
+(def-vertex ds-vec-doc ()
+  ((embedding :vector-index t))
+  :detach-store-1)
+
+(defun %ds-vec (dim base)
+  (let ((v (make-array dim :element-type 'single-float)))
+    (dotimes (i dim v)
+      (setf (aref v i) (coerce (+ base (* 0.01 i)) 'single-float)))))
+
+(test open-shadow-graph-expected-vectors-presizes-the-segment
+  "OPEN-SHADOW-GRAPH :EXPECTED-VECTORS presizes every vector segment the
+shadow's graph object carries: capacity is already >= the requested N right
+after open, and a subsequent burst of vector-bearing writes on the shadow
+does not grow the segment again.  Exercises the wiring end to end: a live
+write creates the segment, SHADOW-STORE copies its file, and RESTORE-VECTOR-
+SEGMENTS (inside OPEN-GRAPH, before :EXPECTED-VECTORS runs) is what
+populates VECTOR-SEGMENTS for this hook to iterate."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (make-ds-vec-doc :embedding (%ds-vec 8 1.0) :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 10000)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end)
+                        :expected-vectors 10000)))
+               (unwind-protect
+                    (let ((seg (gethash (cons 'ds-vec-doc 'embedding)
+                                        (graph-db::vector-segments sg))))
+                      (is (not (null seg))
+                          "the ds-vec-doc/embedding segment was not carried ~
+                           into the open shadow")
+                      (is (>= (graph-db::segment-capacity seg) 10000))
+                      (let ((cap-before (graph-db::segment-capacity seg)))
+                        (with-transaction ((graph-db::transaction-manager sg))
+                          (dotimes (i 500)
+                            (make-ds-vec-doc
+                             :embedding (%ds-vec 8 (float i 1.0)) :graph sg)))
+                        (is (= cap-before (graph-db::segment-capacity seg))
+                            "a burst within the presized headroom must not ~
+                             grow the shadow's segment again (before ~D, ~
+                             after ~D)"
+                            cap-before (graph-db::segment-capacity seg))))
+                 (let ((graph-db:*graph* sg))
+                   (ignore-errors (close-graph sg :snapshot-p nil))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test open-shadow-graph-expected-vectors-is-a-no-op-with-no-segments
+  "A shadow whose graph declares :VECTOR-INDEX nowhere used (only :GENERIC
+nodes) has an EMPTY vector-segments table.  :EXPECTED-VECTORS must be a
+clean no-op there, not an error -- OPEN-SHADOW-GRAPH must still return
+normally with a usable graph."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 1000)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end)
+                        :expected-vectors 10000)))
+               (unwind-protect
+                    (progn
+                      (is (= 0 (hash-table-count (graph-db::vector-segments sg))))
+                      (is (= 1 (length (graph-db:map-vertices
+                                        #'identity sg :collect-p t)))))
+                 (let ((graph-db:*graph* sg))
+                   (ignore-errors (close-graph sg :snapshot-p nil))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
 ;;; Swap (GH #170 Task 3).
 
 (defun %directory-file-hashes (dir)

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -448,3 +448,33 @@ service (reads AND writes)."
                  (graph-db:make-vertex :generic nil :graph g2))
                (setq g g2)))
         (ignore-errors (delete-file bare-shadow))))))
+
+(test shadow-lease-consumed-exactly-to-its-boundary-exhausts-at-open
+  "Fix round 2 (GH #170): the range is half-open [start,end) --
+NEXT == END means fully consumed, not merely at the boundary.  Consume
+a 2-epoch lease [n, n+2) with exactly 2 writes, close, and re-open from
+lease.dat WITHOUT :lease: EPOCH-LEASE-EXHAUSTED must signal AT OPEN, not
+be deferred to the first write.  Nearest wrong implementation: a
+strict > check that lets NEXT == END silently reopen and only fails
+later."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 2)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end))))
+               (dotimes (i 2)
+                 (with-transaction ((graph-db::transaction-manager sg))
+                   (graph-db:make-vertex :generic nil :graph sg)))
+               (let ((graph-db:*graph* sg))
+                 (close-graph sg :snapshot-p nil))
+               (signals graph-db:epoch-lease-exhausted
+                 (graph-db:open-shadow-graph
+                  shadow-location :detach-store-1))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -630,6 +630,107 @@ would still be unset when the error propagates."
             (uiop:ensure-directory-pathname retired)
             :validate t :if-does-not-exist :ignore)))))))
 
+;;; Fix round 3 (GH #170): %COPY-DIRECTORY-TREE must preserve sparse
+;;; holes -- a fresh store reserves ~12GB of mostly-zero mmap regions,
+;;; and a byte-for-byte copy materializes every one of them.
+
+(defun %file-real-bytes (path)
+  "REAL on-disk bytes for the file at PATH: STAT(2)'s ST_BLOCKS * 512,
+the standard sparse-file idiom.  OSICAT is NOT a dependency of this
+system (POSIX.LISP's own header explains why: it replaces OSICAT with
+hand-rolled CFFI to avoid OSICAT's C grovel/wrapper, notably for ECL
+cross-compilation) and this build's SB-POSIX:STAT has no ST_BLOCKS
+accessor either -- so this uses SBCL's own SB-UNIX:UNIX-STAT, whose
+14th value is ST-BLOCKS (confirmed against sbcl/src/code/unix.lisp's
+%EXTRACT-STAT-RESULTS field order: dev ino mode nlink uid gid rdev size
+atime mtime ctime blksize blocks) (GH #170)."
+  (multiple-value-bind (ok dev ino mode nlink uid gid rdev size
+                        atime mtime ctime blksize blocks)
+      (sb-unix:unix-stat (namestring path))
+    (declare (ignore dev ino mode nlink uid gid rdev size
+                     atime mtime ctime blksize))
+    (unless ok (error "SB-UNIX:UNIX-STAT failed for ~A" path))
+    (* 512 blocks)))
+
+(defun %directory-usage (dir)
+  "(values APPARENT-SIZES REAL-BYTES) for every regular file under DIR:
+APPARENT-SIZES is a relpath -> byte-length hash table (the logical
+FILE-LENGTH); REAL-BYTES is the sum of %FILE-REAL-BYTES over every file
+(GH #170)."
+  (let ((root (uiop:ensure-directory-pathname dir))
+        (sizes (make-hash-table :test 'equal))
+        (real 0))
+    (uiop:collect-sub*directories
+     root t t
+     (lambda (subdir)
+       (dolist (file (uiop:directory-files subdir))
+         (setf (gethash (namestring (uiop:enough-pathname file root)) sizes)
+               (with-open-file (in file :element-type '(unsigned-byte 8))
+                 (file-length in)))
+         (incf real (%file-real-bytes file)))))
+    (values sizes real)))
+
+(test shadow-store-copy-preserves-sparseness
+  "%COPY-DIRECTORY-TREE must not materialize a fresh store's reserved
+mmap holes: a near-empty store's shadow should use a SMALL FRACTION of
+its apparent size on disk (< 1/100 here), while every file's apparent
+LENGTH matches the source exactly -- MAPPED-FILE-LENGTH (mmap.lisp)
+reads the file's actual on-disk length to size the initial mapping, so
+a short file breaks remapping; this is confirmed by reading the code,
+not merely assumed.  Also confirms sparseness doesn't corrupt: the
+shadow still OPENS (OPEN-SHADOW-GRAPH) and reads the live data back."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (source-sizes source-real)
+        (%directory-usage (graph-db::location g))
+      (declare (ignore source-real))
+      ;; .dirty exists only while G is OPEN (as it is here, pre-
+      ;; SHADOW-STORE) and is gone by the time SHADOW-STORE's internal
+      ;; CLOSE-GRAPH runs the copy -- not part of what the copy is
+      ;; supposed to reproduce, so exclude it from the comparison
+      ;; (same idiom as KILLED-LOADER-LEAVES-LIVE-BYTE-IDENTICAL's
+      ;; measured exclusion list).
+      (remhash ".dirty" source-sizes)
+      (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+        (unwind-protect
+             (progn
+               (multiple-value-bind (shadow-sizes shadow-real)
+                   (%directory-usage shadow-location)
+                 ;; Every SOURCE file must have landed in the shadow at
+                 ;; the exact same apparent size.  Not asserted the
+                 ;; other way around: SHADOW-STORE's internal
+                 ;; CLOSE-GRAPH :SNAPSHOT-P T takes a backup under
+                 ;; txn-log/ as part of the close that PRECEDES the
+                 ;; copy, so the shadow legitimately gains one file
+                 ;; SOURCE-SIZES (measured before that close) never
+                 ;; had -- same shape as the .dirty exclusion above.
+                 (maphash (lambda (path size)
+                            (is (eql size (gethash path shadow-sizes))
+                                "~A: apparent size must match the source ~
+exactly" path))
+                          source-sizes)
+                 (let ((apparent (loop for v being the hash-values
+                                            of shadow-sizes
+                                       sum v)))
+                   (is (plusp apparent))
+                   (is (< shadow-real (/ apparent 100))
+                       "real ~A bytes should be a small fraction of ~
+apparent ~A bytes" shadow-real apparent)))
+               (multiple-value-bind (start end)
+                   (graph-db:clock-lease-epochs clock 1000)
+                 (let ((sg (graph-db:open-shadow-graph
+                           shadow-location :detach-store-1
+                           :lease (cons start end))))
+                   (unwind-protect
+                        (is (= 1 (length (graph-db:map-vertices
+                                         #'identity sg :collect-p t))))
+                     (let ((graph-db:*graph* sg))
+                       (ignore-errors (close-graph sg :snapshot-p nil)))))))
+          (let ((graph-db:*graph* g2))
+            (ignore-errors (close-graph g2 :snapshot-p nil))))))))
+
 (test killed-loader-leaves-live-byte-identical
   "ABANDON-SHADOW is the discard path exercised here; it must also
 restore write service.  Nearest wrong implementation: the loader writes

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1211,3 +1211,241 @@ on the thread that last set it."
                       (merge-pathnames
                        "*.committed"
                        (graph-db::persistent-transaction-directory g))))))))
+
+;;; Whole-branch review fixes (GH #170, 2026-08-22).
+
+(test detach-drain-timeout-restores-read-only-not-t
+  "C1 (GH #170 review): a drain timeout during SHADOW-STORE's :READ-ONLY
+window must restore ACCEPTING-P to :READ-ONLY, not hardcoded T --
+hardcoded T would silently lift the shadow-window guard and let a write
+land in the doomed generation.  Mechanism: shadow the store (G2 comes
+back :READ-ONLY), open+close a shadow so SWAP-IN-SHADOW's precondition
+is satisfiable, hold a read pin on G2 across a SWAP-IN-SHADOW call with
+a 1-second timeout so its quiesce cannot drain, and confirm G2 is
+STILL :READ-ONLY afterward -- a write still signals reason
+:SHADOW-LOAD, not fully open again.  ABLATION (recorded, not re-run
+here): reverting %QUIESCE-TRANSACTION-MANAGER's timeout branch to
+\(%SET-ACCEPTING-P TRANSACTION-MANAGER T) makes the :READ-ONLY assertion
+below fail."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (let ((tm2 (graph-db::transaction-manager g2)))
+             (multiple-value-bind (start end)
+                 (graph-db:clock-lease-epochs clock 1000)
+               (let ((sg (graph-db:open-shadow-graph
+                          shadow-location :detach-store-1
+                          :lease (cons start end))))
+                 (let ((graph-db:*graph* sg))
+                   (close-graph sg :snapshot-p nil))))
+             (let ((pin (graph-db:pin-read-epoch tm2)))
+               (unwind-protect
+                    (progn
+                      (signals graph-db:detach-drain-timeout
+                        (graph-db:swap-in-shadow
+                         g2 shadow-location :timeout 1))
+                      (is (eq :read-only (graph-db:accepting-p tm2))))
+                 (graph-db:unpin-read-epoch tm2 pin)))
+             (handler-case
+                 (progn
+                   (with-transaction (tm2)
+                     (graph-db:make-vertex :generic nil :graph g2))
+                   (fail "write must still be refused after the timeout"))
+               (graph-db:store-not-accepting-error (c)
+                 (is (eq :shadow-load
+                         (graph-db:store-not-accepting-reason c)))))
+             (graph-db:abandon-shadow g2 shadow-location)
+             (with-transaction (tm2)
+               (graph-db:make-vertex :generic nil :graph g2)))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test detach-refuses-replicated-graphs
+  "I1 (GH #170 review): DETACH-STORE / SHADOW-STORE / SWAP-IN-SHADOW all
+refuse a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH with
+DETACH-UNSUPPORTED-GRAPH-ERROR -- their reopen paths use OPEN-GRAPH's
+plain default arguments, which would silently strip replication/peer
+configuration.  A bare MAKE-INSTANCE shell is enough: the check is a
+TYPEP on the graph object made before anything else runs, so it never
+touches any slot the shell leaves unbound."
+  (dolist (g (list (make-instance 'graph-db::master-graph
+                                  :graph-name :fake-master)
+                   (make-instance 'graph-db::slave-graph
+                                  :graph-name :fake-slave)
+                   (make-instance 'graph-db::peer-graph
+                                  :graph-name :fake-peer)))
+    (signals graph-db:detach-unsupported-graph-error
+      (graph-db:detach-store g))
+    (signals graph-db:detach-unsupported-graph-error
+      (graph-db:shadow-store g))
+    (signals graph-db:detach-unsupported-graph-error
+      (graph-db:swap-in-shadow g "/nonexistent-shadow/"))))
+
+(test shadow-store-clears-stale-shadow-directory
+  "I2 (GH #170 review): a pre-existing <location>-shadow/ from a
+previous, never-cleaned SHADOW-STORE must be DISCARDED before the copy,
+not merged with -- %COPY-DIRECTORY-TREE's per-file :SUPERSEDE never
+clears the destination, so a stale .txn file left over there would be
+replayed into the fresh shadow on its next open.  Pre-create the shadow
+dir with a junk file, run SHADOW-STORE, and confirm the junk file is
+gone."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let* ((shadow-dir (graph-db::%shadow-location (graph-db:location g)))
+           (junk (merge-pathnames "junk.txt" shadow-dir)))
+      (ensure-directories-exist shadow-dir)
+      (with-open-file (out junk :direction :output :if-exists :supersede
+                          :if-does-not-exist :create)
+        (write-string "stale" out))
+      (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+        (unwind-protect
+             (progn
+               (is (not (probe-file junk)))
+               (is-true (probe-file shadow-location)))
+          (let ((graph-db:*graph* g2))
+            (ignore-errors (close-graph g2 :snapshot-p nil))))))))
+
+(test detach-store-failure-between-quiesce-and-close-restores-service
+  "I3 (GH #170 review): a failure AFTER a successful quiesce but BEFORE
+the durable close (CLOCK-LEASE-EPOCHS / JOURNAL-APPEND) must not strand
+ACCEPTING-P at :DETACHING.  Mechanism: swap G's system clock for a mock
+clock (same %MAKE-SYSTEM-CLOCK-with-invalid-location technique as
+SWAP-IN-SHADOW-1-PROGRESS-SURVIVES-A-JOURNAL-APPEND-FAILURE) whose
+%CLOCK-RESERVE write fails deterministically, so DETACH-STORE's
+CLOCK-LEASE-EPOCHS call fails after the quiesce has already succeeded.
+DETACH-STORE must re-signal AND leave the store fully accepting again,
+still open."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let ((tm (graph-db::transaction-manager g))
+          (mock-clock (graph-db::%make-system-clock
+                       :location "/nonexistent-dir-for-gh-170-i3/"
+                       :counter 1)))
+      (setf (graph-db:graph-system-clock g) mock-clock)
+      (unwind-protect
+           (signals error (graph-db:detach-store g))
+        ;; Restore the real clock so the fixture's own teardown can close
+        ;; G normally regardless of this test's outcome.
+        (setf (graph-db:graph-system-clock g) clock))
+      (is (eq t (graph-db:accepting-p tm)))
+      (is (graph-db::graph-open-p g))
+      (with-transaction (tm)
+        (graph-db:make-vertex :generic nil :graph g)))))
+
+(test open-graph-initial-accepting-state-refuses-write-immediately
+  "I4 (GH #170 review): OPEN-GRAPH's :INITIAL-ACCEPTING-STATE sets the
+fresh transaction manager's ACCEPTING-P at construction, before the
+graph is registered in *GRAPHS* -- not published writable then flipped
+after, which would leave a window for a racing writer to land a commit
+in a generation meant to come up non-accepting.  A true race is not
+practical to test at the unit level; the ordering itself is the proof
+(the transaction manager did not even exist yet at registration time
+under the pre-fix code path).  This checks the observable contract
+instead: a graph opened with :INITIAL-ACCEPTING-STATE :READ-ONLY
+refuses a write the INSTANT OPEN-GRAPH returns."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :detach-store-1 (namestring dir)
+                             :buffer-pool-size 1000)))
+          (let ((graph-db:*graph* g))
+            (close-graph g :snapshot-p nil)))
+        (let ((g2 (open-graph :detach-store-1 (namestring dir)
+                              :buffer-pool-size 1000
+                              :initial-accepting-state :read-only)))
+          (unwind-protect
+               (progn
+                 (is (eq :read-only
+                         (graph-db:accepting-p
+                          (graph-db::transaction-manager g2))))
+                 (handler-case
+                     (progn
+                       (with-transaction
+                           ((graph-db::transaction-manager g2))
+                         (graph-db:make-vertex :generic nil :graph g2))
+                       (fail "write must be refused immediately"))
+                   (graph-db:store-not-accepting-error (c)
+                     (is (eq :shadow-load
+                             (graph-db:store-not-accepting-reason c))))))
+            (let ((graph-db:*graph* g2))
+              (ignore-errors (close-graph g2 :snapshot-p nil)))))))))
+
+(test open-shadow-graph-failed-open-closes-cleanly-for-retry
+  "M1 (GH #170 review): an error AFTER OPEN-GRAPH inside OPEN-SHADOW-
+GRAPH (lease exhaustion here) must not leak the opened graph -- an mmap
+left open plus a set .dirty marker would make a RETRY open fail on \"not
+closed properly\" instead of just re-raising the exhaustion.  Exhaust a
+2-epoch lease, close, confirm EPOCH-LEASE-EXHAUSTED at open (same shape
+as SHADOW-LEASE-CONSUMED-EXACTLY-TO-ITS-BOUNDARY-EXHAUSTS-AT-OPEN), then
+re-open the SAME shadow location with a FRESH lease and confirm it
+succeeds cleanly (no .dirty refusal), with the data intact."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (progn
+             (multiple-value-bind (start end)
+                 (graph-db:clock-lease-epochs clock 2)
+               (let ((sg (graph-db:open-shadow-graph
+                          shadow-location :detach-store-1
+                          :lease (cons start end))))
+                 (dotimes (i 2)
+                   (with-transaction ((graph-db::transaction-manager sg))
+                     (graph-db:make-vertex :generic nil :graph sg)))
+                 (let ((graph-db:*graph* sg))
+                   (close-graph sg :snapshot-p nil))
+                 (signals graph-db:epoch-lease-exhausted
+                   (graph-db:open-shadow-graph
+                    shadow-location :detach-store-1))))
+             (multiple-value-bind (start2 end2)
+                 (graph-db:clock-lease-epochs clock 1000)
+               (let ((sg2 (graph-db:open-shadow-graph
+                          shadow-location :detach-store-1
+                          :lease (cons start2 end2))))
+                 (unwind-protect
+                      (is (= 3 (length (graph-db:map-vertices
+                                       #'identity sg2 :collect-p t))))
+                   (let ((graph-db:*graph* sg2))
+                     (ignore-errors (close-graph sg2 :snapshot-p nil)))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test swap-in-shadow-deletes-the-promoted-lease-file
+  "M2 (GH #170 review): the promoted generation's lease.dat (copied in
+from the shadow) is deleted right after the second rename -- it has no
+meaning once the location is a plain, non-shadow live store."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (multiple-value-bind (start end)
+          (graph-db:clock-lease-epochs clock 1000)
+        (let ((sg (graph-db:open-shadow-graph
+                   shadow-location :detach-store-1
+                   :lease (cons start end))))
+          (let ((graph-db:*graph* sg))
+            (close-graph sg :snapshot-p nil))))
+      (multiple-value-bind (new-graph retired-path)
+          (graph-db:swap-in-shadow g2 shadow-location)
+        (is (not (probe-file
+                  (merge-pathnames
+                   "lease.dat"
+                   (uiop:ensure-directory-pathname
+                    (graph-db::location new-graph))))))
+        (let ((graph-db:*graph* new-graph))
+          (ignore-errors (close-graph new-graph :snapshot-p nil)))
+        (ignore-errors
+         (uiop:delete-directory-tree
+          (uiop:ensure-directory-pathname retired-path)
+          :validate t :if-does-not-exist :ignore))))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -8,11 +8,13 @@
   :description "Quiescence, DETACH-STORE, and REATTACH-STORE.")
 (in-suite detach-suite)
 
-(defmacro with-clocked-store ((g clock sys) &body body)
+(defmacro with-clocked-store ((g clock sys &key recovery-policy) &body body)
   "One disk store, under a fresh *SYSTEM-DIRECTORY*, attached to its own
 system clock -- the fixture DETACH-STORE / REATTACH-STORE need, adapted
 from TESTS/SYSTEM-CLOCK-TESTS.LISP's
-TWO-STORES-ON-ONE-CLOCK-GET-DISJOINT-ORDERED-EPOCHS."
+TWO-STORES-ON-ONE-CLOCK-GET-DISJOINT-ORDERED-EPOCHS.  :RECOVERY-POLICY
+(GH #170 Task 4) is passed through to MAKE-GRAPH; NIL (default) persists
+nothing, matching every pre-Task-4 use of this fixture."
   (let ((cdir (gensym)) (ddir (gensym)))
     `(with-temp-directory (,sys)
        (with-temp-directory (,cdir)
@@ -24,7 +26,8 @@ TWO-STORES-ON-ONE-CLOCK-GET-DISJOINT-ORDERED-EPOCHS."
                     (let ((,g (make-graph :detach-store-1
                                           (namestring ,ddir)
                                           :buffer-pool-size 1000
-                                          :system-clock ,clock)))
+                                          :system-clock ,clock
+                                          :recovery-policy ,recovery-policy)))
                       (unwind-protect (progn ,@body)
                         (when (graph-db::graph-open-p ,g)
                           (let ((graph-db:*graph* ,g))
@@ -643,14 +646,21 @@ cross-compilation) and this build's SB-POSIX:STAT has no ST_BLOCKS
 accessor either -- so this uses SBCL's own SB-UNIX:UNIX-STAT, whose
 14th value is ST-BLOCKS (confirmed against sbcl/src/code/unix.lisp's
 %EXTRACT-STAT-RESULTS field order: dev ino mode nlink uid gid rdev size
-atime mtime ctime blksize blocks) (GH #170)."
+atime mtime ctime blksize blocks) (GH #170).  SBCL-only:
+SB-UNIX:UNIX-STAT is a bare SBCL symbol, so the whole body is #+SBCL --
+otherwise it is a read-time package error on ECL/CCL (fold-in from Task
+3's re-review; see tests/geometry-tests.lisp for the same #+sbcl idiom)."
+  #+sbcl
   (multiple-value-bind (ok dev ino mode nlink uid gid rdev size
                         atime mtime ctime blksize blocks)
       (sb-unix:unix-stat (namestring path))
     (declare (ignore dev ino mode nlink uid gid rdev size
                      atime mtime ctime blksize))
     (unless ok (error "SB-UNIX:UNIX-STAT failed for ~A" path))
-    (* 512 blocks)))
+    (* 512 blocks))
+  #-sbcl
+  (error "%FILE-REAL-BYTES (sparse-file real-usage check) is SBCL-only; ~
+no portable ST_BLOCKS accessor is wired up for this implementation."))
 
 (defun %directory-usage (dir)
   "(values APPARENT-SIZES REAL-BYTES) for every regular file under DIR:
@@ -947,3 +957,124 @@ later."
                   shadow-location :detach-store-1))))
         (let ((graph-db:*graph* g2))
           (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+;;; Recovery policy + the WAL-suppressed fast path (GH #170 Task 4).
+
+(defun %txn-file-count (graph)
+  "Count of *.txn files in GRAPH's persistent transaction directory
+(GH #170)."
+  (length (directory
+           (merge-pathnames
+            "*.txn"
+            (graph-db::persistent-transaction-directory graph)))))
+
+(test recovery-policy-round-trips-through-make-graph
+  "MAKE-GRAPH :RECOVERY-POLICY :DERIVABLE persists policy.dat, and
+STORE-RECOVERY-POLICY reads it back; a store made without the keyword
+has no policy.dat and reads back :AUTHORED (the documented absent-file
+default)."
+  (with-clocked-store (g clock sys :recovery-policy :derivable)
+    clock sys
+    (is (eq :derivable
+            (graph-db:store-recovery-policy (graph-db::location g)))))
+  (with-clocked-store (g clock sys)
+    clock sys
+    (is (eq :authored
+            (graph-db:store-recovery-policy (graph-db::location g))))))
+
+(test recovery-policy-file-rejects-garbage
+  "A policy.dat that holds neither :DERIVABLE nor :AUTHORED is a hard
+error, not a silent fall back to :AUTHORED -- a corrupt gate input for
+:FAST-LOAD must never pass unnoticed.  SET-STORE-RECOVERY-POLICY itself
+also refuses a bad value outright."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (signals error
+      (graph-db:set-store-recovery-policy (graph-db::location g) :bogus))
+    (with-open-file (out (merge-pathnames
+                          "policy.dat"
+                          (uiop:ensure-directory-pathname
+                           (graph-db::location g)))
+                        :direction :output :if-exists :supersede
+                        :if-does-not-exist :create)
+      (prin1 :bogus out))
+    (signals error
+      (graph-db:store-recovery-policy (graph-db::location g)))))
+
+(test fast-load-on-authored-store-signals
+  "OPEN-SHADOW-GRAPH :FAST-LOAD T against a shadow whose source store's
+recovery policy is :AUTHORED (the default -- no :RECOVERY-POLICY was
+ever given) signals FAST-LOAD-REQUIRES-DERIVABLE rather than silently
+dropping the WAL.  ABLATION (recorded, not re-run here): remove the
+gate in OPEN-SHADOW-GRAPH and this test is the one that fails."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 1000)
+             (signals graph-db:fast-load-requires-derivable
+               (graph-db:open-shadow-graph
+                shadow-location :detach-store-1
+                :lease (cons start end) :fast-load t)))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test fast-load-writes-no-txn-files-and-data-survives-reopen
+  "OPEN-SHADOW-GRAPH :FAST-LOAD T against a :DERIVABLE source: writes
+into the shadow leave its transaction directory EMPTY of .txn files
+(PERSIST-TRANSACTION's WAL-suppressed no-op), yet the data reads back
+after CLOSE-GRAPH + a plain reopen -- durability comes from the
+heap/index writes themselves, which is what licenses discard-on-crash
+for a shadow (the spec's whole premise for this path)."
+  (with-clocked-store (g clock sys :recovery-policy :derivable)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 1000)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end) :fast-load t)))
+               (is-true (graph-db::wal-suppressed-p sg))
+               (dotimes (i 3)
+                 (with-transaction ((graph-db::transaction-manager sg))
+                   (graph-db:make-vertex :generic nil :graph sg)))
+               (is (zerop (%txn-file-count sg)))
+               (let ((graph-db:*graph* sg))
+                 (close-graph sg :snapshot-p nil))
+               (let ((sg2 (graph-db:open-shadow-graph
+                           shadow-location :detach-store-1)))
+                 (unwind-protect
+                      (is (= 4 (length (graph-db:map-vertices
+                                       #'identity sg2 :collect-p t))))
+                   (let ((graph-db:*graph* sg2))
+                     (ignore-errors
+                      (close-graph sg2 :snapshot-p nil)))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test normal-graph-still-writes-txn-files
+  "The no-leak pin: an ordinary (non-shadow) graph's commit really does
+rename a .txn file into place -- CLEANUP-TRANSACTION deletes it right
+after (the default *DELETE-COMMITTED-TRANSACTION-FILES* T), so bind
+that NIL and look for the renamed *.committed file instead, proof that
+FINALIZE-TX-PERSISTENCE's rename actually ran.  Nearest wrong
+implementation: WAL suppression via a dynamic variable, which -- unlike
+the per-graph WAL-SUPPRESSED-P slot this checks indirectly by observing
+its effect -- would leak onto whatever graph happens to be committing
+on the thread that last set it."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (is (= 0 (%txn-file-count g)))
+    (let ((graph-db::*delete-committed-transaction-files* nil))
+      (with-transaction ((graph-db::transaction-manager g))
+        (graph-db:make-vertex :generic nil :graph g)))
+    (is (= 1 (length (directory
+                      (merge-pathnames
+                       "*.committed"
+                       (graph-db::persistent-transaction-directory g))))))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -365,3 +365,86 @@ safety story."
     clock sys
     (signals error (graph-db:discard-shadow (graph-db::location g)))
     (is-true (probe-file (graph-db::location g)))))
+
+;;; Fix round 1 (GH #170): lease resume-from-watermark, copy-failure
+;;; recovery.
+
+(test shadow-lease-resumes-from-its-own-watermark
+  "RULED FIX: the resume cursor comes from the shadow's own durable
+highest-transaction-id, never a persisted NEXT.  Write 2 nodes, close
+the shadow, re-open it WITHOUT :lease (lease.dat path) and confirm the
+next write's id is strictly past the pre-close ids and still within the
+leased range.  Nearest wrong implementation: NEXT reset to START on
+every open, re-minting an id already committed in the shadow."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+      (unwind-protect
+           (multiple-value-bind (start end)
+               (graph-db:clock-lease-epochs clock 1000)
+             (let ((sg (graph-db:open-shadow-graph
+                        shadow-location :detach-store-1
+                        :lease (cons start end)))
+                   (max-id 0))
+               (dotimes (i 2)
+                 ;; COMMIT-EPOCH is stamped when the transaction commits,
+                 ;; at the END of the WITH-TRANSACTION body -- read it
+                 ;; only AFTER the block, or it is still the pre-commit
+                 ;; default (0).
+                 (let (v)
+                   (with-transaction ((graph-db::transaction-manager sg))
+                     (setq v (graph-db:make-vertex :generic nil :graph sg)))
+                   (setq max-id (max max-id (graph-db::commit-epoch v)))))
+               (let ((graph-db:*graph* sg))
+                 (close-graph sg :snapshot-p nil))
+               (let ((sg2 (graph-db:open-shadow-graph
+                           shadow-location :detach-store-1)))
+                 (unwind-protect
+                      (let (v new-id)
+                        (with-transaction
+                            ((graph-db::transaction-manager sg2))
+                          (setq v (graph-db:make-vertex
+                                  :generic nil :graph sg2)))
+                        (setq new-id (graph-db::commit-epoch v))
+                        (is (> new-id max-id))
+                        (is (<= start new-id))
+                        (is (< new-id end)))
+                   (let ((graph-db:*graph* sg2))
+                     (ignore-errors
+                      (close-graph sg2 :snapshot-p nil)))))))
+        (let ((graph-db:*graph* g2))
+          (ignore-errors (close-graph g2 :snapshot-p nil)))))))
+
+(test shadow-store-recovers-service-on-copy-failure
+  "RULED FIX: a mid-copy failure must not leave the live store stranded
+closed.  Deterministic failure: pre-create the shadow target as a plain
+FILE (not a directory), so %COPY-DIRECTORY-TREE's
+ENSURE-DIRECTORIES-EXIST signals.  SHADOW-STORE must re-signal that
+error, but only after reopening the live store and restoring full
+service (reads AND writes)."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let* ((name (graph-db:graph-name g))
+           (shadow-dir (graph-db::%shadow-location (graph-db:location g)))
+           (bare-shadow (string-right-trim "/" (namestring shadow-dir))))
+      (with-open-file (out bare-shadow :direction :output
+                          :if-exists :supersede :if-does-not-exist :create)
+        (write-string "not a directory" out))
+      (unwind-protect
+           (progn
+             (signals error (graph-db:shadow-store g))
+             (let* ((g2 (graph-db:lookup-graph name))
+                    (tm2 (graph-db::transaction-manager g2)))
+               (is-true g2)
+               (is (graph-db::graph-open-p g2))
+               (is (eq t (graph-db:accepting-p tm2)))
+               (let ((pin (graph-db:pin-read-epoch tm2)))
+                 (graph-db:unpin-read-epoch tm2 pin))
+               (with-transaction (tm2)
+                 (graph-db:make-vertex :generic nil :graph g2))
+               (setq g g2)))
+        (ignore-errors (delete-file bare-shadow))))))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -466,9 +466,17 @@ write; the retired dir exists; the journal carries :SWAP and :ATTACH."
           :validate t :if-does-not-exist :ignore))))))
 
 (test swap-failure-before-rename-restores-service
-  "A nonexistent shadow location fails SWAP-IN-SHADOW before the first
-rename; the live store is reopened (or was never closed) and still
-serves reads and writes."
+  "A nonexistent shadow location fails SWAP-IN-SHADOW before ANYTHING
+touches the live store (fix round 1): the precondition check runs
+before the quiesce, so there is no outage at all, not merely a
+recovered one.  Asserted by OBJECT IDENTITY, not just service: the
+SAME graph object G stays the one LOOKUP-GRAPH returns, ACCEPTING-P
+never leaves T, and a write succeeds immediately with no reopen in
+between.  ABLATION: reverting SWAP-IN-SHADOW to validate AFTER
+quiesce+close (the pre-fix ordering) makes the (EQ G ...) assertion
+fail, because that ordering closes G and recovers onto a NEW graph
+object -- a real, if brief, outage -- even though it also eventually
+restores service."
   (with-clocked-store (g clock sys)
     clock sys
     (with-transaction ((graph-db::transaction-manager g))
@@ -476,19 +484,80 @@ serves reads and writes."
     (let ((nonexistent (merge-pathnames
                         "nope-shadow/"
                         (uiop:ensure-directory-pathname
-                         (graph-db::location g)))))
+                         (graph-db::location g))))
+          (tm (graph-db::transaction-manager g)))
       (signals error (graph-db:swap-in-shadow g nonexistent))
-      (let* ((name (graph-db:graph-name g))
-             (g2 (graph-db:lookup-graph name))
-             (tm2 (graph-db::transaction-manager g2)))
-        (is-true g2)
-        (is (graph-db::graph-open-p g2))
-        (is (eq t (graph-db:accepting-p tm2)))
-        (let ((pin (graph-db:pin-read-epoch tm2)))
-          (graph-db:unpin-read-epoch tm2 pin))
-        (with-transaction (tm2)
-          (graph-db:make-vertex :generic nil :graph g2))
-        (setq g g2)))))
+      (is (eq t (graph-db:accepting-p tm)))
+      (is (eq g (graph-db:lookup-graph (graph-db:graph-name g))))
+      (is (graph-db::graph-open-p g))
+      (let ((pin (graph-db:pin-read-epoch tm)))
+        (graph-db:unpin-read-epoch tm pin))
+      (with-transaction (tm)
+        (graph-db:make-vertex :generic nil :graph g)))))
+
+;;; Fix round 1 (GH #170): a swap that completed its renames+journal but
+;;; then fails on the follow-up reopen must be reported as a SUCCESS
+;;; (recovered onto the new generation), not resignalled as a failure.
+
+(test swap-completed-p-discriminates-progress
+  "Pure unit test for the discrimination predicate itself: unset
+PROGRESS means \"not yet complete, recover the OLD store and
+resignal\"; PROGRESS marked complete means \"already succeeded,
+recover the NEW one and return\"."
+  (is (not (graph-db::%swap-completed-p (vector nil nil))))
+  (is-true (graph-db::%swap-completed-p (vector t "/some/retired/path"))))
+
+(test swap-in-shadow-1-progress-survives-a-post-rename-failure
+  "%SWAP-IN-SHADOW-1 must mark PROGRESS complete BEFORE attempting the
+follow-up OPEN-GRAPH, so a failure there is distinguishable from a
+failure in the renames/journal themselves.  There is no clean way to
+make SWAP-IN-SHADOW's own reopen fail once and then succeed on the
+recovery retry without a purpose-built test hook in production code
+(judged too invasive -- the same call the review flagged for
+*SYSTEM-CLOCK*-unbinding): a corrupted file fails identically on every
+subsequent open attempt, which only reproduces the already-tested
+SHADOW-RECOVERY-FAILED path, never the \"recovered onto the new
+generation\" happy path.  So this tests %SWAP-IN-SHADOW-1 directly
+instead (honestly, per the review's own fallback): renames + journal
+succeed, then the follow-up OPEN-GRAPH fails on a corrupted
+schema.dat, and PROGRESS must already show completion when the error
+propagates."
+  (with-clocked-store (g clock sys)
+    sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let ((name (graph-db:graph-name g))
+          (location (graph-db::location g))
+          (retired nil))
+      (unwind-protect
+           (progn
+             (let ((graph-db:*graph* g))
+               (close-graph g :snapshot-p nil))
+             (with-temp-directory (shadow-dir)
+               (let ((sg (make-graph name (namestring shadow-dir)
+                                    :buffer-pool-size 1000)))
+                 (with-transaction ((graph-db::transaction-manager sg))
+                   (graph-db:make-vertex :generic nil :graph sg))
+                 (let ((graph-db:*graph* sg))
+                   (close-graph sg :snapshot-p nil)))
+               ;; Corrupt the shadow's schema.dat: the reopen -- which
+               ;; only runs AFTER both renames -- fails deterministically.
+               (with-open-file (out (merge-pathnames "schema.dat" shadow-dir)
+                                    :direction :output :if-exists :supersede)
+                 (write-string "not a valid cl-store payload" out))
+               (let ((progress (vector nil nil)))
+                 (signals error
+                   (graph-db::%swap-in-shadow-1
+                    name location shadow-dir clock progress))
+                 (is-true (aref progress 0))
+                 (is-true (aref progress 1))
+                 (setq retired (aref progress 1))
+                 (is-true (probe-file retired)))))
+        (when (and retired (probe-file retired))
+          (ignore-errors
+           (uiop:delete-directory-tree
+            (uiop:ensure-directory-pathname retired)
+            :validate t :if-does-not-exist :ignore)))))))
 
 (test killed-loader-leaves-live-byte-identical
   "ABANDON-SHADOW is the discard path exercised here; it must also

--- a/tests/segment-tests.lisp
+++ b/tests/segment-tests.lisp
@@ -1310,6 +1310,82 @@ must fail (EBADF); succeeding would mean MMAP-FILE leaked it."
       (setf (fdefinition 'truename) orig-truename)
       (ignore-errors (delete-file path)))))
 
+;;; ---------------------------------------------------------------------------
+;;; PRESIZE-VECTOR-SEGMENT (GH #170 Task 5): turn a mid-apply capacity failure
+;;; into an upfront one.
+;;; ---------------------------------------------------------------------------
+
+(test presize-grows-once-then-a-burst-does-not-grow-again
+  "PRESIZE-VECTOR-SEGMENT to N gives capacity >= N up front; a subsequent
+burst of SEGMENT-PUTs that stays within that headroom triggers NO further
+growth.  Ablation: a no-op PRESIZE-VECTOR-SEGMENT would leave capacity at the
+tiny initial value, and the burst below would grow the segment repeatedly --
+this assertion is exactly what would then fail."
+  (let ((path (%seg-path)))
+    (unwind-protect
+         (let ((s (create-vector-segment path 32 :initial-capacity 8)))
+           (unwind-protect
+                (progn
+                  (graph-db:presize-vector-segment s 10000)
+                  (is (>= (segment-capacity s) 10000))
+                  (let ((cap-before (segment-capacity s)))
+                    (dotimes (i 5000)
+                      (segment-put s (%id i) (%vec 32 (float i 1.0))))
+                    (is (= cap-before (segment-capacity s))
+                        "a burst within the presized headroom must not grow ~
+                         the segment again (before ~D, after ~D)"
+                        cap-before (segment-capacity s))))
+             (close-vector-segment s)))
+      (ignore-errors (delete-file path)))))
+
+(test presize-is-a-no-op-when-already-big-enough
+  "PRESIZE-VECTOR-SEGMENT to N <= the current capacity changes nothing."
+  (let ((path (%seg-path)))
+    (unwind-protect
+         (let ((s (create-vector-segment path 32 :initial-capacity 64)))
+           (unwind-protect
+                (progn
+                  (graph-db:presize-vector-segment s 10)
+                  (is (= 64 (segment-capacity s)))
+                  (graph-db:presize-vector-segment s 64)
+                  (is (= 64 (segment-capacity s))))
+             (close-vector-segment s)))
+      (ignore-errors (delete-file path)))))
+
+(test presize-failure-signals-before-writing-anything
+  "A presize that cannot be satisfied signals VECTOR-SEGMENT-CAPACITY-
+EXHAUSTED -- the same condition %SEG-GROW always signals on reservation
+failure, surfaced unchanged -- and leaves the segment exactly as it was:
+capacity and live-count unchanged, still usable afterward.
+
+SIMULATION NOTE: the brief's suggested \"an absurd N\" is not reliably
+simulable here -- %SEG-GROW's doubling+relocate loop does O(capacity) work
+per doubling (it memcpys the whole vector block), so an N large enough to
+exhaust real reservation would first spend unbounded time growing toward it.
+Substituted the SAME deterministic technique
+SEGMENT-RELOCATION-CAN-BE-SWITCHED-OFF already uses two tests up: a tiny
+reservation (WITH-TINY-SEGMENT-RESERVATION) with both growth mechanisms
+switched off, so the very first doubling this presize needs has nowhere to
+go and %SEG-ENSURE-RESERVATION signals for real."
+  (with-adjacent-extension-disabled
+    (let ((path (%seg-path)))
+      (unwind-protect
+           (let ((s (with-tiny-segment-reservation
+                      (create-vector-segment path 64 :initial-capacity 8))))
+             (unwind-protect
+                  (let ((graph-db::*segment-relocate-on-exhaustion* nil))
+                    (signals graph-db::vector-segment-capacity-exhausted
+                      (graph-db:presize-vector-segment s 9))
+                    (is (= 8 (segment-capacity s))
+                        "a failed presize must not have changed capacity")
+                    (is (= 0 (segment-live-count s))
+                        "a failed presize must not have written anything")
+                    ;; The segment must still be fully usable afterward.
+                    (segment-put s (%id 0) (%vec 64 1.0))
+                    (is (every #'= (%vec 64 1.0) (segment-get s (%id 0)))))
+               (close-vector-segment s)))
+        (ignore-errors (delete-file path))))))
+
 
 
 

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -9,6 +9,12 @@
                 validate-value-constraints))
 
 (defvar *transaction* nil)
+(defvar *quiesced-store-closing-p* nil
+  "Bound T only in the detaching thread's dynamic extent, while
+DETACH-STORE's own CLOSE-GRAPH runs its post-quiesce snapshot scan.  Lets
+that one internal read through despite ACCEPTING-P being non-T, without
+opening the door to any other caller -- the binding is thread-local, so
+a concurrent thread still sees the refusal (GH #170).")
 (defvar *read-snapshots* nil
   "Graph -> read-only snapshot transaction, or NIL.  Read-only snapshots are
 per graph and may compose; read-write transactions are not (GH #53).")
@@ -141,6 +147,29 @@ in-flight transactions. Attach only a quiescent store."
                      (graph-name (attach-with-active-transactions-graph
                                   condition))))))
 
+(define-condition store-not-accepting-error (error)
+  ;; ACCEPTING-P states: T (all), :READ-ONLY (pins/reads yes, txns no),
+  ;; :DETACHING/:SWAPPING (nothing new).  REASON mirrors the flag, except
+  ;; :READ-ONLY reports as :SHADOW-LOAD -- the human-facing name for the
+  ;; state Task 2's shadow window puts the store in (GH #170).
+  ((name :initarg :name :reader store-not-accepting-name)
+   (reason :initarg :reason :reader store-not-accepting-reason))
+  (:report (lambda (condition stream)
+             (format stream "Store ~S is not accepting new work (~S)."
+                     (store-not-accepting-name condition)
+                     (store-not-accepting-reason condition)))))
+
+(define-condition detach-drain-timeout (error)
+  ;; ACCEPTING-P is restored to T before this is signalled -- a failed
+  ;; detach must not strand the store half-dead (GH #170).
+  ((name :initarg :name :reader detach-timeout-name)
+   (seconds :initarg :seconds :reader detach-timeout-seconds))
+  (:report (lambda (condition stream)
+             (format stream "Store ~S did not drain within ~D second~:P; ~
+detach aborted and the store resumes accepting new work."
+                     (detach-timeout-name condition)
+                     (detach-timeout-seconds condition)))))
+
 (define-condition no-transaction-in-progress-warning (warning) ()
   (:report
    (lambda (condition stream)
@@ -185,7 +214,7 @@ in-flight transactions. Attach only a quiescent store."
              (copying-uncommitted-node-node condition)))))
 
 ;;; Transaction manager
-(defgeneric create-transaction (transaction-manager))
+(defgeneric create-transaction (transaction-manager &key allow-read-only))
 (defgeneric cleanup-transaction (transaction))
 
 (defgeneric graph (object)
@@ -650,7 +679,15 @@ vertices (the normal case for ingested source records) are unaffected."
 ;;; cannot be reclaimed out from under the reader.
 
 (defun pin-read-epoch (transaction-manager)
-  "Register a read pin at the current epoch; return its token (for UNPIN)."
+  "Register a read pin at the current epoch; return its token (for UNPIN).
+Refused -- STORE-NOT-ACCEPTING-ERROR -- only under FULL quiescence
+(:DETACHING / :SWAPPING); :READ-ONLY admits new pins (GH #170)."
+  (let ((state (accepting-p transaction-manager)))
+    (unless (or (eq state t) (eq state :read-only)
+                *quiesced-store-closing-p*)
+      (error 'store-not-accepting-error
+             :name (graph-name (graph transaction-manager))
+             :reason state)))
   ;; Racy read of the epoch is fine: it is monotonic, and a slightly stale
   ;; (smaller) value only makes the reaper MORE conservative, never less.
   (let ((epoch (tm-peek-epoch transaction-manager)))
@@ -2801,7 +2838,13 @@ stops appearing in queries.  MARK-DELETED is the usual entry point.")
     :initform (make-recursive-lock "read-pins lock"))
    (read-pin-counter
     :accessor read-pin-counter
-    :initform 0)))
+    :initform 0)
+   ;; Detach quiescence (GH #170).  T = accepting everything.  :READ-ONLY =
+   ;; pins/reads yes, new transactions no (Task 2's shadow window).
+   ;; :DETACHING / :SWAPPING = nothing new -- a full drain is in progress.
+   (accepting-p
+    :accessor accepting-p
+    :initform t)))
 
 (defmethod print-object ((transaction-manager transaction-manager) stream)
   (print-unreadable-object (transaction-manager stream :type t)
@@ -3010,8 +3053,19 @@ transaction; see that condition for why."
   (:method (transaction-manager)
     (incf (sequence-number transaction-manager))))
 
-(defmethod create-transaction (transaction-manager)
+(defmethod create-transaction (transaction-manager &key allow-read-only)
+  ;; ALLOW-READ-ONLY is CALL-WITH-READ-SNAPSHOT's escape hatch: its
+  ;; bookkeeping TX is never committed, so it follows the read-pin
+  ;; rule (admitted under :READ-ONLY) rather than the write rule
+  ;; (refused under any non-T state) -- see PIN-READ-EPOCH (GH #170).
   (with-recursive-lock-held ((lock transaction-manager))
+    (let ((state (accepting-p transaction-manager)))
+      (unless (or (eq state t)
+                  (and allow-read-only (eq state :read-only))
+                  *quiesced-store-closing-p*)
+        (error 'store-not-accepting-error
+               :name (graph-name (graph transaction-manager))
+               :reason (if (eq state :read-only) :shadow-load state))))
     (let* ((sequence-number (next-sequence-number transaction-manager))
            (graph (graph transaction-manager))
            (cache (cache graph))
@@ -3078,7 +3132,7 @@ store it touched."
       ;; already snapshotted this graph -> inherit
       ((and *read-snapshots* (gethash graph *read-snapshots*)) (funcall thunk))
       (t
-       (let ((txn (create-transaction tm))
+       (let ((txn (create-transaction tm :allow-read-only t))
              (table (or *read-snapshots* (make-hash-table :test 'eq)))
              (pin (pin-read-epoch tm)))
          (unwind-protect
@@ -3274,3 +3328,90 @@ Signals NO-TRANSACTION-IN-PROGRESS if none is active."
     :reader graph))
   (:default-initargs
    :writes nil))
+
+;;; Detach quiescence (GH #170).  A store hands its epoch range to its
+;;; system clock and closes durably, so it can move (media swap, cold
+;;; storage) and reopen later without colliding with epochs the clock
+;;; issued elsewhere meanwhile.  See docs/superpowers/specs/
+;;; 2026-08-20-namespaces-design.md.
+
+(defparameter *quiesce-poll-interval* 0.05
+  "Seconds between REAP-SAFE-FLOOR polls in %QUIESCE-TRANSACTION-MANAGER.")
+
+(defun %quiesce-transaction-manager (transaction-manager reason timeout)
+  "Flip TRANSACTION-MANAGER's ACCEPTING-P to REASON (a keyword) and wait,
+in short sleeps, for REAP-SAFE-FLOOR to go NIL -- no active transaction and
+no read pin left that could observe a version underneath the coming close.
+On TIMEOUT seconds elapsed with no drain: restore ACCEPTING-P to T (a
+failed detach must not strand the store half-dead) and signal
+DETACH-DRAIN-TIMEOUT.  On success return T with ACCEPTING-P left at
+REASON (GH #170)."
+  (with-transaction-manager-lock (transaction-manager)
+    (setf (accepting-p transaction-manager) reason))
+  (let ((deadline (+ (get-internal-real-time)
+                     (round (* timeout internal-time-units-per-second)))))
+    (loop
+      (when (null (reap-safe-floor transaction-manager))
+        (return t))
+      (when (> (get-internal-real-time) deadline)
+        (setf (accepting-p transaction-manager) t)
+        (error 'detach-drain-timeout
+               :name (graph-name (graph transaction-manager))
+               :seconds timeout))
+      (sleep *quiesce-poll-interval*))))
+
+(defstruct store-detachment
+  "A detached store's handle: everything REATTACH-STORE needs to reopen it
+and rejoin its system clock (GH #170)."
+  graph-name location store-id lease-start lease-end)
+
+(defun detach-store (graph &key (lease-epochs 1000000) (timeout 60))
+  "Quiesce GRAPH (no new transactions or read pins), lease it
+LEASE-EPOCHS of its system clock's epoch space, journal the handoff, and
+CLOSE-GRAPH it durably.  Returns a STORE-DETACHMENT for REATTACH-STORE.
+
+Requires (GRAPH-SYSTEM-CLOCK GRAPH) non-NIL: detach without an image
+clock has no lease to hand over.  Propagates DETACH-DRAIN-TIMEOUT
+unchanged if the quiesce wave cannot drain in TIMEOUT seconds -- GRAPH
+is left open and accepting again (GH #170)."
+  (let ((clock (graph-system-clock graph)))
+    (unless clock
+      (error "DETACH-STORE requires GRAPH to be attached to a system ~
+clock (GRAPH-SYSTEM-CLOCK is NIL) -- detach without one has no lease to ~
+hand over."))
+    (let ((tm (transaction-manager graph))
+          (name (graph-name graph))
+          (location (location graph))
+          (store-id (store-id graph)))
+      (%quiesce-transaction-manager tm :detaching timeout)
+      (multiple-value-bind (start end) (clock-lease-epochs clock lease-epochs)
+        (journal-append clock :detach
+                        :store name :lease-start start :lease-end end)
+        ;; CLOSE-GRAPH's own snapshot scans the graph via WITH-READ-PIN;
+        ;; ACCEPTING-P is already :DETACHING, so it needs the one bypass
+        ;; above -- see *QUIESCED-STORE-CLOSING-P*'s docstring.
+        (let ((*graph* graph)
+              (*quiesced-store-closing-p* t))
+          (close-graph graph :snapshot-p t))
+        (make-store-detachment :graph-name name
+                               :location location
+                               :store-id store-id
+                               :lease-start start
+                               :lease-end end)))))
+
+(defun reattach-store (detachment &key (buffer-pool-size nil bps-p))
+  "Reopen the store DETACHMENT names at its recorded location and rejoin
+it to the image clock (*SYSTEM-CLOCK*).  Composes OPEN-GRAPH with
+ATTACH-TO-SYSTEM-CLOCK -- which already refuses active transactions and
+journals :ATTACH -- rather than reimplementing either.  Returns the new
+GRAPH (GH #170)."
+  (let* ((open-args (list (store-detachment-graph-name detachment)
+                          (namestring (store-detachment-location detachment))
+                          :system-clock nil))
+        (graph (apply #'open-graph
+                      (if bps-p
+                          (append open-args
+                                 (list :buffer-pool-size buffer-pool-size))
+                          open-args))))
+    (attach-to-system-clock graph *system-clock*)
+    graph))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -12,9 +12,12 @@
 (defvar *quiesced-store-closing-p* nil
   "Bound T only in the detaching thread's dynamic extent, while
 DETACH-STORE's own CLOSE-GRAPH runs its post-quiesce snapshot scan.  Lets
-that one internal read through despite ACCEPTING-P being non-T, without
-opening the door to any other caller -- the binding is thread-local, so
-a concurrent thread still sees the refusal (GH #170).")
+that one internal PIN-READ-EPOCH through despite ACCEPTING-P being
+non-T, without opening the door to any other caller -- the binding is
+thread-local, so a concurrent thread still sees the refusal.  Checked
+only by PIN-READ-EPOCH: CLOSE-GRAPH's snapshot path (BACKUP via
+MAP-VERTICES/MAP-EDGES) takes read pins, never a transaction, so
+CREATE-TRANSACTION has no matching bypass (GH #170).")
 (defvar *read-snapshots* nil
   "Graph -> read-only snapshot transaction, or NIL.  Read-only snapshots are
 per graph and may compose; read-write transactions are not (GH #53).")
@@ -681,20 +684,32 @@ vertices (the normal case for ingested source records) are unaffected."
 (defun pin-read-epoch (transaction-manager)
   "Register a read pin at the current epoch; return its token (for UNPIN).
 Refused -- STORE-NOT-ACCEPTING-ERROR -- only under FULL quiescence
-(:DETACHING / :SWAPPING); :READ-ONLY admits new pins (GH #170)."
-  (let ((state (accepting-p transaction-manager)))
-    (unless (or (eq state t) (eq state :read-only)
-                *quiesced-store-closing-p*)
-      (error 'store-not-accepting-error
-             :name (graph-name (graph transaction-manager))
-             :reason state)))
-  ;; Racy read of the epoch is fine: it is monotonic, and a slightly stale
-  ;; (smaller) value only makes the reaper MORE conservative, never less.
-  (let ((epoch (tm-peek-epoch transaction-manager)))
-    (with-recursive-lock-held ((read-pins-lock transaction-manager))
-      (let ((token (incf (read-pin-counter transaction-manager))))
-        (setf (gethash token (read-pins transaction-manager)) epoch)
-        token))))
+(:DETACHING / :SWAPPING); :READ-ONLY admits new pins.
+
+The accepting-p CHECK and the pin REGISTRATION run as one critical
+section under READ-PINS-LOCK -- the same lock
+%QUIESCE-TRANSACTION-MANAGER's flip takes (after TM-LOCK; see its
+docstring for the lock-ordering argument).  Without this, the check
+here and the HASH-TABLE write below ran under two different locks, so a
+racing caller could observe ACCEPTING-P as T, then have the flip and
+the full drain both complete, and only THEN land its pin -- a straggler
+admitted after DETACH-STORE had already reported success and begun
+tearing down mmaps (GH #170, fix round 1)."
+  (with-recursive-lock-held ((read-pins-lock transaction-manager))
+    (let ((state (accepting-p transaction-manager)))
+      (unless (or (eq state t) (eq state :read-only)
+                  *quiesced-store-closing-p*)
+        (error 'store-not-accepting-error
+               :name (graph-name (graph transaction-manager))
+               :reason state)))
+    ;; Racy read of the epoch is fine: it is monotonic, and a slightly
+    ;; stale (smaller) value only makes the reaper MORE conservative,
+    ;; never less.  Reading it inside the lock now (rather than before
+    ;; it) costs nothing -- TM-PEEK-EPOCH is itself lock-free.
+    (let* ((epoch (tm-peek-epoch transaction-manager))
+           (token (incf (read-pin-counter transaction-manager))))
+      (setf (gethash token (read-pins transaction-manager)) epoch)
+      token)))
 
 (defun unpin-read-epoch (transaction-manager token)
   (with-recursive-lock-held ((read-pins-lock transaction-manager))
@@ -3061,8 +3076,7 @@ transaction; see that condition for why."
   (with-recursive-lock-held ((lock transaction-manager))
     (let ((state (accepting-p transaction-manager)))
       (unless (or (eq state t)
-                  (and allow-read-only (eq state :read-only))
-                  *quiesced-store-closing-p*)
+                  (and allow-read-only (eq state :read-only)))
         (error 'store-not-accepting-error
                :name (graph-name (graph transaction-manager))
                :reason (if (eq state :read-only) :shadow-load state))))
@@ -3338,6 +3352,22 @@ Signals NO-TRANSACTION-IN-PROGRESS if none is active."
 (defparameter *quiesce-poll-interval* 0.05
   "Seconds between REAP-SAFE-FLOOR polls in %QUIESCE-TRANSACTION-MANAGER.")
 
+(defun %set-accepting-p (transaction-manager reason)
+  "Set ACCEPTING-P while holding TM-LOCK, then READ-PINS-LOCK, in that
+fixed order -- the same order every caller of this function uses, and
+the order PIN-READ-EPOCH is compatible with because it only ever takes
+READ-PINS-LOCK alone (never TM-LOCK), so this can never deadlock against
+it.  Grepped every existing site that takes both locks
+(CREATE-TRANSACTION: TM-LOCK only; PIN-READ-EPOCH/UNPIN-READ-EPOCH/
+MINIMUM-READ-PIN: READ-PINS-LOCK only) and found no path that nests them
+in the opposite order.  Holding READ-PINS-LOCK across the SETF is what
+makes the flip atomic with PIN-READ-EPOCH's own check-then-register
+critical section: once this returns, no pin admitted after it can have
+missed seeing REASON (GH #170, fix round 1)."
+  (with-transaction-manager-lock (transaction-manager)
+    (with-recursive-lock-held ((read-pins-lock transaction-manager))
+      (setf (accepting-p transaction-manager) reason))))
+
 (defun %quiesce-transaction-manager (transaction-manager reason timeout)
   "Flip TRANSACTION-MANAGER's ACCEPTING-P to REASON (a keyword) and wait,
 in short sleeps, for REAP-SAFE-FLOOR to go NIL -- no active transaction and
@@ -3346,15 +3376,14 @@ On TIMEOUT seconds elapsed with no drain: restore ACCEPTING-P to T (a
 failed detach must not strand the store half-dead) and signal
 DETACH-DRAIN-TIMEOUT.  On success return T with ACCEPTING-P left at
 REASON (GH #170)."
-  (with-transaction-manager-lock (transaction-manager)
-    (setf (accepting-p transaction-manager) reason))
+  (%set-accepting-p transaction-manager reason)
   (let ((deadline (+ (get-internal-real-time)
                      (round (* timeout internal-time-units-per-second)))))
     (loop
       (when (null (reap-safe-floor transaction-manager))
         (return t))
       (when (> (get-internal-real-time) deadline)
-        (setf (accepting-p transaction-manager) t)
+        (%set-accepting-p transaction-manager t)
         (error 'detach-drain-timeout
                :name (graph-name (graph transaction-manager))
                :seconds timeout))
@@ -3401,10 +3430,15 @@ hand over."))
 
 (defun reattach-store (detachment &key (buffer-pool-size nil bps-p))
   "Reopen the store DETACHMENT names at its recorded location and rejoin
-it to the image clock (*SYSTEM-CLOCK*).  Composes OPEN-GRAPH with
-ATTACH-TO-SYSTEM-CLOCK -- which already refuses active transactions and
-journals :ATTACH -- rather than reimplementing either.  Returns the new
-GRAPH (GH #170)."
+it to the image clock.  REQUIRES *SYSTEM-CLOCK* to already be bound to
+that clock in the caller's dynamic extent -- this function takes no
+clock argument (the contract fixes its lambda list), so it reads the
+ambient *SYSTEM-CLOCK* the same way MAKE-GRAPH/OPEN-GRAPH's own
+:SYSTEM-CLOCK default does.  Passes :SYSTEM-CLOCK NIL to OPEN-GRAPH
+itself (to avoid OPEN-GRAPH attaching a second time from its own
+default) and then calls ATTACH-TO-SYSTEM-CLOCK explicitly -- which
+already refuses active transactions and journals :ATTACH -- rather than
+reimplementing either.  Returns the new GRAPH (GH #170)."
   (let* ((open-args (list (store-detachment-graph-name detachment)
                           (namestring (store-detachment-location detachment))
                           :system-clock nil))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -173,6 +173,18 @@ detach aborted and the store resumes accepting new work."
                      (detach-timeout-name condition)
                      (detach-timeout-seconds condition)))))
 
+(define-condition epoch-lease-exhausted (error)
+  ;; A shadow store's leased range is [START, END) -- see EPOCH-LEASE in
+  ;; graph-class.lisp.  Signalled instead of silently falling through to
+  ;; the clock/counter, which would collide with the live store's ids
+  ;; (GH #170).
+  ((name :initarg :name :reader epoch-lease-exhausted-name)
+   (end :initarg :end :reader epoch-lease-exhausted-end))
+  (:report (lambda (condition stream)
+             (format stream "Store ~S exhausted its leased epoch range ~
+(end ~D)." (epoch-lease-exhausted-name condition)
+                     (epoch-lease-exhausted-end condition)))))
+
 (define-condition no-transaction-in-progress-warning (warning) ()
   (:report
    (lambda (condition stream)
@@ -3013,29 +3025,53 @@ A transaction-manager always has a graph -- INITIALIZE-INSTANCE :AFTER
 dereferences it immediately, so a NIL graph dies there first."
   (graph-system-clock (graph transaction-manager)))
 
+(defun tm-lease (transaction-manager)
+  "TRANSACTION-MANAGER's leased epoch range, or NIL -- shadow stores
+only (GH #170).  Checked BEFORE both the clock and the per-store
+counter in TM-NEXT-EPOCH/TM-CURRENT-EPOCH/TM-PEEK-EPOCH: a shadow's
+transaction ids must come from its lease, never from either."
+  (graph-epoch-lease (graph transaction-manager)))
+
 (defun tm-next-epoch (transaction-manager)
-  "Allocate a fresh epoch: from the image clock when the graph has one,
-otherwise from this manager's own counter (pre-#168 behaviour)."
-  (let ((clock (tm-clock transaction-manager)))
-    (if clock
-        (clock-next-epoch clock)
-        (prog1 (tx-id-counter transaction-manager)
-          (incf (tx-id-counter transaction-manager))))))
+  "Allocate a fresh epoch: from the lease when TRANSACTION-MANAGER's
+graph has one (shadow stores, GH #170), else from the image clock when
+the graph has one, otherwise from this manager's own counter (pre-#168
+behaviour)."
+  (let ((lease (tm-lease transaction-manager)))
+    (if lease
+        (let ((next (epoch-lease-next lease)))
+          (when (>= next (epoch-lease-end lease))
+            (error 'epoch-lease-exhausted
+                   :name (graph-name (graph transaction-manager))
+                   :end (epoch-lease-end lease)))
+          (setf (epoch-lease-next lease) (1+ next))
+          next)
+        (let ((clock (tm-clock transaction-manager)))
+          (if clock
+              (clock-next-epoch clock)
+              (prog1 (tx-id-counter transaction-manager)
+                (incf (tx-id-counter transaction-manager))))))))
 
 (defun tm-current-epoch (transaction-manager)
   "The next epoch TM-NEXT-EPOCH would return."
-  (let ((clock (tm-clock transaction-manager)))
-    (if clock
-        (clock-current-epoch clock)
-        (tx-id-counter transaction-manager))))
+  (let ((lease (tm-lease transaction-manager)))
+    (if lease
+        (epoch-lease-next lease)
+        (let ((clock (tm-clock transaction-manager)))
+          (if clock
+              (clock-current-epoch clock)
+              (tx-id-counter transaction-manager))))))
 
 (defun tm-peek-epoch (transaction-manager)
   "Like TM-CURRENT-EPOCH but lock-free under a clock -- see
 CLOCK-PEEK-EPOCH.  For PIN-READ-EPOCH, where a racy read is fine."
-  (let ((clock (tm-clock transaction-manager)))
-    (if clock
-        (clock-peek-epoch clock)
-        (tx-id-counter transaction-manager))))
+  (let ((lease (tm-lease transaction-manager)))
+    (if lease
+        (epoch-lease-next lease)
+        (let ((clock (tm-clock transaction-manager)))
+          (if clock
+              (clock-peek-epoch clock)
+              (tx-id-counter transaction-manager))))))
 
 (defun attach-to-system-clock (graph clock)
   "Raise CLOCK above GRAPH's persisted history and record the attach --

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -163,13 +163,15 @@ in-flight transactions. Attach only a quiescent store."
                      (store-not-accepting-reason condition)))))
 
 (define-condition detach-drain-timeout (error)
-  ;; ACCEPTING-P is restored to T before this is signalled -- a failed
-  ;; detach must not strand the store half-dead (GH #170).
+  ;; ACCEPTING-P is restored to whatever it was BEFORE this quiesce call,
+  ;; not hardcoded T -- a timeout during an already-non-accepting window
+  ;; (e.g. SHADOW-STORE's :READ-ONLY) must not silently lift it (GH #170,
+  ;; review finding C1).
   ((name :initarg :name :reader detach-timeout-name)
    (seconds :initarg :seconds :reader detach-timeout-seconds))
   (:report (lambda (condition stream)
              (format stream "Store ~S did not drain within ~D second~:P; ~
-detach aborted and the store resumes accepting new work."
+detach aborted and the store resumes its prior accepting state."
                      (detach-timeout-name condition)
                      (detach-timeout-seconds condition)))))
 
@@ -2901,8 +2903,11 @@ stops appearing in queries.  MARK-DELETED is the usual entry point.")
    ;; Detach quiescence (GH #170).  T = accepting everything.  :READ-ONLY =
    ;; pins/reads yes, new transactions no (Task 2's shadow window).
    ;; :DETACHING / :SWAPPING = nothing new -- a full drain is in progress.
+   ;; :INITARG so OPEN-GRAPH's :INITIAL-ACCEPTING-STATE can set this at
+   ;; construction, before the graph is published anywhere (GH #170, I4).
    (accepting-p
     :accessor accepting-p
+    :initarg :accepting-p
     :initform t)))
 
 (defmethod print-object ((transaction-manager transaction-manager) stream)
@@ -3422,6 +3427,34 @@ Signals NO-TRANSACTION-IN-PROGRESS if none is active."
 ;;; issued elsewhere meanwhile.  See docs/superpowers/specs/
 ;;; 2026-08-20-namespaces-design.md.
 
+(define-condition detach-unsupported-graph-error (error)
+  ;; v1 scope (GH #170 review, finding I1): DETACH-STORE / SHADOW-STORE /
+  ;; SWAP-IN-SHADOW all reopen with OPEN-GRAPH's plain default args, which
+  ;; would silently drop a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH's
+  ;; replication/peer configuration on the reopened generation.  Threading
+  ;; the FULL open-args set (master-p, replication-key, peer-role, etc.)
+  ;; through detachment/shadowing is deferred follow-on work -- see the
+  ;; review thread on GH #170.
+  ((graph :initarg :graph :reader detach-unsupported-graph-error-graph)
+   (operation :initarg :operation
+              :reader detach-unsupported-graph-error-operation))
+  (:report (lambda (c s)
+             (format s "~S does not support ~S: it is a ~S, and v1 of ~
+detach/shadow covers only plain clocked stores.  Reopening a replicated ~
+or peer graph with default OPEN-GRAPH args would silently strip its ~
+replication/peer configuration (GH #170)."
+                     (graph-name (detach-unsupported-graph-error-graph c))
+                     (detach-unsupported-graph-error-operation c)
+                     (class-name
+                      (class-of (detach-unsupported-graph-error-graph c)))))))
+
+(defun %check-detach-supported (graph operation)
+  "Signal DETACH-UNSUPPORTED-GRAPH-ERROR unless GRAPH is a plain clocked
+store -- MASTER-GRAPH, SLAVE-GRAPH and PEER-GRAPH are refused by all
+three v1 entry points (GH #170, review finding I1)."
+  (when (typep graph '(or master-graph slave-graph peer-graph))
+    (error 'detach-unsupported-graph-error :graph graph :operation operation)))
+
 (defparameter *quiesce-poll-interval* 0.05
   "Seconds between REAP-SAFE-FLOOR polls in %QUIESCE-TRANSACTION-MANAGER.")
 
@@ -3445,22 +3478,25 @@ missed seeing REASON (GH #170, fix round 1)."
   "Flip TRANSACTION-MANAGER's ACCEPTING-P to REASON (a keyword) and wait,
 in short sleeps, for REAP-SAFE-FLOOR to go NIL -- no active transaction and
 no read pin left that could observe a version underneath the coming close.
-On TIMEOUT seconds elapsed with no drain: restore ACCEPTING-P to T (a
-failed detach must not strand the store half-dead) and signal
-DETACH-DRAIN-TIMEOUT.  On success return T with ACCEPTING-P left at
-REASON (GH #170)."
-  (%set-accepting-p transaction-manager reason)
-  (let ((deadline (+ (get-internal-real-time)
-                     (round (* timeout internal-time-units-per-second)))))
-    (loop
-      (when (null (reap-safe-floor transaction-manager))
-        (return t))
-      (when (> (get-internal-real-time) deadline)
-        (%set-accepting-p transaction-manager t)
-        (error 'detach-drain-timeout
-               :name (graph-name (graph transaction-manager))
-               :seconds timeout))
-      (sleep *quiesce-poll-interval*))))
+On TIMEOUT seconds elapsed with no drain: restore ACCEPTING-P to whatever
+it was PRIOR to this call (captured before the flip) and signal
+DETACH-DRAIN-TIMEOUT -- NOT hardcoded T, which would silently lift an
+already-in-force window (e.g. SHADOW-STORE's :READ-ONLY) that this call
+did not open and has no business closing (GH #170, review finding C1).
+On success return T with ACCEPTING-P left at REASON (GH #170)."
+  (let ((prior (accepting-p transaction-manager)))
+    (%set-accepting-p transaction-manager reason)
+    (let ((deadline (+ (get-internal-real-time)
+                       (round (* timeout internal-time-units-per-second)))))
+      (loop
+        (when (null (reap-safe-floor transaction-manager))
+          (return t))
+        (when (> (get-internal-real-time) deadline)
+          (%set-accepting-p transaction-manager prior)
+          (error 'detach-drain-timeout
+                 :name (graph-name (graph transaction-manager))
+                 :seconds timeout))
+        (sleep *quiesce-poll-interval*)))))
 
 (defstruct store-detachment
   "A detached store's handle: everything REATTACH-STORE needs to reopen it
@@ -3472,34 +3508,51 @@ and rejoin its system clock (GH #170)."
 LEASE-EPOCHS of its system clock's epoch space, journal the handoff, and
 CLOSE-GRAPH it durably.  Returns a STORE-DETACHMENT for REATTACH-STORE.
 
+Refuses a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH with
+DETACH-UNSUPPORTED-GRAPH-ERROR -- v1 scope, see that condition's
+docstring (GH #170).
+
 Requires (GRAPH-SYSTEM-CLOCK GRAPH) non-NIL: detach without an image
 clock has no lease to hand over.  Propagates DETACH-DRAIN-TIMEOUT
 unchanged if the quiesce wave cannot drain in TIMEOUT seconds -- GRAPH
-is left open and accepting again (GH #170)."
+is left open and accepting again (GH #170).
+
+Between a successful quiesce and the durable CLOSE-GRAPH, CLOCK-LEASE-
+EPOCHS or JOURNAL-APPEND can still fail; that span is wrapped so an
+error there restores ACCEPTING-P to its pre-quiesce state (not left
+stranded at :DETACHING) before re-signalling (GH #170, review finding
+I3)."
+  (%check-detach-supported graph 'detach-store)
   (let ((clock (graph-system-clock graph)))
     (unless clock
       (error "DETACH-STORE requires GRAPH to be attached to a system ~
 clock (GRAPH-SYSTEM-CLOCK is NIL) -- detach without one has no lease to ~
 hand over."))
-    (let ((tm (transaction-manager graph))
-          (name (graph-name graph))
-          (location (location graph))
-          (store-id (store-id graph)))
+    (let* ((tm (transaction-manager graph))
+           (name (graph-name graph))
+           (location (location graph))
+           (store-id (store-id graph))
+           (prior (accepting-p tm)))
       (%quiesce-transaction-manager tm :detaching timeout)
-      (multiple-value-bind (start end) (clock-lease-epochs clock lease-epochs)
-        (journal-append clock :detach
-                        :store name :lease-start start :lease-end end)
-        ;; CLOSE-GRAPH's own snapshot scans the graph via WITH-READ-PIN;
-        ;; ACCEPTING-P is already :DETACHING, so it needs the one bypass
-        ;; above -- see *QUIESCED-STORE-CLOSING-P*'s docstring.
-        (let ((*graph* graph)
-              (*quiesced-store-closing-p* t))
-          (close-graph graph :snapshot-p t))
-        (make-store-detachment :graph-name name
-                               :location location
-                               :store-id store-id
-                               :lease-start start
-                               :lease-end end)))))
+      (handler-case
+          (multiple-value-bind (start end)
+              (clock-lease-epochs clock lease-epochs)
+            (journal-append clock :detach
+                            :store name :lease-start start :lease-end end)
+            ;; CLOSE-GRAPH's own snapshot scans the graph via WITH-READ-PIN;
+            ;; ACCEPTING-P is already :DETACHING, so it needs the one bypass
+            ;; above -- see *QUIESCED-STORE-CLOSING-P*'s docstring.
+            (let ((*graph* graph)
+                  (*quiesced-store-closing-p* t))
+              (close-graph graph :snapshot-p t))
+            (make-store-detachment :graph-name name
+                                   :location location
+                                   :store-id store-id
+                                   :lease-start start
+                                   :lease-end end))
+        (error (c)
+          (%set-accepting-p tm prior)
+          (error c))))))
 
 (defun reattach-store (detachment &key (buffer-pool-size nil bps-p))
   "Reopen the store DETACHMENT names at its recorded location and rejoin

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -152,9 +152,11 @@ in-flight transactions. Attach only a quiescent store."
 
 (define-condition store-not-accepting-error (error)
   ;; ACCEPTING-P states: T (all), :READ-ONLY (pins/reads yes, txns no),
-  ;; :DETACHING/:SWAPPING (nothing new).  REASON mirrors the flag, except
-  ;; :READ-ONLY reports as :SHADOW-LOAD -- the human-facing name for the
-  ;; state Task 2's shadow window puts the store in (GH #170).
+  ;; :OPENING (same admit-pins/refuse-txns shape, for OPEN-GRAPH's own
+  ;; mid-open window -- GH #170 review round 3), :DETACHING/:SWAPPING
+  ;; (nothing new).  REASON mirrors the flag, except :READ-ONLY reports
+  ;; as :SHADOW-LOAD -- the human-facing name for the state Task 2's
+  ;; shadow window puts the store in (GH #170).
   ((name :initarg :name :reader store-not-accepting-name)
    (reason :initarg :reason :reader store-not-accepting-reason))
   (:report (lambda (condition stream)
@@ -698,7 +700,11 @@ vertices (the normal case for ingested source records) are unaffected."
 (defun pin-read-epoch (transaction-manager)
   "Register a read pin at the current epoch; return its token (for UNPIN).
 Refused -- STORE-NOT-ACCEPTING-ERROR -- only under FULL quiescence
-(:DETACHING / :SWAPPING); :READ-ONLY admits new pins.
+(:DETACHING / :SWAPPING); :READ-ONLY and :OPENING (OPEN-GRAPH's own
+mid-open window, GH #170 review round 3) both admit new pins -- OPEN-
+GRAPH's own rebuild/recovery scans run under WITH-READ-PIN and must not
+be refused by the very state that protects them from a concurrent
+writer.
 
 The accepting-p CHECK and the pin REGISTRATION run as one critical
 section under READ-PINS-LOCK -- the same lock
@@ -711,7 +717,7 @@ admitted after DETACH-STORE had already reported success and begun
 tearing down mmaps (GH #170, fix round 1)."
   (with-recursive-lock-held ((read-pins-lock transaction-manager))
     (let ((state (accepting-p transaction-manager)))
-      (unless (or (eq state t) (eq state :read-only)
+      (unless (or (eq state t) (eq state :read-only) (eq state :opening)
                   *quiesced-store-closing-p*)
         (error 'store-not-accepting-error
                :name (graph-name (graph transaction-manager))
@@ -2902,9 +2908,14 @@ stops appearing in queries.  MARK-DELETED is the usual entry point.")
     :initform 0)
    ;; Detach quiescence (GH #170).  T = accepting everything.  :READ-ONLY =
    ;; pins/reads yes, new transactions no (Task 2's shadow window).
-   ;; :DETACHING / :SWAPPING = nothing new -- a full drain is in progress.
-   ;; :INITARG so OPEN-GRAPH's :INITIAL-ACCEPTING-STATE can set this at
-   ;; construction, before the graph is published anywhere (GH #170, I4).
+   ;; :OPENING = same admit-pins/refuse-transactions shape as :READ-ONLY,
+   ;; but for OPEN-GRAPH's own mid-open window (review round 3): every
+   ;; construction site starts here, before the graph is published to
+   ;; *GRAPHS* -- a name-lookup writer racing the open now gets a loud
+   ;; STORE-NOT-ACCEPTING-ERROR reason :OPENING instead of colliding with
+   ;; a still-running rebuild/recovery.  :DETACHING / :SWAPPING = nothing
+   ;; new -- a full drain is in progress.  :INITARG so OPEN-GRAPH can set
+   ;; this at construction (GH #170, I4/round 3).
    (accepting-p
     :accessor accepting-p
     :initarg :accepting-p

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -2299,17 +2299,24 @@ left in the stream."
                    :defaults (transaction-pathname transaction))))
 
 (defgeneric persist-transaction (transaction)
+  (:documentation
+   "Legacy single-shot persistence path -- superseded on the commit hot
+path by the PREPARE-TX-PERSISTENCE / FINALIZE-TX-PERSISTENCE split (GH
+#135), which this generic has no callers left in this system; kept
+current for any external caller and honors the same WAL-suppressed
+no-op as FINALIZE-TX-PERSISTENCE (GH #170 Task 4).")
   (:method (transaction)
-    (persist-tx transaction
-                (transaction-temporary-pathname transaction)
-                (transaction-pathname transaction))
-    (let* ((transaction-manager (transaction-manager transaction))
-           (stream (replication-log transaction-manager))
-           (lock (replication-log-lock transaction-manager)))
-      (with-recursive-lock-held (lock)
-        (write-sequence (bytes transaction)
-                        (replication-log (transaction-manager transaction)))
-        (finish-output stream)))))
+    (unless (wal-suppressed-p (graph transaction))
+      (persist-tx transaction
+                  (transaction-temporary-pathname transaction)
+                  (transaction-pathname transaction))
+      (let* ((transaction-manager (transaction-manager transaction))
+             (stream (replication-log transaction-manager))
+             (lock (replication-log-lock transaction-manager)))
+        (with-recursive-lock-held (lock)
+          (write-sequence (bytes transaction)
+                          (replication-log (transaction-manager transaction)))
+          (finish-output stream))))))
 
 (defun transaction-prepare-pathname (transaction)
   "A unique per-attempt temp pathname, keyed by SEQUENCE-NUMBER (the
@@ -2555,16 +2562,25 @@ the transaction-manager lock, so the bulk serialization + disk write (and the
 flush at close) are off the serialized commit path.  The header id is written as
 the placeholder 0 — the real id is encoded in the final FILENAME by the rename in
 FINALIZE-TX-PERSISTENCE, and recovery reads it from there.  Returns the temp
-pathname."
+pathname.
+
+WAL-suppressed (GH #170 Task 4): when (GRAPH TRANSACTION)'s WAL-SUPPRESSED-P
+is set, no temp file is written and BYTES is left unpopulated -- FINALIZE-TX-
+PERSISTENCE checks the same slot and skips both the rename and the
+replication-log write, so nothing here would ever be read.  REFRESH-CREATE-
+SET-BYTES still runs unconditionally: it refreshes each node's own BYTES from
+DATA, which APPLY-TRANSACTION's heap allocation depends on regardless of WAL
+suppression (GH #135)."
   (refresh-create-set-bytes transaction)
   (let ((tmp (transaction-prepare-pathname transaction)))
-    (with-open-file (stream tmp :direction :output
-                            :if-exists :supersede
-                            :if-does-not-exist :create
-                            :element-type '(unsigned-byte 8))
-      (write-tx-header-to-stream transaction stream 0)
-      (write-tx-writes-to-stream transaction stream))
-    (initialize-bytes-from-components transaction)
+    (unless (wal-suppressed-p (graph transaction))
+      (with-open-file (stream tmp :direction :output
+                              :if-exists :supersede
+                              :if-does-not-exist :create
+                              :element-type '(unsigned-byte 8))
+        (write-tx-header-to-stream transaction stream 0)
+        (write-tx-writes-to-stream transaction stream))
+      (initialize-bytes-from-components transaction))
     tmp))
 
 (defun finalize-tx-persistence (transaction tmp)
@@ -2577,57 +2593,73 @@ lock).  Recovery reads the id from this filename, so the file's header id stays
 at its placeholder 0.  Master graphs additionally patch the real id into the
 in-memory bytes and append them to the replication log in commit order for
 downstream slaves (the replication path is the only consumer of the header id,
-and it reads these patched bytes, never the .txn files)."
-  ;; Use POSIX rename(2) (atomic; replaces an existing target) rather than
-  ;; cl:rename-file.  SBCL/ECL's rename-file already overwrites per POSIX, but
-  ;; CCL's signals "File exists" when the target exists — which intermittently
-  ;; crashed concurrent-stress on CCL.  %posix-rename gives portable, atomic,
-  ;; overwrite-on-rename behavior across all implementations.
-  (%posix-rename (namestring tmp)
-                 (namestring (transaction-pathname transaction)))
-  (let ((tm (transaction-manager transaction)))
-    ;; peer-replication WP-2: generalized from MASTER-GRAPH-P so a peer-graph also
-    ;; journals its own committed writes (a device's push feed / a hub's pull feed).
-    ;; The patched-in transaction-id is the per-origin feed sequence (design §3 #3).
-    (when (journals-own-feed-p (graph tm))
-      (serialize-uint64 (bytes transaction)
-                        (transaction-id transaction)
-                        +tx-header-id-offset+)
-      (let ((repl-stream (replication-log tm))
-            (lock (replication-log-lock tm))
-            (gr (graph tm)))
-        (with-recursive-lock-held (lock)
-          ;; peer-replication WP-0: a peer-graph prefixes the feed entry with a
-          ;; peer-meta packet (op identity + lamport), then records that it has
-          ;; applied its own authored op so a re-homed bounce-back is deduped
-          ;; (design §6).  A master journals plain tx bytes, unchanged.
-          (when (peer-graph-p gr)
-            (if *peer-rehome-op*
-                ;; B2d-2: a hub re-home preserves the ORIGINAL op's identity on the
-                ;; feed entry (design §5) so device E pulls it as the author's op and
-                ;; the author dedups its own bounce-back; the re-home caller applies
-                ;; the merge's per-field stamps, so finalize does not stamp here.
-                (destructuring-bind (rop-id rorigin rlamport) *peer-rehome-op*
-                  (write-sequence
-                   (serialize-peer-meta rorigin rop-id rlamport +peer-op-authored+)
-                   repl-stream)
-                  (record-applied-op gr rop-id rlamport))
-                (let ((op-id (gen-op-id))
-                      (lamport (peer-next-lamport gr))
-                      (origin (or (origin-id gr) +peer-null-origin+)))
-                  (write-sequence
-                   (serialize-peer-meta origin op-id lamport +peer-op-authored+)
-                   repl-stream)
-                  (record-applied-op gr op-id lamport)
-                  ;; B2b: stamp every field this locally-authored op changed with
-                  ;; (lamport . origin) -- the LWW basis a later concurrent edit
-                  ;; from another replica compares against.
-                  (dolist (w (writes transaction))
-                    (let ((nid (id (node w))))
-                      (dolist (slot (authored-changed-slots w))
-                        (set-node-field-stamp gr nid slot lamport origin)))))))
-          (write-sequence (bytes transaction) repl-stream)
-          (finish-output repl-stream))))))
+and it reads these patched bytes, never the .txn files).
+
+WAL-suppressed (GH #170 Task 4): when (GRAPH TRANSACTION)'s WAL-SUPPRESSED-P
+is set, this whole body is skipped -- no rename (PREPARE-TX-PERSISTENCE wrote
+no TMP file to rename), no replication-log entry.  Checked on the transaction's
+own GRAPH, a per-graph slot, never a dynamic variable -- a special would leak
+suppression onto any OTHER graph committing on the same thread."
+  (unless (wal-suppressed-p (graph transaction))
+    ;; Use POSIX rename(2) (atomic; replaces an existing target) rather
+    ;; than cl:rename-file.  SBCL/ECL's rename-file already overwrites
+    ;; per POSIX, but CCL's signals "File exists" when the target
+    ;; exists — which intermittently crashed concurrent-stress on CCL.
+    ;; %posix-rename gives portable, atomic, overwrite-on-rename
+    ;; behavior across all implementations.
+    (%posix-rename (namestring tmp)
+                   (namestring (transaction-pathname transaction)))
+    (let ((tm (transaction-manager transaction)))
+      ;; peer-replication WP-2: generalized from MASTER-GRAPH-P so a
+      ;; peer-graph also journals its own committed writes (a device's
+      ;; push feed / a hub's pull feed).  The patched-in transaction-id
+      ;; is the per-origin feed sequence (design §3 #3).
+      (when (journals-own-feed-p (graph tm))
+        (serialize-uint64 (bytes transaction)
+                          (transaction-id transaction)
+                          +tx-header-id-offset+)
+        (let ((repl-stream (replication-log tm))
+              (lock (replication-log-lock tm))
+              (gr (graph tm)))
+          (with-recursive-lock-held (lock)
+            ;; peer-replication WP-0: a peer-graph prefixes the feed
+            ;; entry with a peer-meta packet (op identity + lamport),
+            ;; then records that it has applied its own authored op so
+            ;; a re-homed bounce-back is deduped (design §6).  A master
+            ;; journals plain tx bytes, unchanged.
+            (when (peer-graph-p gr)
+              (if *peer-rehome-op*
+                  ;; B2d-2: a hub re-home preserves the ORIGINAL op's
+                  ;; identity on the feed entry (design §5) so device E
+                  ;; pulls it as the author's op and the author dedups
+                  ;; its own bounce-back; the re-home caller applies
+                  ;; the merge's per-field stamps, so finalize does not
+                  ;; stamp here.
+                  (destructuring-bind (rop-id rorigin rlamport) *peer-rehome-op*
+                    (write-sequence
+                     (serialize-peer-meta
+                      rorigin rop-id rlamport +peer-op-authored+)
+                     repl-stream)
+                    (record-applied-op gr rop-id rlamport))
+                  (let ((op-id (gen-op-id))
+                        (lamport (peer-next-lamport gr))
+                        (origin (or (origin-id gr) +peer-null-origin+)))
+                    (write-sequence
+                     (serialize-peer-meta
+                      origin op-id lamport +peer-op-authored+)
+                     repl-stream)
+                    (record-applied-op gr op-id lamport)
+                    ;; B2b: stamp every field this locally-authored op
+                    ;; changed with (lamport . origin) -- the LWW basis
+                    ;; a later concurrent edit from another replica
+                    ;; compares against.
+                    (dolist (w (writes transaction))
+                      (let ((nid (id (node w))))
+                        (dolist (slot (authored-changed-slots w))
+                          (set-node-field-stamp
+                           gr nid slot lamport origin)))))))
+            (write-sequence (bytes transaction) repl-stream)
+            (finish-output repl-stream)))))))
 
 ;;; Locking for object sets
 
@@ -3294,7 +3326,12 @@ image / snapshot at each clean close) is its only durable record.")
 (defmethod cleanup-transaction ((tx tx))
   (let ((transaction-manager (transaction-manager tx)))
     (if (eql (state tx) :committed)
-        (unless (retain-committed-transaction-p (graph tx))
+        ;; WAL-suppressed (GH #170 Task 4): FINALIZE-TX-PERSISTENCE never
+        ;; renamed a .txn file into place for this commit, so there is
+        ;; nothing here for MARK-AS-COMMITTED to delete/rename -- calling
+        ;; it anyway would RENAME-FILE a path that was never created.
+        (unless (or (wal-suppressed-p (graph tx))
+                    (retain-committed-transaction-p (graph tx)))
           (mark-as-committed (transaction-pathname tx)))
         (remove-transaction tx transaction-manager))))
 


### PR DESCRIPTION
Fixes #170 (namespaces unit 5; spec §8, D12, including the #182-constraint
comment). A store can now be taken out of service without stopping the
system, and a bulk load builds a shadow generation and swaps it in — the
store is offline only for two brief windows (the consistent copy and the
swap), and a killed loader leaves the live generation byte-identical.

## What changed

- **Quiescence protocol** over the existing pin machinery: `accepting-p` on
  the transaction manager (`t` / `:read-only` / `:opening` /
  `:detaching`/`:swapping`), refusal at the two choke points
  (`create-transaction`, `pin-read-epoch`) with the check atomic against the
  flip (tm-lock → read-pins-lock, the only nesting, ordering audited);
  `detach-store` (drain via `reap-safe-floor`, epoch lease from the image
  clock, `:detach` journaled, durable close, `store-detachment` handle) and
  `reattach-store`. A timed-out drain restores the *prior* accepting state —
  never hardcoded `t` — so it cannot silently lift a shadow window.
- **Shadow generations** (`shadow-store.lisp`, new): a consistent copy via a
  seconds-long close-copy-reopen window, sparse-preserving (a fresh store is
  ~12GB of mmap reservation holes; the copy keeps them holes — the naive
  copy materialized 12GB per shadow and once drove this host to 814MB free);
  the live store then serves reads but refuses writes (reason `:shadow-load`,
  Kevin's ruling: no write is ever silently discarded at swap) until
  `swap-in-shadow` or `abandon-shadow`. `open-shadow-graph` opens the copy
  unregistered under the live store's name and tag, transaction ids drawn
  from a leased epoch range (cursor derived from the shadow's own watermark;
  `lease.dat` persists the range for out-of-process later), `discard-shadow`
  hard-gated on the `-shadow` suffix.
- **The swap**: validate first (a typo'd path never costs an outage), live
  renamed away before the shadow renames in (the data always exists under
  some name), completion defined as the second rename — the `:swap` journal
  record is best-effort (#212) and a durably-completed swap *returns* with
  `swap-recovered-warning` rather than reporting failure. The retired
  generation is kept (#213 tracks retention).
- **Recovery policy licenses the fast path**: `policy.dat`
  (:derivable/:authored, file authoritative, mismatch warns),
  `open-shadow-graph :fast-load` gates on it and suppresses the WAL
  per-graph (no .txn files, no replication log — sound because a crashed
  shadow load is discarded and redone; refused for authored stores).
- **Presize**: `presize-vector-segment` + `:expected-vectors` turn a
  mid-apply capacity failure into an upfront one.
- **Engine-wide hardening the reviews forced**: every `open-graph` now
  publishes at `:opening` (writes refused loudly until fully open); crash
  recovery re-seeds the tx-id watermark AND the replication-log name the
  early-constructed tm read stale — pinned by the suite's first
  crash-recovery tests, a class that did not exist before this branch.
- v1 scope: plain clocked stores — master/slave/peer graphs are refused
  (`detach-unsupported-graph-error`) rather than silently stripped of their
  replication config on reopen; full open-args threading is the noted
  follow-on.

## Verification

- Definitive gate `(asdf:test-system :graph-db)` on SBCL: **4231 checks —
  4221 pass / 10 skip / 0 fail** (baseline 4073; the 158 new checks account
  for the entire delta across five intermediate gates). ECL skipped per the
  standing demotion.
- Six tasks, ten task-level fix rounds, one hang investigation (the
  "deadlock" was `CL:MISMATCH`'s unvectorized ~16ms/MB on byte arrays —
  thread dumps showed zero lock-wait frames ever), and a three-round
  whole-branch fix wave; every finding fixed with a failable, ablated test
  or parked with a recorded ruling.
- Acceptance list: bulk-load while serving reads ✔ (end-to-end test), offline
  only for the windows ✔, killed loader leaves live byte-identical ✔
  (measured exclusion list), capacity fails before writing ✔, suite green ✔.

Follow-ups filed: #211 (read-snapshot pin leak, pre-existing), #212
(post-rename step atomicity family), #213 (retired-dir retention), #214
(test-scratch hygiene). Unblocks #171 (restore), the epic's last unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95