### PR TITLE
fix(posix): open(2)'s mode must go through CFFI varargs (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`%POSIX-OPEN` created files with an arbitrary permission mode on Apple
+  arm64** (#218). `open(2)` is `int open(const char *, int, ...)`, and the
+  `mode` argument was passed through a plain `CFFI:FOREIGN-FUNCALL` — as a
+  *fixed* argument. On Darwin/arm64 variadic arguments use a different
+  convention, so the callee read `mode` from where nothing had written it:
+  `0140` and `0200` were both observed for a requested `0640`, on consecutive
+  runs. When the resulting mode omitted owner read/write, the next ordinary
+  `WITH-OPEN-FILE` on that path failed `EACCES` — and since the type registry
+  (#186) and the system clock (#182) both create their files this way, **no
+  graph in the image could be opened at all**, with a zero-byte file left
+  behind that reproduced the failure on every subsequent run. Now routed
+  through `CFFI:FOREIGN-FUNCALL-VARARGS`, which emits SBCL's variadic marker.
+  x86_64 was never affected (the two conventions coincide there), which is why
+  this reached a release: it presented as a broken developer machine rather
+  than a defect. `open` was the only variadic call in `posix.lisp`; the rest
+  (`flock`, `close`, `lseek`, `write`, `fchmod`, `rename`, `mmap`, `munmap`,
+  `msync`, `getpagesize`, `gettimeofday`) have fixed signatures and are
+  correct as written. Regression test asserts the created file's **mode** —
+  every previous test asserted only that the fd was valid, which is exactly
+  what a garbage mode still yields to its creator.
+
 ### Added
 
 - **New node ids are tagged UUIDv8, carrying a 12-bit store field** for

--- a/posix.lisp
+++ b/posix.lisp
@@ -97,12 +97,26 @@
                  %posix-msync))
 
 (defun %posix-open (path flags &optional (mode #o640))
-  "open(2).  PATH is a Lisp pathname/string.  Returns the fd, signals on error."
-  (let ((fd (cffi:foreign-funcall "open"
-                                  :string (namestring path)
-                                  :int flags
-                                  :unsigned-int mode
-                                  :int)))
+  "open(2).  PATH is a Lisp pathname/string.  Returns the fd, signals on error.
+
+MODE rides CFFI's VARARGS path, not a plain FOREIGN-FUNCALL.  open(2) is
+`int open(const char *, int, ...)`, and Apple arm64 passes a variadic argument
+differently from a fixed one, so a fixed-argument MODE is read from somewhere
+the callee never wrote: the file is created with an arbitrary mode, and a
+different one each run (0140 and 0200 both observed for this 0640 default).
+When that mode omits owner read/write the next ordinary OPEN of the path fails
+EACCES -- which is every graph in the image, since the type registry (#186) and
+the system clock (#182) both create their files here.  GH #218.
+
+Only the SBCL/Darwin/arm64 backend actually needs the distinction -- CFFI emits
+SBCL's `&optional` variadic marker under `#+(and darwin arm64)` alone -- but
+routing every caller through the correct form is what keeps the next port from
+inheriting the bug."
+  (let ((fd (cffi:foreign-funcall-varargs
+             "open"
+             (:string (namestring path) :int flags)
+             :unsigned-int mode
+             :int)))
     (when (minusp fd)
       (error "posix open failed for ~A (flags ~D)" path flags))
     fd))

--- a/tests/posix-tests.lisp
+++ b/tests/posix-tests.lisp
@@ -9,6 +9,52 @@
   (graph-db::%posix-open path (logior graph-db::+o-creat+
                                       graph-db::+o-rdwr+)))
 
+;;; ---------------------------------------------------------------------------
+;;; GH #218.  open(2) is variadic; MODE must go through CFFI's varargs path.
+;;;
+;;; Every test above this point asserts only that the fd is valid, which is
+;;; why the defect shipped: a file created with a garbage mode still yields a
+;;; perfectly good descriptor to the process that created it.  The mode is the
+;;; thing to assert.
+;;; ---------------------------------------------------------------------------
+
+#+sbcl
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (require :sb-posix))
+
+#+sbcl
+(test posix-open-creates-with-exactly-the-requested-mode
+  "Apple arm64 passes variadic arguments differently from fixed ones, so a
+MODE handed to open(2) as a fixed argument is read from where the callee never
+wrote.  Observed 0140 and 0200 on consecutive runs for a requested 0640 --
+arbitrary, and different each time, which is why an equality assertion is the
+only honest one.  Ablate by restoring the plain FOREIGN-FUNCALL in
+%POSIX-OPEN: this goes red on Darwin/arm64.  It cannot fail on x86_64, where
+the two conventions coincide -- that platform split is the whole of GH #218."
+  (with-temp-directory (dir)
+    (let* ((path (namestring (merge-pathnames "modeprobe" dir)))
+           (fd (graph-db::%posix-open path (logior graph-db::+o-creat+
+                                                   graph-db::+o-rdwr+)
+                                      #o640)))
+      (graph-db::%posix-close fd)
+      (is (= #o640 (logand #o777 (sb-posix:stat-mode (sb-posix:stat path))))
+          "created with the requested mode, not an arbitrary one"))))
+
+(test posix-open-creates-a-file-its-own-image-can-reopen
+  "The consequence the mode bug actually had: %REGISTRY-APPEND (#186) reopens
+the path it just created with an ordinary WITH-OPEN-FILE, and a mode without
+owner read/write fails it EACCES -- after which no graph in the image opens at
+all.  Weaker than the mode assertion above (a too-permissive mode passes) but
+implementation-independent, so it holds where SB-POSIX is unavailable."
+  (with-temp-directory (dir)
+    (let* ((path (namestring (merge-pathnames "reopenme" dir)))
+           (fd (%open-rw path)))
+      (graph-db::%posix-close fd)
+      (finishes
+        (with-open-file (s path :direction :io :if-exists :append
+                                :if-does-not-exist :error)
+          (declare (ignorable s)))))))
+
 (test flock-denies-a-second-open-file-description
   "flock locks attach to the open file description, not the process, so two
 OPEN(2) calls in one image contend exactly as two processes would.  That is


### PR DESCRIPTION
Closes #218.

`open(2)` is `int open(const char *, int, ...)`, and `mode` was passed as a **fixed** argument through a plain `CFFI:FOREIGN-FUNCALL`. CFFI's SBCL backend emits SBCL's `&optional` variadic marker only under `#+(and darwin arm64)`, and only via `%foreign-funcall-varargs` — so on Apple silicon the callee read `mode` from where nothing wrote it. Measured `0140` and `0200` on consecutive runs for a requested `0640`.

When the garbage mode omitted owner read/write, the next ordinary `WITH-OPEN-FILE` on that path failed `EACCES`. The type registry (#186) and the system clock (#182) both create their files here, so **no graph in the image could be opened at all**, and the zero-byte file left behind reproduced it every subsequent run.

x86_64 was never affected — the conventions coincide — which is why this shipped: it presented as a broken developer machine. Verified both ways: odm (x86_64) already produced `0640`; this Mac now does too.

`open` was the only variadic call in `posix.lisp`. The other eleven (`flock`, `close`, `lseek`, `write`, `fchmod`, `rename`, `mmap`, `munmap`, `msync`, `getpagesize`, `gettimeofday`) have fixed signatures and are correct as written.

## Verification

| check | result |
|---|---|
| `POSIX-SUITE` | 7/7 |
| ablated (plain `foreign-funcall` restored) | exact-mode test **f**, reopen test **Xf** |
| `TYPE-REGISTRY-SUITE` / `STORE-REGISTRY-SUITE` | 12/12, 22/22 |
| `SYSTEM-CLOCK-SUITE` | **16/45 → 46/60** |

The new test asserts the created file's **mode**. Every pre-existing test in that file asserted only that the fd was valid — which a garbage mode still hands its own creator, and is exactly why nothing caught this.

The 14 checks still failing in `SYSTEM-CLOCK-SUITE` are `SYSTEM-DIRECTORY-REQUIRED`, unrelated and pre-existing — verified against a stashed tree, filed as #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)