### PR TITLE
Peer wire protocol v2: gated, qualified, scoped (#206, #201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,27 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Changed
 
+- **BREAKING: peer wire protocol bumped 1 -> 2; a v1 device is now
+  refused, not misparsed** (#206, #201). This is a wire-generation
+  change — every peer device and hub must move together. The v2
+  contract, in four points: (1) the peer wire now carries v3 node
+  heads (33-byte vertex / 73-byte edge, #166's on-disk format) instead
+  of the old v1 layout; (2) the type table's `name` and `supers`
+  fields are downcased, **package-qualified** names
+  (`package:symbol`), so two same-named types from different packages
+  no longer collide on the wire (#201); (3) the type table the hub
+  ships in `:auth-ok` is now **scoped to the replicated store's own
+  schema**, closure-completed over `supers` so no row's superclass
+  reference dangles; (4) the device auth plist **must** carry
+  `:peer-protocol-version` — absent (a v1 device) or mismatched
+  refuses the connection with `peer-protocol-mismatch-error`, checked
+  hub-side before the schema-compatibility gate and before any
+  mutation. A stale-but-present node-head size is refused too
+  (`node-head-size-mismatch-error` in `transactions.lisp`), as defense
+  in depth below the version gate. The wire *grammar* (4-field
+  `kind,id,name,supers` type-table rows; `:` still unreserved) is
+  unchanged. Coordinates with mine-action-android#29.
+
 - **The hub resolves its type registry on the thread that starts
   replication** (#186). A hub serves each device connection on a new thread,
   and a new thread does not inherit dynamic bindings, so a session calling

--- a/docs/superpowers/plans/2026-08-23-wire-v2-206.md
+++ b/docs/superpowers/plans/2026-08-23-wire-v2-206.md
@@ -1,0 +1,267 @@
+# Peer Wire v2 (#206, #201-flip, #118-scoping) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Peer protocol version 2 — one wire generation, one fleet
+upgrade: the v3 node head is version-gated on BOTH ends (#206 and its
+recorded gap 1), the type table emits package-qualified names (#201's
+engine flip), the table is scoped to the session's replicated store
+(the #118 disclosure ruling), and the hub's transaction-node reader
+honours the header-size byte it already parses (#206 gap 2).
+
+**Architecture:** Four small layers on `peer-streaming.lisp` +
+`transactions.lisp`. (1) **Gate**: `*peer-protocol-version*` 1→2; the
+hub already announces it (handshake plist, peer-streaming.lisp:729) and
+the reference device check (:1438) refuses a mismatch pre-auth. New:
+`peer-device-auth-plist` carries `:peer-protocol-version`, and
+`peer-authenticate-device` refuses absent-or-mismatched with a named
+`peer-protocol-mismatch-error` — so the push direction (the one the hub
+could not previously detect, #206) is gated on both ends. (2)
+**Qualified names**: `%peer-qualified-wire-name` = downcased
+`package:name`; used for every NAME and every SUPERS entry; the
+encoder's reserved-character check runs on the full qualified string
+(package names are unconstrained too); collision validation now fires
+only on true residual ambiguity (two symbols whose qualified names
+downcase alike). D15's comparisons stay mechanically unchanged — both
+sides emit qualified names, and a v1 peer never reaches the comparison
+(the gate refuses first). (3) **Scoping**: the auth-ok call site
+(peer-streaming.lisp ~:850) already has GRAPH in scope; the table's
+rows are filtered to types instantiated in that graph's own schema
+(direct symbol lookup via `lookup-node-type-by-name` per row —
+non-keyword path, exact). A device is only ever sent ids from the store
+it replicates, so a scoped table is honest under D14, D15 tolerates
+missing rows (conflicts key on the hub's rows), and dark-store type
+names never reach a device. Side benefit, documented: an
+unrepresentable type in an UNRELATED store no longer fails every peer
+session in the image. (4) **Header-size honour**:
+`deserialize-transaction-node-vector` (transactions.lisp) currently
+parses the envelope's header-size byte and discards it; it now refuses
+a size that is not the current `+node-header-size+`/`+edge-header-size+`
+with a named condition — a wrong-format head becomes a refusal, never a
+misparse. Defense in depth behind the gate, exactly as #206 framed it.
+
+**The wire-v2 contract, stated once (goes verbatim into
+peer-streaming.lisp's header comment and the docs):** protocol 2 =
+v3 node heads + package-qualified type-table names + store-scoped
+table + `:peer-protocol-version` required in the device auth plist.
+Fleet coordination lives on mine-action-android#29 (comment posted
+2026-08-23 listing the four device-side requirements).
+
+**Tech Stack:** Common Lisp (SBCL primary), FiveAM.
+
+**Spec:** GH #206 (authoritative for the gate + both gaps), GH #201's
+decision comment (qualified names, 2026-08-21), Kevin's scoping ruling
+(2026-08-23, recorded on #206/#118/#29), namespaces design §3.1/D14/D15,
+and the frozen-grammar constraint: the table's 4-field `kind,id,name,
+supers` grammar and the plist channel are UNCHANGED — only the version
+number, the name strings, the row set, and one new auth plist key move.
+
+## Global Constraints
+
+- Lisp: spaces only, never tabs; hard 80-column limit (96 is a defect).
+  Comments terse: invariant + `(GH #206)`/`(GH #201)` as fits.
+- Every SBCL run: from the worktree, FIRST
+  `--eval '(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))'`,
+  `--dynamic-space-size 16384`.
+- **The merge gate is `(asdf:test-system :graph-db)`, controller-run.**
+  Implementers run focused suites only. Baseline: MEASURE at branch
+  point (experiment may or may not carry #215 when this branch starts;
+  the controller runs a baseline gate first and records it in the
+  ledger). If #215 merges mid-branch, merge experiment in before the
+  definitive gate.
+- **Existing peer tests WILL break by design**: peer-type-table-tests
+  and peer-conflict-tests assert bare names and (possibly) version 1.
+  Updating them to the v2 contract is in scope and is NOT a regression
+  — but every updated assertion must be listed in the task report so
+  the reviewer can distinguish contract-following updates from
+  weakened tests.
+- Ablate every guard; nearest wrong implementation named per test.
+- ECL demoted: SBCL only, say so. Host safety: live `ma-dev-server` —
+  NEVER `pkill`/`killall`/`pgrep`; kill only a PID you started; one
+  SBCL at a time; never touch `/data0`. Never end a turn waiting on a
+  background run — bounded foreground stretches
+  (`timeout 570 bash -c 'while kill -0 <PID> 2>/dev/null; do sleep 15; done'`).
+  Clean your own `/tmp/graph-db-test-*` at the end of your work.
+- Test-form LAW: `(with-transaction ((transaction-manager g)) ...)`;
+  rebind `graph-db::*store-registry*` (and `*type-registry*` where
+  types are minted) nil with `*system-directory*`;
+  `(make-vertex :generic nil :graph g)`; `:generic` edges invisible to
+  typed scans.
+- Worktree `.worktrees/206-wire-v2`, branch `206-wire-v2` off
+  `experiment`. PR against `experiment`. Pushing explicit-only.
+  PUBLIC repo: domain-neutral text (the dark-store scoping test uses
+  neutral store/type names, never the #118 comment's domain names).
+
+## Contract-first note
+
+Same regime as #170: contracts fixed here, splice points verified
+against source, substantive deviations flagged loudly, NEEDS_CONTEXT on
+contradiction. Verified this session: `*peer-protocol-version*` at
+peer-streaming.lisp:42; hub announce :729; device check :1438 (pre-auth,
+pre-pull, pre-push); auth-ok table call ~:850 with GRAPH in scope;
+`peer-authenticate-device` :735 (schema gate + replication key, no
+protocol check today); the table machinery `%peer-type-table-rows` /
+`%peer-check-wire-name` / `%peer-validate-type-table-rows` /
+`%peer-registry-conflicts` / `peer-parse-type-table` at :92-:473.
+
+---
+
+### Task 1: The version gate, both ends
+
+**Files:** `peer-streaming.lisp` (bump; device auth plist key; hub auth
+check; named condition), `package.lisp` (exports), existing peer test
+files as needed (+ a new `tests/peer-wire-v2-tests.lisp` if the
+existing files don't fit — implementer's call, reported; .asd entry).
+
+**Contracts:**
+- `*peer-protocol-version*` → 2. Its docstring becomes the wire-v2
+  contract statement (the four-point list above).
+- `peer-device-auth-plist` gains `:peer-protocol-version
+  *peer-protocol-version*`.
+- `peer-authenticate-device` refuses when the auth plist's
+  `:peer-protocol-version` is ABSENT or ≠ `*peer-protocol-version*`,
+  with `peer-protocol-mismatch-error` (readers
+  `peer-protocol-mismatch-hub` / `-device`; device nil = absent),
+  BEFORE the schema gate and BEFORE any device registration side
+  effects (read the function; the refusal must precede every mutation).
+  Absent-means-refuse is deliberate: a v1 device never sends the key,
+  and a v1 device pushing v1 heads at a v2 hub is exactly the
+  misparse #206 exists to prevent.
+- The device-side check (:1438) needs no change — verify and say so.
+
+**Tests:** (a) hub refuses an auth plist without the key (build the
+plist by hand, drive `peer-authenticate-device` directly — read how
+peer tests construct auth plists and reuse); (b) hub refuses a wrong
+version; (c) a correct v2 plist passes to the schema gate (i.e. the
+check is ordered first — assert by giving a BAD schema version with a
+GOOD protocol version and seeing the SCHEMA error, and vice versa
+seeing the protocol error); (d) the full in-process peer round-trip
+tests (whichever suite drives peer-sync end to end) still pass with
+both ends at 2. Ablation: revert the hub check → (a)/(b) fail.
+
+---
+
+### Task 2: Qualified wire names (the #201 flip)
+
+**Files:** `peer-streaming.lisp`, existing table/conflict tests.
+
+**Contracts:**
+- `%peer-qualified-wire-name (symbol)` → downcased
+  `"<package-name>:<symbol-name>"`. Used by `%peer-type-table-rows`
+  for NAME and by `%peer-type-direct-supers` for every SUPERS entry.
+- `%peer-check-wire-name` runs on the full qualified string (and its
+  error text now naturally shows the qualified name; keep the message
+  accurate).
+- `%peer-validate-type-table-rows`'s collision check keys on the
+  qualified emitted name — two same-named types in different packages
+  now encode fine (THE #201 acceptance); a collision fires only when
+  two symbols' QUALIFIED names downcase alike (pin with |Pkg|-style
+  case-colliding packages or symbols — construct the cheapest honest
+  pair).
+- `%peer-registry-conflicts` needs no mechanical change (it compares
+  emitted names; both sides now emit qualified) — verify and state it.
+- `peer-parse-type-table` unchanged (names are opaque strings) —
+  verify no strictness rule breaks on `:` (it does not; `:` was never
+  reserved — state it).
+
+**Tests:** the #201 acceptance (two same-named types in different
+packages, both in the table, distinct rows); supers qualified; the
+residual-collision refusal; every existing bare-name assertion updated
+(LISTED in the report); round-trip through `peer-parse-type-table`.
+Ablation: emit bare names again → the acceptance test fails with the
+old collision error.
+
+---
+
+### Task 3: Store-scoped table
+
+**Files:** `peer-streaming.lisp` (row filter + the auth-ok call site
+passes the graph), tests.
+
+**Contracts:**
+- `peer-type-table-string` gains an optional GRAPH; when given, rows
+  are filtered to types instantiated in GRAPH's own schema — per row,
+  `(lookup-node-type-by-name (row-symbol) (row-parent) :graph graph)`
+  non-nil (the direct, non-keyword symbol path; exact). No graph =
+  whole-image table (preserves every existing direct caller/test until
+  they opt in — enumerate the callers and report which ones should
+  pass the graph; the auth-ok site MUST).
+- The auth-ok site (~:850) passes the session's graph.
+- `%peer-validate-type-table-rows` validates the SCOPED rows on the
+  hub path — document the blast-radius improvement (an
+  unrepresentable type in an unrelated store no longer fails this
+  session) in the docstring.
+- D15: the device compares the hub's (scoped) rows against its own
+  registry; missing rows are not conflicts — verify against
+  `%peer-registry-conflicts` (conflicts key on hub rows) and pin it.
+
+**Tests:** two stores under one system directory, types A-only and
+B-only plus one shared; session table for store A contains A's and the
+shared type's rows and NOT B-only's (the disclosure pin — assert the
+absence explicitly, neutral names); device-side
+`peer-check-type-registry-agreement` accepts a scoped table whose rows
+are a subset of the device registry's world; the scoped table still
+round-trips the parser. Ablation: drop the filter → the absence
+assertion fails.
+
+---
+
+### Task 4: The hub reader honours header-size
+
+**Files:** `transactions.lisp` (`deserialize-transaction-node-vector`
+region — find where the header-size byte is read and discarded),
+`package.lisp`, tests.
+
+**Contracts:** a new named condition (e.g.
+`node-head-size-mismatch-error`, readers for expected/actual/kind)
+signaled when the envelope's header-size byte ≠ the current
+`+node-header-size+` / `+edge-header-size+` for its kind — BEFORE any
+head bytes are interpreted. This runs on the peer/replication apply
+path; verify which paths reach it (peer push apply, slave apply,
+txn-log replay?) and confirm the check cannot refuse LEGITIMATE current
+traffic (every writer in this image emits the current sizes — state
+the evidence). Defense in depth: the version gate is the contract;
+this makes a gate bypass a refusal, not a misparse (#206 gap 2).
+
+**Tests:** a hand-built tx-write vector with the OLD (31/71) sizes is
+refused with the named condition; a current-size vector still applies
+(drive the real deserialize path per existing peer/txn tests'
+idioms). Ablation: drop the check → the refusal test fails (and
+document what the misparse DID produce, as the issue's evidence).
+
+---
+
+### Task 5: Docs + close-out
+
+CHANGELOG (`### Changed` — this is a wire-generation change, say so
+loudly, with the four-point v2 contract and the coordination pointer
+to mine-action-android#29); manual (the peer replication chapter's
+protocol/type-table sections: version 2 semantics, qualified names,
+scoped table, the auth key; search for where the type-table format is
+documented); spec §3.1/§7-adjacent Built-note style entry for the #201
+flip ("**Built (#206/#201):**" wherever §3.4's peer-wire text lives —
+find the right anchor, likely the D15 discussion). Fold-in: none
+pending. Commit `docs: peer wire v2 — gated, qualified, scoped (#206, #201)`.
+
+Whole-branch review (capable model; point it at the frozen-contract
+surfaces: grammar unchanged, plist compat, the multi-process peer
+harnesses as a consideration it may recommend running) + definitive
+gate + PR are the controller's.
+
+---
+
+## Self-Review
+
+- #206's ask (the bump) is Task 1; its two recorded gaps are Tasks 1
+  (hub-side gate) and 4 (header-size honour). #201's engine flip is
+  Task 2, matching the decision comment's mechanics (qualified NAME +
+  SUPERS, encode-time checks, residual-collision-only refusal).
+  Kevin's scoping ruling is Task 3 with the disclosure pin asserted as
+  an absence test. The android-side coordination contract is posted on
+  #29 and restated in the version docstring.
+- The one deliberate compat break — absent auth key refuses — is the
+  point of the gate and is documented as such.
+- Existing-test updates are contract-following by design and must be
+  itemized for review.
+- Placeholders: none; deep splices are contract-first with verified
+  line anchors.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -148,6 +148,21 @@ replication is off by default — so two such images can independently assign th
 different ids. Silent reconciliation would mean a data migration triggered by a network
 handshake; a disagreement between two populated stores is an operator event.
 
+**Built (#206/#201):** the type-table's `name` and `supers` fields flipped
+to downcased, package-qualified names (`package:symbol`), so two
+same-named types from different packages no longer collide on the wire —
+the collision check now fires only on residual ambiguity after
+downcasing. The hub's `:auth-ok` table is scoped to the session's own
+graph plus the transitive `supers`-closure of that set (D14 still holds:
+type-ids stay image-level; only what one session's table *lists*
+narrowed), which also narrows an unrepresentable-name failure from every
+peer session in the image to sessions on stores that actually hold the
+offending type. The peer wire protocol version gate (`*peer-protocol-
+version*`, now 2) is a *new*, independent axis — it refuses a device
+whose `:peer-protocol-version` is absent or mismatched before D15's
+registry-agreement check ever runs, since a v1 device cannot parse the
+qualified-name table or the v3 node heads this protocol carries.
+
 ### 3.5 Runtime schema is metadata, never source
 
 Restart must never `load` code written at runtime. Metadata is diffable, versionable,

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2811,6 +2811,24 @@ A device is constructed with a hub-minted ~:origin-id~ (an opaque 16-byte id) an
 
 As with master/slave, a *minor* schema drift (same major version) still syncs, degraded-safe; a *major* mismatch is rejected before any data moves.
 
+**** The peer wire protocol version gate
+
+Independently of schema versioning, the peer wire itself carries a
+protocol version (~*peer-protocol-version*~, currently 2), gating the
+byte-level framing rather than the graph's schema. The device's auth
+plist must carry a matching ~:peer-protocol-version~; the hub checks
+it *before* the schema-compatibility gate and before any mutation.
+Absent (a pre-v2 device) or mismatched, the hub refuses the connection
+with ~peer-protocol-mismatch-error~ rather than attempt to parse a wire
+it does not speak. Protocol 2 is a wire-generation break from 1: it
+carries the v3 (33/73-byte) node heads, package-qualified type-table
+names, and a store-scoped type table (all described below), none of
+which a v1 parser can read — refusing a v1 device is deliberate, not a
+gap. As defense in depth below the version gate, a node envelope whose
+header-size byte does not match this image's current head layout is
+likewise refused (~node-head-size-mismatch-error~) rather than
+misparsed.
+
 *** Type-ids on the wire, and the handshake that refuses a disagreeing peer
 
 A ~type-id~ crosses the peer wire as an opaque integer; no type *name* ever
@@ -2826,17 +2844,32 @@ implementations this repository does not build,
 is part of the specification — an ~id~ is decimal digits only in 0..65535, a
 record has exactly four fields, ~kind~ is exactly ~"v"~ or ~"e"~, and a
 consumer must read *all* rows before resolving superclass names, because the
-table is sorted by id and may carry forward references.
+table is sorted by id and may carry forward references. Since protocol 2
+(GH #201) ~name~ and every ~supers~ entry are *downcased,
+package-qualified* names, ~"package:symbol"~ — e.g. ~"graph-db:site"~ —
+rather than the bare symbol name; ~:~ is not a reserved character, so a
+consumer treats the whole field as one opaque string. Qualifying by
+package is what lets two same-named types from two different packages
+share one wire table without colliding.
 
 **What the table contains changed with GH #186: it is the IMAGE's type
-registry, not the hub graph's schema.** Type-ids are image-level now
-(Chapter 17), so a device may be sent an id belonging to any store in the
-system, and the hub therefore ships the whole mapping. Two consequences
-follow, both intended:
+registry, not the hub graph's schema — narrowed again to the hub's own
+store by GH #206.** Type-ids are image-level (Chapter 17), so in
+principle a device could be sent an id belonging to any store in the
+system; since #206, though, the hub's ~:auth-ok~ table is *scoped* to
+the types actually registered in the session's own graph, plus the
+transitive ~supers~-closure of that set (so no kept row's superclass
+reference ever dangles). A device may know of more types than the
+table lists — that is not itself a conflict, only the handshake
+disagreement check further below is — but the table itself now names
+only what the replicated store can actually produce.
+Two consequences follow, both intended:
 
-- a type the hub's own graph does not instantiate still appears in the table;
-- a type name that cannot be encoded fails *every* device connection in the
-  image, not only sessions for the store that declared it.
+- a type registered only in some *other*, unrelated store no longer appears
+  in this session's table at all;
+- a type name that cannot be encoded now fails only sessions for stores that
+  actually hold the offending type, not every device connection in the
+  image.
 
 The encoder refuses rather than emit something a device cannot recover from.
 It signals, naming the offending type package-qualified, when a name is empty

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -511,6 +511,7 @@ cl-temporal-extent."
                (:file "peer-rehome-tests")
                (:file "peer-conflict-tests")
                (:file "peer-type-table-tests")
+               (:file "peer-wire-v2-tests")
                (:file "peer-scope-tests")
                (:file "view-tests")
                (:file "query-tests")

--- a/package.lisp
+++ b/package.lisp
@@ -179,6 +179,11 @@
            #:read-last-txn-id
            #:start-replication
            #:stop-replication
+           ;; peer replication: the wire-v2 protocol gate (GH #206)
+           #:*peer-protocol-version*
+           #:peer-protocol-mismatch-error
+           #:peer-protocol-mismatch-hub
+           #:peer-protocol-mismatch-device
            #:stop-buffer-pool
            #:set-buffer-pool-size
            #:*buffer-pool-size*

--- a/package.lisp
+++ b/package.lisp
@@ -179,11 +179,6 @@
            #:read-last-txn-id
            #:start-replication
            #:stop-replication
-           ;; peer replication: the wire-v2 protocol gate (GH #206)
-           #:*peer-protocol-version*
-           #:peer-protocol-mismatch-error
-           #:peer-protocol-mismatch-hub
-           #:peer-protocol-mismatch-device
            #:stop-buffer-pool
            #:set-buffer-pool-size
            #:*buffer-pool-size*

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -115,8 +115,8 @@ treats #\\: specially either)."
           (symbol-name symbol)))
 
 (defun %peer-type-direct-supers (name)
-  "The downcased names of type NAME's direct graph superclasses, as a LIST of strings.
-NIL when NAME roots directly at VERTEX/EDGE.
+  "Downcased package-qualified names of NAME's direct superclasses.
+LIST of strings, NIL when NAME roots directly at VERTEX/EDGE.
 
 A LIST, not a single name: DEF-NODE-TYPE's docstring claims single inheritance but does
 NOT enforce it -- it splices PARENT-TYPES straight into DEFCLASS -- so

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -191,12 +191,12 @@ type the developer actually wrote (the emitted NAME is downcased and may be
 the very thing at fault).
 
 The rows are the IMAGE's type registry, not one graph's schema (D14, GH #186).
-A type-id means one thing across every store in the system, so the hub ships
-the whole mapping and a device can resolve any id it may ever be sent.  Two
-consequences, both intended: a type the hub's own graph does not hold is still
-emitted, and ONE unrepresentable type name anywhere in the image fails every
-device connection rather than only the store holding it -- see
-%PEER-VALIDATE-TYPE-TABLE-ROWS.
+A type-id means one thing across every store in the system, so the ids are
+globally meaningful and a device can resolve any id it may ever be sent.
+Callers that hold a graph narrow the rows to that store's schema
+(%PEER-GRAPH-SCOPED-ROWS -- the auth-ok path does, GH #206), so an
+unrepresentable type name elsewhere in the image fails only unscoped
+callers -- see %PEER-VALIDATE-TYPE-TABLE-ROWS.
 
 SUPERS comes from CLOS, so a registered symbol whose class this image has not
 loaded emits an EMPTY supers field -- indistinguishable on the wire from a
@@ -384,12 +384,12 @@ id.  A consumer must key on (KIND . ID), never ID alone.
 Signals an error if the registry cannot be represented -- see
 %PEER-VALIDATE-TYPE-TABLE-ROWS.  That is deliberate: a corrupt table is
 undebuggable on the device, so the failure belongs at the hub.  Note WHERE it
-lands: this runs on the auth-ok path, so an unrepresentable type fails every
-device CONNECTION, not the offending DEF-VERTEX.  Since GH #186 the table is
-the IMAGE's registry, so that one type need not even be in the store being
-replicated -- the blast radius is every peer session in the image.  Loud and
-hub-side either way, but the traceback points at a session, not at the schema
-form that caused it."
+lands: this runs on the auth-ok path, so an unrepresentable type fails the
+device CONNECTION, not the offending DEF-VERTEX.  With GRAPH the blast radius
+is that store's sessions only (the auth-ok path passes it, GH #206); only
+unscoped calls still expose the whole image's registry.  Loud and hub-side
+either way, but the traceback points at a session, not at the schema form
+that caused it."
   (let* ((rows (%peer-type-table-rows registry))
          (rows (if graph (%peer-graph-scoped-rows rows graph) rows))
          (rows (%peer-validate-type-table-rows rows)))
@@ -832,11 +832,13 @@ safe integers; schema-digest carried as a within-major integrity signal)."
 ;; Deliberately internal, like sibling PEER-SCHEMA-INCOMPATIBLE-ERROR above --
 ;; no peer symbol is exported (review ruling, GH #206 fix round 1).
 (define-condition peer-protocol-mismatch-error (error)
-  ((hub-version    :initarg :hub-version    :reader peer-protocol-mismatch-hub)
-   (device-version :initarg :device-version :reader peer-protocol-mismatch-device))
+  ((hub-version    :initarg :hub-version
+                   :reader peer-protocol-mismatch-hub)
+   (device-version :initarg :device-version
+                   :reader peer-protocol-mismatch-device))
   (:report (lambda (c s)
-             (format s "Peer protocol version mismatch: hub ~S, device ~S (absent ~
-means a v1 device -- refused, not misparsed; GH #206)"
+             (format s "Peer protocol version mismatch: hub ~S, device ~S ~
+(absent means a v1 device -- refused, not misparsed; GH #206)"
                      (peer-protocol-mismatch-hub c)
                      (peer-protocol-mismatch-device c)))))
 
@@ -853,7 +855,8 @@ device's last-pushed schema version for the drain-and-update barrier signal (§1
   (let ((dev-protocol (getf auth :peer-protocol-version)))
     (unless (eql dev-protocol *peer-protocol-version*)
       (error 'peer-protocol-mismatch-error
-             :hub-version *peer-protocol-version* :device-version dev-protocol)))
+             :hub-version *peer-protocol-version*
+             :device-version dev-protocol)))
   (let ((hub-version (peer-schema-version graph))
         (dev-version (list (getf auth :schema-major) (getf auth :schema-minor))))
     (unless (peer-schema-compatible-p hub-version dev-version)

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -102,6 +102,18 @@ most likely to choke on.  A CL symbol name may contain ANY character (|escaped s
 and DEF-VERTEX constrains nothing, so this is checked at ENCODE time -- see
 PEER-TYPE-TABLE-STRING.")
 
+(defun %peer-qualified-wire-name (symbol)
+  "SYMBOL's wire name: downcased \"<package-name>:<symbol-name>\" (GH #201).
+Package-qualifying is what lets two same-named types from different
+packages share one wire table without colliding -- STRING-DOWNCASE is not
+injective on the bare name alone, but the package is almost never the same
+accident twice.  #\\: is not in *PEER-TYPE-NAME-RESERVED-CHARS*, so this
+cannot itself introduce a delimiter collision (PEER-PARSE-TYPE-TABLE never
+treats #\\: specially either)."
+  (format nil "~(~A:~A~)"
+          (package-name (symbol-package symbol))
+          (symbol-name symbol)))
+
 (defun %peer-type-direct-supers (name)
   "The downcased names of type NAME's direct graph superclasses, as a LIST of strings.
 NIL when NAME roots directly at VERTEX/EDGE.
@@ -122,7 +134,7 @@ want only the direct parents so the consumer can rebuild the closure itself."
       (loop for super in (class-direct-superclasses class)
             unless (member (class-name super)
                            '(vertex edge primitive-node node standard-object t))
-              collect (string-downcase (symbol-name (class-name super)))))))
+              collect (%peer-qualified-wire-name (class-name super))))))
 
 (defun %peer-type-label (type)
   "TYPE printed package-qualified, for an error an operator has to act on.  ~S
@@ -172,10 +184,11 @@ replicate until the field is widened (GH #199)."
 
 (defun %peer-type-table-rows (registry)
   "REGISTRY's types as a list of (KIND-STRING ID NAME SUPERS TYPE): vertex
-types then edge types, each sorted by type-id.  SUPERS is a list of downcased
-names; TYPE is the node-type symbol, carried only so a validation error can
-name the type the developer actually wrote (the emitted NAME is downcased and
-may be the very thing at fault).
+types then edge types, each sorted by type-id.  NAME and every SUPERS entry
+are downcased PACKAGE-QUALIFIED names (%PEER-QUALIFIED-WIRE-NAME, GH #201);
+TYPE is the node-type symbol, carried only so a validation error can name the
+type the developer actually wrote (the emitted NAME is downcased and may be
+the very thing at fault).
 
 The rows are the IMAGE's type registry, not one graph's schema (D14, GH #186).
 A type-id means one thing across every store in the system, so the hub ships
@@ -198,7 +211,7 @@ one level down."
              (loop for (type nil id) in (sort entries #'< :key #'third)
                    collect (list kind-string
                                  id
-                                 (string-downcase (symbol-name type))
+                                 (%peer-qualified-wire-name type)
                                  (%peer-type-direct-supers type)
                                  type)))))
     (append (rows-for :vertex "v") (rows-for :edge "e"))))
@@ -209,15 +222,16 @@ range, a name carrying a reserved character or empty, or two types emitting
 the SAME name.  Returns ROWS.
 
 STRING-DOWNCASE is NOT injective -- P-PERSON and |P-Person| are distinct
-classes that emit one name, as are same-named symbols from different
-packages.  A device would then resolve one type-id's name to the other
-type's row.
-
-This matters MORE under the image-level registry, not less (GH #186).  ROWS
-pool every store's types into one table, so two types that never shared a
-schema now share this namespace, and the same-named-symbols-in-two-packages
-case stops being exotic.  Hence %PEER-TYPE-LABEL: the error has to print the
-package or an operator cannot tell the two apart, let alone find them."
+classes that would emit one name if only the symbol-name were on the wire.
+Since #201 NAME is package-qualified (%PEER-QUALIFIED-WIRE-NAME), so two
+same-named types in DIFFERENT packages now encode fine -- the pooled
+image-level registry (GH #186) makes that the ordinary case, not the
+exotic one.  A collision now fires only on RESIDUAL ambiguity: the full
+qualified string still downcases alike, e.g. same package + P-PERSON /
+|P-Person|, or two packages whose own names downcase alike.  A device would
+then resolve one type-id's name to the other type's row.  Hence
+%PEER-TYPE-LABEL: the error has to print the package or an operator cannot
+tell the two apart, let alone find them."
   (let ((seen (make-hash-table :test 'equal)))
     (dolist (row rows rows)
       (destructuring-bind (kind id name supers type) row
@@ -257,15 +271,22 @@ Format: records separated by #\\; , fields by #\\, :
 
     kind,id,name,supers
 
-KIND is \"v\" or \"e\"; ID is the decimal type-id; NAME is the downcased type name;
-SUPERS is a SPACE-separated list of the downcased DIRECT graph superclass names, EMPTY
-when the type roots directly at VERTEX/EDGE.  Example:
+KIND is \"v\" or \"e\"; ID is the decimal type-id; NAME is the downcased,
+PACKAGE-QUALIFIED type name (\"<package>:<symbol>\", %PEER-QUALIFIED-WIRE-NAME,
+GH #201) -- since two same-named symbols from different packages are ordinary
+under the image-level registry (GH #186) and must not collide on the wire;
+SUPERS is a SPACE-separated list of the downcased, package-qualified DIRECT
+graph superclass names, EMPTY when the type roots directly at VERTEX/EDGE.
+Example:
 
-    v,1,site,;v,2,ord-mine,ordnance-type;v,3,m-uav,m-hazard m-asset;e,1,find-of-type,
+    v,1,graph-db:site,;v,2,graph-db:mine,graph-db:hazard;e,1,graph-db:finds,
 
 SUPERS is a LIST because multiple inheritance WORKS: DEF-NODE-TYPE does not enforce the
 single inheritance its docstring claims (see %PEER-TYPE-DIRECT-SUPERS).  A consumer
-rebuilds the transitive closure itself from the direct edges.
+rebuilds the transitive closure itself from the direct edges.  #\\: is not
+reserved (see *PEER-TYPE-NAME-RESERVED-CHARS*) and PEER-PARSE-TYPE-TABLE never
+special-cases it -- NAME and each SUPERS entry are opaque strings to the
+parser either way.
 
 *** CONSUMERS MUST TWO-PASS. ***  Read ALL rows first, THEN resolve superclass names.
 Type-ids are STABLE across schema evolution, so this table is sorted by ID and is NOT
@@ -420,8 +441,11 @@ its type.  ~D conflict~:P:~{~%  ~A~}"
 REGISTRY, as a list of conflict descriptors
 (REASON PARENT KEY HUB-SIDE LOCAL-SIDE LOCAL-SYMBOL).
 
-Compared by DOWNCASED NAME, because that is all the wire carries -- which is
-exactly why %PEER-VALIDATE-TYPE-TABLE-ROWS must go on refusing two types that
+Compared by DOWNCASED NAME -- since #201 that name is package-qualified, on
+both sides: HUB-ROWS came off the wire from a hub's %PEER-TYPE-TABLE-ROWS and
+LOCAL below is this call's OWN %PEER-TYPE-TABLE-ROWS, so the two are directly
+comparable strings.  That is all the wire carries, which is exactly why
+%PEER-VALIDATE-TYPE-TABLE-ROWS must go on refusing two types that
 downcase alike.  It is applied to the LOCAL rows here too: if this image's own
 registry is ambiguous the comparison below is unsound, so that has to signal
 rather than silently check one of the two.

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -216,10 +216,32 @@ one level down."
                                  type)))))
     (append (rows-for :vertex "v") (rows-for :edge "e"))))
 
+(defun %peer-graph-scoped-rows (rows graph)
+  "ROWS (%PEER-TYPE-TABLE-ROWS output) filtered to the types actually
+registered in GRAPH's own schema: a row survives iff LOOKUP-NODE-TYPE-BY-NAME
+finds its TYPE symbol under its KIND (:VERTEX/:EDGE) in GRAPH.  The row's
+TYPE is already the type's real (non-keyword) symbol, so this is the direct
+identity lookup, never bare-name resolution -- there is no ambiguity to
+reintroduce here (GH #190)."
+  (remove-if-not
+   (lambda (row)
+     (destructuring-bind (kind id name supers type) row
+       (declare (ignore id name supers))
+       (lookup-node-type-by-name
+        type (if (string= kind "v") :vertex :edge) :graph graph)))
+   rows))
+
 (defun %peer-validate-type-table-rows (rows)
   "Signal if ROWS cannot be encoded unambiguously: an id outside the wire's
 range, a name carrying a reserved character or empty, or two types emitting
 the SAME name.  Returns ROWS.
+
+Called on the SCOPED rows on the hub's auth-ok path (PEER-TYPE-TABLE-STRING
+with a GRAPH argument): an unrepresentable type living in a store unrelated
+to the session's graph no longer fails this connection at all, since it is
+filtered out before this check ever sees it -- narrowing the blast radius
+from every peer session in the image (GH #186) to sessions on stores that
+actually hold the offending type.
 
 STRING-DOWNCASE is NOT injective -- P-PERSON and |P-Person| are distinct
 classes that would emit one name if only the symbol-name were on the wire.
@@ -252,7 +274,8 @@ edit."
                    (%peer-type-label other) (%peer-type-label type) name))
           (setf (gethash name seen) type))))))
 
-(defun peer-type-table-string (&optional (registry (ensure-type-registry)))
+(defun peer-type-table-string (&optional (registry (ensure-type-registry))
+                                graph)
   "Encode this IMAGE's type registry as ONE delimited string, for the plist
 control channel.  A nested list would trip PLIST-TOO-FANCY-ERROR, so the table
 rides as a single string -- the same dodge as PEER-IDS->STRING.
@@ -262,6 +285,14 @@ names every type this system has assigned, not the subset one store happens to
 instantiate.  Signals SYSTEM-DIRECTORY-REQUIRED when *SYSTEM-DIRECTORY* is
 NIL, which no graph-owning image can be -- MAKE-GRAPH and OPEN-GRAPH both
 refuse without one.
+
+Optional GRAPH scopes the table to the types actually registered in that
+GRAPH's own schema (%PEER-GRAPH-SCOPED-ROWS), dropping every row for a type
+that graph does not instantiate.  Omitted, the table stays whole-image (every
+existing direct caller keeps its prior behaviour); the hub's auth-ok call site
+passes the session's graph so an unrelated store's type -- including one that
+is unrepresentable on the wire -- no longer affects this session at all
+(GH #206).
 
 *** THIS FORMAT IS A FROZEN EXTERNAL CONTRACT. *** It is parsed by non-Lisp peers (the
 Kotlin/SQLite device).  PEER-PARSE-TYPE-TABLE is the reference implementation and its
@@ -322,8 +353,9 @@ the IMAGE's registry, so that one type need not even be in the store being
 replicated -- the blast radius is every peer session in the image.  Loud and
 hub-side either way, but the traceback points at a session, not at the schema
 form that caused it."
-  (let ((rows (%peer-validate-type-table-rows
-               (%peer-type-table-rows registry))))
+  (let* ((rows (%peer-type-table-rows registry))
+         (rows (if graph (%peer-graph-scoped-rows rows graph) rows))
+         (rows (%peer-validate-type-table-rows rows)))
     (with-output-to-string (s)
       (loop for row in rows
             for firstp = t then nil
@@ -875,9 +907,14 @@ authenticate, ship the schema type table, serve one pull, then RECEIVE the devic
 push and re-home it, close.  Models MAKE-SLAVE-SESSION-HANDLER but stays distinct
 from it.
 
-The auth-ok plist carries :TYPE-TABLE (PEER-TYPE-TABLE-STRING) so a non-Lisp peer can
-resolve a raw type-id to a type NAME.  It is not otherwise recoverable: ids come from
-DEF-VERTEX/DEF-EDGE evaluation order and no name crosses the wire."
+The auth-ok plist carries :TYPE-TABLE (PEER-TYPE-TABLE-STRING, scoped to
+GRAPH) so a non-Lisp peer can resolve a raw type-id to a type NAME.  It is
+not otherwise recoverable: ids come from DEF-VERTEX/DEF-EDGE evaluation order
+and no name crosses the wire.  Scoping to GRAPH's own schema (GH #206) means
+a type registered only in some unrelated store never appears in this
+session's table -- and, since %PEER-VALIDATE-TYPE-TABLE-ROWS runs on the
+scoped rows, an unrepresentable name in that unrelated store no longer fails
+this connection either."
   (lambda ()
     (let ((*graph* graph))
       (handler-case
@@ -894,7 +931,7 @@ DEF-VERTEX/DEF-EDGE evaluation order and no name crosses the wire."
                    (peer-write-plist
                     (list :peer-control :auth-ok
                           :type-table (peer-type-table-string
-                                       (%peer-registry graph)))
+                                       (%peer-registry graph) graph))
                     socket)
                    (peer-pull-phase graph socket device
                                     :full-resync-p (and (getf auth :full-resync) t)

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -218,18 +218,36 @@ one level down."
 
 (defun %peer-graph-scoped-rows (rows graph)
   "ROWS (%PEER-TYPE-TABLE-ROWS output) filtered to the types actually
-registered in GRAPH's own schema: a row survives iff LOOKUP-NODE-TYPE-BY-NAME
-finds its TYPE symbol under its KIND (:VERTEX/:EDGE) in GRAPH.  The row's
-TYPE is already the type's real (non-keyword) symbol, so this is the direct
-identity lookup, never bare-name resolution -- there is no ambiguity to
-reintroduce here (GH #190)."
-  (remove-if-not
-   (lambda (row)
-     (destructuring-bind (kind id name supers type) row
-       (declare (ignore id name supers))
-       (lookup-node-type-by-name
-        type (if (string= kind "v") :vertex :edge) :graph graph)))
-   rows))
+registered in GRAPH's own schema, PLUS the transitive SUPERS-closure of that
+set: a row is DIRECT iff LOOKUP-NODE-TYPE-BY-NAME finds its TYPE symbol under
+its KIND (:VERTEX/:EDGE) in GRAPH; a row is kept if it is direct or its NAME
+is referenced (directly or transitively) by some kept row's SUPERS.  The
+row's TYPE is already the type's real (non-keyword) symbol, so DIRECT-ness is
+the identity lookup, never bare-name resolution (GH #190).
+
+DEF-NODE-TYPE never requires a type's CLOS parent to be registered under the
+same graph-name, so a child registered in graph B whose parent lives only in
+graph A would otherwise survive scoping while the parent's row is dropped --
+a dangling SUPERS reference the device's closure walk cannot resolve (GH
+#206).  Closure completion fixes that.  It adds no meaningful disclosure: a
+kept child's SUPERS already names its parents' qualified names, so shipping
+the parent rows too tells a device nothing it could not already see."
+  (let ((keep (make-hash-table :test 'equal)))
+    (dolist (row rows)
+      (destructuring-bind (kind id name supers type) row
+        (declare (ignore id name supers))
+        (when (lookup-node-type-by-name
+               type (if (string= kind "v") :vertex :edge) :graph graph)
+          (setf (gethash (third row) keep) t))))
+    (loop for added = nil
+          do (dolist (row rows)
+               (when (gethash (third row) keep)
+                 (dolist (super (fourth row))
+                   (unless (gethash super keep)
+                     (setf (gethash super keep) t)
+                     (setf added t)))))
+          while added)
+    (remove-if-not (lambda (row) (gethash (third row) keep)) rows)))
 
 (defun %peer-validate-type-table-rows (rows)
   "Signal if ROWS cannot be encoded unambiguously: an id outside the wire's
@@ -253,9 +271,15 @@ qualified string still downcases alike, e.g. same package + P-PERSON /
 |P-Person|, or two packages whose own names downcase alike.  A device would
 then resolve one type-id's name to the other type's row.  Hence
 %PEER-TYPE-LABEL: the error has to print the package or an operator cannot
-tell the two apart, let alone find them."
+tell the two apart, let alone find them.
+
+Also signals if any row's SUPERS entry names no row in ROWS: a dangling
+reference the device's closure walk cannot resolve.  After
+%PEER-GRAPH-SCOPED-ROWS closure-completes (GH #206) this cannot fire from
+scoping alone -- it is defense in depth against registry corruption (a
+super pointing at a type this image never registered)."
   (let ((seen (make-hash-table :test 'equal)))
-    (dolist (row rows rows)
+    (dolist (row rows)
       (destructuring-bind (kind id name supers type) row
         (declare (ignore kind))
         (%peer-check-wire-id id type)
@@ -272,7 +296,18 @@ or even a store -- the packages above are what tells them apart.  Retire or ~
 rename one; for a type with nodes on disk that is a store migration, not an ~
 edit."
                    (%peer-type-label other) (%peer-type-label type) name))
-          (setf (gethash name seen) type))))))
+          (setf (gethash name seen) type))))
+    (dolist (row rows rows)
+      (destructuring-bind (kind id name supers type) row
+        (declare (ignore kind id))
+        (dolist (super supers)
+          (unless (gethash super seen)
+            (error "Node type ~A's SUPERS entry ~S names no row in this ~
+type table: a dangling reference the device's closure walk cannot resolve.  ~
+Row ~S is the referencing type; ~S is the missing parent.  This should be ~
+unreachable after %PEER-GRAPH-SCOPED-ROWS closure-completion (GH #206) -- ~
+it signals only on registry corruption."
+                   (%peer-type-label type) super name super)))))))
 
 (defun peer-type-table-string (&optional (registry (ensure-type-registry))
                                 graph)
@@ -287,12 +322,14 @@ NIL, which no graph-owning image can be -- MAKE-GRAPH and OPEN-GRAPH both
 refuse without one.
 
 Optional GRAPH scopes the table to the types actually registered in that
-GRAPH's own schema (%PEER-GRAPH-SCOPED-ROWS), dropping every row for a type
-that graph does not instantiate.  Omitted, the table stays whole-image (every
-existing direct caller keeps its prior behaviour); the hub's auth-ok call site
-passes the session's graph so an unrelated store's type -- including one that
-is unrepresentable on the wire -- no longer affects this session at all
-(GH #206).
+GRAPH's own schema, PLUS the transitive SUPERS-closure of that set
+(%PEER-GRAPH-SCOPED-ROWS) -- a type's CLOS parent need not be registered
+under the same graph-name, so the closure keeps the table resolvable even
+when a kept child's parent lives only in a different store.  Omitted, the
+table stays whole-image (every existing direct caller keeps its prior
+behaviour); the hub's auth-ok call site passes the session's graph so an
+unrelated store's type -- including one that is unrepresentable on the wire
+-- no longer affects this session at all (GH #206).
 
 *** THIS FORMAT IS A FROZEN EXTERNAL CONTRACT. *** It is parsed by non-Lisp peers (the
 Kotlin/SQLite device).  PEER-PARSE-TYPE-TABLE is the reference implementation and its

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -736,6 +736,8 @@ safe integers; schema-digest carried as a within-major integrity signal)."
         :schema-minor (second (peer-schema-version graph))
         :schema-digest (schema-digest (schema graph))))
 
+;; Deliberately internal, like sibling PEER-SCHEMA-INCOMPATIBLE-ERROR above --
+;; no peer symbol is exported (review ruling, GH #206 fix round 1).
 (define-condition peer-protocol-mismatch-error (error)
   ((hub-version    :initarg :hub-version    :reader peer-protocol-mismatch-hub)
    (device-version :initarg :device-version :reader peer-protocol-mismatch-device))

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -39,8 +39,12 @@
 ;;; connection.
 ;;; ===========================================================================
 
-(defvar *peer-protocol-version* 1
-  "Peer wire protocol version, independent of *REPLICATION-PROTOCOL-VERSION*.")
+(defvar *peer-protocol-version* 2
+  "Peer wire protocol version, independent of *REPLICATION-PROTOCOL-VERSION*.
+
+The wire-v2 contract, stated once: protocol 2 = v3 node heads +
+package-qualified type-table names + store-scoped table +
+:PEER-PROTOCOL-VERSION required in the device auth plist.  (GH #206)")
 
 ;;; ---------------------------------------------------------------------------
 ;;; Small encodings: ids on the plist channel, and the purge packet.
@@ -732,13 +736,29 @@ safe integers; schema-digest carried as a within-major integrity signal)."
         :schema-minor (second (peer-schema-version graph))
         :schema-digest (schema-digest (schema graph))))
 
+(define-condition peer-protocol-mismatch-error (error)
+  ((hub-version    :initarg :hub-version    :reader peer-protocol-mismatch-hub)
+   (device-version :initarg :device-version :reader peer-protocol-mismatch-device))
+  (:report (lambda (c s)
+             (format s "Peer protocol version mismatch: hub ~S, device ~S (absent ~
+means a v1 device -- refused, not misparsed; GH #206)"
+                     (peer-protocol-mismatch-hub c)
+                     (peer-protocol-mismatch-device c)))))
+
 (defun peer-authenticate-device (graph auth)
-  "Validate a device AUTH plist against GRAPH (the hub): the same-major schema gate
-(WP-6/PT-6), a known origin in the device registry, and the replication key.  The key
-checked is the device's OWN key when it has one (per-device provisioning), else the hub's
+  "Validate a device AUTH plist against GRAPH (the hub): the protocol gate FIRST
+(:PEER-PROTOCOL-VERSION absent or /= *PEER-PROTOCOL-VERSION* signals
+PEER-PROTOCOL-MISMATCH-ERROR -- absent means a v1 device, refused rather than
+misparsed, GH #206), then the same-major schema gate (WP-6/PT-6), a known origin
+in the device registry, and the replication key.  The key checked is the
+device's OWN key when it has one (per-device provisioning), else the hub's
 shared REPLICATION-KEY (back-compat for un-keyed devices).  The device is looked up FIRST
 so its key is known before the key check.  Returns the PEER-DEVICE, or signals.  Records the
 device's last-pushed schema version for the drain-and-update barrier signal (§14)."
+  (let ((dev-protocol (getf auth :peer-protocol-version)))
+    (unless (eql dev-protocol *peer-protocol-version*)
+      (error 'peer-protocol-mismatch-error
+             :hub-version *peer-protocol-version* :device-version dev-protocol)))
   (let ((hub-version (peer-schema-version graph))
         (dev-version (list (getf auth :schema-major) (getf auth :schema-minor))))
     (unless (peer-schema-compatible-p hub-version dev-version)
@@ -1349,12 +1369,14 @@ the writer (WP-8)."
 
 (defun peer-device-auth-plist (graph &key full-resync)
   "What a device sends to authenticate + drive a pull: origin, its PULL-CURSOR
-(the op-stream lower bound), the same-major schema gate inputs, and optionally
+(the op-stream lower bound), :PEER-PROTOCOL-VERSION (checked by the hub BEFORE
+anything else, GH #206), the same-major schema gate inputs, and optionally
 :FULL-RESYNC to ask the hub to re-ship the whole scope (seed/recovery)."
   (list :origin-id (peer-id->hex (origin-id graph))
         :pull-cursor (load-peer-pull-cursor graph)
         :push-ack 0
         :full-resync (and full-resync t)
+        :peer-protocol-version *peer-protocol-version*
         :schema-major (first (peer-schema-version graph))
         :schema-minor (second (peer-schema-version graph))
         :replication-key (replication-key graph)))

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -65,6 +65,12 @@ so REGISTRY holds NAME's types and nothing else."
              (ignore-errors (close-graph ,g :snapshot-p nil))
              (collect-garbage)))))))
 
+(defun %ptt-qname (symbol)
+  "SYMBOL as it now appears in the wire table's NAME/SUPERS fields: downcased
+package-qualified (GH #201).  Tests below assert against this instead of the
+bare symbol-name so they track the encoder's actual contract."
+  (graph-db::%peer-qualified-wire-name symbol))
+
 (defun %ptt-adopt (registry symbol parent id)
   "Record SYMBOL at exactly ID in REGISTRY, no graph involved.  The tests below
 need registries holding ids and symbols DEF-VERTEX cannot produce -- an id
@@ -176,16 +182,18 @@ away."
 
 (test type-table-reports-direct-superclasses-only
   "A subclass reports its DIRECT parents; a root type reports NIL (not
-VERTEX/EDGE)."
+VERTEX/EDGE).  NAME and SUPERS are package-qualified since #201 -- updated
+from the pre-#201 bare-name assertions."
   (with-ptt-registry-graph (g *integration-graph-name*)
     (declare (ignorable g))
     (let ((parsed (graph-db::peer-parse-type-table
                    (graph-db::peer-type-table-string))))
       (flet ((supers-of (name)
                (fourth (find name parsed :key #'third :test #'string=))))
-        (is (equal '("g-person") (supers-of "g-employee")))
-        (is (null (supers-of "g-person")))
-        (is (null (supers-of "g-knows")))))))
+        (is (equal (list (%ptt-qname 'g-person))
+                   (supers-of (%ptt-qname 'g-employee))))
+        (is (null (supers-of (%ptt-qname 'g-person))))
+        (is (null (supers-of (%ptt-qname 'g-knows))))))))
 
 (test type-table-survives-the-plist-channel
   "The whole point of encoding the table as a STRING: a nested list would trip
@@ -220,7 +228,8 @@ of them.
 Non-vacuous by construction: each store's schema is asserted NOT to know the
 other's type, so no single SCHEMA-TYPE-TABLE could produce this table -- an
 implementation that still read (SCHEMA GRAPH) fails here whichever graph it
-read."
+read.  ROW is looked up by the package-qualified name (GH #201) -- updated
+from the pre-#201 bare-name lookup."
   (with-ptt-registry (r)
     (with-temp-directory (d1)
       (with-temp-directory (d2)
@@ -237,17 +246,17 @@ read."
                           (and (graph-db::lookup-node-type-by-name
                                 sym parent :graph g)
                                t)))
-                   (is (row "g-person")
+                   (is (row (%ptt-qname 'g-person))
                        "the first store's type is in the table")
-                   (is (row "m-uav") "and so is the second store's")
+                   (is (row (%ptt-qname 'm-uav)) "and so is the second store's")
                    (is (not (knows-p g1 'm-uav :vertex))
                        "store 1's schema does not know M-UAV")
                    (is (not (knows-p g2 'g-person :vertex))
                        "store 2's schema does not know G-PERSON")
                    ;; The ids are the registry's, not either store's counter.
-                   (is (eql (second (row "m-uav"))
+                   (is (eql (second (row (%ptt-qname 'm-uav)))
                             (graph-db::registry-id-for r 'm-uav :vertex)))
-                   (is (eql (second (row "g-knows"))
+                   (is (eql (second (row (%ptt-qname 'g-knows)))
                             (graph-db::registry-id-for r 'g-knows :edge)))))
             (ignore-errors (close-graph g1 :snapshot-p nil))
             (ignore-errors (close-graph g2 :snapshot-p nil))
@@ -263,20 +272,24 @@ read."
 M-HAZARD and an M-ASSET on the hub.  Emitting only the FIRST parent would
 silently drop M-UAV from a device's \"all m-assets\" closure while the hub kept
 it: per-peer divergent wrong answers. The supers field is therefore a SPACE-
-SEPARATED LIST."
+SEPARATED LIST.  NAME/SUPERS are package-qualified since #201 -- updated from
+the pre-#201 bare-name assertions."
   (with-ptt-registry-graph (g :peer-type-table-mi-test)
     (declare (ignorable g))
     ;; The hub genuinely believes in the second parent.
     (is (subtypep 'm-uav 'm-asset))
     (let* ((s (graph-db::peer-type-table-string))
            (parsed (graph-db::peer-parse-type-table s)))
-      (is (search ",m-uav,m-hazard m-asset" s))
+      (is (search (format nil ",~A,~A ~A" (%ptt-qname 'm-uav)
+                          (%ptt-qname 'm-hazard) (%ptt-qname 'm-asset))
+                  s))
       (flet ((supers-of (name)
                (fourth (find name parsed :key #'third :test #'string=))))
-        (is (equal '("m-hazard" "m-asset") (supers-of "m-uav")))
-        (is (null (supers-of "m-hazard")))
-        (is (null (supers-of "m-asset")))
-        (is (null (supers-of "m-find-of-type")))))))
+        (is (equal (list (%ptt-qname 'm-hazard) (%ptt-qname 'm-asset))
+                   (supers-of (%ptt-qname 'm-uav))))
+        (is (null (supers-of (%ptt-qname 'm-hazard))))
+        (is (null (supers-of (%ptt-qname 'm-asset))))
+        (is (null (supers-of (%ptt-qname 'm-find-of-type))))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Encode-time validation: a loud hub error beats silent device corruption
@@ -293,23 +306,46 @@ corrupt table to a device that cannot possibly recover from it."
     (signals error (graph-db::peer-type-table-string))))
 
 (test type-table-encoder-rejects-names-that-collide-when-downcased
-  "STRING-DOWNCASE is not injective: P-PERSON and |P-Person| are distinct CLOS
-classes that emit the SAME name.  A device would resolve one type-id's name to
-the other type."
+  "A RESIDUAL collision (#201): P-PERSON and |P-Person| are distinct CLOS
+classes in the SAME package, so package-qualifying does not separate them --
+their qualified names still downcase alike.  STRING-DOWNCASE is not
+injective, and a device would resolve one type-id's name to the other type.
+Contrast TYPE-TABLE-ENCODES-TWO-SAME-NAMED-TYPES-FROM-DIFFERENT-PACKAGES,
+where qualifying the DIFFERENT packages is exactly what avoids this."
   (with-ptt-registry-graph (g :peer-type-table-dupname-test)
     (declare (ignorable g))
     (signals error (graph-db::peer-type-table-string))))
 
-(test type-table-collision-error-names-the-packages
-  "The collision the image-level registry made ordinary: two symbols with the
-SAME name in DIFFERENT packages, registered from different stores (GH #186).
-DEF-VERTEX cannot build this case -- a schema file defines its types in one
-package -- so it is registered directly.
+(test type-table-encoder-rejects-packages-that-collide-when-downcased
+  "The OTHER residual-collision shape (#201): two DIFFERENT packages whose
+own names downcase alike -- \"Wv2-Case-Pkg\" and \"WV2-CASE-PKG\" -- each
+holding a symbol of the SAME name.  Package-qualifying does not help here
+because the PACKAGE half of the qualified string is what collides."
+  (with-ptt-registry (r)
+    (let* ((p1 (or (find-package "Wv2-Case-Pkg")
+                   (make-package "Wv2-Case-Pkg")))
+           (p2 (or (find-package "WV2-CASE-PKG") (make-package "WV2-CASE-PKG")))
+           (s1 (intern "TWIN" p1))
+           (s2 (intern "TWIN" p2)))
+      (unwind-protect
+           (progn
+             (%ptt-adopt r s1 :vertex 1)
+             (%ptt-adopt r s2 :vertex 2)
+             (signals error (graph-db::peer-type-table-string r)))
+        (delete-package p1)
+        (delete-package p2)))))
 
-The message must print both symbols PACKAGE-QUALIFIED.  Bare ~S omits the
-package whenever the symbol is accessible in the ambient *PACKAGE*, and an
-error naming PTT-TWIN twice tells an operator with two stores nothing at all.
-It must also stop advising a rename as if both types were in one schema."
+(test type-table-encodes-two-same-named-types-from-different-packages
+  "THE #201 ACCEPTANCE.  Two symbols with the SAME name in DIFFERENT
+packages, registered from different stores (GH #186), used to be
+UNREPRESENTABLE (see the retired TYPE-TABLE-COLLISION-ERROR-NAMES-THE-
+PACKAGES): the pre-#201 encoder emitted the bare symbol-name, so both rows
+collided under STRING-DOWNCASE and PEER-TYPE-TABLE-STRING signalled.  Since
+#201's package-qualified NAME (%PEER-QUALIFIED-WIRE-NAME) the two packages
+themselves disambiguate the rows, so this now encodes cleanly with both
+rows present, present under DISTINCT qualified names, and round-trips.
+DEF-VERTEX cannot build this case -- a schema file defines its types in one
+package -- so it is registered directly."
   (with-ptt-registry (r)
     (let* ((p1 (or (find-package "PTT-PKG-ONE") (make-package "PTT-PKG-ONE")))
            (p2 (or (find-package "PTT-PKG-TWO") (make-package "PTT-PKG-TWO")))
@@ -317,14 +353,42 @@ It must also stop advising a rename as if both types were in one schema."
            (s2 (intern "PTT-TWIN" p2)))
       (%ptt-adopt r s1 :vertex 1)
       (%ptt-adopt r s2 :vertex 2)
-      (let ((text (handler-case
-                      (progn (graph-db::peer-type-table-string r) nil)
-                    (error (c) (princ-to-string c)))))
-        (is (stringp text) "the encoder must refuse the collision")
-        (is (search "PTT-PKG-ONE::PTT-TWIN" text)
-            "the first type must be named package-qualified")
-        (is (search "PTT-PKG-TWO::PTT-TWIN" text)
-            "and so must the second")))))
+      (let* ((table (graph-db::peer-type-table-string r))
+             (parsed (graph-db::peer-parse-type-table table)))
+        (is (stringp table) "the encoder no longer refuses this pair")
+        (is (search "ptt-pkg-one:ptt-twin" table))
+        (is (search "ptt-pkg-two:ptt-twin" table))
+        (is (find "ptt-pkg-one:ptt-twin" parsed :key #'third :test #'string=)
+            "the first type has its own row")
+        (is (find "ptt-pkg-two:ptt-twin" parsed :key #'third :test #'string=)
+            "and the second, DISTINCT from the first")
+        (is (/= (second (find "ptt-pkg-one:ptt-twin" parsed
+                              :key #'third :test #'string=))
+                (second (find "ptt-pkg-two:ptt-twin" parsed
+                              :key #'third :test #'string=)))
+            "distinct rows carry their own ids")))))
+
+(test type-table-encoder-rejects-a-package-name-carrying-a-reserved-char
+  "Package names are UNCONSTRAINED too (MAKE-PACKAGE takes any string), and
+since #201 the package half is now part of what hits the wire.
+%PEER-CHECK-WIRE-NAME runs on the FULL qualified string, so a package name
+with a space -- the cheapest honest reserved-char case -- must refuse exactly
+as a bad symbol-name would, not just get silently mangled into the SUPERS
+field's own space-separator convention."
+  (with-ptt-registry (r)
+    (let* ((p (or (find-package "PTT BAD PKG") (make-package "PTT BAD PKG")))
+           (s (intern "OK-NAME" p)))
+      (unwind-protect
+           (progn
+             (%ptt-adopt r s :vertex 1)
+             (let ((text (handler-case
+                             (progn (graph-db::peer-type-table-string r) nil)
+                           (error (c) (princ-to-string c)))))
+               (is (stringp text)
+                   "the encoder must refuse a reserved char in the package ~
+name")
+               (is (search "reserved character" text))))
+        (delete-package p)))))
 
 (test type-table-encoder-rejects-an-id-the-wire-cannot-carry
   "The registry assigns 32-bit type-ids; the wire's ID field is frozen at
@@ -365,14 +429,19 @@ materialise as the wrong class here.  Refuse, and NAME the symbol -- an
 operator has to find it in two stores, so the package has to be in the message.
 
 Reconciling instead would mean rewriting every node of that type because a
-network handshake said so, which is why this is a refusal and not a merge."
+network handshake said so, which is why this is a refusal and not a merge.
+
+The hand-built hub table's NAME field is package-qualified (#201) -- updated
+from the pre-#201 bare \"ptt-conflict-type\", which no longer matches this
+image's now-qualified row and so no longer triggers the conflict at all."
   (with-ptt-registry (r)
     (%ptt-adopt r 'ptt-conflict-type :vertex 7)
     (let ((text (%ptt-refusal-text
                  (lambda ()
                    (graph-db::peer-device-accept-auth-ok
                     (list :peer-control :auth-ok
-                          :type-table "v,4,ptt-conflict-type,")
+                          :type-table (format nil "v,4,~A,"
+                                              (%ptt-qname 'ptt-conflict-type)))
                     r)))))
       (is (stringp text) "the handshake must REFUSE a disagreeing registry")
       (is (search "GRAPH-DB/TEST::PTT-CONFLICT-TYPE" text)
@@ -563,11 +632,15 @@ after auth-ok, so a device that gets past the guard fails on the pull)."
 (test peer-sync-refuses-a-hub-whose-registry-disagrees
   "PEER-SYNC itself must run the guard, over a real socket.  The three tests
 above call PEER-DEVICE-ACCEPT-AUTH-OK directly and would all still pass if
-PEER-SYNC stopped calling it."
+PEER-SYNC stopped calling it.
+
+The hand-built hub table's NAME field is package-qualified (#201) -- updated
+from the pre-#201 bare \"g-person\", which would no longer match this
+image's now-qualified row."
   (with-ptt-device (g r)
     (let* ((mine (graph-db::registry-id-for r 'g-person :vertex))
            (c (%ptt-sync-against
-               g (format nil "v,~D,g-person," (+ 100 mine)))))
+               g (format nil "v,~D,~A," (+ 100 mine) (%ptt-qname 'g-person)))))
       (is (typep c 'graph-db::peer-type-registry-conflict-error)
           "PEER-SYNC must refuse at auth-ok; it signalled ~S" c)
       (when (typep c 'graph-db::peer-type-registry-conflict-error)

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -331,7 +331,14 @@ because the PACKAGE half of the qualified string is what collides."
            (progn
              (%ptt-adopt r s1 :vertex 1)
              (%ptt-adopt r s2 :vertex 2)
-             (signals error (graph-db::peer-type-table-string r)))
+             (let ((text (handler-case
+                             (progn (graph-db::peer-type-table-string r) nil)
+                           (error (c) (princ-to-string c)))))
+               (is (stringp text) "the encoder must refuse the collision")
+               (is (search "Wv2-Case-Pkg" text)
+                   "the first package must be named package-qualified")
+               (is (search "WV2-CASE-PKG::TWIN" text)
+                   "the second type must be named package-qualified")))
         (delete-package p1)
         (delete-package p2)))))
 

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -136,6 +136,20 @@ asserts STRINGP first."
   ()
   :peer-type-table-scope-b)
 
+;;; --- A CLOS parent registered under a DIFFERENT graph-name (Task 3 fix,
+;;; GH #206).  PTS-CROSS-PARENT lives only in store A; PTS-CROSS-CHILD names
+;;; it as a direct superclass but is registered only in store B.  Scoping B
+;;; naively would keep the child and drop the parent's row -- a dangling
+;;; SUPERS reference.
+
+(def-vertex pts-cross-parent ()
+  ()
+  :peer-type-table-scope-a)
+
+(def-vertex pts-cross-child (pts-cross-parent)
+  ()
+  :peer-type-table-scope-b)
+
 ;;; --- A schema no wire format can represent: a name with a delimiter. -----
 ;;; CL symbol names may contain ANY character via |escaped| syntax, and
 ;;; DEF-VERTEX constrains nothing.  The ENCODER is the only possible defense:
@@ -880,3 +894,63 @@ changing the function."
                  (graph-db::peer-check-type-registry-agreement hub-table r))
           "a scoped table that is a subset of the device's own registry's
 world must be accepted, not refused"))))
+
+;;; ---------------------------------------------------------------------------
+;;; Fix round (GH #206): scoping closure-completes SUPERS across stores.
+;;; ---------------------------------------------------------------------------
+
+(test type-table-scoped-graph-closure-completes-a-cross-store-parent
+  "PTS-CROSS-PARENT lives only in store A; PTS-CROSS-CHILD names it as a
+direct superclass but is registered only in store B.  B's scoped table must
+carry BOTH rows -- the child (direct) and the parent (closure-completed) --
+and every SUPERS entry in the scoped table must resolve to some row's NAME,
+so a device's closure walk never dangles.  ABLATION: disabling closure
+completion (reverting %PEER-GRAPH-SCOPED-ROWS to the direct-only filter)
+makes the \"parent row present\" assertion below fail -- the parent is
+dropped while the child's SUPERS still names it."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable ga))
+    (let* ((scoped-b (graph-db::peer-parse-type-table
+                      (graph-db::peer-type-table-string r gb))))
+      (flet ((row (name) (find name scoped-b :key #'third :test #'string=)))
+        (is (row (%ptt-qname 'pts-cross-child))
+            "the direct type is in B's session table")
+        (is (row (%ptt-qname 'pts-cross-parent))
+            "the cross-store parent must be closure-completed into B's table")
+        (dolist (row scoped-b)
+          (dolist (super (fourth row))
+            (is (find super scoped-b :key #'third :test #'string=)
+                "SUPERS entry ~S must resolve within the scoped table" super))))
+      (is (equal (graph-db::peer-parse-type-table
+                  (graph-db::peer-type-table-string r gb))
+                 scoped-b)
+          "the closure-completed scoped table still round-trips"))))
+
+(test type-table-scoped-to-graph-excludes-the-other-store-s-type-still-holds
+  "The original disclosure pin must not be weakened by closure completion:
+B-only's row (PTS-B-ONLY, no one's parent) is still excluded from A's
+scoped table."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable gb))
+    (let* ((scoped-a (graph-db::peer-parse-type-table
+                      (graph-db::peer-type-table-string r ga))))
+      (is (not (find (%ptt-qname 'pts-b-only) scoped-a
+                     :key #'third :test #'string=))
+          "B-only is no one's parent, so closure completion must not pull
+it in"))))
+
+(test type-table-validate-rows-signals-on-dangling-super
+  "%PEER-VALIDATE-TYPE-TABLE-ROWS's closure-integrity check: a synthetic row
+set with a SUPERS entry naming no row must signal.  ABLATION: removing this
+check makes this test fail, since %PEER-GRAPH-SCOPED-ROWS's own closure
+completion can never produce a dangling reference on its own."
+  (let ((dangling (list (list "v" 1 "pkg:child" '("pkg:missing-parent")
+                              'pts-a-only))))
+    (signals error (graph-db::%peer-validate-type-table-rows dangling))))
+
+(test type-table-validate-rows-does-not-false-positive-on-empty-supers
+  "A top-level type (empty SUPERS, rooted at VERTEX/EDGE) must not trip the
+closure-integrity check, and neither must a whole-image table."
+  (with-ptt-registry-graph (g *integration-graph-name*)
+    (declare (ignorable g))
+    (is (stringp (graph-db::peer-type-table-string)))))

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -110,6 +110,32 @@ asserts STRINGP first."
   ()
   :peer-type-table-mi-test)
 
+;;; --- Two stores, disjoint types plus one shared type (Task 3, GH #206). --
+;;; PTS-A-ONLY lives only in store A's schema, PTS-B-ONLY only in store B's,
+;;; and PTS-SHARED is registered under BOTH graph-names -- the same symbol,
+;;; identical slots, so %WARN-IF-DIVERGENT-ACROSS-STORES stays silent (that
+;;; is the documented multi-store feature, not a redefinition warning).
+
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :peer-type-table-scope-a *schema-node-metadata*) nil)
+  (setf (gethash :peer-type-table-scope-b *schema-node-metadata*) nil))
+
+(def-vertex pts-a-only ()
+  ()
+  :peer-type-table-scope-a)
+
+(def-vertex pts-b-only ()
+  ()
+  :peer-type-table-scope-b)
+
+(def-vertex pts-shared ()
+  ()
+  :peer-type-table-scope-a)
+
+(def-vertex pts-shared ()
+  ()
+  :peer-type-table-scope-b)
+
 ;;; --- A schema no wire format can represent: a name with a delimiter. -----
 ;;; CL symbol names may contain ANY character via |escaped| syntax, and
 ;;; DEF-VERTEX constrains nothing.  The ENCODER is the only possible defense:
@@ -718,3 +744,139 @@ that refused every peer-graph would pass the test above."
                    "and its writer funnel is running"))
           (ignore-errors (close-graph g :snapshot-p nil))))
       (collect-garbage))))
+
+;;; ---------------------------------------------------------------------------
+;;; Task 3 (GH #206): store-scoped table.  PEER-TYPE-TABLE-STRING's optional
+;;; GRAPH filters rows to types actually registered in GRAPH's own schema
+;;; (LOOKUP-NODE-TYPE-BY-NAME, direct symbol path, GH #190) -- the hub's
+;;; auth-ok call site passes the session's graph so a device only ever learns
+;;; about the store it is actually replicating.
+;;; ---------------------------------------------------------------------------
+
+(defmacro with-ptt-two-stores ((r ga gb) &body body)
+  "One registry R, two stores under it: GA is
+:PEER-TYPE-TABLE-SCOPE-A (PTS-A-ONLY, PTS-SHARED), GB is
+:PEER-TYPE-TABLE-SCOPE-B (PTS-B-ONLY, PTS-SHARED)."
+  (let ((da (gensym "DA")) (db (gensym "DB")))
+    `(with-ptt-registry (,r)
+       (with-temp-directory (,da)
+         (with-temp-directory (,db)
+           (let ((,ga (make-graph :peer-type-table-scope-a (namestring ,da)
+                                  :buffer-pool-size 1000))
+                 (,gb (make-graph :peer-type-table-scope-b (namestring ,db)
+                                  :buffer-pool-size 1000)))
+             (unwind-protect (let () ,@body)
+               (ignore-errors (close-graph ,ga :snapshot-p nil))
+               (ignore-errors (close-graph ,gb :snapshot-p nil))
+               (collect-garbage))))))))
+
+(test type-table-scoped-to-graph-excludes-the-other-store-s-type
+  "THE DISCLOSURE PIN.  Store A's session table contains A's own type and the
+SHARED type, and explicitly does NOT contain B-only's row.  Ablation: an
+implementation that drops the GRAPH filter (the nearest wrong
+implementation is calling PEER-TYPE-TABLE-STRING with no GRAPH, i.e. the
+whole-image table) makes the absence assertion below fail, because the
+whole-image control table (asserted first) DOES carry all three."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable gb))
+    (let* ((whole-image (graph-db::peer-parse-type-table
+                         (graph-db::peer-type-table-string r)))
+           (scoped-a (graph-db::peer-parse-type-table
+                      (graph-db::peer-type-table-string r ga))))
+      (flet ((row (parsed name)
+               (find name parsed :key #'third :test #'string=)))
+        ;; Control: the unscoped table is the whole image, so it is NOT
+        ;; vacuously missing B-only -- proving the absence below is the
+        ;; filter's doing, not an empty registry.
+        (is (row whole-image (%ptt-qname 'pts-a-only)))
+        (is (row whole-image (%ptt-qname 'pts-b-only)))
+        (is (row whole-image (%ptt-qname 'pts-shared)))
+        ;; The scoped table for store A.
+        (is (row scoped-a (%ptt-qname 'pts-a-only))
+            "A's own type is in A's session table")
+        (is (row scoped-a (%ptt-qname 'pts-shared))
+            "the shared type is in A's session table too")
+        (is (not (row scoped-a (%ptt-qname 'pts-b-only)))
+            "B-only's row must NOT be disclosed to a session scoped to A")))))
+
+(test type-table-scoped-to-graph-is-symmetric
+  "The mirror of the pin above: B's session table carries B's own type and the
+shared type, and not A-only's."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable ga))
+    (let* ((scoped-b (graph-db::peer-parse-type-table
+                      (graph-db::peer-type-table-string r gb))))
+      (flet ((row (name) (find name scoped-b :key #'third :test #'string=)))
+        (is (row (%ptt-qname 'pts-b-only)))
+        (is (row (%ptt-qname 'pts-shared)))
+        (is (not (row (%ptt-qname 'pts-a-only))))))))
+
+(test type-table-no-graph-argument-stays-whole-image
+  "Every existing direct caller (and the tests above this section) calls
+PEER-TYPE-TABLE-STRING with no GRAPH and must keep seeing every type in the
+registry -- the opt-in is additive, not a behaviour change for callers that
+do not pass one."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable ga gb))
+    (let ((parsed (graph-db::peer-parse-type-table
+                   (graph-db::peer-type-table-string r))))
+      (dolist (name (list 'pts-a-only 'pts-b-only 'pts-shared))
+        (is (find (%ptt-qname name) parsed :key #'third :test #'string=)
+            "no GRAPH argument must still disclose ~A" name)))))
+
+(test type-table-scoped-still-round-trips
+  "The scoped table is still exactly what PEER-PARSE-TYPE-TABLE expects: same
+grammar, fewer rows."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable gb))
+    (let* ((s (graph-db::peer-type-table-string r ga))
+           (parsed (graph-db::peer-parse-type-table s)))
+      (is (stringp s))
+      (is (plusp (length parsed)))
+      (dolist (row parsed)
+        (is (member (first row) '(:vertex :edge)))
+        (is (integerp (second row)))
+        (is (stringp (third row)))
+        (is (listp (fourth row)))))))
+
+(test type-table-scoped-graph-survives-an-unrepresentable-type-elsewhere
+  "The blast-radius improvement %PEER-VALIDATE-TYPE-TABLE-ROWS's docstring now
+documents: an unrepresentable type living in a store UNRELATED to the
+session's graph used to fail every device connection in the image (GH #186);
+scoped to a graph that does not instantiate that type, the session's table
+encodes cleanly."
+  (with-ptt-registry (r)
+    (with-temp-directory (da)
+      (with-temp-directory (dbad)
+        (let ((ga (make-graph :peer-type-table-scope-a (namestring da)
+                              :buffer-pool-size 1000))
+              (gbad (make-graph :peer-type-table-badname-test
+                                (namestring dbad) :buffer-pool-size 1000)))
+          (unwind-protect
+               (progn
+                 ;; The whole-image table still fails: |odd,name| is
+                 ;; unrepresentable and it IS in the registry.
+                 (signals error (graph-db::peer-type-table-string r))
+                 ;; But A's session, which does not instantiate |odd,name|,
+                 ;; is unaffected.
+                 (is (stringp (graph-db::peer-type-table-string r ga))))
+            (ignore-errors (close-graph ga :snapshot-p nil))
+            (ignore-errors (close-graph gbad :snapshot-p nil))
+            (collect-garbage)))))))
+
+(test d15-scoped-hub-table-is-a-subset-the-device-does-not-conflict-on
+  "D15 restated for a scoped table: a device whose OWN registry knows MORE
+types than the hub's (scoped) table -- because the hub only disclosed one
+store's worth -- must NOT see that as a conflict.  %PEER-REGISTRY-CONFLICTS
+keys conflicts on HUB rows, so a row present locally but absent from
+HUB-ROWS is silently not-a-conflict; this pins that behaviour rather than
+changing the function."
+  (with-ptt-two-stores (r ga gb)
+    (declare (ignorable gb))
+    (let ((hub-table (graph-db::peer-type-table-string r ga)))
+      ;; The device's own registry (R) knows PTS-B-ONLY too -- strictly more
+      ;; than the scoped hub table -- and must still be accepted.
+      (is (equal (graph-db::peer-parse-type-table hub-table)
+                 (graph-db::peer-check-type-registry-agreement hub-table r))
+          "a scoped table that is a subset of the device's own registry's
+world must be accepted, not refused"))))

--- a/tests/peer-wire-v2-tests.lisp
+++ b/tests/peer-wire-v2-tests.lisp
@@ -112,3 +112,103 @@ and fail the existing schema gate -- the new check does not swallow it."
                (error (e) e))))
       (is (typep c 'graph-db::peer-schema-incompatible-error)
           "bad schema + good protocol must surface the SCHEMA error, got ~S" c))))
+
+;;; ---------------------------------------------------------------------------
+;;; #206 gap 2: the envelope's own header-size byte is checked against this
+;;; image's current head layout, BEFORE any head byte is interpreted.  The
+;;; protocol/schema gates above are the primary contract; this is defense in
+;;; depth for a gate bypass (or a stale on-disk .txn file predating a head-size
+;;; change) so it is refused, not misparsed. See DESERIALIZE-TRANSACTION-NODE-
+;;; VECTOR in transactions.lisp.
+;;; ---------------------------------------------------------------------------
+
+(defun %wv2-fake-node-vector (kind header-size)
+  "A hand-built transaction-node-vector envelope: KIND (:VERTEX or :EDGE), a
+HEADER-SIZE byte, and exactly HEADER-SIZE zero bytes of 'head' -- no data.
+Enough to drive DESERIALIZE-TRANSACTION-NODE-VECTOR's own size check without a
+real node.  A vector this short cannot hold a current-size head, so a skipped
+check would run GET-BYTE past the array end, not just decode wrong fields --
+that is the ablation evidence for GH #206."
+  (let* ((type-code (ecase kind
+                      (:vertex graph-db::+transaction-node-vertex-code+)
+                      (:edge   graph-db::+transaction-node-edge-code+)))
+         (total (+ graph-db::+transaction-node-base-header-size+ header-size))
+         (vec (make-array total :element-type '(unsigned-byte 8)
+                          :initial-element 0)))
+    (graph-db::serialize-uint64 vec total 0)
+    (setf (aref vec 9) type-code)
+    (setf (aref vec 26) header-size)
+    vec))
+
+(test hub-refuses-old-vertex-head-size
+  "A hand-built envelope carrying the OLD (31-byte) vertex head size is
+refused with NODE-HEAD-SIZE-MISMATCH-ERROR before any head byte is read."
+  (let ((c (handler-case
+               (progn (graph-db::deserialize-transaction-node-vector
+                       (%wv2-fake-node-vector :vertex 31))
+                      nil)
+             (error (e) e))))
+    (is (typep c 'graph-db::node-head-size-mismatch-error)
+        "expected NODE-HEAD-SIZE-MISMATCH-ERROR, got ~S" c)
+    (when (typep c 'graph-db::node-head-size-mismatch-error)
+      (is (eql graph-db::+node-header-size+
+               (graph-db::node-head-size-mismatch-expected c)))
+      (is (eql 31 (graph-db::node-head-size-mismatch-actual c)))
+      (is (eq :vertex (graph-db::node-head-size-mismatch-kind c))))))
+
+(test hub-refuses-old-edge-head-size
+  "Same check, edge side: the OLD (71-byte) edge head size is refused."
+  (let ((c (handler-case
+               (progn (graph-db::deserialize-transaction-node-vector
+                       (%wv2-fake-node-vector :edge 71))
+                      nil)
+             (error (e) e))))
+    (is (typep c 'graph-db::node-head-size-mismatch-error)
+        "expected NODE-HEAD-SIZE-MISMATCH-ERROR, got ~S" c)
+    (when (typep c 'graph-db::node-head-size-mismatch-error)
+      (is (eql graph-db::+edge-header-size+
+               (graph-db::node-head-size-mismatch-expected c)))
+      (is (eql 71 (graph-db::node-head-size-mismatch-actual c)))
+      (is (eq :edge (graph-db::node-head-size-mismatch-kind c))))))
+
+(test hub-refuses-before-reading-any-head-byte
+  "Ordering pin: the fake vertex envelope has zero bytes past its declared
+(old) header -- if the size check ran AFTER any head interpretation started
+(or not at all), reading the current 33-byte head layout from a 31-byte
+buffer would run GET-BYTE off the end of the array, not signal our named
+condition. It must be OUR condition, not an array-bounds error."
+  (let ((c (handler-case
+               (progn (graph-db::deserialize-transaction-node-vector
+                       (%wv2-fake-node-vector :vertex 31))
+                      nil)
+             (error (e) e))))
+    (is (typep c 'graph-db::node-head-size-mismatch-error)
+        "check must fire before any head byte is read; got ~S" c)))
+
+(test hub-applies-current-size-vertex-vector
+  "Control: a REAL vertex, freshly loaded from disk (so BYTES reflects the
+image's current head layout), round-trips through DESERIALIZE-TRANSACTION-
+NODE-VECTOR untouched -- the new check does not refuse legitimate current
+traffic."
+  (with-test-graph (g)
+    (let (id)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq id (id (make-g-person :name "X"))))
+      (let* ((node (lookup-vertex id))
+             (vector (graph-db::transaction-node-vector node))
+             (decoded (graph-db::deserialize-transaction-node-vector vector)))
+        (is (equalp id (id decoded)))))))
+
+(test hub-applies-current-size-edge-vector
+  "Control, edge side: a REAL edge round-trips through DESERIALIZE-
+TRANSACTION-NODE-VECTOR untouched."
+  (with-test-graph (g)
+    (let (a b eid)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq a (id (make-g-person :name "A")))
+        (setq b (id (make-g-person :name "B")))
+        (setq eid (id (make-g-knows :from a :to b))))
+      (let* ((edge (lookup-edge eid))
+             (vector (graph-db::transaction-node-vector edge))
+             (decoded (graph-db::deserialize-transaction-node-vector vector)))
+        (is (equalp eid (id decoded)))))))

--- a/tests/peer-wire-v2-tests.lisp
+++ b/tests/peer-wire-v2-tests.lisp
@@ -1,0 +1,114 @@
+;;;; The wire-v2 version gate, hub side (GH #206).
+;;;;
+;;;; *PEER-PROTOCOL-VERSION* bumps 1 -> 2.  The reference DEVICE already refused
+;;;; a mismatched hub pre-auth (peer-streaming.lisp, PEER-SYNC) -- that half of
+;;;; the gate needed no change.  What #206 actually reports missing is the other
+;;;; direction: the HUB never checked the device's protocol version at all, so a
+;;;; stale v1 device could push v1-shaped heads at a v2 hub and get misparsed
+;;;; instead of refused.  PEER-AUTHENTICATE-DEVICE now checks first, before the
+;;;; schema gate and before any device-registration side effect.
+;;;;
+;;;; Drives PEER-AUTHENTICATE-DEVICE directly with hand-built auth plists --
+;;;; no socket needed, since the question is purely "does this function refuse
+;;;; before it mutates," not a wire-encoding question.
+
+(in-package #:graph-db/test)
+
+(def-suite peer-wire-v2-suite
+  :description "The hub-side protocol-version gate (GH #206)."
+  :in graph-db-suite)
+
+(in-suite peer-wire-v2-suite)
+
+(defparameter *wv2-hub-origin* (id16 41))
+(defparameter *wv2-dev-origin* (id16 42))
+
+(defmacro with-wv2-hub ((g) &body body)
+  "A hub peer-graph with shared REPLICATION-KEY \"k\" and one registered device
+at *WV2-DEV-ORIGIN* (no per-device key, so it falls back to the hub's)."
+  `(with-temp-directory (dir)
+     (let ((,g (make-graph *integration-graph-name* (namestring dir)
+                           :peer-role :hub :origin-id *wv2-hub-origin*
+                           :replication-port 0 :replication-key "k"
+                           :buffer-pool-size 1000)))
+       (unwind-protect
+            (let ((*graph* ,g))
+              (graph-db::register-peer-device ,g :origin-id *wv2-dev-origin*)
+              ,@body)
+         (close-graph ,g :snapshot-p nil)))))
+
+(defun %wv2-plist (g &key (protocol graph-db::*peer-protocol-version* protocol-p)
+                        (omit-protocol nil)
+                        (schema-major (first (graph-db::peer-schema-version g)))
+                        (schema-minor (second (graph-db::peer-schema-version g))))
+  "A device auth plist against hub G: good by default (matches *PEER-PROTOCOL-
+VERSION* and G's own schema version); callers pass OMIT-PROTOCOL or PROTOCOL
+to build the bad variants under test."
+  (declare (ignore protocol-p))
+  (append
+   (list :origin-id (graph-db::peer-id->hex *wv2-dev-origin*)
+         :replication-key "k"
+         :schema-major schema-major
+         :schema-minor schema-minor)
+   (unless omit-protocol (list :peer-protocol-version protocol))))
+
+(test hub-authenticates-a-good-v2-plist
+  "Control: a plist with the current protocol version and a matching schema
+version authenticates -- a guard that refused everything would pass the
+refusal tests below for the wrong reason."
+  (with-wv2-hub (g)
+    (is (graph-db::peer-device-p
+         (graph-db::peer-authenticate-device g (%wv2-plist g))))))
+
+(test hub-refuses-auth-plist-without-protocol-key
+  "A v1 device never sends :PEER-PROTOCOL-VERSION at all.  Absent must refuse,
+not default to compatible -- the #206 misparse this gate exists to prevent."
+  (with-wv2-hub (g)
+    (let ((c (handler-case
+                 (progn (graph-db::peer-authenticate-device
+                         g (%wv2-plist g :omit-protocol t))
+                        nil)
+               (error (e) e))))
+      (is (typep c 'graph-db::peer-protocol-mismatch-error)
+          "expected PEER-PROTOCOL-MISMATCH-ERROR, got ~S" c)
+      (when (typep c 'graph-db::peer-protocol-mismatch-error)
+        (is (eql 2 (graph-db::peer-protocol-mismatch-hub c)))
+        (is (null (graph-db::peer-protocol-mismatch-device c))
+            "absent key reads back as NIL, not 0 or some other sentinel")))))
+
+(test hub-refuses-a-wrong-protocol-version
+  "A device that sends a stale (or too-new) version number, present but wrong."
+  (with-wv2-hub (g)
+    (let ((c (handler-case
+                 (progn (graph-db::peer-authenticate-device
+                         g (%wv2-plist g :protocol 1))
+                        nil)
+               (error (e) e))))
+      (is (typep c 'graph-db::peer-protocol-mismatch-error)
+          "expected PEER-PROTOCOL-MISMATCH-ERROR, got ~S" c)
+      (when (typep c 'graph-db::peer-protocol-mismatch-error)
+        (is (eql 1 (graph-db::peer-protocol-mismatch-device c)))))))
+
+(test hub-orders-protocol-gate-before-schema-gate
+  "Ordering pin: a BAD protocol + a GOOD schema version must fail as a protocol
+error, not a schema error -- proving the protocol check runs first."
+  (with-wv2-hub (g)
+    (let ((c (handler-case
+                 (progn (graph-db::peer-authenticate-device
+                         g (%wv2-plist g :protocol 1))
+                        nil)
+               (error (e) e))))
+      (is (typep c 'graph-db::peer-protocol-mismatch-error)
+          "bad protocol + good schema must surface the PROTOCOL error, got ~S" c))))
+
+(test hub-still-runs-schema-gate-behind-a-good-protocol
+  "Ordering's other half: a GOOD protocol + a BAD schema major must still reach
+and fail the existing schema gate -- the new check does not swallow it."
+  (with-wv2-hub (g)
+    (let ((c (handler-case
+                 (progn (graph-db::peer-authenticate-device
+                         g (%wv2-plist g :schema-major 99))
+                        nil)
+               (error (e) e))))
+      (is (typep c 'graph-db::peer-schema-incompatible-error)
+          "bad schema + good protocol must surface the SCHEMA error, got ~S" c))))

--- a/tests/peer-wire-v2-tests.lisp
+++ b/tests/peer-wire-v2-tests.lisp
@@ -37,14 +37,15 @@ at *WV2-DEV-ORIGIN* (no per-device key, so it falls back to the hub's)."
               ,@body)
          (close-graph ,g :snapshot-p nil)))))
 
-(defun %wv2-plist (g &key (protocol graph-db::*peer-protocol-version* protocol-p)
-                        (omit-protocol nil)
-                        (schema-major (first (graph-db::peer-schema-version g)))
-                        (schema-minor (second (graph-db::peer-schema-version g))))
+(defun %wv2-plist (g &key (protocol graph-db::*peer-protocol-version*)
+                       (omit-protocol nil)
+                       (schema-major
+                        (first (graph-db::peer-schema-version g)))
+                       (schema-minor
+                        (second (graph-db::peer-schema-version g))))
   "A device auth plist against hub G: good by default (matches *PEER-PROTOCOL-
 VERSION* and G's own schema version); callers pass OMIT-PROTOCOL or PROTOCOL
 to build the bad variants under test."
-  (declare (ignore protocol-p))
   (append
    (list :origin-id (graph-db::peer-id->hex *wv2-dev-origin*)
          :replication-key "k"
@@ -99,7 +100,8 @@ error, not a schema error -- proving the protocol check runs first."
                         nil)
                (error (e) e))))
       (is (typep c 'graph-db::peer-protocol-mismatch-error)
-          "bad protocol + good schema must surface the PROTOCOL error, got ~S" c))))
+          "bad protocol + good schema must surface the PROTOCOL error, got ~S"
+          c))))
 
 (test hub-still-runs-schema-gate-behind-a-good-protocol
   "Ordering's other half: a GOOD protocol + a BAD schema major must still reach
@@ -111,7 +113,8 @@ and fail the existing schema gate -- the new check does not swallow it."
                         nil)
                (error (e) e))))
       (is (typep c 'graph-db::peer-schema-incompatible-error)
-          "bad schema + good protocol must surface the SCHEMA error, got ~S" c))))
+          "bad schema + good protocol must surface the SCHEMA error, got ~S"
+          c))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; #206 gap 2: the envelope's own header-size byte is checked against this

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -2014,6 +2014,23 @@ With no FILTER, returns WRITES unchanged."
         (setf (data vertex) nil))
     vertex))
 
+;; Envelope's header-size byte MUST match this image's current head layout
+;; before any head byte is interpreted -- a version-gate bypass (or a stale
+;; on-disk txn-log predating a head-size change) would otherwise misparse
+;; head fields as data, not fail loudly. Defense in depth for GH #206 gap 2;
+;; the version/schema gates (peer-streaming.lisp) are the primary contract.
+(define-condition node-head-size-mismatch-error (error)
+  ((expected :initarg :expected :reader node-head-size-mismatch-expected)
+   (actual   :initarg :actual   :reader node-head-size-mismatch-actual)
+   (kind     :initarg :kind     :reader node-head-size-mismatch-kind))
+  (:report (lambda (c s)
+             (format s "Node head size mismatch for ~A: expected ~A byte~:P, ~
+got ~A (old-format or corrupt wire data, refused rather than misparsed; ~
+GH #206)"
+                     (node-head-size-mismatch-kind c)
+                     (node-head-size-mismatch-expected c)
+                     (node-head-size-mismatch-actual c)))))
+
 (defun deserialize-transaction-node-vector (vector &optional (offset 0))
   "Return the edge or vertex represented by VECTOR."
   (let (size uuid type header-size end)
@@ -2028,6 +2045,19 @@ With no FILTER, returns WRITES unchanged."
     (incf offset 16)
     (setf header-size (get-byte vector offset))
     (incf offset)
+    ;; Validate BEFORE any head byte is interpreted (below).
+    (let ((expected (cond ((eql type +transaction-node-edge-code+)
+                           +edge-header-size+)
+                          ((eql type +transaction-node-vertex-code+)
+                           +node-header-size+)
+                          (t
+                           (error "Unknown transaction node type ~S" type)))))
+      (unless (= header-size expected)
+        (error 'node-head-size-mismatch-error
+               :expected expected :actual header-size
+               :kind (if (eql type +transaction-node-edge-code+)
+                         :edge
+                         :vertex))))
     (let* ((header-offset offset)
            (data-offset (+ offset header-size))
            (node


### PR DESCRIPTION
One wire generation, one fleet upgrade. Closes the two gaps #206 recorded and ships #201's engine flip plus the store-scoping disclosure ruling.

## The v2 contract (four points)

1. **Version gate, both ends** — `*peer-protocol-version*` 1→2; the device auth plist must carry `:peer-protocol-version`; the hub refuses absence or mismatch (`peer-protocol-mismatch-error`, internal) **before** the schema gate and before any mutation. Absent = a v1 device; refusing it is the point — a v1 device pushing at a v2 hub was a silent misparse (#206).
2. **Package-qualified type-table names (#201)** — every NAME and SUPERS entry is downcased `package:symbol`; two same-named types from different packages now share one table without colliding; refusal only on residual qualified-downcase collisions, naming both parties package-qualified. The 4-field grammar is unchanged; `:` was never reserved.
3. **Store-scoped table** — the auth-ok table is scoped to the replicated store's own schema plus the transitive SUPERS-closure of that set (closure completion keeps cross-store parentage resolvable; the residual mixin corner is #216). A device knowing more types than the table is not a conflict (D15, pinned). Blast-radius win: an unrepresentable type in an unrelated store no longer fails this session.
4. **Header-size honour** — `deserialize-transaction-node-vector` refuses a stale header-size byte (`node-head-size-mismatch-error`) before reading any head byte. Ablation evidence: without it, an old-size envelope either dies in a raw array-bounds error or silently decodes a garbage `prev-pointer` into an otherwise plausible node (#206 gap 2).

## Verification (SBCL; ECL skipped per standing directive)

- Full gate on the merged branch (includes #215): **4294 checks / 4284 pass / 10 skips / 0 fail** (baseline 4073/4063/10/0).
- Focused suites: peer-wire-v2 19/19 (new), peer-type-table 282/282 (+44 net), peer-conflict 16/16.
- **Two-process peer harness PASS** on the final commit — real socket handshake under the v2 gate with the qualified, scoped table.
- Every guard ablated during development; each ablation broke exactly its pinned assertion.

## Coordination

Wire-generation break: hub and devices move together. Device-side requirements posted on mine-action-android#29 before implementation. Docs: CHANGELOG (breaking entry), manual ch. 16, namespaces spec §3.4 Built-note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95