### PR TITLE
Namespaces unit 6: restore across a shadow swap (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,48 @@ between releases; cutting a release renames it to the new version and dates it.
   epoch lease already shaped to carry that later without a redesign.
   (#170)
 
+- **Whole-system restore across a shadow swap.** `retired-generations`
+  lists every `<location>-retired-<epoch>` directory a system's clock
+  knows about, joined to its journal record where one exists (a
+  directory with none is reported `:journaled nil` and warns
+  `swap-record-missing-warning`, the #212 shape; a record with no
+  directory is `:present nil`). Each generation carries its ERAS — the
+  half-open `[from, to)` intervals of content it actually held, which
+  keeps working across a restore-then-swap chain where a promoted
+  directory is later retired again under a new name.
+  `prune-retired-generations (clock floor &key discard-derivable
+  dry-run)` deletes generations at or before `floor`; an `:authored`
+  generation still inside the window is refused by name
+  (`retention-required-error`) rather than silently discarded, and a
+  `:derivable` one is kept unless `:discard-derivable t`.
+  `plan-system-restore` / `restore-system (clock epoch &key
+  require-exact rebuild timeout)` restore every affected store to the
+  generation live at `epoch`, at generation granularity — the swap is
+  the *generation* mechanism, and `snapshot`/`replay` remains the sole
+  mechanism for content *inside* a generation (this does **not**
+  supersede it; point-in-time rewind inside a generation is a separate
+  follow-up). A retained generation frozen at or before `epoch` is
+  exact; one frozen later is used anyway and reported `:exact nil`
+  unless `:require-exact t` refuses instead. A `:derivable` store with
+  no retained generation is rebuilt by a caller-supplied `(lambda (name
+  graph) ...)`, cascading to any `:derivable` dependent whose edges
+  point into the rebuilt store's tag (an `:authored` dependent is left
+  alone and reported `:dangling n`). Every refusal — an authored
+  generation gone, no rebuild callback, the store not open, a
+  replicated/peer graph (v1 is plain-graph-only), an inexact result
+  under `:require-exact`, or a stranded interrupted swap — surfaces as
+  one `restore-refused-error` naming every `(store . reason)` before
+  any rename happens, `:authored-generation-missing`
+  `:no-rebuild` `:not-open` `:unsupported-graph` `:inexact`
+  `:interrupted-swap`. A manifest (`(:restore t :requested ... :at ...
+  :clock ... :stores (...))`) is written to `restore-<epoch>.manifest`
+  and returned; `read-restore-manifest` reads it back with
+  `*read-eval*` nil. `repair-interrupted-swap (clock name location)`
+  fixes the one window `swap-in-shadow` (#170) cannot recover from
+  itself — a crash between its two renames — by renaming the stranded
+  generation back and journaling `:swap-aborted`; restore refuses to
+  start against a store in that state and names the tool. (#171)
+
 - Defining one class name in two stores with *different* slot sets now
   signals `divergent-node-type-redefinition` (a `style-warning`): both
   definitions name one CLOS class, so the last one loaded determines the

--- a/docs/superpowers/plans/2026-08-23-restore-171.md
+++ b/docs/superpowers/plans/2026-08-23-restore-171.md
@@ -1,0 +1,1283 @@
+# Restore Across a Shadow Swap (#171) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Whole-system restore to an epoch `T` that puts back the generation
+each store had at `T`, enforces retention of authored generations, cascades
+rebuilds of derivable stores, and records exactly what it did in a manifest.
+
+**Architecture:** One new file `system-restore.lisp` after `shadow-store.lisp`.
+Generations are discovered on the filesystem (`<location>-retired-<E3>`) and
+annotated from the clock journal. Restore is plan-then-execute: every refusal
+fires inside `plan-system-restore` before any rename; execution reuses
+`swap-in-shadow`'s quiesce/close/rename/reopen sequence per store.
+
+**Tech Stack:** Common Lisp (SBCL verified; ECL demoted), FiveAM, uiop.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-restore-171-design.md` (rulings
+R1–R6; read it first — this plan argues from it).
+
+## Global Constraints
+
+- Lisp: spaces only, **hard 80-column limit**, terse comments that cite
+  `(GH #171)` and point to the spec for detail.
+- Journal and manifest are read with `*read-eval*` bound to NIL — data, never
+  code (spec R4, §4).
+- Every refusal in `restore-system` fires before any rename (spec §3).
+- Test forms: `(with-transaction ((graph-db::transaction-manager g)) ...)`,
+  `(graph-db:make-vertex :generic nil :graph g)`, rebind
+  `graph-db::*system-directory*` and `graph-db::*store-registry*` NIL under a
+  temp dir (see `with-clocked-store` in `tests/detach-tests.lisp:11-37`).
+  Neutral names only — this repo is public.
+- Run tests in a worktree SBCL with `--dynamic-space-size 16384` and FIRST
+  `(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))`.
+  Focused run: `(ql:quickload :graph-db/test) (in-package :graph-db/test)` then
+  `(let ((graph-db::*system-directory* (namestring (make-temp-directory))) (graph-db::*type-registry* nil)) (fiveam:run! 'system-restore-suite))`.
+- One SBCL at a time on this host; never kill processes you did not start.
+- Docs travel with code: CHANGELOG + manual + spec note (Task 6).
+
+---
+
+### Task 1: Generation discovery — `retired-generations`
+
+**Files:**
+- Create: `system-restore.lisp`
+- Modify: `graph-db.asd:112` (add `(:file "system-restore" :depends-on ("shadow-store"))` right after the shadow-store line)
+- Modify: `package.lisp` (export `#:retired-generations #:swap-record-missing-warning #:generation-store #:generation-location #:generation-retired #:generation-swap-epoch #:generation-journaled-p #:generation-present-p #:generation-policy`)
+- Modify: `system-clock.lisp:119-122` (docstring: KIND now also `:retire :retire-live :restore :swap-aborted`)
+- Create: `tests/system-restore-tests.lisp`
+- Modify: `graph-db.asd:539` (add `(:file "system-restore-tests")` after detach-tests)
+
+**Interfaces:**
+- Produces: `(retired-generations clock) → list of GENERATION structs`, sorted by store name then swap-epoch ascending. `%retired-dirs-for (location) → ((E3 . dir) ...)`. `%live-location-of-retired (path) → string` (strips `-retired-<digits>`). Condition `swap-record-missing-warning` (reader `swap-record-missing-path`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+;;;; Whole-system restore across a shadow swap (GH #171).  Spec:
+;;;; docs/superpowers/specs/2026-08-23-restore-171-design.md
+(in-package #:graph-db/test)
+
+(def-suite system-restore-suite :in graph-db-suite
+  :description "RETIRED-GENERATIONS, PRUNE, PLAN/RESTORE-SYSTEM (GH #171).")
+(in-suite system-restore-suite)
+
+(defmacro with-restore-system ((g clock sys &key (policy :authored))
+                               &body body)
+  "WITH-CLOCKED-STORE's shape, with the store named :RESTORE-STORE-1 and a
+persisted recovery POLICY.  G is SETQ-able: tests rebind it to whatever
+SWAP-IN-SHADOW / RESTORE-SYSTEM return."
+  (let ((cdir (gensym)) (ddir (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,cdir)
+         (with-temp-directory (,ddir)
+           (let ((graph-db::*system-directory* (namestring ,sys))
+                 (graph-db::*store-registry* nil))
+             (let ((,clock (open-system-clock (namestring ,cdir))))
+               (unwind-protect
+                    (let ((,g (make-graph :restore-store-1
+                                          (namestring ,ddir)
+                                          :buffer-pool-size 1000
+                                          :system-clock ,clock
+                                          :recovery-policy ,policy)))
+                      (unwind-protect (progn ,@body)
+                        (when (graph-db::graph-open-p ,g)
+                          (let ((graph-db:*graph* ,g))
+                            (ignore-errors
+                             (close-graph ,g :snapshot-p nil))))
+                        (collect-garbage)))
+                 (close-system-clock ,clock)))))))))
+
+(defun %rs-write (g)
+  "One generic vertex into G; returns the epoch the commit used."
+  (with-transaction ((graph-db::transaction-manager g))
+    (graph-db:make-vertex :generic nil :graph g))
+  (graph-db::load-highest-transaction-id g))
+
+(defun %rs-count (g)
+  (length (graph-db:map-vertices #'identity g :collect-p t)))
+
+(defun %rs-swap (g clock &key (shadow-writes 1))
+  "Shadow G, write SHADOW-WRITES vertices into the shadow, swap it in.
+Returns (values NEW-GRAPH RETIRED-PATH)."
+  (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+    (multiple-value-bind (start end) (graph-db:clock-lease-epochs clock 1000)
+      (let ((sg (graph-db:open-shadow-graph
+                 shadow-location :restore-store-1 :lease (cons start end))))
+        (dotimes (i shadow-writes)
+          (with-transaction ((graph-db::transaction-manager sg))
+            (graph-db:make-vertex :generic nil :graph sg)))
+        (let ((graph-db:*graph* sg)) (close-graph sg :snapshot-p nil))))
+    (graph-db:swap-in-shadow g2 shadow-location)))
+
+(test retired-generations-joins-directory-and-journal
+  "After one swap: exactly one generation for the store, PRESENT, JOURNALED,
+its SWAP-EPOCH equal to the :SWAP record's :epoch, POLICY read from the
+RETIRED directory's policy.dat."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng retired) (%rs-swap g clock)
+      (setq g ng)
+      (let ((gens (graph-db:retired-generations clock)))
+        (is (= 1 (length gens)))
+        (let ((gen (first gens))
+              (swap (find :swap (journal-records clock)
+                          :key (lambda (r) (getf r :kind)))))
+          (is (eq :restore-store-1 (graph-db:generation-store gen)))
+          (is (string= (string-right-trim "/" retired)
+                       (graph-db:generation-retired gen)))
+          (is (= (getf swap :epoch) (graph-db:generation-swap-epoch gen)))
+          (is-true (graph-db:generation-journaled-p gen))
+          (is-true (graph-db:generation-present-p gen))
+          (is (eq :authored (graph-db:generation-policy gen))))))))
+
+(test retired-generations-tolerates-a-missing-swap-record
+  "The #212 shape: the retired directory exists but its :SWAP record was
+never written.  The generation is still listed (JOURNALED NIL) and
+SWAP-RECORD-MISSING-WARNING names the path.  Ablation: a reader that trusts
+the journal alone lists nothing."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng retired) (%rs-swap g clock)
+      (setq g ng)
+      ;; Drop the :SWAP line from the journal file by rewriting it.
+      (let ((file (graph-db::%clock-journal-file
+                   (graph-db::system-clock-location clock)))
+            (kept (remove :swap (journal-records clock)
+                          :key (lambda (r) (getf r :kind)))))
+        (close-system-clock clock)
+        (with-open-file (out file :direction :output :if-exists :supersede)
+          (let ((*print-readably* nil) (*print-pretty* nil))
+            (dolist (r kept) (format out "~S~%" r))))
+        (setq clock (open-system-clock
+                     (namestring (graph-db::system-clock-location clock))))
+        (let* ((warned nil)
+               (gens (handler-bind
+                         ((graph-db:swap-record-missing-warning
+                            (lambda (w)
+                              (setq warned (graph-db:swap-record-missing-path w))
+                              (muffle-warning w))))
+                       (graph-db:retired-generations clock))))
+          (is (= 1 (length gens)))
+          (is-false (graph-db:generation-journaled-p (first gens)))
+          (is (string= (string-right-trim "/" retired) warned))
+          (is (= (parse-integer retired
+                                :start (1+ (position #\- retired :from-end t)))
+                 (graph-db:generation-swap-epoch (first gens)))))))))
+
+(test retired-generations-reports-a-pruned-directory
+  "A :SWAP record whose directory is gone lists as PRESENT NIL."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng retired) (%rs-swap g clock)
+      (setq g ng)
+      (uiop:delete-directory-tree (uiop:ensure-directory-pathname retired)
+                                  :validate t)
+      (let ((gens (graph-db:retired-generations clock)))
+        (is (= 1 (length gens)))
+        (is-false (graph-db:generation-present-p (first gens)))
+        (is-true (graph-db:generation-journaled-p (first gens)))))))
+```
+
+Note: `with-restore-system` binds `clock` with `let`, so `setq clock` inside
+the body is legal. The test that rewrites the journal closes and reopens the
+clock because `journal-records` holds the file open for append.
+
+- [ ] **Step 2: Run to verify failure**
+
+Expected: compile failure / `unbound function RETIRED-GENERATIONS`.
+
+- [ ] **Step 3: Implement**
+
+`system-restore.lisp`:
+
+```lisp
+(in-package :graph-db)
+
+;;; Whole-system restore across a shadow swap (GH #171).  Generations
+;;; live on the filesystem as <location>-retired-<E3>; the journal only
+;;; annotates them (spec R4).  See
+;;; docs/superpowers/specs/2026-08-23-restore-171-design.md
+
+(defstruct (generation (:constructor %make-generation))
+  store location retired swap-epoch journaled-p present-p policy)
+
+(define-condition swap-record-missing-warning (warning)
+  ;; The #212 shape: renames landed, JOURNAL-APPEND did not.  Tolerated,
+  ;; like #191's torn tail -- the directory name carries the epoch.
+  ((path :initarg :path :reader swap-record-missing-path))
+  (:report (lambda (c s)
+             (format s "Retired generation ~A has no :SWAP journal ~
+record (GH #212); its epoch is taken from the directory name."
+                     (swap-record-missing-path c)))))
+
+(defun %retired-suffix-epoch (name live-name)
+  "NAME's epoch when NAME is LIVE-NAME-retired-<digits>, else NIL."
+  (let ((prefix (concatenate 'string live-name "-retired-")))
+    (when (and (> (length name) (length prefix))
+               (string= prefix name :end2 (length prefix))
+               (every #'digit-char-p (subseq name (length prefix))))
+      (parse-integer name :start (length prefix)))))
+
+(defun %retired-dirs-for (location)
+  "((E3 . \"<location>-retired-E3\") ...) for LOCATION, ascending by E3."
+  (let* ((live (%trimmed-namestring location))
+         (parent (uiop:pathname-parent-directory-pathname
+                  (uiop:ensure-directory-pathname live)))
+         (live-name (car (last (pathname-directory
+                                (uiop:ensure-directory-pathname live)))))
+         (found nil))
+    (dolist (dir (uiop:subdirectories parent))
+      (let* ((name (car (last (pathname-directory dir))))
+             (epoch (%retired-suffix-epoch name live-name)))
+        (when epoch
+          (push (cons epoch (%trimmed-namestring dir)) found))))
+    (sort found #'< :key #'car)))
+
+(defun %live-location-of-retired (path)
+  "\"<loc>-retired-123\" -> \"<loc>\"."
+  (let* ((s (%trimmed-namestring path))
+         (pos (search "-retired-" s :from-end t)))
+    (if pos (subseq s 0 pos) s)))
+
+(defun %swap-records (clock)
+  (remove :swap (journal-records clock)
+          :key (lambda (r) (getf r :kind)) :test-not #'eq))
+
+(defun retired-generations (clock)
+  "Every retired generation known to CLOCK's system, as GENERATION
+structs sorted by store then SWAP-EPOCH.  Filesystem is authoritative:
+a directory without a :SWAP record is listed JOURNALED-P NIL and
+warned (SWAP-RECORD-MISSING-WARNING); a record without a directory is
+listed PRESENT-P NIL (GH #171, spec R4)."
+  (let ((by-retired (make-hash-table :test 'equal))
+        (locations (make-hash-table :test 'equal)))
+    ;; Journal first: records name the live locations to scan.
+    (dolist (r (%swap-records clock))
+      (let ((retired (%trimmed-namestring (getf r :retired))))
+        (setf (gethash (%live-location-of-retired retired) locations)
+              (getf r :store))
+        (setf (gethash retired by-retired)
+              (%make-generation
+               :store (getf r :store)
+               :location (%live-location-of-retired retired)
+               :retired retired
+               :swap-epoch (getf r :epoch)
+               :journaled-p t
+               :present-p (and (probe-file
+                                (uiop:ensure-directory-pathname retired))
+                               t)))))
+    ;; Then every open clocked store, so unjournaled directories are found.
+    (maphash (lambda (name graph)
+               (when (and (typep graph 'graph)
+                          (eq (graph-system-clock graph) clock))
+                 (setf (gethash (%trimmed-namestring (location graph))
+                                locations)
+                       name)))
+             *graphs*)
+    (maphash
+     (lambda (location store)
+       (loop for (epoch . dir) in (%retired-dirs-for location)
+             unless (gethash dir by-retired)
+               do (warn 'swap-record-missing-warning :path dir)
+                  (setf (gethash dir by-retired)
+                        (%make-generation :store store :location location
+                                          :retired dir :swap-epoch epoch
+                                          :journaled-p nil :present-p t))))
+     locations)
+    (let ((gens nil))
+      (maphash (lambda (k gen)
+                 (declare (ignore k))
+                 (setf (generation-policy gen)
+                       (if (generation-present-p gen)
+                           (store-recovery-policy (generation-retired gen))
+                           (store-recovery-policy (generation-location gen))))
+                 (push gen gens))
+               by-retired)
+      (sort gens (lambda (a b)
+                   (let ((sa (princ-to-string (generation-store a)))
+                         (sb (princ-to-string (generation-store b))))
+                     (or (string< sa sb)
+                         (and (string= sa sb)
+                              (< (generation-swap-epoch a)
+                                 (generation-swap-epoch b))))))))))
+```
+
+Journal docstring edit in `system-clock.lisp:120-121`:
+
+```lisp
+  "Append one lifecycle record.  KIND is :CREATE :DETACH :SWAP :ATTACH
+:RETIRE :RETIRE-LIVE :RESTORE or :SWAP-ABORTED (the last four: GH #171)."
+```
+
+Package exports (inside the existing `:export` list, near the #170 block):
+
+```lisp
+           ;; whole-system restore (GH #171)
+           #:retired-generations #:swap-record-missing-warning
+           #:swap-record-missing-path
+           #:generation-store #:generation-location #:generation-retired
+           #:generation-swap-epoch #:generation-journaled-p
+           #:generation-present-p #:generation-policy
+```
+
+- [ ] **Step 4: Run tests** — expected 3 tests pass.
+- [ ] **Step 5: Commit**
+
+```bash
+git add system-restore.lisp system-clock.lisp package.lisp graph-db.asd tests/system-restore-tests.lisp
+git commit -m "feat(restore): retired-generations joins filesystem and journal (#171)"
+```
+
+---
+
+### Task 2: Retention — `prune-retired-generations`
+
+**Files:**
+- Modify: `system-restore.lisp`, `package.lisp`, `tests/system-restore-tests.lisp`
+
+**Interfaces:**
+- Consumes: `retired-generations`, `generation-*` readers (Task 1).
+- Produces: `(prune-retired-generations clock floor &key discard-derivable dry-run) → list of GENERATION deleted (or would-be)`; condition `retention-required-error` (reader `retention-required-generations`, a list of GENERATION).
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(defun %rs-gen-epochs (clock)
+  (mapcar #'graph-db:generation-swap-epoch
+          (graph-db:retired-generations clock)))
+
+(test prune-deletes-generations-at-or-below-the-floor
+  "Two swaps; floor = first swap's epoch: the first generation goes, the
+second stays; a :RETIRE record names the deleted path."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (multiple-value-bind (ng2 r2) (%rs-swap g clock)
+        (setq g ng2)
+        (destructuring-bind (e1 e2) (%rs-gen-epochs clock)
+          (let ((gone (graph-db:prune-retired-generations clock e1)))
+            (is (= 1 (length gone)))
+            (is (= e1 (graph-db:generation-swap-epoch (first gone))))
+            (is-false (probe-file (uiop:ensure-directory-pathname r1)))
+            (is-true (probe-file (uiop:ensure-directory-pathname r2)))
+            (is (equal (list e2) (%rs-gen-epochs clock)))
+            (let ((retire (find :retire (journal-records clock)
+                                :key (lambda (r) (getf r :kind)))))
+              (is (string= (string-right-trim "/" r1)
+                           (getf retire :retired)))
+              (is (= e1 (getf retire :swap-epoch))))))))))
+
+(test prune-refuses-an-authored-generation-inside-the-window
+  "Floor below the swap epoch on an :AUTHORED store: RETENTION-REQUIRED-
+ERROR naming the generation, directory untouched.  Ablation: no guard
+deletes the only copy of authored data."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (let* ((e1 (first (%rs-gen-epochs clock)))
+             (c (handler-case
+                    (progn (graph-db:prune-retired-generations clock (1- e1))
+                           nil)
+                  (graph-db:retention-required-error (c) c))))
+        (is-true c)
+        (when c
+          (is (= 1 (length (graph-db:retention-required-generations c)))))
+        (is-true (probe-file (uiop:ensure-directory-pathname r1)))))))
+
+(test prune-deletes-a-derivable-generation-only-when-told
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (let ((e1 (first (%rs-gen-epochs clock))))
+        (is (null (graph-db:prune-retired-generations clock (1- e1))))
+        (is-true (probe-file (uiop:ensure-directory-pathname r1)))
+        (is (= 1 (length (graph-db:prune-retired-generations
+                          clock (1- e1) :discard-derivable t))))
+        (is-false (probe-file (uiop:ensure-directory-pathname r1)))))))
+
+(test prune-dry-run-deletes-nothing
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (let ((e1 (first (%rs-gen-epochs clock))))
+        (is (= 1 (length (graph-db:prune-retired-generations
+                          clock e1 :dry-run t))))
+        (is-true (probe-file (uiop:ensure-directory-pathname r1)))
+        (is-false (find :retire (journal-records clock)
+                        :key (lambda (r) (getf r :kind))))))))
+```
+
+- [ ] **Step 2: Run** — expected failures: undefined `prune-retired-generations`.
+- [ ] **Step 3: Implement**
+
+```lisp
+(define-condition retention-required-error (error)
+  ;; Authored data is never silently discarded inside the restore
+  ;; window (spec R3, §9.2).
+  ((generations :initarg :generations
+                :reader retention-required-generations))
+  (:report (lambda (c s)
+             (format s "Refusing to prune ~D :AUTHORED generation~:P still ~
+inside the restore window:~{ ~A~} (GH #171)."
+                     (length (retention-required-generations c))
+                     (mapcar #'generation-retired
+                             (retention-required-generations c))))))
+
+(defun %retired-suffix-p (path)
+  "The deletion gate for retired generations, mirroring %SHADOW-SUFFIX-P."
+  (and (search "-retired-" (%trimmed-namestring path)) t))
+
+(defun %delete-generation (clock gen)
+  (uiop:delete-directory-tree
+   (uiop:ensure-directory-pathname (generation-retired gen))
+   :validate #'%retired-suffix-p :if-does-not-exist :ignore)
+  (journal-append clock :retire
+                  :store (generation-store gen)
+                  :retired (generation-retired gen)
+                  :swap-epoch (generation-swap-epoch gen)))
+
+(defun prune-retired-generations (clock floor &key discard-derivable dry-run)
+  "Delete retired generations the restore window no longer covers: those
+with SWAP-EPOCH <= FLOOR.  Above FLOOR an :AUTHORED generation is
+refused by name (RETENTION-REQUIRED-ERROR, before anything is deleted);
+a :DERIVABLE one is deleted only with DISCARD-DERIVABLE.  DRY-RUN
+returns what would go and touches nothing.  Each deletion journals
+:RETIRE (GH #171, spec R3)."
+  (let* ((gens (remove-if-not #'generation-present-p
+                              (retired-generations clock)))
+         (blocked (remove-if-not
+                   (lambda (g) (and (> (generation-swap-epoch g) floor)
+                                    (eq (generation-policy g) :authored)))
+                   gens))
+         (victims (remove-if-not
+                   (lambda (g)
+                     (or (<= (generation-swap-epoch g) floor)
+                         (and discard-derivable
+                              (eq (generation-policy g) :derivable))))
+                   gens)))
+    ;; Only a deliberate discard of a derivable generation proceeds past
+    ;; blocked authored ones; a floor-only call refuses outright.
+    (when (and blocked (not discard-derivable) (some (lambda (g) (> (generation-swap-epoch g) floor)) gens) (null victims))
+      (error 'retention-required-error :generations blocked))
+    (unless dry-run
+      (dolist (g victims) (%delete-generation clock g)))
+    victims))
+```
+
+Re-read that guard before writing it: the contract is *refuse when the
+caller asked to prune inside the window on an authored store*. Simplify to
+exactly this and delete the longer form above:
+
+```lisp
+    (when (and blocked (null victims))
+      (error 'retention-required-error :generations blocked))
+```
+
+i.e. a call that would delete nothing but was blocked by authored
+generations is the refusal case; a call that deletes something below the
+floor and merely *skips* authored ones above it returns normally. The tests
+above exercise both. (Ruling: skipping is not silent — the return value
+omits them — and refusing a legitimate below-floor prune because an
+unrelated authored generation exists would make routine pruning impossible.)
+
+Exports: `#:prune-retired-generations #:retention-required-error
+#:retention-required-generations`.
+
+- [ ] **Step 4: Run** — 7 tests pass. **Step 5: Commit**
+  `feat(restore): prune-retired-generations enforces authored retention (#171)`
+
+---
+
+### Task 3: `plan-system-restore` — selection, exactness, refusals
+
+**Files:**
+- Modify: `system-restore.lisp`, `package.lisp`, `tests/system-restore-tests.lisp`
+
+**Interfaces:**
+- Consumes: Task 1–2 accessors; `store-recovery-policy`; `load-highest-transaction-id` is per open graph, so add `%generation-state-epoch (retired-path)` reading `transaction-id.dat` directly.
+- Produces: `(plan-system-restore clock epoch &key require-exact rebuild) → manifest plist`; `restore-refused-error` (readers `restore-refused-reasons` list of `(store . keyword)`); helper `%restore-plan-entries (clock epoch rebuild)`.
+- Manifest shape (spec §4): `(:restore :requested T :at Enow :clock LOC :stores (ENTRY...))`, ENTRY = `(:store NAME :action :rewound|:rebuilt|:unchanged|:refused :state-at E :exact BOOL :from PATH :reason KW)`.
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(defun %rs-entry (manifest store)
+  (find store (getf manifest :stores)
+        :key (lambda (e) (getf e :store))))
+
+(test plan-selects-the-retained-generation-exactly
+  "Write at E0, swap at E3 > T >= E0: the plan is :REWOUND :EXACT T with
+:STATE-AT E0 and :FROM the retired path; nothing on disk changes."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (let* ((tt (1+ e0))
+               (m (graph-db:plan-system-restore clock tt))
+               (e (%rs-entry m :restore-store-1)))
+          (is (= tt (getf m :requested)))
+          (is (eq :rewound (getf e :action)))
+          (is (eq t (getf e :exact)))
+          (is (= e0 (getf e :state-at)))
+          (is (string= (string-right-trim "/" r1) (getf e :from)))
+          (is-true (graph-db::graph-open-p g)))))))
+
+(test plan-marks-inexact-when-writes-follow-t
+  "T before the generation's last commit: :EXACT NIL, :STATE-AT E0.  With
+:REQUIRE-EXACT the plan refuses with reason :INEXACT instead."
+  (with-restore-system (g clock sys)
+    sys
+    (let* ((t0 (%rs-write g))
+           (e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((e (%rs-entry (graph-db:plan-system-restore clock t0)
+                            :restore-store-1)))
+          (is (eq :rewound (getf e :action)))
+          (is (null (getf e :exact)))
+          (is (= e0 (getf e :state-at))))
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock t0
+                                                          :require-exact t)
+                            nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :inexact))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-leaves-an-unaffected-store-unchanged
+  "T after the swap: :UNCHANGED."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (declare (ignore r1))
+      (setq g ng)
+      (let* ((now (graph-db:clock-current-epoch clock))
+             (e (%rs-entry (graph-db:plan-system-restore clock now)
+                           :restore-store-1)))
+        (is (eq :unchanged (getf e :action)))))))
+
+(test plan-refuses-when-an-authored-generation-is-gone
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock e0) nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :authored-generation-missing))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-rebuilds-a-derivable-store-whose-generation-is-gone
+  "Derivable, generation pruned: with :REBUILD the plan is :REBUILT :EXACT
+NIL; without it, refused with reason :NO-REBUILD."
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let ((e (%rs-entry (graph-db:plan-system-restore
+                             clock e0 :rebuild (lambda (name graph)
+                                                 (declare (ignore name graph))))
+                            :restore-store-1)))
+          (is (eq :rebuilt (getf e :action)))
+          (is (null (getf e :exact))))
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock e0) nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :no-rebuild))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-handles-two-swaps-by-picking-the-generation-live-at-t
+  "Swap twice.  T between the swaps selects the SECOND retired
+generation (the one live at T), not the first."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (declare (ignore r1))
+      (setq g ng)
+      (let ((mid (%rs-write g)))
+        (multiple-value-bind (ng2 r2) (%rs-swap g clock)
+          (setq g ng2)
+          (let ((e (%rs-entry (graph-db:plan-system-restore clock mid)
+                              :restore-store-1)))
+            (is (eq :rewound (getf e :action)))
+            (is (string= (string-right-trim "/" r2) (getf e :from)))))))))
+```
+
+- [ ] **Step 2: Run** — undefined `plan-system-restore`.
+- [ ] **Step 3: Implement**
+
+```lisp
+(define-condition restore-refused-error (error)
+  ;; Every refusal fires here, before any rename (spec §3).
+  ((reasons :initarg :reasons :reader restore-refused-reasons)
+   (epoch :initarg :epoch :reader restore-refused-epoch))
+  (:report (lambda (c s)
+             (format s "Restore to epoch ~D refused:~{ ~A~} (GH #171)."
+                     (restore-refused-epoch c)
+                     (mapcar (lambda (r) (format nil "~A=~A" (car r) (cdr r)))
+                             (restore-refused-reasons c))))))
+
+(defun %generation-state-epoch (retired)
+  "The last epoch committed into RETIRED, from its transaction-id.dat;
+0 when absent.  The closed generation's E0 (spec R2)."
+  (let ((file (merge-pathnames "transaction-id.dat"
+                               (uiop:ensure-directory-pathname retired)))
+        (buf (make-byte-vector 8)))
+    (if (probe-file file)
+        (with-open-file (in file :element-type '(unsigned-byte 8))
+          (unless (= 8 (read-sequence buf in))
+            (error "Short read on ~A" file))
+          (deserialize-uint64 buf 0))
+        0)))
+
+(defun %generation-live-at (gens epoch)
+  "Among GENS (one store, ascending SWAP-EPOCH), the generation that was
+live at EPOCH: the earliest with SWAP-EPOCH > EPOCH, or NIL when the
+current generation already was."
+  (find-if (lambda (g) (> (generation-swap-epoch g) epoch)) gens))
+
+(defun %restore-plan-entries (clock epoch rebuild)
+  "One manifest entry per store CLOCK knows about, plus the refusal list
+for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS)."
+  (let ((by-store (make-hash-table :test 'equal))
+        (entries nil) (reasons nil))
+    (dolist (g (retired-generations clock))
+      (push g (gethash (generation-store g) by-store)))
+    ;; Open clocked stores with no generations at all are :UNCHANGED.
+    (maphash (lambda (name graph)
+               (when (and (typep graph 'graph)
+                          (eq (graph-system-clock graph) clock))
+                 (unless (nth-value 1 (gethash name by-store))
+                   (setf (gethash name by-store) nil))))
+             *graphs*)
+    (maphash
+     (lambda (store gens)
+       (let* ((gens (sort (copy-list gens) #'< :key #'generation-swap-epoch))
+              (target (%generation-live-at gens epoch)))
+         (cond
+           ((null target)
+            (push (list :store store :action :unchanged) entries))
+           ((generation-present-p target)
+            (let ((e0 (%generation-state-epoch (generation-retired target))))
+              (push (list :store store :action :rewound
+                          :state-at e0 :exact (<= e0 epoch)
+                          :from (generation-retired target)
+                          :swap-epoch (generation-swap-epoch target))
+                    entries)))
+           ((eq (generation-policy target) :authored)
+            (push (cons store :authored-generation-missing) reasons)
+            (push (list :store store :action :refused
+                        :reason :authored-generation-missing) entries))
+           ((null rebuild)
+            (push (cons store :no-rebuild) reasons)
+            (push (list :store store :action :refused :reason :no-rebuild)
+                  entries))
+           (t
+            (push (list :store store :action :rebuilt :exact nil
+                        :state-at (clock-current-epoch clock))
+                  entries)))))
+     by-store)
+    (values (nreverse entries) (nreverse reasons))))
+
+(defun plan-system-restore (clock epoch &key require-exact rebuild)
+  "The manifest RESTORE-SYSTEM would act on for EPOCH, with no side
+effects.  Signals RESTORE-REFUSED-ERROR listing every (STORE . REASON):
+:AUTHORED-GENERATION-MISSING, :NO-REBUILD, :INEXACT (only under
+REQUIRE-EXACT), :INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's
+(lambda (name graph)) loader for :DERIVABLE stores (GH #171, spec R1/R2)."
+  (multiple-value-bind (entries reasons)
+      (%restore-plan-entries clock epoch rebuild)
+    (when require-exact
+      (dolist (e entries)
+        (when (and (eq (getf e :action) :rewound) (not (getf e :exact)))
+          (push (cons (getf e :store) :inexact) reasons))))
+    (when reasons
+      (error 'restore-refused-error :reasons (nreverse reasons) :epoch epoch))
+    (list :restore :requested epoch :at (clock-current-epoch clock)
+          :clock (namestring (system-clock-location clock))
+          :stores entries)))
+```
+
+Exports: `#:plan-system-restore #:restore-refused-error
+#:restore-refused-reasons #:restore-refused-epoch`.
+
+- [ ] **Step 4: Run** — 13 pass. **Step 5: Commit**
+  `feat(restore): plan-system-restore selects generations and refuses by name (#171)`
+
+---
+
+### Task 4: `restore-system` — execution, manifest file, cascade
+
+**Files:**
+- Modify: `system-restore.lisp`, `package.lisp`, `tests/system-restore-tests.lisp`
+
+**Interfaces:**
+- Consumes: `plan-system-restore`; `%quiesce-transaction-manager (tm reason timeout)`, `*quiesced-store-closing-p*`, `close-graph`, `%posix-rename`, `%reopen-and-resume (name location clock reason)`, `journal-append`, `lookup-graph`, `id-store-tag`, `store-registry-id-for`, `map-edges`, `from`/`to`.
+- Produces: `(restore-system clock epoch &key require-exact rebuild (timeout 60)) → manifest`; `restore-inexact-warning` (reader `restore-inexact-manifest`); `%restore-one-store`, `%rebuild-one-store`, `%dangling-into (store-id)`; manifest written to `<clock-dir>/restore-<Enow>.manifest`; `read-restore-manifest (path)`.
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test restore-puts-the-retained-generation-back-and-round-trips
+  "1 vertex, swap (+1), restore to before the swap: 1 vertex readable,
+store open and accepting; journal carries :RETIRE-LIVE then :RESTORE; the
+post-swap generation is itself retained, and a restore to NOW-1 of that
+state puts the 2-vertex generation back."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (is (= 2 (%rs-count g)))
+        (let ((after-swap (graph-db:clock-current-epoch clock)))
+          (let ((m (graph-db:restore-system clock e0)))
+            (setq g (lookup-graph :restore-store-1))
+            (is (eq :rewound (getf (%rs-entry m :restore-store-1) :action)))
+            (is (= 1 (%rs-count g)))
+            (with-transaction ((graph-db::transaction-manager g))
+              (graph-db:make-vertex :generic nil :graph g))
+            (let ((kinds (mapcar (lambda (r) (getf r :kind))
+                                 (journal-records clock))))
+              (is-true (member :retire-live kinds))
+              (is-true (member :restore kinds))
+              (is (< (position :retire-live kinds)
+                     (position :restore kinds)))))
+          ;; Round trip: the 2-vertex generation was retired, not lost.
+          (graph-db:restore-system clock after-swap)
+          (setq g (lookup-graph :restore-store-1))
+          (is (= 2 (%rs-count g))))))))
+
+(test restore-refuses-before-any-rename
+  ":REQUIRE-EXACT on an inexact plan: nothing moved, graph still open and
+accepting, no new journal records."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((t0 (%rs-write g)))
+      (%rs-write g)
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (let ((n (length (journal-records clock))))
+          (signals graph-db:restore-refused-error
+            (graph-db:restore-system clock t0 :require-exact t))
+          (is (= n (length (journal-records clock))))
+          (is-true (probe-file (uiop:ensure-directory-pathname r1)))
+          (is-true (graph-db::graph-open-p g))
+          (with-transaction ((graph-db::transaction-manager g))
+            (graph-db:make-vertex :generic nil :graph g)))))))
+
+(test restore-writes-a-readable-manifest-and-warns-when-inexact
+  (with-restore-system (g clock sys)
+    sys
+    (let ((t0 (%rs-write g)))
+      (%rs-write g)
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let* ((warned nil)
+               (m (handler-bind
+                      ((graph-db:restore-inexact-warning
+                         (lambda (w) (setq warned t) (muffle-warning w))))
+                    (graph-db:restore-system clock t0)))
+               (file (merge-pathnames
+                      (format nil "restore-~D.manifest" (getf m :at))
+                      (uiop:ensure-directory-pathname
+                       (graph-db::system-clock-location clock)))))
+          (is-true warned)
+          (is-true (probe-file file))
+          (is (equal m (graph-db:read-restore-manifest file))))))))
+
+(test restore-rebuilds-a-derivable-store-through-the-callback
+  "Generation pruned, :REBUILD supplied: the callback runs against a fresh
+empty graph at the live location; its writes are what the store holds
+afterwards; manifest :REBUILT."
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let* ((seen nil)
+               (m (handler-bind
+                      ((graph-db:restore-inexact-warning #'muffle-warning))
+                    (graph-db:restore-system
+                     clock e0
+                     :rebuild (lambda (name graph)
+                                (setq seen name)
+                                (is (= 0 (%rs-count graph)))
+                                (dotimes (i 3)
+                                  (with-transaction
+                                      ((graph-db::transaction-manager graph))
+                                    (graph-db:make-vertex :generic nil
+                                                          :graph graph))))))))
+          (setq g (lookup-graph :restore-store-1))
+          (is (eq :restore-store-1 seen))
+          (is (eq :rebuilt (getf (%rs-entry m :restore-store-1) :action)))
+          (is (= 3 (%rs-count g)))
+          (is (eq :derivable (graph-db:store-recovery-policy
+                              (graph-db::location g)))))))))
+```
+
+Cascade test needs two stores on one clock. Add a second-store helper:
+
+```lisp
+(defmacro with-second-store ((g2 clock name dir-var &key (policy :derivable))
+                             &body body)
+  `(with-temp-directory (,dir-var)
+     (let ((,g2 (make-graph ,name (namestring ,dir-var)
+                            :buffer-pool-size 1000 :system-clock ,clock
+                            :recovery-policy ,policy)))
+       (unwind-protect (progn ,@body)
+         (let ((live (lookup-graph ,name)))
+           (when (and live (graph-db::graph-open-p live))
+             (let ((graph-db:*graph* live))
+               (ignore-errors (close-graph live :snapshot-p nil)))))))))
+
+(test restore-cascades-to-a-derivable-dependent-and-reports-an-authored-one
+  "Store A (derivable) is rebuilt.  Store B (derivable) holds an edge into
+A: B is rebuilt too (callback sees both names, A first).  Store C
+(authored) holds an edge into A: untouched, manifest :DANGLING 1."
+  (with-restore-system (ga clock sys :policy :derivable)
+    sys
+    (with-second-store (gb clock :restore-store-b bdir :policy :derivable)
+      (with-second-store (gc clock :restore-store-c cdir :policy :authored)
+        (let (a-id)
+          (with-transaction ((graph-db::transaction-manager ga))
+            (setq a-id (graph-db:id (graph-db:make-vertex :generic nil
+                                                           :graph ga))))
+          (dolist (gx (list gb gc))
+            (with-transaction ((graph-db::transaction-manager gx))
+              (let ((v (graph-db:make-vertex :generic nil :graph gx)))
+                (graph-db:make-edge :generic (graph-db:id v) a-id nil nil
+                                    :graph gx))))
+          (let ((e0 (graph-db:clock-current-epoch clock)))
+            (multiple-value-bind (ng r1) (%rs-swap ga clock)
+              (setq ga ng)
+              (uiop:delete-directory-tree
+               (uiop:ensure-directory-pathname r1) :validate t)
+              (let* ((order nil)
+                     (m (handler-bind
+                            ((graph-db:restore-inexact-warning
+                               #'muffle-warning))
+                          (graph-db:restore-system
+                           clock e0
+                           :rebuild (lambda (name graph)
+                                      (declare (ignore graph))
+                                      (push name order))))))
+                (is (equal '(:restore-store-1 :restore-store-b)
+                           (reverse order)))
+                (is (eq :rebuilt (getf (%rs-entry m :restore-store-b)
+                                       :action)))
+                (is (eq :restore-store-1
+                        (getf (%rs-entry m :restore-store-b)
+                              :cascade-from)))
+                (is (eq :unchanged (getf (%rs-entry m :restore-store-c)
+                                         :action)))
+                (is (= 1 (getf (%rs-entry m :restore-store-c)
+                               :dangling)))))))))))
+```
+
+Check `make-edge`'s signature in `edge.lisp` before relying on the positional
+form above (`(make-edge type from to weight data &key graph)` is the shape
+used elsewhere in `tests/`); adapt to the actual arglist, keeping the intent.
+
+- [ ] **Step 2: Run** — undefined `restore-system`.
+- [ ] **Step 3: Implement**
+
+```lisp
+(define-condition restore-inexact-warning (warning)
+  ;; Spec §4: a mixed manifest is the inconsistent instant §9 exists to
+  ;; record; this makes it impossible to miss.
+  ((manifest :initarg :manifest :reader restore-inexact-manifest))
+  (:report (lambda (c s)
+             (format s "Restore to ~D is not an exact instant:~{ ~A~} ~
+(GH #171)."
+                     (getf (restore-inexact-manifest c) :requested)
+                     (loop for e in (getf (restore-inexact-manifest c)
+                                          :stores)
+                           when (or (eq (getf e :action) :rebuilt)
+                                    (and (eq (getf e :action) :rewound)
+                                         (not (getf e :exact))))
+                             collect (format nil "~A=~A" (getf e :store)
+                                             (getf e :action)))))))
+
+(defun %manifest-file (clock epoch)
+  (merge-pathnames (format nil "restore-~D.manifest" epoch)
+                   (uiop:ensure-directory-pathname
+                    (system-clock-location clock))))
+
+(defun %write-manifest (clock manifest)
+  (with-open-file (out (%manifest-file clock (getf manifest :at))
+                       :direction :output :if-exists :supersede
+                       :if-does-not-exist :create)
+    (let ((*print-readably* nil) (*print-pretty* nil))
+      (prin1 manifest out)))
+  manifest)
+
+(defun read-restore-manifest (path)
+  "PATH's manifest plist.  *READ-EVAL* NIL: data, never code (GH #171)."
+  (with-open-file (in path)
+    (let ((*read-eval* nil)) (read in))))
+
+(defun %close-quiesced (graph timeout)
+  "SWAP-IN-SHADOW's close sequence: quiesce as :RESTORING, close with
+snapshot, no writer can land in the doomed generation."
+  (%quiesce-transaction-manager (transaction-manager graph) :restoring
+                                timeout)
+  (let ((*graph* graph) (*quiesced-store-closing-p* t))
+    (close-graph graph :snapshot-p t)))
+
+(defun %restore-one-store (clock name entry timeout)
+  "Rename live -> <loc>-retired-<Enow> (:RETIRE-LIVE), retained -> live
+(:RESTORE), reopen + attach.  Commit point is the second rename, as in
+%SWAP-IN-SHADOW-1: failure before it renames back and resignals; after
+it, reopens the restored generation and warns (GH #171)."
+  (let* ((graph (lookup-graph name))
+         (live (%trimmed-namestring (location graph)))
+         (from (getf entry :from))
+         (retired (format nil "~A-retired-~D" live
+                          (clock-current-epoch clock)))
+         (done nil))
+    (%close-quiesced graph timeout)
+    (handler-case
+        (progn
+          (%posix-rename live retired)
+          (journal-append clock :retire-live :store name :retired retired)
+          (%posix-rename from live)
+          (setq done t)
+          (journal-append clock :restore :store name :from from
+                          :retired-live retired
+                          :requested-epoch (getf entry :requested)
+                          :state-at (getf entry :state-at)
+                          :exact (getf entry :exact))
+          (%reopen-and-resume name live clock t))
+      (error (original)
+        (unless done
+          (ignore-errors (%posix-rename retired live)))
+        (handler-case (%reopen-and-resume name live clock t)
+          (error (recovery)
+            (error 'shadow-recovery-failed :original original
+                                           :recovery recovery)))
+        (if done
+            (warn 'swap-recovered-warning :original original)
+            (error original))))
+    (list :retired-live retired)))
+
+(defun %rebuild-one-store (clock name rebuild timeout)
+  "Retire the live generation (:RETIRE-LIVE), MAKE-GRAPH a fresh one at
+the same location with the same policy, run REBUILD on it, journal
+:RESTORE :mode :rebuilt."
+  (let* ((graph (lookup-graph name))
+         (live (%trimmed-namestring (location graph)))
+         (policy (store-recovery-policy live))
+         (retired (format nil "~A-retired-~D" live
+                          (clock-current-epoch clock))))
+    (%close-quiesced graph timeout)
+    (%posix-rename live retired)
+    (journal-append clock :retire-live :store name :retired retired)
+    (let ((fresh (make-graph name (concatenate 'string live "/")
+                             :system-clock clock :recovery-policy policy)))
+      (funcall rebuild name fresh)
+      (journal-append clock :restore :store name :mode :rebuilt
+                      :retired-live retired)
+      (list :retired-live retired))))
+
+(defun %dangling-into (store-id exclude)
+  "((STORE-NAME . COUNT) ...) of edges in open clocked stores other than
+EXCLUDE whose FROM or TO carries STORE-ID's tag (spec R5)."
+  (let ((result nil))
+    (maphash
+     (lambda (name graph)
+       (when (and (typep graph 'graph) (graph-system-clock graph)
+                  (not (member name exclude)))
+         (let ((n 0))
+           (map-edges (lambda (e)
+                        (when (or (eql (id-store-tag (from e)) store-id)
+                                  (eql (id-store-tag (to e)) store-id))
+                          (incf n)))
+                      graph)
+           (when (> n 0) (push (cons name n) result)))))
+     *graphs*)
+    result))
+
+(defun restore-system (clock epoch &key require-exact rebuild (timeout 60))
+  "Execute PLAN-SYSTEM-RESTORE's manifest for EPOCH: every refusal fires
+before any rename.  Rewinds first, then rebuilds, then cascades: a
+:DERIVABLE store holding edges into a rebuilt store is rebuilt in turn
+(fixpoint); an :AUTHORED one is left alone and reported :DANGLING N.
+Writes <clock-dir>/restore-<Enow>.manifest and signals RESTORE-INEXACT-
+WARNING when any store is rebuilt or inexact.  Returns the manifest
+(GH #171, spec §3-§4)."
+  (let* ((manifest (plan-system-restore clock epoch
+                                        :require-exact require-exact
+                                        :rebuild rebuild))
+         (entries (getf manifest :stores))
+         (rebuilt nil))
+    (dolist (e entries)
+      (when (eq (getf e :action) :rewound)
+        (let ((extra (%restore-one-store
+                      clock (getf e :store)
+                      (list* :requested epoch e) timeout)))
+          (setf (getf e :retired-live) (getf extra :retired-live)))))
+    (dolist (e entries)
+      (when (eq (getf e :action) :rebuilt)
+        (%rebuild-one-store clock (getf e :store) rebuild timeout)
+        (push (getf e :store) rebuilt)))
+    ;; Cascade to a fixpoint over derivable dependents.
+    (let ((queue (copy-list rebuilt)))
+      (loop while queue do
+        (let* ((source (pop queue))
+               (tag (store-registry-id-for source)))
+          (loop for (name . n) in (%dangling-into tag rebuilt) do
+            (let ((entry (find name entries
+                               :key (lambda (x) (getf x :store)))))
+              (if (eq (store-recovery-policy
+                       (location (lookup-graph name)))
+                      :derivable)
+                  (progn
+                    (%rebuild-one-store clock name rebuild timeout)
+                    (push name rebuilt) (push name queue)
+                    (setf (getf entry :action) :rebuilt
+                          (getf entry :exact) nil
+                          (getf entry :state-at) (clock-current-epoch clock)
+                          (getf entry :cascade-from) source))
+                  (setf (getf entry :dangling) n)))))))
+    (setf (getf manifest :at) (clock-current-epoch clock))
+    (%write-manifest clock manifest)
+    (when (some (lambda (e) (or (eq (getf e :action) :rebuilt)
+                                (and (eq (getf e :action) :rewound)
+                                     (not (getf e :exact)))))
+                entries)
+      (warn 'restore-inexact-warning :manifest manifest))
+    manifest))
+```
+
+Notes for the implementer:
+- `%dangling-into` must run against the *rebuilt* store's tag, which
+  `store-registry-id-for` returns for its name; verify the name key type
+  matches what `make-graph` interned (symbol).
+- `make-edge`'s real arglist: check `edge.lisp:353` region / existing tests
+  and use it; the plan's call is illustrative.
+- `(setf (getf e ...))` on the entry plists mutates the manifest in place —
+  intended; `entries` is `(getf manifest :stores)`.
+- Cascade must not rebuild an `:unchanged` authored entry: the `:dangling`
+  branch is the only authored outcome.
+
+Exports: `#:restore-system #:restore-inexact-warning
+#:restore-inexact-manifest #:read-restore-manifest`.
+
+- [ ] **Step 4: Run** — 18 pass. **Step 5: Commit**
+  `feat(restore): restore-system executes the plan, cascades, writes the manifest (#171)`
+
+---
+
+### Task 5: `repair-interrupted-swap` and the restore pre-check
+
+**Files:**
+- Modify: `system-restore.lisp`, `package.lisp`, `tests/system-restore-tests.lisp`, `shadow-store.lisp:545-549` (docstring: the crash window is now repaired by `repair-interrupted-swap`)
+
+**Interfaces:**
+- Produces: `(repair-interrupted-swap clock name location) → :repaired | :nothing-to-do`; `%interrupted-swap-p (clock location) → retired-path-or-nil`; `plan-system-restore` gains reason `:interrupted-swap`.
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test restore-refuses-while-a-swap-is-interrupted
+  "Construct the between-renames layout: live renamed away, nothing at the
+live location.  The plan refuses with :INTERRUPTED-SWAP; the repair tool
+renames it back, returns :REPAIRED, journals :SWAP-ABORTED, and is
+idempotent (:NOTHING-TO-DO on a second call)."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (let* ((live (graph-db::%trimmed-namestring (graph-db::location g)))
+           (now (graph-db:clock-current-epoch clock))
+           (stranded (format nil "~A-retired-~D" live (+ now 50))))
+      (let ((graph-db:*graph* g)) (close-graph g :snapshot-p nil))
+      (graph-db::%posix-rename live stranded)
+      (let ((c (handler-case
+                   (progn (graph-db:plan-system-restore clock now) nil)
+                 (graph-db:restore-refused-error (c) c))))
+        (is-true c)
+        (when c
+          (is (equal '((:restore-store-1 . :interrupted-swap))
+                     (graph-db:restore-refused-reasons c)))))
+      (is (eq :repaired (graph-db:repair-interrupted-swap
+                         clock :restore-store-1 live)))
+      (is-true (probe-file (uiop:ensure-directory-pathname live)))
+      (is-false (probe-file (uiop:ensure-directory-pathname stranded)))
+      (is-true (find :swap-aborted (journal-records clock)
+                     :key (lambda (r) (getf r :kind))))
+      (is (eq :nothing-to-do (graph-db:repair-interrupted-swap
+                              clock :restore-store-1 live)))
+      (setq g (open-graph :restore-store-1 (concatenate 'string live "/")
+                          :system-clock clock))
+      (is (= 1 (%rs-count g))))))
+```
+
+Since the graph is closed in this test, `retired-generations` cannot find
+the store via `*graphs*`; `%interrupted-swap-p` must be driven from the
+journal's `:attach`/`:create` records or from an explicit `location` — this
+test passes `location` to the repair tool and the plan learns the location
+from the `:retired` paths of swap records **or** the open graph. For the
+refusal to work with the graph closed, make `%restore-plan-entries` also
+consult `(journal-records clock)` for `:retire-live`/`:swap` records to
+collect locations, and treat "location has retired dirs newer than every
+`:swap`/`:retire-live` record **and** no live directory" as interrupted.
+
+- [ ] **Step 2: Run** — undefined `repair-interrupted-swap`.
+- [ ] **Step 3: Implement**
+
+```lisp
+(defun %known-locations (clock)
+  "(LOCATION . STORE) for every store the journal or *GRAPHS* names."
+  (let ((acc (make-hash-table :test 'equal)))
+    (dolist (r (journal-records clock))
+      (let ((retired (getf r :retired)))
+        (when (and retired (member (getf r :kind) '(:swap :retire-live)))
+          (setf (gethash (%live-location-of-retired retired) acc)
+                (getf r :store)))))
+    (maphash (lambda (name graph)
+               (when (and (typep graph 'graph)
+                          (eq (graph-system-clock graph) clock))
+                 (setf (gethash (%trimmed-namestring (location graph)) acc)
+                       name)))
+             *graphs*)
+    acc))
+
+(defun %interrupted-swap-p (clock location)
+  "The retired path stranded between SWAP-IN-SHADOW's two renames, or NIL:
+no live directory, and a retired directory newer than every journaled
+:SWAP / :RETIRE-LIVE for LOCATION (GH #171, spec R6)."
+  (let ((live (%trimmed-namestring location)))
+    (unless (probe-file (uiop:ensure-directory-pathname live))
+      (let ((journaled
+              (loop for r in (journal-records clock)
+                    when (and (member (getf r :kind) '(:swap :retire-live))
+                              (string= (%live-location-of-retired
+                                        (getf r :retired))
+                                       live))
+                      collect (%trimmed-namestring (getf r :retired)))))
+        (loop for (nil . dir) in (reverse (%retired-dirs-for live))
+              unless (member dir journaled :test #'string=)
+                return dir)))))
+
+(defun repair-interrupted-swap (clock name location)
+  "Rename a stranded pre-swap generation back to LOCATION and journal
+:SWAP-ABORTED.  :REPAIRED, or :NOTHING-TO-DO when LOCATION is intact.
+Idempotent; never touches a live directory (GH #171, spec R6)."
+  (let ((stranded (%interrupted-swap-p clock location)))
+    (cond ((null stranded) :nothing-to-do)
+          (t (%posix-rename stranded (%trimmed-namestring location))
+             (journal-append clock :swap-aborted :store name
+                             :restored-from stranded)
+             :repaired))))
+```
+
+And in `%restore-plan-entries`, before the per-store `cond`, add an
+interrupted check using `%known-locations`:
+
+```lisp
+    (maphash (lambda (location store)
+               (when (%interrupted-swap-p clock location)
+                 (push (cons store :interrupted-swap) reasons)
+                 (push (list :store store :action :refused
+                             :reason :interrupted-swap) entries)
+                 (remhash store by-store)))
+             (%known-locations clock))
+```
+
+(Place it after `by-store` is filled and before the main `maphash` over
+`by-store`; the `remhash` keeps the store from being planned twice.)
+
+Update the docstring paragraph in `shadow-store.lisp` ("A failure BETWEEN
+the two renames is NOT recovered here ...") to end: "... manual recovery is
+`repair-interrupted-swap` (GH #171)."
+
+Exports: `#:repair-interrupted-swap`.
+
+- [ ] **Step 4: Run** — 19 pass; also `(fiveam:run! 'detach-suite)` still green.
+- [ ] **Step 5: Commit**
+  `feat(restore): repair-interrupted-swap closes #170's rename window (#171)`
+
+---
+
+### Task 6: Docs
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased `### Added`)
+- Modify: `docs/vivace-graph-v3-doc.org` — new `*** Restore across a swap` after `*** Detach, shadow load, and the swap` (ch.17, ~line 3341+), and one paragraph + pointer in ch.11 after "Restoring a Graph from a Snapshot"
+- Modify: `docs/superpowers/specs/2026-08-20-namespaces-design.md` §9 — append `**Built (#171):**` paragraph naming R1–R6 and the generation-granularity ruling; flip unit 6's row in §11 to **Done**.
+
+- [ ] **Step 1: CHANGELOG**
+
+```markdown
+### Added
+- Whole-system restore across a shadow swap (#171): `retired-generations`,
+  `prune-retired-generations` (authored generations inside the restore
+  window are refused by name), `plan-system-restore` / `restore-system`
+  (generation-granularity restore to an epoch, exactness reported per store,
+  derivable rebuild via a caller callback with cascade, manifest written to
+  `restore-<epoch>.manifest`), and `repair-interrupted-swap` for the
+  crash-between-renames window #170 left open. Restore does **not**
+  supersede `snapshot`/`replay`: point-in-time inside a generation is a
+  separate follow-up.
+```
+
+- [ ] **Step 2: Manual section** — write ~60 lines covering: what a
+generation is; the five functions with their keyword arguments; the manifest
+shape (copy spec §4); the exactness rule (R2) with the `:require-exact`
+flag; retention/prune with the epoch floor (R3); rebuild callback contract
+`(lambda (name graph))` and the cascade/`:dangling` rule (R5);
+`repair-interrupted-swap`; and the explicit limitation "no point-in-time
+inside a generation". ch.11 gets a two-sentence pointer.
+
+- [ ] **Step 3: Spec note** in §9 and §11 as above.
+- [ ] **Step 4: Commit** `docs(restore): manual ch.17 section, CHANGELOG, spec Built note (#171)`
+
+---
+
+## Self-review
+
+- Spec coverage: R1 (Task 3 selection, Task 6 docs), R2 (Task 3 exactness +
+  `:require-exact`), R3 (Task 2), R4 (Task 1), R5 (Task 4 rebuild/cascade),
+  R6 (Task 5); manifest §4 (Task 4, `read-restore-manifest`); tests §6 all
+  mapped; docs §7 (Task 6). Detach-window case is covered by the exact-path
+  test (R2 makes it the same code path).
+- Type consistency: `generation-*` readers, `restore-refused-reasons` as
+  `(store . keyword)`, manifest entry keys `:action :state-at :exact :from
+  :retired-live :cascade-from :dangling :reason` used identically across
+  Tasks 3–5.
+- Known judgment point left to the implementer: `make-edge` arglist in
+  Task 4's cascade test, and the `:retire-live`/`:restore` journal shapes are
+  defined in Task 4 only — Task 5's `%known-locations` consumes them as
+  written there.

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -461,6 +461,26 @@ that generation rewound to `E0`, noted in the manifest.
 truncates the restore window whenever any store is bulk-loaded. The restore window is a
 system property; one store's routine maintenance must not shorten it.
 
+**Built (#171):** implemented in `system-restore.lisp` against what #170 actually
+shipped, at **generation granularity** — a generation is a retired directory
+(`<location>-retired-<epoch>`, never deleted by a swap) plus the journal records that
+annotate it. This answers this section's own open item: **the shadow swap does not
+supersede logical replay** — the swap is the generation mechanism, `snapshot`/`replay`
+remains the sole mechanism for content inside one generation, and true point-in-time
+rewind inside a generation is an explicit, unbuilt follow-up (R1). §9.3 step 3 ("rewind
+physically to T") is realized as *exact-if-frozen-before-T, reported otherwise* (R2):
+a retained generation frozen at `E0 <= T` is exact; frozen later, it is used anyway
+and reported `:exact nil` (`:require-exact t` refuses instead). §9.2's retention split
+is enforced at prune time, not swap time, since swap never deletes
+(`prune-retired-generations`, R3): an `:authored` generation inside the window is
+refused by name, a `:derivable` one is optional. The rebuild-and-cascade of §9.3 steps
+4–6 is a caller-supplied `(lambda (name graph) ...)` plus a fixpoint over `:derivable`
+dependents keyed on the rebuilt store's tag (R5), and the manifest of step 6 is a
+plist written readably to `restore-<epoch>.manifest` (R4/R6 cover the filesystem's
+authority over the journal, and the crash-between-renames window #170 left open,
+respectively). Full design and the two implementation-only defects found along the
+way: `docs/superpowers/specs/2026-08-23-restore-171-design.md`.
+
 ## 10. Migration
 
 Three migrations, each chosen for a reversible failure mode.
@@ -542,7 +562,7 @@ before this ships. That is a release gate, not a design gate.
 | 3 | Image-level clock, system journal, epoch leases | #168 | — | **Done** |
 | 4 | Tagged UUIDv8 store field, resolver, detached-read marker | #169 | 3 | Not started |
 | 5 | Detach quiescence protocol and shadow bulk load | #170 | 3, 4, #191 | Blocked |
-| 6 | Restore: retention policy, algorithm, manifest, cascade | #171 | 5, #191 | Blocked |
+| 6 | Restore: retention policy, algorithm, manifest, cascade | #171 | 5, #191 | **Done** |
 | 7 | Runtime schema from persisted metadata | #172 | 1b, 2 | Blocked |
 
 Defects found while building the units above, which gate later ones: #187 (memory-image

--- a/docs/superpowers/specs/2026-08-23-restore-171-design.md
+++ b/docs/superpowers/specs/2026-08-23-restore-171-design.md
@@ -164,13 +164,14 @@ manifest as `:action :unchanged`.
 One plist per store, plus a header; printed readably, no evaluation:
 
 ```
-(:restore :requested T :at Enow :clock LOCATION
+(:restore t :requested T :at Enow :clock LOCATION
  :stores
- ((:store "orders"  :action :rewound  :state-at E0 :exact t
+ ((:store "shipping" :action :rewound  :state-at E0 :exact t
    :from "<loc>-retired-1234" :retired-live "<loc>-retired-5678")
-  (:store "catalog" :action :rebuilt  :state-at Enow :exact nil
+  (:store "orders"   :action :rebuilt  :state-at Enow :exact nil)
+  (:store "catalog"  :action :rebuilt  :state-at Enow :exact nil
    :cascade-from "orders")
-  (:store "audit"   :action :unchanged :dangling 17)
+  (:store "audit"    :action :unchanged :dangling 17)
   ...))
 ```
 

--- a/docs/superpowers/specs/2026-08-23-restore-171-design.md
+++ b/docs/superpowers/specs/2026-08-23-restore-171-design.md
@@ -1,0 +1,209 @@
+# Restore across a shadow swap (#171) — design
+
+Unit 6 of the namespaces epic (#110). Implements
+`2026-08-20-namespaces-design.md` §9 (decision D13) against what #170
+actually built. Public repo: names and examples are domain-neutral.
+
+## 1. What exists, and the one thing that does not
+
+- `swap-in-shadow` (#170) renames the live generation to
+  `<location>-retired-<E3>` and appends `(:kind :swap :store NAME
+  :retired PATH :epoch E3)`. Nothing ever deletes a retired generation,
+  so retention today is infinite and unmanaged.
+- The clock journal (`journal-records`) is the lifecycle history, read
+  with `*read-eval*` nil. A `:swap` record can be missing after a
+  post-rename failure (#212); the retired directory's name still
+  carries `E3`.
+- `store-recovery-policy` reads `policy.dat`: `:authored` (default) or
+  `:derivable`.
+- A crash between the two renames leaves the live data only at the
+  retired path (#170 docstring: "#171's territory").
+- **There is no physical point-in-time rewind inside a generation.** An
+  on-disk graph discards each `.txn` once applied
+  (`retain-committed-transaction-p` → NIL); `snapshot`/`replay` is
+  logical and restores *a snapshot*, not *T*, into an empty graph. The
+  spec's "rewind physically to T" has no primitive to stand on.
+
+## 2. Rulings
+
+These decide the issue's open question and the gaps §9 leaves.
+
+**R1 — Restore resolves at generation granularity; shadow swap does
+not supersede logical replay.** The issue's open item is answered *no*:
+the swap is the *generation* mechanism, `snapshot`/`replay` stays the
+*content* mechanism inside a generation, and true point-in-time
+recovery inside a generation is a separate feature (filed as a
+follow-up, not built here). Restore-to-T therefore means: for every
+store, put in place the generation that was live at `T`, and state
+exactly which epoch that generation's content reflects.
+*Cost if wrong:* a later PITR unit adds a `:rewind` step after
+generation selection; nothing here blocks it, because the manifest
+already records requested-vs-actual epoch.
+
+**R2 — "Rewound to T" is exact when the retained generation has no
+writes after T, and is otherwise reported, never faked.** A retained
+generation was frozen at its last commit `E0 ≤ E3`. If `E0 ≤ T`, its
+content at `T` *is* its content at `E0` — exact, and this covers the
+spec's detach-window case `E1 ≤ T < E2` directly. If `T < E0`, writes in
+`(T, E0]` cannot be undone; the manifest marks the store
+`:exact nil :state-at E0`. Default behaviour is to proceed (the manifest
+makes it non-silent, which is what §9 forbids); `:require-exact t`
+refuses instead. *Cost if wrong:* an operator who wanted refusal by
+default gets a manifest line to read; the flag is one keyword away.
+
+**R3 — Retention is enforced at prune time, not swap time, because
+swap never deletes.** New `prune-retired-generations (clock floor)`
+deletes retired generations with `E3 ≤ FLOOR`. For `E3 > FLOOR` an
+`:authored` store's generation is refused by name
+(`retention-required-error`, listing every blocked generation); a
+`:derivable` one is kept unless `:discard-derivable t`. `FLOOR` is the
+operator's restore-window floor in epochs — epochs are the system's
+time axis (§6), and no wall-clock is persisted in the journal. Every
+deletion appends `(:kind :retire :store NAME :retired PATH :swap-epoch
+E3)`. *Cost if wrong:* a window expressed in epochs is less intuitive
+than days; an operator can map it with the journal's `:epoch` stamps.
+
+**R4 — The filesystem is the source of truth for generations; the
+journal annotates it.** `retired-generations (clock)` lists
+`<location>-retired-<E3>` directories for every registered store and
+joins them to `:swap` records. A directory with no record (the #212
+shape) is kept, reported with `:journaled nil`, and warned about
+(`swap-record-missing-warning`) — the same tolerance the torn-tail
+reader chose in #191. A record with no directory is reported as
+`:present nil` (pruned or lost). *Cost if wrong:* none foreseeable;
+this strictly adds information.
+
+**R5 — Rebuild is a caller-supplied function; cascade is found by
+store tag.** The engine cannot regenerate a derivable store; the
+operator passes `:rebuild (lambda (name graph) ...)` which populates a
+fresh, empty graph the engine created at the live location. After a
+rebuild the store's node ids are new, so every edge in *any other open
+store* whose endpoint carries the rebuilt store's 12-bit tag
+(`id-store-tag`, #169) now dangles. Cascade: a dependent `:derivable`
+store is rebuilt too (fixpoint over the set); a dependent `:authored`
+store is **not** touched — §9 says authored cross-boundary assertions
+key on external identity — and the manifest records its dangling-edge
+count under `:dangling`. *Cost if wrong:* a scan of every open store's
+edges per rebuild; bounded by the rebuild itself, which is already a
+full load.
+
+**R6 — The interrupted-swap window is repaired by an explicit,
+idempotent tool, not inside restore.** `repair-interrupted-swap (name
+location)` handles the only shape #170 cannot: live missing (or a
+half-moved shadow) while exactly one `<location>-retired-<E3>` is newer
+than any `:swap` record. It renames the retired generation back and
+appends `(:kind :swap-aborted ...)`. Restore refuses to start while a
+registered store is in that state, naming the tool. *Cost if wrong:* an
+operator runs one extra command.
+
+## 3. Operations
+
+All live in a new `system-restore.lisp` (after `shadow-store.lisp` in
+the `.asd`), exported from `package.lisp`.
+
+```
+(retired-generations clock)  → list of plists
+  (:store NAME :location LIVE :retired PATH :swap-epoch E3
+   :journaled BOOL :present BOOL :policy :authored|:derivable)
+
+(prune-retired-generations clock floor &key discard-derivable dry-run)
+  → list of plists actually (or, dry-run, would-be) deleted; signals
+  retention-required-error listing blocked :authored generations.
+
+(plan-system-restore clock T &key require-exact rebuild)
+  → manifest (see §4) with no side effects. Signals
+  restore-refused-error (authored generation gone; inexact under
+  :require-exact; interrupted swap present; :derivable store with no
+  retained generation and no :rebuild).
+
+(restore-system clock T &key require-exact rebuild (timeout 60))
+  → manifest, after executing the plan:
+    per affected store, in dependency order:
+      quiesce + close the live graph (same sequence as swap-in-shadow)
+      rename live → <location>-retired-<Enow>   (:kind :retire-live)
+      rename <location>-retired-<E3> → live     (:kind :restore ...)
+      reopen + attach-to-system-clock
+    per rebuilt store: make-graph at live, call REBUILD, then cascade.
+    The manifest is also written to <clock-dir>/restore-<Enow>.manifest
+    readably, *read-eval* nil on read — same discipline as the journal.
+
+(repair-interrupted-swap name location) → :repaired | :nothing-to-do
+```
+
+`restore-system` uses `plan-system-restore` first and executes only a
+plan that raised nothing: every refusal fires before any rename.
+Failure after the first rename of a store follows the `swap-in-shadow`
+pattern exactly: the store's two renames are the commit point, a
+failure before them restores the old name and resignals, a failure
+after them reopens the new generation and warns.
+
+Epoch `T` is an integer epoch from the system clock. Stores not
+affected by any swap with `E3 > T` are untouched and appear in the
+manifest as `:action :unchanged`.
+
+## 4. The manifest
+
+One plist per store, plus a header; printed readably, no evaluation:
+
+```
+(:restore :requested T :at Enow :clock LOCATION
+ :stores
+ ((:store "orders"  :action :rewound  :state-at E0 :exact t
+   :from "<loc>-retired-1234" :retired-live "<loc>-retired-5678")
+  (:store "catalog" :action :rebuilt  :state-at Enow :exact nil
+   :cascade-from "orders")
+  (:store "audit"   :action :unchanged :dangling 17)
+  ...))
+```
+
+`:action` ∈ `:rewound | :rebuilt | :unchanged | :refused` (refused only
+in a plan). `:dangling` appears on an `:authored` dependent of a
+rebuilt store. A manifest in which any store is `:rebuilt` or
+`:exact nil` is exactly the "inconsistent instant" §9 wants *recorded*;
+`restore-system` also signals `restore-inexact-warning` summarising
+those lines so a caller cannot miss it.
+
+## 5. Out of scope (filed as follow-ups, not built)
+
+- Point-in-time rewind inside a generation (needs retained `.txn` +
+  snapshot base; R1).
+- Out-of-process rebuild; retention by wall-clock.
+- #212's double-open on attach failure (unchanged by this unit).
+
+## 6. Testing
+
+FiveAM, `tests/system-restore-tests.lisp`, registered after
+`detach-tests`. All under a temporary system directory with its own
+clock; every guard ablated:
+
+- retired-generations: joins dir+record; `:journaled nil` on a dir with
+  no record (simulate #212 by deleting the record's line); `:present
+  nil` on a record with no dir.
+- prune: deletes `E3 ≤ floor`; refuses authored `E3 > floor` naming it;
+  deletes derivable only with `:discard-derivable`; `:dry-run` deletes
+  nothing; appends `:retire`.
+- plan/restore, exact path: swap at `E3 > T` with `E0 ≤ T` → `:rewound
+  :exact t`; data read back equals the pre-swap content; journal has
+  `:retire-live` + `:restore`; the post-swap generation is retained and
+  a second restore to a later T puts it back (round trip).
+- inexact: write after T, then swap → `:exact nil :state-at E0`;
+  `:require-exact t` refuses before any rename (directory layout
+  unchanged, graph still open and accepting).
+- authored generation pruned → `restore-refused-error`, nothing moved.
+- derivable, no generation, `:rebuild` → `:rebuilt`; cascade rebuilds a
+  derivable dependent whose edges pointed at the rebuilt store, and
+  reports `:dangling N` on an authored dependent; dependency order.
+- detach-window case `E1 ≤ T < E2` → generation restored, `:state-at
+  E0`, exact.
+- interrupted swap: construct the between-renames layout by hand;
+  restore refuses naming `repair-interrupted-swap`; the tool repairs,
+  is idempotent, and appends `:swap-aborted`.
+- manifest file written; reads back with `*read-eval*` nil.
+- Full suite green on SBCL (ECL demoted).
+
+## 7. Docs
+
+`docs/vivace-graph-v3-doc.org` ch.17: new "Restore across a swap"
+section after "Detach, shadow load, and the swap", and ch.11 gains a
+pointer; `CHANGELOG.md` Unreleased `### Added`; the namespaces spec §9
+gets a **Built (#171)** note naming R1–R6.

--- a/docs/superpowers/specs/2026-08-23-restore-171-design.md
+++ b/docs/superpowers/specs/2026-08-23-restore-171-design.md
@@ -225,3 +225,24 @@ clock; every guard ablated:
 section after "Detach, shadow load, and the swap", and ch.11 gains a
 pointer; `CHANGELOG.md` Unreleased `### Added`; the namespaces spec §9
 gets a **Built (#171)** note naming R1–R6.
+
+**Built (#171):** all five operations shipped as designed in §3, with
+one shape the design didn't anticipate: a generation's content is
+tracked by ERAS (a list of `[from, to)` intervals, R2a), not a single
+live-window interval, because a restore can promote a retired
+directory back to live and a later swap can retire it again under a
+new name — without inheritance that directory's original content era
+would be attributed to nobody. Two defects surfaced only by
+implementation, not foreseeable from the design: retired-generation
+name collisions (`%retired-path-for` now consumes epochs until an
+unused `<location>-retired-<E>` name is free — two retiring events
+with no commit between them, e.g. two restores in a row, otherwise
+compute the same name), and a `%reopen-and-resume` bug where a
+slashless `location` string misplaced sidecar files in the parent
+directory and froze the transaction-id watermark (worked around here,
+filed as the real defect against `open-graph`/`make-graph` at #222).
+`%known-locations`'s stranded-swap detection also widened past the
+design's two sources (journal `:swap`/`:retire-live` records, open
+`*graphs*`) to a third — an `:attach` record's own `:location` field —
+since that is the only trace left when a crash lands between
+`swap-in-shadow`'s two renames before any `:swap` record exists.

--- a/docs/superpowers/specs/2026-08-23-restore-171-design.md
+++ b/docs/superpowers/specs/2026-08-23-restore-171-design.md
@@ -106,8 +106,8 @@ rebuilds) do not collide. *Cost if wrong:* eras are derived from the
 journal on every read, so a corrected rule needs no on-disk migration.
 
 **R6 — The interrupted-swap window is repaired by an explicit,
-idempotent tool, not inside restore.** `repair-interrupted-swap (name
-location)` handles the only shape #170 cannot: live missing (or a
+idempotent tool, not inside restore.** `repair-interrupted-swap (clock
+name location)` handles the only shape #170 cannot: live missing (or a
 half-moved shadow) while exactly one `<location>-retired-<E3>` is newer
 than any `:swap` record. It renames the retired generation back and
 appends `(:kind :swap-aborted ...)`. Restore refuses to start while a
@@ -145,7 +145,7 @@ the `.asd`), exported from `package.lisp`.
     The manifest is also written to <clock-dir>/restore-<Enow>.manifest
     readably, *read-eval* nil on read — same discipline as the journal.
 
-(repair-interrupted-swap name location) → :repaired | :nothing-to-do
+(repair-interrupted-swap clock name location) → :repaired | :nothing-to-do
 ```
 
 `restore-system` uses `plan-system-restore` first and executes only a
@@ -175,8 +175,11 @@ One plist per store, plus a header; printed readably, no evaluation:
   ...))
 ```
 
-`:action` ∈ `:rewound | :rebuilt | :unchanged | :refused` (refused only
-in a plan). `:dangling` appears on an `:authored` dependent of a
+`:action` ∈ `:rewound | :rebuilt | :unchanged | :refused` — but
+`plan-system-restore` raises `restore-refused-error` as soon as any
+refusal exists, so a caller never actually receives a manifest
+containing `:refused`; the reasons instead ride on the error's own
+`reasons` slot. `:dangling` appears on an `:authored` dependent of a
 rebuilt store. A manifest in which any store is `:rebuilt` or
 `:exact nil` is exactly the "inconsistent instant" §9 wants *recorded*;
 `restore-system` also signals `restore-inexact-warning` summarising

--- a/docs/superpowers/specs/2026-08-23-restore-171-design.md
+++ b/docs/superpowers/specs/2026-08-23-restore-171-design.md
@@ -89,6 +89,22 @@ count under `:dangling`. *Cost if wrong:* a scan of every open store's
 edges per rebuild; bounded by the rebuild itself, which is already a
 full load.
 
+**R2a (fix round 3) — A generation's content era is not always its own
+last live window.** Selection of "the generation live at T" runs over
+each generation's ERAS: a list of half-open `[from, to)` intervals made
+of its own live window plus, when a `:restore` record promoted a
+directory into the window this generation later closed, that directory's
+eras as well — recursively through chains of restores. Ties go to the
+matching era with the latest `from`. Without inheritance the sequence
+swap (retires r1) → restore-to-T (promotes r1, retires r2) → swap
+(retires the promoted directory as r3) leaves T's content in r3 while
+the plan for T reports `:unchanged` — the generation is still on disk
+but unreachable. Retiring also consumes epochs until the
+`<location>-retired-<E>` name is free, so two retiring events with no
+commit between them (two restores in a row, or a rewind the cascade then
+rebuilds) do not collide. *Cost if wrong:* eras are derived from the
+journal on every read, so a corrected rule needs no on-disk migration.
+
 **R6 — The interrupted-swap window is repaired by an explicit,
 idempotent tool, not inside restore.** `repair-interrupted-swap (name
 location)` handles the only shape #170 cannot: live missing (or a

--- a/docs/superpowers/specs/2026-08-23-restore-171-design.md
+++ b/docs/superpowers/specs/2026-08-23-restore-171-design.md
@@ -70,7 +70,9 @@ joins them to `:swap` records. A directory with no record (the #212
 shape) is kept, reported with `:journaled nil`, and warned about
 (`swap-record-missing-warning`) — the same tolerance the torn-tail
 reader chose in #191. A record with no directory is reported as
-`:present nil` (pruned or lost). *Cost if wrong:* none foreseeable;
+`:present nil` — *lost*, since a deliberate prune leaves a `:retire`
+record and `retired-generations` omits such generations entirely (Task 2
+ruling: pruned is bookkeeping, lost is a finding). *Cost if wrong:* none foreseeable;
 this strictly adds information.
 
 **R5 — Rebuild is a caller-supplied function; cascade is found by

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3614,9 +3614,12 @@ to ~<clock-dir>/restore-<Enow>.manifest~:
     (:store "audit"    :action :unchanged :dangling 17)))
 #+END_SRC
 
-~:action~ is one of ~:rewound~, ~:rebuilt~, ~:unchanged~, or (in a
-*plan*, not an executed restore) ~:refused~. A store untouched by any
-swap with ~swap-epoch > epoch~ is simply ~:unchanged~. Any store
+~:action~ is one of ~:rewound~, ~:rebuilt~, ~:unchanged~, or
+~:refused~ — but ~plan-system-restore~ raises
+~restore-refused-error~ the moment any refusal exists, so a caller
+never actually receives a manifest containing ~:refused~; the reasons
+instead ride on the error's own ~reasons~ slot. A store untouched by
+any swap with ~swap-epoch > epoch~ is simply ~:unchanged~. Any store
 ~:rebuilt~, or ~:rewound~ with ~:exact nil~, means the restored instant
 is not perfectly consistent across the system — exactly the case §9
 requires to be *recorded*, never faked — and ~restore-system~ signals

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -1981,6 +1981,8 @@ The `replay` function is the counterpart to `snapshot`. It reads a snapshot file
 
 *Important Prerequisite:* The `replay` function must be run on a *new, empty graph*. You cannot replay a snapshot on top of an existing graph with data in it.
 
+*Restoring a whole multi-store system to an epoch, across a shadow swap, is a different mechanism* — ~restore-system~ (Chapter 17, "Restore across a swap") selects which retired generation was live at a given epoch. It does not replace `replay`: `replay` remains the only way to recover content to a point *inside* one generation.
+
 The restoration process is as follows:
 
 1.  *Create a new, empty graph* in a different directory.
@@ -3531,6 +3533,138 @@ territory, not this one's.
 safety story is gating on that same suffix. A real store that happens
 to already end in ~-shadow~ would be indistinguishable from an actual
 shadow to that guard.
+
+*** Restore across a swap
+
+GH #171 answers the question #170 leaves open: once a store has been
+swapped, how does a whole system get back to how it looked at some
+earlier epoch ~T~? **A generation** is one retired directory
+(~<location>-retired-<E3>~, never deleted by a swap) plus the journal
+records that annotate it, plus its ERAS — the half-open ~[from, to)~
+epoch intervals the directory actually held content for. Ordinarily a
+generation's era is just its own live window, but when a
+~restore-system~ call promotes a directory back to live and a later
+swap retires it again under a new name, that directory's own eras
+travel with it — recursively through a chain of restores — so it is
+never attributed to the wrong content just because it changed names.
+The swap is the *generation* mechanism; ~snapshot~/~replay~ (Chapter
+11) remains the *content* mechanism inside one generation. Restore
+does **not** supersede it: there is no physical rewind to an arbitrary
+point inside a generation's own lifetime, only a choice of which whole
+generation was live at ~T~.
+
+**Five entry points**, all exported and all operating on a system
+clock (Chapter 17's ~*system-clock*~/~attach-to-system-clock~):
+
+- ~(retired-generations clock)~ — every retired generation the
+  filesystem and the journal together know about, as ~generation~
+  structs (~generation-store~, ~-location~, ~-retired~, ~-swap-epoch~,
+  ~-eras~, ~-journaled-p~, ~-present-p~, ~-policy~). The filesystem is
+  authoritative (spec R4): a directory with no joining ~:swap~ or
+  ~:retire-live~ record is still listed, ~journaled-p~ ~nil~, with
+  ~swap-record-missing-warning~ signalled (the #212 shape); a record
+  naming a directory that no longer exists is listed ~present-p~
+  ~nil~ — *lost*. A generation a deliberate prune or a later restore
+  has consumed is omitted entirely, not merely marked absent, though
+  its eras still travel forward to whatever inherited its content.
+- ~(prune-retired-generations clock floor &key discard-derivable
+  dry-run)~ — deletes generations with ~swap-epoch <= floor~. Above
+  ~floor~, an ~:authored~ generation is refused *by name*
+  (~retention-required-error~, before anything is deleted — spec R3);
+  a ~:derivable~ one survives unless ~discard-derivable t~. ~dry-run~
+  reports what would go and deletes nothing. Every deletion appends a
+  ~:retire~ journal record. ~floor~ is an epoch, the system's only time
+  axis — no wall-clock is persisted in the journal.
+- ~(plan-system-restore clock epoch &key require-exact rebuild)~ — the
+  manifest ~restore-system~ would act on, with no side effects.
+- ~(restore-system clock epoch &key require-exact rebuild (timeout
+  60))~ — plans, then executes: every refusal in the plan fires before
+  any rename.
+- ~(repair-interrupted-swap clock name location)~ — see below.
+
+**The exactness rule (R2).** A retained generation was frozen at its
+last committed epoch ~E0 <= its swap-epoch~. If ~E0 <= T~, the
+generation's content at ~T~ *is* its content at ~E0~ — reported
+~:exact t~ — and this is exactly what makes a detach window's ~T~
+(~E1 <= T < E2~) resolve cleanly: the store was frozen throughout that
+window anyway. If ~T < E0~, writes in ~(T, E0]~ cannot be undone; the
+manifest instead reports ~:exact nil :state-at E0~ and ~restore-system~
+proceeds — the manifest makes the approximation visible rather than
+silent, which is the whole point. Passing ~:require-exact t~ refuses
+instead of proceeding, surfaced as reason ~:inexact~ in
+~restore-refused-error~. ~:require-exact~ never applies to a
+~:rebuilt~ entry — a rebuild is already an explicit, acknowledged
+approximation (R5), not a candidate for the exactness check.
+
+**The manifest** is a plist, one entry per store plus a header,
+written readably (no ~#.~ or other evaluated forms — ~read-restore-manifest~
+reads it back with ~*read-eval*~ ~nil~, the journal's own discipline)
+to ~<clock-dir>/restore-<Enow>.manifest~:
+
+#+BEGIN_SRC lisp
+  (:restore t :requested 4000 :at 4108 :clock "/data/system/"
+   :stores
+   ((:store "orders"  :action :rewound  :state-at 3982 :exact t
+     :from "/data/orders-retired-3982"
+     :retired-live "/data/orders-retired-4102")
+    (:store "catalog" :action :rebuilt  :state-at 4108 :exact nil
+     :cascade-from "orders")
+    (:store "audit"   :action :unchanged :dangling 17)))
+#+END_SRC
+
+~:action~ is one of ~:rewound~, ~:rebuilt~, ~:unchanged~, or (in a
+*plan*, not an executed restore) ~:refused~. A store untouched by any
+swap with ~swap-epoch > epoch~ is simply ~:unchanged~. Any store
+~:rebuilt~, or ~:rewound~ with ~:exact nil~, means the restored instant
+is not perfectly consistent across the system — exactly the case §9
+requires to be *recorded*, never faked — and ~restore-system~ signals
+~restore-inexact-warning~ summarising every such line so a caller
+cannot silently miss it.
+
+**Rebuild and cascade (R5).** The engine has no way to regenerate a
+~:derivable~ store's content on its own; the operator supplies
+~:rebuild (lambda (name graph) ...)~, called against a fresh, empty
+graph the engine has already created at the live location. Only
+~:recovery-policy~ carries over from the retired generation into that
+fresh ~make-graph~ call — index backend, buffer pool size, spatial
+precision and bucket counts do not, a documented v1 limitation; a
+caller relying on any of those reconfigures the rebuilt store itself
+afterward. A rebuild mints fresh node ids, so any edge in *any other
+open store* whose endpoint carries the rebuilt store's tag now dangles
+(~id-store-tag~, #169). The cascade follows this to a fixpoint: a
+~:derivable~ dependent is rebuilt in turn; an ~:authored~ dependent is
+left untouched — #9 keys authored cross-boundary assertions on
+external identity, not node id — and the manifest instead records its
+dangling-edge count under ~:dangling~. Finding the dangling set is a
+scan of every open store's edges per rebuilt store, bounded by the
+rebuild itself (already a full load), not by graph size independently.
+
+**Restore is v1-scoped to plain graphs**: a ~master-graph~,
+~slave-graph~ or ~peer-graph~ open under the clock is refused
+~:unsupported-graph~, the same boundary ~detach-store~ draws, rather
+than reopening a replicated graph with its configuration silently
+dropped.
+
+**Repairing an interrupted swap: ~repair-interrupted-swap~.** #170's
+~swap-in-shadow~ cannot recover from a crash *between* its two
+renames — the live data sits at a retired path and the live location
+is missing or half-replaced. ~repair-interrupted-swap (clock name
+location)~ is the explicit, idempotent tool for that one shape: when
+exactly one ~<location>-retired-<E>~ is newer than any completing
+~:swap~/~:restore~ record for it, it renames that directory back to
+~location~ and appends ~(:kind :swap-aborted ...)~; called again with
+nothing stranded, it returns ~:nothing-to-do~ rather than erroring.
+~restore-system~ refuses to start at all while a registered store is in
+this state (reason ~:interrupted-swap~), naming the tool rather than
+attempting to reason about which side holds the truth.
+
+**Limitations, stated plainly.** There is no point-in-time rewind
+*inside* a generation — ~snapshot~/~replay~ (Chapter 11) is the only
+mechanism for that, and it restores a snapshot's content into an empty
+graph, not a live store to an arbitrary prior instant. A rebuilt
+store's ~make-graph~ call carries forward only ~:recovery-policy~, no
+other creation option. And restore only ever operates on plain graphs,
+never a replicated or peer one.
 
 *** Cross-image effects: a peer sync can advance the clock
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3559,9 +3559,10 @@ clock (Chapter 17's ~*system-clock*~/~attach-to-system-clock~):
 - ~(retired-generations clock)~ — every retired generation the
   filesystem and the journal together know about, as ~generation~
   structs (~generation-store~, ~-location~, ~-retired~, ~-swap-epoch~,
-  ~-eras~, ~-journaled-p~, ~-present-p~, ~-policy~). The filesystem is
-  authoritative (spec R4): a directory with no joining ~:swap~ or
-  ~:retire-live~ record is still listed, ~journaled-p~ ~nil~, with
+  ~-live-from~, ~-eras~, ~-journaled-p~, ~-present-p~, ~-policy~).
+  The filesystem is authoritative (spec R4): a directory with no
+  joining ~:swap~ or ~:retire-live~ record is still listed,
+  ~journaled-p~ ~nil~, with
   ~swap-record-missing-warning~ signalled (the #212 shape); a record
   naming a directory that no longer exists is listed ~present-p~
   ~nil~ — *lost*. A generation a deliberate prune or a later restore
@@ -3604,12 +3605,13 @@ to ~<clock-dir>/restore-<Enow>.manifest~:
 #+BEGIN_SRC lisp
   (:restore t :requested 4000 :at 4108 :clock "/data/system/"
    :stores
-   ((:store "orders"  :action :rewound  :state-at 3982 :exact t
-     :from "/data/orders-retired-3982"
-     :retired-live "/data/orders-retired-4102")
-    (:store "catalog" :action :rebuilt  :state-at 4108 :exact nil
+   ((:store "shipping" :action :rewound  :state-at 3982 :exact t
+     :from "/data/shipping-retired-3982"
+     :retired-live "/data/shipping-retired-4102")
+    (:store "orders"   :action :rebuilt  :state-at 4108 :exact nil)
+    (:store "catalog"  :action :rebuilt  :state-at 4108 :exact nil
      :cascade-from "orders")
-    (:store "audit"   :action :unchanged :dangling 17)))
+    (:store "audit"    :action :unchanged :dangling 17)))
 #+END_SRC
 
 ~:action~ is one of ~:rewound~, ~:rebuilt~, ~:unchanged~, or (in a

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -110,6 +110,7 @@
                ;; just before BACKUP, which it does not depend on -- it needs
                ;; only the graph and transaction layers.
                (:file "shadow-store" :depends-on ("graph" "transactions"))
+               (:file "system-restore" :depends-on ("shadow-store"))
                (:file "backup" :depends-on ("edge" "type-seeding"))
                (:file "replication" :depends-on ("backup"))
                (:file "txn-log" :depends-on ("replication"))
@@ -537,6 +538,7 @@ cl-temporal-extent."
                (:file "store-registry-tests")     ; GH #169
                (:file "store-resolver-tests")     ; GH #169
                (:file "detach-tests")             ; GH #170
+               (:file "system-restore-tests")     ; GH #171
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/package.lisp
+++ b/package.lisp
@@ -101,7 +101,8 @@
            #:retired-generations #:swap-record-missing-warning
            #:swap-record-missing-path
            #:generation-store #:generation-location #:generation-retired
-           #:generation-swap-epoch #:generation-journaled-p
+           #:generation-swap-epoch #:generation-live-from
+           #:generation-journaled-p
            #:generation-present-p #:generation-policy
            #:prune-retired-generations #:retention-required-error
            #:retention-required-generations

--- a/package.lisp
+++ b/package.lisp
@@ -103,6 +103,8 @@
            #:generation-store #:generation-location #:generation-retired
            #:generation-swap-epoch #:generation-journaled-p
            #:generation-present-p #:generation-policy
+           #:prune-retired-generations #:retention-required-error
+           #:retention-required-generations
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -97,6 +97,12 @@
            #:recovery-policy-mismatch-warning-location
            #:recovery-policy-mismatch-warning-requested
            #:recovery-policy-mismatch-warning-on-disk
+           ;; whole-system restore (GH #171)
+           #:retired-generations #:swap-record-missing-warning
+           #:swap-record-missing-path
+           #:generation-store #:generation-location #:generation-retired
+           #:generation-swap-epoch #:generation-journaled-p
+           #:generation-present-p #:generation-policy
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -107,6 +107,8 @@
            #:retention-required-generations
            #:plan-system-restore #:restore-refused-error
            #:restore-refused-reasons #:restore-refused-epoch
+           #:restore-system #:restore-inexact-warning
+           #:restore-inexact-manifest #:read-restore-manifest
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -105,6 +105,8 @@
            #:generation-present-p #:generation-policy
            #:prune-retired-generations #:retention-required-error
            #:retention-required-generations
+           #:plan-system-restore #:restore-refused-error
+           #:restore-refused-reasons #:restore-refused-epoch
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -110,6 +110,7 @@
            #:restore-refused-reasons #:restore-refused-epoch
            #:restore-system #:restore-inexact-warning
            #:restore-inexact-manifest #:read-restore-manifest
+           #:repair-interrupted-swap
            ;; image-level type-id registry (GH #186)
            #:type-registry
            #:open-type-registry

--- a/package.lisp
+++ b/package.lisp
@@ -101,7 +101,7 @@
            #:retired-generations #:swap-record-missing-warning
            #:swap-record-missing-path
            #:generation-store #:generation-location #:generation-retired
-           #:generation-swap-epoch #:generation-live-from
+           #:generation-swap-epoch #:generation-live-from #:generation-eras
            #:generation-journaled-p
            #:generation-present-p #:generation-policy
            #:prune-retired-generations #:retention-required-error

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -192,8 +192,15 @@ copy-failure recovery path.  REASON is applied to the fresh transaction
 manager BEFORE the graph publishes to *GRAPHS*, not flipped after open
 -- a post-open flip would leave a window where the just-reopened graph
 is fully accepting and a racing writer could land a commit that belongs
-in the doomed generation (GH #170, review finding I4)."
-  (let ((reopened (open-graph name (namestring location)
+in the doomed generation (GH #170, review finding I4).
+
+LOCATION is normalised to a DIRECTORY pathname first: OPEN-GRAPH keeps
+whatever it is handed, and a slashless string makes every
+(MAKE-PATHNAME :defaults (LOCATION GRAPH)) sidecar -- transaction-id.dat
+above all -- land in the store's PARENT directory (GH #171)."
+  (let ((reopened (open-graph name (namestring
+                                    (uiop:ensure-directory-pathname
+                                     location))
                               :system-clock nil
                               :initial-accepting-state reason)))
     (attach-to-system-clock reopened clock)

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -553,8 +553,7 @@ FAILED, carrying both conditions.
 
 A failure BETWEEN the two renames is NOT recovered here: the live data
 sits at the retired path and the live location may be missing or
-half-replaced; manual recovery is required.  That crash window is GH
-#171's territory.
+half-replaced; manual recovery is REPAIR-INTERRUPTED-SWAP (GH #171).
 
 Refuses a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH with
 DETACH-UNSUPPORTED-GRAPH-ERROR -- v1 scope, see that condition's

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -117,8 +117,8 @@ later open in this image, for the life of the process (GH #182)."
   clock)
 
 (defun journal-append (clock kind &rest plist)
-  "Append one lifecycle record.  KIND is :CREATE :DETACH :SWAP :ATTACH or
-:RETIRE.  Consumed by #170 and #171."
+  "Append one lifecycle record.  KIND is :CREATE :DETACH :SWAP :ATTACH
+:RETIRE :RETIRE-LIVE :RESTORE or :SWAP-ABORTED (the last four: GH #171)."
   (let ((record (list* :kind kind :epoch (clock-current-epoch clock) plist)))
     (with-recursive-lock-held ((system-clock-lock clock))
       (unless (system-clock-journal clock)

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -441,7 +441,11 @@ generation to track."
 
 (defun %restore-plan-entries (clock epoch rebuild)
   "One manifest entry per store CLOCK knows about, plus the refusal list
-for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS).
+for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS);
+REASONS is in reverse encounter order -- PUSH-accumulated, NOT
+NREVERSEd here -- so a caller adding more reasons (e.g. :INEXACT) can
+PUSH onto it and NREVERSE exactly once for a single deterministic order
+(GH #171).
 
 A store that needs a rename (:REWOUND or :REBUILT) but is not open
 under CLOCK right now is refused :NOT-OPEN -- RESTORE-SYSTEM can only
@@ -520,7 +524,7 @@ lands in the same RESTORE-REFUSED-ERROR as every other refusal."
                         :state-at (clock-current-epoch clock))
                   entries)))))
      by-store)
-    (values (nreverse entries) (nreverse reasons))))
+    (values (nreverse entries) reasons)))
 
 (defun plan-system-restore (clock epoch &key require-exact rebuild)
   "The manifest RESTORE-SYSTEM would act on for EPOCH, with no side
@@ -575,18 +579,20 @@ R1/R2)."
   (with-open-file (out (%manifest-file clock (getf manifest :at))
                        :direction :output :if-exists :supersede
                        :if-does-not-exist :create)
-    ;; *PACKAGE* KEYWORD: a store named by a non-keyword symbol still
-    ;; PRIN1s readably; *PRINT-READABLY* stays NIL, as the journal's
-    ;; own records already do (GH #171).
+    ;; *PACKAGE* COMMON-LISP, not KEYWORD: keywords keep their printed
+    ;; colon only when *package* is NOT the keyword package itself, and
+    ;; a bare T/NIL in an entry stays unqualified since CL is its home
+    ;; package; *PRINT-READABLY* stays NIL, as the journal's own
+    ;; records already do (GH #171).
     (let ((*print-readably* nil) (*print-pretty* nil)
-          (*package* (find-package :keyword)))
+          (*package* (find-package :common-lisp)))
       (prin1 manifest out)))
   manifest)
 
 (defun read-restore-manifest (path)
   "PATH's manifest plist.  *READ-EVAL* NIL: data, never code (GH #171)."
   (with-open-file (in path)
-    (let ((*read-eval* nil) (*package* (find-package :keyword)))
+    (let ((*read-eval* nil) (*package* (find-package :common-lisp)))
       (read in))))
 
 (defun %entry-with (entry &rest kvs)
@@ -601,18 +607,34 @@ holds elsewhere -- it never mutates the manifest (GH #171)."
                   unless (member k keys)
                     append (list k v)))))
 
+(defun %journal-named-paths (clock)
+  "EQUAL-hash set of every path a :RETIRED, :RETIRED-LIVE,
+:RESTORED-FROM or :FROM key names in any journal record -- including a
+rolled-back :RETIRE-LIVE-ABORTED's own path, which names no live
+directory but must still never be re-minted (GH #171)."
+  (let ((set (make-hash-table :test 'equal)))
+    (dolist (r (journal-records clock))
+      (dolist (key '(:retired :retired-live :restored-from :from))
+        (let ((v (getf r key)))
+          (when v (setf (gethash (%trimmed-namestring v) set) t)))))
+    set))
+
 (defun %retired-path-for (clock live)
-  "<LIVE>-retired-<E> for an E no directory already uses.  Two retiring
-events with no commit between them -- two RESTORE-SYSTEM calls in a row,
-or a rewind the cascade then rebuilds -- otherwise compute the SAME name
-and the second rename fails on the non-empty directory: consume epochs
-until the name is free, so the journal record's own :EPOCH still matches
-the name (GH #171)."
-  (loop for path = (format nil "~A-retired-~D" live
-                           (clock-current-epoch clock))
-        while (probe-file (uiop:ensure-directory-pathname path))
-        do (clock-next-epoch clock)
-        finally (return path)))
+  "<LIVE>-retired-<E> for an E no directory already uses AND no journal
+record already names.  Two retiring events with no commit between them
+-- two RESTORE-SYSTEM calls in a row, or a rewind the cascade then
+rebuilds -- otherwise compute the SAME name and the second rename fails
+on the non-empty directory: consume epochs until the name is free.  The
+journal check alone matters too: a rolled-back retry's aborted rename
+names a path with no directory at all, and re-minting it would alias a
+live :RETIRE-LIVE-ABORTED record onto a fresh attempt (GH #171)."
+  (let ((named (%journal-named-paths clock)))
+    (loop for path = (format nil "~A-retired-~D" live
+                             (clock-current-epoch clock))
+          while (or (probe-file (uiop:ensure-directory-pathname path))
+                    (gethash path named))
+          do (clock-next-epoch clock)
+          finally (return path))))
 
 (defun %close-quiesced (graph timeout)
   "SWAP-IN-SHADOW's close sequence: quiesce as :RESTORING, close with
@@ -799,8 +821,13 @@ Returns the manifest (GH #171, spec S3-S4)."
                                :state-at (clock-current-epoch clock)
                                :cascade-from source
                                :retired-live (getf extra :retired-live))))
+                      ;; Accumulate: a second rebuilt source dangling
+                      ;; into the same authored store must not erase
+                      ;; the first's count (GH #171).
                       (setf (nth pos entries)
-                            (%entry-with entry :dangling n))))))))))
+                            (%entry-with entry :dangling
+                                        (+ n (or (getf entry :dangling)
+                                                 0))))))))))))
     (setf (getf manifest :at) (clock-current-epoch clock))
     (%write-manifest clock manifest)
     (when (some (lambda (e) (or (eq (getf e :action) :rebuilt)

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -6,7 +6,7 @@
 ;;; docs/superpowers/specs/2026-08-23-restore-171-design.md
 
 (defstruct (generation (:constructor %make-generation))
-  store location retired swap-epoch journaled-p present-p policy)
+  store location retired swap-epoch live-from journaled-p present-p policy)
 
 (define-condition swap-record-missing-warning (warning)
   ;; The #212 shape: renames landed, JOURNAL-APPEND did not.  Tolerated,
@@ -133,22 +133,40 @@ RESTORE-SYSTEM call has since consumed by promoting it back to live
                                           :retired dir :swap-epoch epoch
                                           :journaled-p nil :present-p t))))
      locations)
-    (let ((gens nil))
+    (let ((all nil))
       (maphash (lambda (k gen)
-                 (unless (gethash k pruned)
-                   (setf (generation-policy gen)
-                         (if (generation-present-p gen)
-                             (store-recovery-policy (generation-retired gen))
-                             (store-recovery-policy (generation-location gen))))
-                   (push gen gens)))
+                 (declare (ignore k))
+                 (setf (generation-policy gen)
+                       (if (generation-present-p gen)
+                           (store-recovery-policy (generation-retired gen))
+                           (store-recovery-policy (generation-location gen))))
+                 (push gen all))
                by-retired)
-      (sort gens (lambda (a b)
-                   (let ((sa (princ-to-string (generation-store a)))
-                         (sb (princ-to-string (generation-store b))))
-                     (or (string< sa sb)
-                         (and (string= sa sb)
-                              (< (generation-swap-epoch a)
-                                 (generation-swap-epoch b))))))))))
+      (setf all
+            (sort all
+                  (lambda (a b)
+                    (let ((sa (princ-to-string (generation-store a)))
+                          (sb (princ-to-string (generation-store b))))
+                      (or (string< sa sb)
+                          (and (string= sa sb)
+                               (< (generation-swap-epoch a)
+                                  (generation-swap-epoch b))))))))
+      ;; LIVE-FROM spans the FULL per-store event order, including a
+      ;; generation a RESTORE has since consumed or PRUNE-RETIRED-
+      ;; GENERATIONS has deleted -- dropping such a generation from the
+      ;; returned list below must not erase what it taught its
+      ;; successor about when ITS OWN live interval began (GH #171,
+      ;; fix round 2; see %GENERATION-LIVE-AT).
+      (let ((prev-store nil) (prev-epoch nil))
+        (dolist (g all)
+          (setf (generation-live-from g)
+                (if (equal (generation-store g) prev-store)
+                    prev-epoch
+                    0))
+          (setf prev-store (generation-store g)
+                prev-epoch (generation-swap-epoch g))))
+      (remove-if (lambda (g) (gethash (generation-retired g) pruned))
+                 all))))
 
 (define-condition retention-required-error (error)
   ;; Authored data is never silently discarded inside the restore
@@ -227,10 +245,18 @@ returns what would go and touches nothing.  Each deletion journals
         0)))
 
 (defun %generation-live-at (gens epoch)
-  "Among GENS (one store, ascending SWAP-EPOCH), the generation that was
-live at EPOCH: the earliest with SWAP-EPOCH > EPOCH, or NIL when the
-current generation already was."
-  (find-if (lambda (g) (> (generation-swap-epoch g) epoch)) gens))
+  "Among GENS (one store), the generation whose live interval
+[LIVE-FROM, SWAP-EPOCH) contains EPOCH, or NIL when EPOCH is covered by
+the CURRENT generation instead (:UNCHANGED).  LIVE-FROM is the epoch
+the PREVIOUS retiring event for this store ended at -- 0 when there was
+none -- so this is interval containment, not just "earliest retired
+generation with SWAP-EPOCH > EPOCH": for a monotone swap chain the two
+rules agree exactly, but a RESTORE can promote an OLDER generation back
+to live, breaking monotonicity -- interval containment is what still
+gets it right (GH #171, fix round 2)."
+  (find-if (lambda (g) (and (<= (generation-live-from g) epoch)
+                            (< epoch (generation-swap-epoch g))))
+           gens))
 
 (defun %open-store-for-clock (name clock)
   "The graph registered as NAME if it is attached to CLOCK -- matched by

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -279,3 +279,183 @@ REQUIRE-EXACT), :INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's
     (list :restore t :requested epoch :at (clock-current-epoch clock)
           :clock (namestring (system-clock-location clock))
           :stores entries)))
+
+;;; Execution (Task 4): rename-based generation swap per store, a
+;;; caller-supplied REBUILD callback for derivable stores, cascade via
+;;; store tags, and a readable manifest file (spec S3/S4).
+
+(define-condition restore-inexact-warning (warning)
+  ;; Spec S4: a mixed manifest is the inconsistent instant S9 exists to
+  ;; record; this makes it impossible to miss.
+  ((manifest :initarg :manifest :reader restore-inexact-manifest))
+  (:report (lambda (c s)
+             (format s "Restore to ~D is not an exact instant:~{ ~A~} ~
+(GH #171)."
+                     (getf (restore-inexact-manifest c) :requested)
+                     (loop for e in (getf (restore-inexact-manifest c)
+                                          :stores)
+                           when (or (eq (getf e :action) :rebuilt)
+                                    (and (eq (getf e :action) :rewound)
+                                         (not (getf e :exact))))
+                             collect (format nil "~A=~A" (getf e :store)
+                                             (getf e :action)))))))
+
+(defun %manifest-file (clock epoch)
+  (merge-pathnames (format nil "restore-~D.manifest" epoch)
+                   (uiop:ensure-directory-pathname
+                    (system-clock-location clock))))
+
+(defun %write-manifest (clock manifest)
+  (with-open-file (out (%manifest-file clock (getf manifest :at))
+                       :direction :output :if-exists :supersede
+                       :if-does-not-exist :create)
+    (let ((*print-readably* nil) (*print-pretty* nil))
+      (prin1 manifest out)))
+  manifest)
+
+(defun read-restore-manifest (path)
+  "PATH's manifest plist.  *READ-EVAL* NIL: data, never code (GH #171)."
+  (with-open-file (in path)
+    (let ((*read-eval* nil)) (read in))))
+
+(defun %close-quiesced (graph timeout)
+  "SWAP-IN-SHADOW's close sequence: quiesce as :RESTORING, close with
+snapshot, no writer can land in the doomed generation."
+  (%quiesce-transaction-manager (transaction-manager graph) :restoring
+                                timeout)
+  (let ((*graph* graph) (*quiesced-store-closing-p* t))
+    (close-graph graph :snapshot-p t)))
+
+(defun %restore-one-store (clock name entry timeout)
+  "Rename live -> <loc>-retired-<Enow> (:RETIRE-LIVE), retained -> live
+(:RESTORE), reopen + attach.  Commit point is the second rename, as in
+%SWAP-IN-SHADOW-1: failure before it renames back and resignals; after
+it, reopens the restored generation and warns (GH #171)."
+  (let* ((graph (lookup-graph name))
+         (live (%trimmed-namestring (location graph)))
+         (from (getf entry :from))
+         (retired (format nil "~A-retired-~D" live
+                          (clock-current-epoch clock)))
+         (done nil))
+    (%close-quiesced graph timeout)
+    (handler-case
+        (progn
+          (%posix-rename live retired)
+          (journal-append clock :retire-live :store name :retired retired)
+          (%posix-rename from live)
+          (setq done t)
+          (journal-append clock :restore :store name :from from
+                          :retired-live retired
+                          :requested-epoch (getf entry :requested)
+                          :state-at (getf entry :state-at)
+                          :exact (getf entry :exact))
+          (%reopen-and-resume name live clock t))
+      (error (original)
+        (unless done
+          (ignore-errors (%posix-rename retired live)))
+        (handler-case (%reopen-and-resume name live clock t)
+          (error (recovery)
+            (error 'shadow-recovery-failed :original original
+                                           :recovery recovery)))
+        (if done
+            (warn 'swap-recovered-warning :original original)
+            (error original))))
+    (list :retired-live retired)))
+
+(defun %rebuild-one-store (clock name rebuild timeout)
+  "Retire the live generation (:RETIRE-LIVE), MAKE-GRAPH a fresh one at
+the same location with the same policy, run REBUILD on it, journal
+:RESTORE :mode :rebuilt."
+  (let* ((graph (lookup-graph name))
+         (live (%trimmed-namestring (location graph)))
+         (policy (store-recovery-policy live))
+         (retired (format nil "~A-retired-~D" live
+                          (clock-current-epoch clock))))
+    (%close-quiesced graph timeout)
+    (%posix-rename live retired)
+    (journal-append clock :retire-live :store name :retired retired)
+    (let ((fresh (make-graph name (concatenate 'string live "/")
+                             :system-clock clock :recovery-policy policy)))
+      (funcall rebuild name fresh)
+      (journal-append clock :restore :store name :mode :rebuilt
+                      :retired-live retired)
+      (list :retired-live retired))))
+
+(defun %dangling-into (store-id exclude)
+  "((STORE-NAME . COUNT) ...) of edges in open clocked stores other than
+EXCLUDE whose FROM or TO carries STORE-ID's tag (spec R5)."
+  (let ((result nil))
+    (maphash
+     (lambda (name graph)
+       (when (and (typep graph 'graph) (graph-system-clock graph)
+                  (not (member name exclude)))
+         (let ((n 0))
+           (map-edges (lambda (e)
+                        (when (or (eql (id-store-tag (from e)) store-id)
+                                  (eql (id-store-tag (to e)) store-id))
+                          (incf n)))
+                      graph)
+           (when (> n 0) (push (cons name n) result)))))
+     *graphs*)
+    result))
+
+(defun restore-system (clock epoch &key require-exact rebuild (timeout 60))
+  "Execute PLAN-SYSTEM-RESTORE's manifest for EPOCH: every refusal fires
+before any rename.  Rewinds first, then rebuilds, then cascades: a
+:DERIVABLE store holding edges into a rebuilt store is rebuilt in turn
+(fixpoint); an :AUTHORED one is left alone and reported :DANGLING N.
+Writes <clock-dir>/restore-<Enow>.manifest and signals RESTORE-INEXACT-
+WARNING when any store is rebuilt or inexact.  Returns the manifest
+(GH #171, spec S3-S4)."
+  (let* ((manifest (plan-system-restore clock epoch
+                                        :require-exact require-exact
+                                        :rebuild rebuild))
+         (entries (getf manifest :stores))
+         (rebuilt nil))
+    ;; NOTE: (SETF (GETF entry :NEW-KEY) v) on a key ENTRIES's element
+    ;; does not already carry rebinds the local loop/FIND variable, not
+    ;; the cons ENTRIES holds -- it never mutates the manifest.  Every
+    ;; branch below therefore replaces the element positionally via
+    ;; (SETF (NTH pos entries) ...) instead (GH #171).
+    (dolist (e entries)
+      (when (eq (getf e :action) :rewound)
+        (let* ((pos (position (getf e :store) entries
+                              :key (lambda (x) (getf x :store))))
+               (extra (%restore-one-store
+                      clock (getf e :store)
+                      (list* :requested epoch e) timeout)))
+          (setf (nth pos entries)
+                (list* :retired-live (getf extra :retired-live) e)))))
+    (dolist (e entries)
+      (when (eq (getf e :action) :rebuilt)
+        (%rebuild-one-store clock (getf e :store) rebuild timeout)
+        (push (getf e :store) rebuilt)))
+    ;; Cascade to a fixpoint over derivable dependents.
+    (let ((queue (copy-list rebuilt)))
+      (loop while queue do
+        (let* ((source (pop queue))
+               (tag (store-registry-id-for source)))
+          (loop for (name . n) in (%dangling-into tag rebuilt) do
+            (let* ((pos (position name entries
+                                  :key (lambda (x) (getf x :store))))
+                   (entry (nth pos entries)))
+              (if (eq (store-recovery-policy
+                       (location (lookup-graph name)))
+                      :derivable)
+                  (progn
+                    (%rebuild-one-store clock name rebuild timeout)
+                    (push name rebuilt) (push name queue)
+                    (setf (nth pos entries)
+                          (list* :action :rebuilt :exact nil
+                                 :state-at (clock-current-epoch clock)
+                                 :cascade-from source entry)))
+                  (setf (nth pos entries)
+                        (list* :dangling n entry))))))))
+    (setf (getf manifest :at) (clock-current-epoch clock))
+    (%write-manifest clock manifest)
+    (when (some (lambda (e) (or (eq (getf e :action) :rebuilt)
+                                (and (eq (getf e :action) :rewound)
+                                     (not (getf e :exact)))))
+                entries)
+      (warn 'restore-inexact-warning :manifest manifest))
+    manifest))

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -13,8 +13,8 @@
   ;; like #191's torn tail -- the directory name carries the epoch.
   ((path :initarg :path :reader swap-record-missing-path))
   (:report (lambda (c s)
-             (format s "Retired generation ~A has no :SWAP journal ~
-record (GH #212); its epoch is taken from the directory name."
+             (format s "Retired generation ~A has no :SWAP or :RETIRE-LIVE ~
+journal record (GH #212); its epoch is taken from the directory name."
                      (swap-record-missing-path c)))))
 
 (defun %retired-suffix-epoch (name live-name)
@@ -46,33 +46,53 @@ record (GH #212); its epoch is taken from the directory name."
          (pos (search "-retired-" s :from-end t)))
     (if pos (subseq s 0 pos) s)))
 
-(defun %swap-records (clock)
-  (remove :swap (journal-records clock)
-          :key (lambda (r) (getf r :kind)) :test-not #'eq))
+(defun %retired-directory-records (clock)
+  "Journal records that name a still-standing <live>-retired-<E> dir:
+:SWAP (a completed shadow promotion) and :RETIRE-LIVE (RESTORE-SYSTEM
+retiring the live generation before a rewind/rebuild) -- both carry
+:STORE/:RETIRED/:EPOCH.  A :RETIRE-LIVE whose second rename then failed
+was rolled back and is excluded via its :RETIRE-LIVE-ABORTED record
+(GH #171)."
+  (let ((aborted (make-hash-table :test 'equal)))
+    (dolist (r (journal-records clock))
+      (when (eq (getf r :kind) :retire-live-aborted)
+        (setf (gethash (%trimmed-namestring (getf r :retired)) aborted) t)))
+    (remove-if (lambda (r)
+                 (or (not (member (getf r :kind) '(:swap :retire-live)))
+                     (gethash (%trimmed-namestring (getf r :retired))
+                              aborted)))
+               (journal-records clock))))
 
 (defun %pruned-retired-paths (clock)
-  "Paths PRUNE-RETIRED-GENERATIONS has already deleted and journaled
-:RETIRE for -- distinct from a :SWAP record whose directory vanished
-some other way, which stays listed PRESENT-P NIL per spec R4 (GH #171)."
+  "Paths omitted from RETIRED-GENERATIONS entirely, not merely marked
+absent: ones PRUNE-RETIRED-GENERATIONS deleted (:RETIRE), and ones a
+RESTORE-SYSTEM call has since CONSUMED by promoting them back to live
+(:RESTORE :FROM) -- both leave the pool of restorable generations the
+same way (GH #171)."
   (let ((set (make-hash-table :test 'equal)))
     (dolist (r (journal-records clock))
-      (when (eq (getf r :kind) :retire)
-        (setf (gethash (%trimmed-namestring (getf r :retired)) set) t)))
+      (case (getf r :kind)
+        (:retire
+         (setf (gethash (%trimmed-namestring (getf r :retired)) set) t))
+        (:restore
+         (when (getf r :from)
+           (setf (gethash (%trimmed-namestring (getf r :from)) set) t)))))
     set))
 
 (defun retired-generations (clock)
   "Every retired generation known to CLOCK's system, as GENERATION
 structs sorted by store then SWAP-EPOCH.  Filesystem is authoritative:
-a directory without a :SWAP record is listed JOURNALED-P NIL and
-warned (SWAP-RECORD-MISSING-WARNING); a record without a directory is
-listed PRESENT-P NIL (GH #171, spec R4).  A generation PRUNE-RETIRED-
-GENERATIONS has already deleted (journaled :RETIRE) is omitted
-entirely, not merely marked absent."
+a directory without a joining :SWAP/:RETIRE-LIVE record is listed
+JOURNALED-P NIL and warned (SWAP-RECORD-MISSING-WARNING); a record
+without a directory is listed PRESENT-P NIL (GH #171, spec R4).  A
+generation PRUNE-RETIRED-GENERATIONS has deleted (:RETIRE) or a
+RESTORE-SYSTEM call has since consumed by promoting it back to live
+(:RESTORE :FROM) is omitted entirely, not merely marked absent."
   (let ((by-retired (make-hash-table :test 'equal))
         (locations (make-hash-table :test 'equal))
         (pruned (%pruned-retired-paths clock)))
     ;; Journal first: records name the live locations to scan.
-    (dolist (r (%swap-records clock))
+    (dolist (r (%retired-directory-records clock))
       (let ((retired (%trimmed-namestring (getf r :retired))))
         (setf (gethash (%live-location-of-retired retired) locations)
               (getf r :store))
@@ -212,32 +232,65 @@ live at EPOCH: the earliest with SWAP-EPOCH > EPOCH, or NIL when the
 current generation already was."
   (find-if (lambda (g) (> (generation-swap-epoch g) epoch)) gens))
 
+(defun %open-store-for-clock (name clock)
+  "The graph registered as NAME if it is attached to CLOCK -- matched by
+SYSTEM-CLOCK-LOCATION string, the comparison every scan in this file
+uses -- else NIL (GH #171)."
+  (let ((graph (lookup-graph name)))
+    (when (and graph (typep graph 'graph) (graph-system-clock graph)
+               (string= (%trimmed-namestring
+                         (system-clock-location (graph-system-clock graph)))
+                        (%trimmed-namestring (system-clock-location clock))))
+      graph)))
+
+(defun %supported-for-restore-p (graph)
+  "NIL when GRAPH is a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH -- v1 scope,
+same refusal %CHECK-DETACH-SUPPORTED enforces for DETACH-STORE/SHADOW-
+STORE/SWAP-IN-SHADOW (GH #171)."
+  (handler-case
+      (progn (%check-detach-supported graph 'plan-system-restore) t)
+    (detach-unsupported-graph-error () nil)))
+
 (defun %restore-plan-entries (clock epoch rebuild)
   "One manifest entry per store CLOCK knows about, plus the refusal list
-for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS)."
+for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS).
+
+A store that needs a rename (:REWOUND or :REBUILT) but is not open
+under CLOCK right now is refused :NOT-OPEN -- RESTORE-SYSTEM can only
+quiesce and rename a live, attached graph, and this must be caught
+before ANY store is renamed, not partway through a multi-store restore
+(GH #171).  Likewise a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH target is
+refused :UNSUPPORTED-GRAPH rather than propagating
+DETACH-UNSUPPORTED-GRAPH-ERROR bare, so it lands in the same
+RESTORE-REFUSED-ERROR as every other refusal."
   (let ((by-store (make-hash-table :test 'equal))
         (entries nil) (reasons nil))
     (dolist (g (retired-generations clock))
       (push g (gethash (generation-store g) by-store)))
     ;; Open clocked stores with no generations at all are :UNCHANGED.
     (maphash (lambda (name graph)
-               (when (and (typep graph 'graph)
-                          (graph-system-clock graph)
-                          (string= (%trimmed-namestring
-                                    (system-clock-location
-                                     (graph-system-clock graph)))
-                                   (%trimmed-namestring
-                                    (system-clock-location clock))))
+               (declare (ignore graph))
+               (when (%open-store-for-clock name clock)
                  (unless (nth-value 1 (gethash name by-store))
                    (setf (gethash name by-store) nil))))
              *graphs*)
     (maphash
      (lambda (store gens)
        (let* ((gens (sort (copy-list gens) #'< :key #'generation-swap-epoch))
-              (target (%generation-live-at gens epoch)))
+              (target (%generation-live-at gens epoch))
+              (open-graph (and target (%open-store-for-clock store clock))))
          (cond
            ((null target)
             (push (list :store store :action :unchanged) entries))
+           ((null open-graph)
+            (push (cons store :not-open) reasons)
+            (push (list :store store :action :refused :reason :not-open)
+                  entries))
+           ((not (%supported-for-restore-p open-graph))
+            (push (cons store :unsupported-graph) reasons)
+            (push (list :store store :action :refused
+                        :reason :unsupported-graph)
+                  entries))
            ((generation-present-p target)
             (let ((e0 (%generation-state-epoch (generation-retired target))))
               (push (list :store store :action :rewound
@@ -263,9 +316,11 @@ for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS)."
 (defun plan-system-restore (clock epoch &key require-exact rebuild)
   "The manifest RESTORE-SYSTEM would act on for EPOCH, with no side
 effects.  Signals RESTORE-REFUSED-ERROR listing every (STORE . REASON):
-:AUTHORED-GENERATION-MISSING, :NO-REBUILD, :INEXACT (only under
-REQUIRE-EXACT), :INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's
-(lambda (name graph)) loader for :DERIVABLE stores (GH #171, spec R1/R2)."
+:AUTHORED-GENERATION-MISSING, :NO-REBUILD, :NOT-OPEN (a store needing a
+rename is not open under CLOCK), :UNSUPPORTED-GRAPH (a MASTER-GRAPH/
+SLAVE-GRAPH/PEER-GRAPH target), :INEXACT (only under REQUIRE-EXACT),
+:INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's (lambda (name
+graph)) loader for :DERIVABLE stores (GH #171, spec R1/R2)."
   (multiple-value-bind (entries reasons)
       (%restore-plan-entries clock epoch rebuild)
     (when require-exact
@@ -309,14 +364,31 @@ REQUIRE-EXACT), :INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's
   (with-open-file (out (%manifest-file clock (getf manifest :at))
                        :direction :output :if-exists :supersede
                        :if-does-not-exist :create)
-    (let ((*print-readably* nil) (*print-pretty* nil))
+    ;; *PACKAGE* KEYWORD: a store named by a non-keyword symbol still
+    ;; PRIN1s readably; *PRINT-READABLY* stays NIL, as the journal's
+    ;; own records already do (GH #171).
+    (let ((*print-readably* nil) (*print-pretty* nil)
+          (*package* (find-package :keyword)))
       (prin1 manifest out)))
   manifest)
 
 (defun read-restore-manifest (path)
   "PATH's manifest plist.  *READ-EVAL* NIL: data, never code (GH #171)."
   (with-open-file (in path)
-    (let ((*read-eval* nil)) (read in))))
+    (let ((*read-eval* nil) (*package* (find-package :keyword)))
+      (read in))))
+
+(defun %entry-with (entry &rest kvs)
+  "ENTRY with each key in KVS applied, REPLACING (not shadowing) any
+existing value: keys in KVS are stripped from ENTRY first, then KVS is
+prepended.  Plain (SETF (GETF entry key) v) on a key ENTRY doesn't
+already carry rebinds the local variable, not the cons ENTRIES still
+holds elsewhere -- it never mutates the manifest (GH #171)."
+  (let ((keys (loop for (k nil) on kvs by #'cddr collect k)))
+    (append kvs
+            (loop for (k v) on entry by #'cddr
+                  unless (member k keys)
+                    append (list k v)))))
 
 (defun %close-quiesced (graph timeout)
   "SWAP-IN-SHADOW's close sequence: quiesce as :RESTORING, close with
@@ -330,18 +402,26 @@ snapshot, no writer can land in the doomed generation."
   "Rename live -> <loc>-retired-<Enow> (:RETIRE-LIVE), retained -> live
 (:RESTORE), reopen + attach.  Commit point is the second rename, as in
 %SWAP-IN-SHADOW-1: failure before it renames back and resignals; after
-it, reopens the restored generation and warns (GH #171)."
+it, reopens the restored generation and warns (GH #171).
+
+If :RETIRE-LIVE was already journaled when the SECOND rename fails, the
+rename-back is not enough on its own -- the journal still claims the
+live generation moved to RETIRED, which it no longer has.  Once the
+rename-back itself succeeds, a :RETIRE-LIVE-ABORTED record cancels it
+(RETIRED-GENERATIONS' journal-join excludes any path a
+:RETIRE-LIVE-ABORTED names)."
   (let* ((graph (lookup-graph name))
          (live (%trimmed-namestring (location graph)))
          (from (getf entry :from))
          (retired (format nil "~A-retired-~D" live
                           (clock-current-epoch clock)))
-         (done nil))
+         (done nil) (retire-live-ok nil))
     (%close-quiesced graph timeout)
     (handler-case
         (progn
           (%posix-rename live retired)
           (journal-append clock :retire-live :store name :retired retired)
+          (setq retire-live-ok t)
           (%posix-rename from live)
           (setq done t)
           (journal-append clock :restore :store name :from from
@@ -352,7 +432,12 @@ it, reopens the restored generation and warns (GH #171)."
           (%reopen-and-resume name live clock t))
       (error (original)
         (unless done
-          (ignore-errors (%posix-rename retired live)))
+          (let ((rolled-back
+                  (ignore-errors (%posix-rename retired live) t)))
+            (when (and retire-live-ok rolled-back)
+              (ignore-errors
+               (journal-append clock :retire-live-aborted
+                               :store name :retired retired)))))
         (handler-case (%reopen-and-resume name live clock t)
           (error (recovery)
             (error 'shadow-recovery-failed :original original
@@ -364,39 +449,71 @@ it, reopens the restored generation and warns (GH #171)."
 
 (defun %rebuild-one-store (clock name rebuild timeout)
   "Retire the live generation (:RETIRE-LIVE), MAKE-GRAPH a fresh one at
-the same location with the same policy, run REBUILD on it, journal
-:RESTORE :mode :rebuilt."
+the same location, run REBUILD on it, journal :RESTORE :MODE :REBUILT.
+
+Only :RECOVERY-POLICY carries over to the fresh MAKE-GRAPH call (v1
+scope) -- :INDEX-BACKEND, :BUFFER-POOL-SIZE, spatial precision and
+bucket counts do NOT; a caller relying on any of those must reopen and
+reconfigure the rebuilt store itself afterward.
+
+A failure in the rename or the :RETIRE-LIVE journal record itself is
+rolled back: the live directory is renamed back and reopened fully
+accepting before the original error is resignalled -- nothing changed.
+A failure inside MAKE-GRAPH or REBUILD is NOT rolled back: the fresh,
+possibly half-populated generation is left live, its predecessor
+retired at :RETIRED-LIVE -- a :RESTORE :MODE :REBUILT :FAILED T journal
+record names both before the original error is resignalled, so the
+journal says what actually happened (GH #171)."
   (let* ((graph (lookup-graph name))
          (live (%trimmed-namestring (location graph)))
          (policy (store-recovery-policy live))
          (retired (format nil "~A-retired-~D" live
                           (clock-current-epoch clock))))
     (%close-quiesced graph timeout)
-    (%posix-rename live retired)
-    (journal-append clock :retire-live :store name :retired retired)
-    (let ((fresh (make-graph name (concatenate 'string live "/")
-                             :system-clock clock :recovery-policy policy)))
-      (funcall rebuild name fresh)
-      (journal-append clock :restore :store name :mode :rebuilt
-                      :retired-live retired)
-      (list :retired-live retired))))
+    (handler-case
+        (progn
+          (%posix-rename live retired)
+          (journal-append clock :retire-live :store name :retired retired))
+      (error (original)
+        (ignore-errors (%posix-rename retired live))
+        (handler-case (%reopen-and-resume name live clock t)
+          (error (recovery)
+            (error 'shadow-recovery-failed :original original
+                                           :recovery recovery)))
+        (error original)))
+    (handler-case
+        (let ((fresh (make-graph name (concatenate 'string live "/")
+                                 :system-clock clock
+                                 :recovery-policy policy)))
+          (funcall rebuild name fresh)
+          (journal-append clock :restore :store name :mode :rebuilt
+                          :retired-live retired)
+          (list :retired-live retired))
+      (error (original)
+        (ignore-errors
+         (journal-append clock :restore :store name :mode :rebuilt
+                         :failed t :retired-live retired))
+        (error original)))))
 
-(defun %dangling-into (store-id exclude)
-  "((STORE-NAME . COUNT) ...) of edges in open clocked stores other than
-EXCLUDE whose FROM or TO carries STORE-ID's tag (spec R5)."
+(defun %dangling-into (clock store-id exclude)
+  "((STORE-NAME . COUNT) ...) of edges in stores open under CLOCK, other
+than EXCLUDE, whose FROM or TO carries STORE-ID's tag (spec R5).  A NIL
+STORE-ID (a name STORE-REGISTRY-ID-FOR has never interned) matches
+nothing, rather than every legacy v5 id (GH #171)."
   (let ((result nil))
-    (maphash
-     (lambda (name graph)
-       (when (and (typep graph 'graph) (graph-system-clock graph)
-                  (not (member name exclude)))
-         (let ((n 0))
-           (map-edges (lambda (e)
-                        (when (or (eql (id-store-tag (from e)) store-id)
-                                  (eql (id-store-tag (to e)) store-id))
-                          (incf n)))
-                      graph)
-           (when (> n 0) (push (cons name n) result)))))
-     *graphs*)
+    (when store-id
+      (maphash
+       (lambda (name graph)
+         (when (and (not (member name exclude))
+                    (%open-store-for-clock name clock))
+           (let ((n 0))
+             (map-edges (lambda (e)
+                          (when (or (eql (id-store-tag (from e)) store-id)
+                                    (eql (id-store-tag (to e)) store-id))
+                            (incf n)))
+                        graph)
+             (when (> n 0) (push (cons name n) result)))))
+       *graphs*))
     result))
 
 (defun restore-system (clock epoch &key require-exact rebuild (timeout 60))
@@ -404,19 +521,16 @@ EXCLUDE whose FROM or TO carries STORE-ID's tag (spec R5)."
 before any rename.  Rewinds first, then rebuilds, then cascades: a
 :DERIVABLE store holding edges into a rebuilt store is rebuilt in turn
 (fixpoint); an :AUTHORED one is left alone and reported :DANGLING N.
-Writes <clock-dir>/restore-<Enow>.manifest and signals RESTORE-INEXACT-
-WARNING when any store is rebuilt or inexact.  Returns the manifest
-(GH #171, spec S3-S4)."
+:RECOVERY-POLICY is the only option %REBUILD-ONE-STORE's MAKE-GRAPH call
+carries forward for a rebuilt store (v1 scope; see its docstring for
+what does not survive).  Writes <clock-dir>/restore-<Enow>.manifest and
+signals RESTORE-INEXACT-WARNING when any store is rebuilt or inexact.
+Returns the manifest (GH #171, spec S3-S4)."
   (let* ((manifest (plan-system-restore clock epoch
                                         :require-exact require-exact
                                         :rebuild rebuild))
          (entries (getf manifest :stores))
          (rebuilt nil))
-    ;; NOTE: (SETF (GETF entry :NEW-KEY) v) on a key ENTRIES's element
-    ;; does not already carry rebinds the local loop/FIND variable, not
-    ;; the cons ENTRIES holds -- it never mutates the manifest.  Every
-    ;; branch below therefore replaces the element positionally via
-    ;; (SETF (NTH pos entries) ...) instead (GH #171).
     (dolist (e entries)
       (when (eq (getf e :action) :rewound)
         (let* ((pos (position (getf e :store) entries
@@ -425,32 +539,46 @@ WARNING when any store is rebuilt or inexact.  Returns the manifest
                       clock (getf e :store)
                       (list* :requested epoch e) timeout)))
           (setf (nth pos entries)
-                (list* :retired-live (getf extra :retired-live) e)))))
+                (%entry-with e :retired-live (getf extra :retired-live))))))
     (dolist (e entries)
       (when (eq (getf e :action) :rebuilt)
-        (%rebuild-one-store clock (getf e :store) rebuild timeout)
-        (push (getf e :store) rebuilt)))
-    ;; Cascade to a fixpoint over derivable dependents.
+        (let* ((pos (position (getf e :store) entries
+                              :key (lambda (x) (getf x :store))))
+               (extra (%rebuild-one-store
+                      clock (getf e :store) rebuild timeout)))
+          (setf (nth pos entries)
+                (%entry-with e :retired-live (getf extra :retired-live)))
+          (push (getf e :store) rebuilt))))
+    ;; Cascade to a fixpoint over derivable dependents.  A store already
+    ;; handled as :REWOUND above can still land here and get REBUILT: its
+    ;; rewound generation may hold edges into a store that was just
+    ;; rebuilt, whose pre-rebuild content no longer exists -- R5 treats
+    ;; that as dangling regardless of how THIS store was restored, so
+    ;; overwriting its action is correct, not a bug (GH #171).
     (let ((queue (copy-list rebuilt)))
       (loop while queue do
         (let* ((source (pop queue))
                (tag (store-registry-id-for source)))
-          (loop for (name . n) in (%dangling-into tag rebuilt) do
-            (let* ((pos (position name entries
-                                  :key (lambda (x) (getf x :store))))
-                   (entry (nth pos entries)))
-              (if (eq (store-recovery-policy
-                       (location (lookup-graph name)))
-                      :derivable)
-                  (progn
-                    (%rebuild-one-store clock name rebuild timeout)
-                    (push name rebuilt) (push name queue)
-                    (setf (nth pos entries)
-                          (list* :action :rebuilt :exact nil
-                                 :state-at (clock-current-epoch clock)
-                                 :cascade-from source entry)))
-                  (setf (nth pos entries)
-                        (list* :dangling n entry))))))))
+          (loop for (name . n) in (%dangling-into clock tag rebuilt) do
+            (let ((pos (position name entries
+                                 :key (lambda (x) (getf x :store)))))
+              (when pos
+                (let ((entry (nth pos entries)))
+                  (if (eq (store-recovery-policy
+                           (location (lookup-graph name)))
+                          :derivable)
+                      (let ((extra (%rebuild-one-store
+                                    clock name rebuild timeout)))
+                        (push name rebuilt) (push name queue)
+                        (setf (nth pos entries)
+                              (%entry-with
+                               entry
+                               :action :rebuilt :exact nil
+                               :state-at (clock-current-epoch clock)
+                               :cascade-from source
+                               :retired-live (getf extra :retired-live))))
+                      (setf (nth pos entries)
+                            (%entry-with entry :dangling n))))))))))
     (setf (getf manifest :at) (clock-current-epoch clock))
     (%write-manifest clock manifest)
     (when (some (lambda (e) (or (eq (getf e :action) :rebuilt)

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -50,14 +50,27 @@ record (GH #212); its epoch is taken from the directory name."
   (remove :swap (journal-records clock)
           :key (lambda (r) (getf r :kind)) :test-not #'eq))
 
+(defun %pruned-retired-paths (clock)
+  "Paths PRUNE-RETIRED-GENERATIONS has already deleted and journaled
+:RETIRE for -- distinct from a :SWAP record whose directory vanished
+some other way, which stays listed PRESENT-P NIL per spec R4 (GH #171)."
+  (let ((set (make-hash-table :test 'equal)))
+    (dolist (r (journal-records clock))
+      (when (eq (getf r :kind) :retire)
+        (setf (gethash (%trimmed-namestring (getf r :retired)) set) t)))
+    set))
+
 (defun retired-generations (clock)
   "Every retired generation known to CLOCK's system, as GENERATION
 structs sorted by store then SWAP-EPOCH.  Filesystem is authoritative:
 a directory without a :SWAP record is listed JOURNALED-P NIL and
 warned (SWAP-RECORD-MISSING-WARNING); a record without a directory is
-listed PRESENT-P NIL (GH #171, spec R4)."
+listed PRESENT-P NIL (GH #171, spec R4).  A generation PRUNE-RETIRED-
+GENERATIONS has already deleted (journaled :RETIRE) is omitted
+entirely, not merely marked absent."
   (let ((by-retired (make-hash-table :test 'equal))
-        (locations (make-hash-table :test 'equal)))
+        (locations (make-hash-table :test 'equal))
+        (pruned (%pruned-retired-paths clock)))
     ;; Journal first: records name the live locations to scan.
     (dolist (r (%swap-records clock))
       (let ((retired (%trimmed-namestring (getf r :retired))))
@@ -102,12 +115,12 @@ listed PRESENT-P NIL (GH #171, spec R4)."
      locations)
     (let ((gens nil))
       (maphash (lambda (k gen)
-                 (declare (ignore k))
-                 (setf (generation-policy gen)
-                       (if (generation-present-p gen)
-                           (store-recovery-policy (generation-retired gen))
-                           (store-recovery-policy (generation-location gen))))
-                 (push gen gens))
+                 (unless (gethash k pruned)
+                   (setf (generation-policy gen)
+                         (if (generation-present-p gen)
+                             (store-recovery-policy (generation-retired gen))
+                             (store-recovery-policy (generation-location gen))))
+                   (push gen gens)))
                by-retired)
       (sort gens (lambda (a b)
                    (let ((sa (princ-to-string (generation-store a)))
@@ -116,3 +129,56 @@ listed PRESENT-P NIL (GH #171, spec R4)."
                          (and (string= sa sb)
                               (< (generation-swap-epoch a)
                                  (generation-swap-epoch b))))))))))
+
+(define-condition retention-required-error (error)
+  ;; Authored data is never silently discarded inside the restore
+  ;; window (spec R3, §9.2).
+  ((generations :initarg :generations
+                :reader retention-required-generations))
+  (:report (lambda (c s)
+             (format s "Refusing to prune ~D :AUTHORED generation~:P still ~
+inside the restore window:~{ ~A~} (GH #171)."
+                     (length (retention-required-generations c))
+                     (mapcar #'generation-retired
+                             (retention-required-generations c))))))
+
+(defun %retired-suffix-p (path)
+  "The deletion gate for retired generations, mirroring %SHADOW-SUFFIX-P."
+  (and (search "-retired-" (%trimmed-namestring path)) t))
+
+(defun %delete-generation (clock gen)
+  (uiop:delete-directory-tree
+   (uiop:ensure-directory-pathname (generation-retired gen))
+   :validate #'%retired-suffix-p :if-does-not-exist :ignore)
+  (journal-append clock :retire
+                  :store (generation-store gen)
+                  :retired (generation-retired gen)
+                  :swap-epoch (generation-swap-epoch gen)))
+
+(defun prune-retired-generations (clock floor &key discard-derivable dry-run)
+  "Delete retired generations the restore window no longer covers: those
+with SWAP-EPOCH <= FLOOR.  Above FLOOR an :AUTHORED generation is
+refused by name (RETENTION-REQUIRED-ERROR, before anything is deleted);
+a :DERIVABLE one is deleted only with DISCARD-DERIVABLE.  DRY-RUN
+returns what would go and touches nothing.  Each deletion journals
+:RETIRE (GH #171, spec R3)."
+  (let* ((gens (remove-if-not #'generation-present-p
+                              (retired-generations clock)))
+         (blocked (remove-if-not
+                   (lambda (g) (and (> (generation-swap-epoch g) floor)
+                                    (eq (generation-policy g) :authored)))
+                   gens))
+         (victims (remove-if-not
+                   (lambda (g)
+                     (or (<= (generation-swap-epoch g) floor)
+                         (and discard-derivable
+                              (eq (generation-policy g) :derivable))))
+                   gens)))
+    ;; A call that deletes nothing but was blocked by authored
+    ;; generations is the refusal case; skipping authored ones above
+    ;; FLOOR while pruning below it returns normally (GH #171).
+    (when (and blocked (null victims))
+      (error 'retention-required-error :generations blocked))
+    (unless dry-run
+      (dolist (g victims) (%delete-generation clock g)))
+    victims))

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -182,3 +182,100 @@ returns what would go and touches nothing.  Each deletion journals
     (unless dry-run
       (dolist (g victims) (%delete-generation clock g)))
     victims))
+
+(define-condition restore-refused-error (error)
+  ;; Every refusal fires here, before any rename (spec §3).
+  ((reasons :initarg :reasons :reader restore-refused-reasons)
+   (epoch :initarg :epoch :reader restore-refused-epoch))
+  (:report (lambda (c s)
+             (format s "Restore to epoch ~D refused:~{ ~A~} (GH #171)."
+                     (restore-refused-epoch c)
+                     (mapcar (lambda (r) (format nil "~A=~A" (car r) (cdr r)))
+                             (restore-refused-reasons c))))))
+
+(defun %generation-state-epoch (retired)
+  "The last epoch committed into RETIRED, from its transaction-id.dat;
+0 when absent.  The closed generation's E0 (spec R2)."
+  (let ((file (merge-pathnames "transaction-id.dat"
+                               (uiop:ensure-directory-pathname retired)))
+        (buf (make-byte-vector 8)))
+    (if (probe-file file)
+        (with-open-file (in file :element-type '(unsigned-byte 8))
+          (unless (= 8 (read-sequence buf in))
+            (error "Short read on ~A" file))
+          (deserialize-uint64 buf 0))
+        0)))
+
+(defun %generation-live-at (gens epoch)
+  "Among GENS (one store, ascending SWAP-EPOCH), the generation that was
+live at EPOCH: the earliest with SWAP-EPOCH > EPOCH, or NIL when the
+current generation already was."
+  (find-if (lambda (g) (> (generation-swap-epoch g) epoch)) gens))
+
+(defun %restore-plan-entries (clock epoch rebuild)
+  "One manifest entry per store CLOCK knows about, plus the refusal list
+for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS)."
+  (let ((by-store (make-hash-table :test 'equal))
+        (entries nil) (reasons nil))
+    (dolist (g (retired-generations clock))
+      (push g (gethash (generation-store g) by-store)))
+    ;; Open clocked stores with no generations at all are :UNCHANGED.
+    (maphash (lambda (name graph)
+               (when (and (typep graph 'graph)
+                          (graph-system-clock graph)
+                          (string= (%trimmed-namestring
+                                    (system-clock-location
+                                     (graph-system-clock graph)))
+                                   (%trimmed-namestring
+                                    (system-clock-location clock))))
+                 (unless (nth-value 1 (gethash name by-store))
+                   (setf (gethash name by-store) nil))))
+             *graphs*)
+    (maphash
+     (lambda (store gens)
+       (let* ((gens (sort (copy-list gens) #'< :key #'generation-swap-epoch))
+              (target (%generation-live-at gens epoch)))
+         (cond
+           ((null target)
+            (push (list :store store :action :unchanged) entries))
+           ((generation-present-p target)
+            (let ((e0 (%generation-state-epoch (generation-retired target))))
+              (push (list :store store :action :rewound
+                          :state-at e0 :exact (<= e0 epoch)
+                          :from (generation-retired target)
+                          :swap-epoch (generation-swap-epoch target))
+                    entries)))
+           ((eq (generation-policy target) :authored)
+            (push (cons store :authored-generation-missing) reasons)
+            (push (list :store store :action :refused
+                        :reason :authored-generation-missing) entries))
+           ((null rebuild)
+            (push (cons store :no-rebuild) reasons)
+            (push (list :store store :action :refused :reason :no-rebuild)
+                  entries))
+           (t
+            (push (list :store store :action :rebuilt :exact nil
+                        :state-at (clock-current-epoch clock))
+                  entries)))))
+     by-store)
+    (values (nreverse entries) (nreverse reasons))))
+
+(defun plan-system-restore (clock epoch &key require-exact rebuild)
+  "The manifest RESTORE-SYSTEM would act on for EPOCH, with no side
+effects.  Signals RESTORE-REFUSED-ERROR listing every (STORE . REASON):
+:AUTHORED-GENERATION-MISSING, :NO-REBUILD, :INEXACT (only under
+REQUIRE-EXACT), :INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's
+(lambda (name graph)) loader for :DERIVABLE stores (GH #171, spec R1/R2)."
+  (multiple-value-bind (entries reasons)
+      (%restore-plan-entries clock epoch rebuild)
+    (when require-exact
+      (dolist (e entries)
+        (when (and (eq (getf e :action) :rewound) (not (getf e :exact)))
+          (push (cons (getf e :store) :inexact) reasons))))
+    (when reasons
+      (error 'restore-refused-error :reasons (nreverse reasons) :epoch epoch))
+    ;; :RESTORE T marks the manifest kind; without a paired value the
+    ;; list is an odd-length plist and GETF signals malformed (GH #171).
+    (list :restore t :requested epoch :at (clock-current-epoch clock)
+          :clock (namestring (system-clock-location clock))
+          :stores entries)))

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -1,0 +1,118 @@
+(in-package :graph-db)
+
+;;; Whole-system restore across a shadow swap (GH #171).  Generations
+;;; live on the filesystem as <location>-retired-<E3>; the journal only
+;;; annotates them (spec R4).  See
+;;; docs/superpowers/specs/2026-08-23-restore-171-design.md
+
+(defstruct (generation (:constructor %make-generation))
+  store location retired swap-epoch journaled-p present-p policy)
+
+(define-condition swap-record-missing-warning (warning)
+  ;; The #212 shape: renames landed, JOURNAL-APPEND did not.  Tolerated,
+  ;; like #191's torn tail -- the directory name carries the epoch.
+  ((path :initarg :path :reader swap-record-missing-path))
+  (:report (lambda (c s)
+             (format s "Retired generation ~A has no :SWAP journal ~
+record (GH #212); its epoch is taken from the directory name."
+                     (swap-record-missing-path c)))))
+
+(defun %retired-suffix-epoch (name live-name)
+  "NAME's epoch when NAME is LIVE-NAME-retired-<digits>, else NIL."
+  (let ((prefix (concatenate 'string live-name "-retired-")))
+    (when (and (> (length name) (length prefix))
+               (string= prefix name :end2 (length prefix))
+               (every #'digit-char-p (subseq name (length prefix))))
+      (parse-integer name :start (length prefix)))))
+
+(defun %retired-dirs-for (location)
+  "((E3 . \"<location>-retired-E3\") ...) for LOCATION, ascending by E3."
+  (let* ((live (%trimmed-namestring location))
+         (parent (uiop:pathname-parent-directory-pathname
+                  (uiop:ensure-directory-pathname live)))
+         (live-name (car (last (pathname-directory
+                                (uiop:ensure-directory-pathname live)))))
+         (found nil))
+    (dolist (dir (uiop:subdirectories parent))
+      (let* ((name (car (last (pathname-directory dir))))
+             (epoch (%retired-suffix-epoch name live-name)))
+        (when epoch
+          (push (cons epoch (%trimmed-namestring dir)) found))))
+    (sort found #'< :key #'car)))
+
+(defun %live-location-of-retired (path)
+  "\"<loc>-retired-123\" -> \"<loc>\"."
+  (let* ((s (%trimmed-namestring path))
+         (pos (search "-retired-" s :from-end t)))
+    (if pos (subseq s 0 pos) s)))
+
+(defun %swap-records (clock)
+  (remove :swap (journal-records clock)
+          :key (lambda (r) (getf r :kind)) :test-not #'eq))
+
+(defun retired-generations (clock)
+  "Every retired generation known to CLOCK's system, as GENERATION
+structs sorted by store then SWAP-EPOCH.  Filesystem is authoritative:
+a directory without a :SWAP record is listed JOURNALED-P NIL and
+warned (SWAP-RECORD-MISSING-WARNING); a record without a directory is
+listed PRESENT-P NIL (GH #171, spec R4)."
+  (let ((by-retired (make-hash-table :test 'equal))
+        (locations (make-hash-table :test 'equal)))
+    ;; Journal first: records name the live locations to scan.
+    (dolist (r (%swap-records clock))
+      (let ((retired (%trimmed-namestring (getf r :retired))))
+        (setf (gethash (%live-location-of-retired retired) locations)
+              (getf r :store))
+        (setf (gethash retired by-retired)
+              (%make-generation
+               :store (getf r :store)
+               :location (%live-location-of-retired retired)
+               :retired retired
+               :swap-epoch (getf r :epoch)
+               :journaled-p t
+               :present-p (and (probe-file
+                                (uiop:ensure-directory-pathname retired))
+                               t)))))
+    ;; Then every open clocked store, so unjournaled directories are found.
+    ;; Compared by LOCATION, not EQ: a clock reopened after
+    ;; CLOSE-SYSTEM-CLOCK (e.g. to repair a torn journal) is a fresh
+    ;; struct at the same path, and an open graph's SYSTEM-CLOCK slot
+    ;; still points at the stale instance (GH #171).
+    (maphash (lambda (name graph)
+               (when (and (typep graph 'graph)
+                          (graph-system-clock graph)
+                          (string= (%trimmed-namestring
+                                    (system-clock-location
+                                     (graph-system-clock graph)))
+                                   (%trimmed-namestring
+                                    (system-clock-location clock))))
+                 (setf (gethash (%trimmed-namestring (location graph))
+                                locations)
+                       name)))
+             *graphs*)
+    (maphash
+     (lambda (location store)
+       (loop for (epoch . dir) in (%retired-dirs-for location)
+             unless (gethash dir by-retired)
+               do (warn 'swap-record-missing-warning :path dir)
+                  (setf (gethash dir by-retired)
+                        (%make-generation :store store :location location
+                                          :retired dir :swap-epoch epoch
+                                          :journaled-p nil :present-p t))))
+     locations)
+    (let ((gens nil))
+      (maphash (lambda (k gen)
+                 (declare (ignore k))
+                 (setf (generation-policy gen)
+                       (if (generation-present-p gen)
+                           (store-recovery-policy (generation-retired gen))
+                           (store-recovery-policy (generation-location gen))))
+                 (push gen gens))
+               by-retired)
+      (sort gens (lambda (a b)
+                   (let ((sa (princ-to-string (generation-store a)))
+                         (sb (princ-to-string (generation-store b))))
+                     (or (string< sa sb)
+                         (and (string= sa sb)
+                              (< (generation-swap-epoch a)
+                                 (generation-swap-epoch b))))))))))

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -368,13 +368,19 @@ clock right now."
 
 (defun %retire-live-completed-p (clock retired)
   "True when RETIRED (a :RETIRE-LIVE record's :RETIRED path) has a
-paired completion: a later :RESTORE naming it as :RETIRED-LIVE, or a
-:RETIRE-LIVE-ABORTED naming it as :RETIRED after a rollback.  A
-:RETIRE-LIVE with NEITHER is exactly RESTORE-SYSTEM's own rename-pair
-crash window, the same shape SWAP-IN-SHADOW's crash leaves but one
-step later (GH #171, spec R6)."
+paired completion: a later, non-:FAILED :RESTORE naming it as
+:RETIRED-LIVE, or a :RETIRE-LIVE-ABORTED naming it as :RETIRED after a
+rollback.  A :RESTORE :FAILED T is excluded even though it names
+:RETIRED-LIVE: %REBUILD-ONE-STORE journals it when MAKE-GRAPH itself
+never got far enough to create anything at the live location, so
+nothing is actually there -- the retired directory is exactly as
+stranded as if no :RESTORE record existed at all.  A :RETIRE-LIVE with
+neither a completing :RESTORE nor a rollback is RESTORE-SYSTEM's own
+rename-pair crash window, the same shape SWAP-IN-SHADOW's crash leaves
+but one step later (GH #171, spec R6, review fix round 1)."
   (some (lambda (r)
           (or (and (eq (getf r :kind) :restore)
+                   (not (getf r :failed))
                    (getf r :retired-live)
                    (string= (%trimmed-namestring (getf r :retired-live))
                             retired))

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -221,8 +221,18 @@ inside the restore window:~{ ~A~} (GH #171)."
                              (retention-required-generations c))))))
 
 (defun %retired-suffix-p (path)
-  "The deletion gate for retired generations, mirroring %SHADOW-SUFFIX-P."
-  (and (search "-retired-" (%trimmed-namestring path)) t))
+  "The deletion gate for retired generations, mirroring %SHADOW-SUFFIX-P
+(shadow-store.lisp:166-172): the LAST path component must itself end in
+-retired-<digits>, not merely contain the substring anywhere -- an
+unanchored SEARCH would also pass a live store literally named
+.../foo-retired-bar-baz/ (GH #171, deferred Task 2 minor)."
+  (let* ((name (car (last (pathname-directory
+                           (uiop:ensure-directory-pathname
+                            (%trimmed-namestring path))))))
+         (pos (and name (search "-retired-" name :from-end t))))
+    (and pos
+         (> (length name) (+ pos (length "-retired-")))
+         (every #'digit-char-p (subseq name (+ pos (length "-retired-")))))))
 
 (defun %delete-generation (clock gen)
   (uiop:delete-directory-tree
@@ -321,6 +331,108 @@ STORE/SWAP-IN-SHADOW (GH #171)."
       (progn (%check-detach-supported graph 'plan-system-restore) t)
     (detach-unsupported-graph-error () nil)))
 
+(defun %known-locations (clock)
+  "EQUAL hash LOCATION (trimmed namestring) -> STORE for every store
+CLOCK's journal or *GRAPHS* names, used by %INTERRUPTED-SWAP-P's
+pre-check so it can run even against a store that is currently closed.
+Three sources, since none alone survives every crash shape: an
+:ATTACH record's own :LOCATION (added GH #171 -- the only trace left
+when a swap-in-shadow crash lands between its two renames, before any
+:SWAP record exists); a :SWAP/:RETIRE-LIVE record's :RETIRED path,
+reversed to its live location (older journals predating :ATTACH's
+:LOCATION field); and any graph *GRAPHS* still holds open under this
+clock right now."
+  (let ((acc (make-hash-table :test 'equal)))
+    (dolist (r (journal-records clock))
+      (when (eq (getf r :kind) :attach)
+        (let ((loc (getf r :location)))
+          (when loc
+            (setf (gethash (%trimmed-namestring loc) acc) (getf r :store))))))
+    (dolist (r (%retired-directory-records clock))
+      (setf (gethash (%live-location-of-retired
+                      (%trimmed-namestring (getf r :retired)))
+                     acc)
+            (getf r :store)))
+    (maphash (lambda (name graph)
+               (when (and (typep graph 'graph)
+                          (graph-system-clock graph)
+                          (string= (%trimmed-namestring
+                                    (system-clock-location
+                                     (graph-system-clock graph)))
+                                   (%trimmed-namestring
+                                    (system-clock-location clock))))
+                 (setf (gethash (%trimmed-namestring (location graph)) acc)
+                       name)))
+             *graphs*)
+    acc))
+
+(defun %retire-live-completed-p (clock retired)
+  "True when RETIRED (a :RETIRE-LIVE record's :RETIRED path) has a
+paired completion: a later :RESTORE naming it as :RETIRED-LIVE, or a
+:RETIRE-LIVE-ABORTED naming it as :RETIRED after a rollback.  A
+:RETIRE-LIVE with NEITHER is exactly RESTORE-SYSTEM's own rename-pair
+crash window, the same shape SWAP-IN-SHADOW's crash leaves but one
+step later (GH #171, spec R6)."
+  (some (lambda (r)
+          (or (and (eq (getf r :kind) :restore)
+                   (getf r :retired-live)
+                   (string= (%trimmed-namestring (getf r :retired-live))
+                            retired))
+              (and (eq (getf r :kind) :retire-live-aborted)
+                   (string= (%trimmed-namestring (getf r :retired))
+                            retired))))
+        (journal-records clock)))
+
+(defun %interrupted-swap-p (clock location)
+  "The retired path stranded between the two renames of a completed-
+looking swap or restore attempt for LOCATION, or NIL when nothing is
+stranded.  Fires only when LOCATION has no live directory -- pruning
+never removes a live directory, and DETACH-STORE leaves one in place,
+so a missing live directory for a store the journal or *GRAPHS* still
+knows about is otherwise unexplained.
+
+A retired directory for LOCATION counts as accounted for (not
+stranded) when either: it is named by a :SWAP record (JOURNAL-APPEND
+there runs only AFTER both renames land, so a :SWAP record IS
+completion -- see %SWAP-IN-SHADOW-1); or it is named by a :RETIRE-LIVE
+record that %RETIRE-LIVE-COMPLETED-P confirms was paired with a
+:RESTORE or rolled back via :RETIRE-LIVE-ABORTED.  Anything else --
+including a directory with NO journal record at all, the shape a hard
+crash between SWAP-IN-SHADOW's renames leaves, since it journals
+nothing until after both complete -- is stranded (GH #171, spec R6)."
+  (let ((live (%trimmed-namestring location)))
+    (unless (probe-file (uiop:ensure-directory-pathname live))
+      (let ((accounted
+              (loop for r in (journal-records clock)
+                    for retired = (and (getf r :retired)
+                                       (%trimmed-namestring (getf r :retired)))
+                    when (and retired
+                              (member (getf r :kind) '(:swap :retire-live))
+                              (string= (%live-location-of-retired retired)
+                                       live)
+                              (or (eq (getf r :kind) :swap)
+                                  (%retire-live-completed-p clock retired)))
+                      collect retired)))
+        (loop for (nil . dir) in (reverse (%retired-dirs-for live))
+              unless (member dir accounted :test #'string=)
+                return dir)))))
+
+(defun repair-interrupted-swap (clock name location)
+  "Rename a stranded pre-swap/pre-restore generation back to LOCATION
+and journal :SWAP-ABORTED :STORE NAME :RESTORED-FROM the stranded path.
+Returns :REPAIRED, or :NOTHING-TO-DO when %INTERRUPTED-SWAP-P finds
+nothing to fix -- idempotent, and never touches a live directory
+(GH #171, spec R6).  :SWAP-ABORTED names no :RETIRED path of its own,
+so it retires nothing and is invisible to RETIRED-GENERATIONS and
+%PRUNED-RETIRED-PATHS -- the directory it moved is live again, not a
+generation to track."
+  (let ((stranded (%interrupted-swap-p clock location)))
+    (cond ((null stranded) :nothing-to-do)
+          (t (%posix-rename stranded (%trimmed-namestring location))
+             (journal-append clock :swap-aborted :store name
+                             :restored-from stranded)
+             :repaired))))
+
 (defun %restore-plan-entries (clock epoch rebuild)
   "One manifest entry per store CLOCK knows about, plus the refusal list
 for PLAN-SYSTEM-RESTORE to raise.  Returns (values ENTRIES REASONS).
@@ -338,6 +450,19 @@ lands in the same RESTORE-REFUSED-ERROR as every other refusal."
         (entries nil) (reasons nil))
     (dolist (g (retired-generations clock))
       (push g (gethash (generation-store g) by-store)))
+    ;; An interrupted swap wins over every other refusal for its store
+    ;; and is checked first: the store's live directory is missing, so
+    ;; without this it would otherwise fall through to :NOT-OPEN below
+    ;; -- true, but not the actionable diagnosis (GH #171, spec R6).
+    ;; %KNOWN-LOCATIONS finds the store even when it is closed, so this
+    ;; runs whether or not it ever reached BY-STORE above.
+    (maphash (lambda (loc store)
+               (when (%interrupted-swap-p clock loc)
+                 (push (cons store :interrupted-swap) reasons)
+                 (push (list :store store :action :refused
+                             :reason :interrupted-swap) entries)
+                 (remhash store by-store)))
+             (%known-locations clock))
     ;; Open clocked stores with no generations at all are :UNCHANGED.
     ;; The supported check runs on EVERY open clocked store, not only on
     ;; the ones this EPOCH plans to touch: the cascade can rebuild a
@@ -397,8 +522,10 @@ effects.  Signals RESTORE-REFUSED-ERROR listing every (STORE . REASON):
 :AUTHORED-GENERATION-MISSING, :NO-REBUILD, :NOT-OPEN (a store needing a
 rename is not open under CLOCK), :UNSUPPORTED-GRAPH (a MASTER-GRAPH/
 SLAVE-GRAPH/PEER-GRAPH target), :INEXACT (only under REQUIRE-EXACT),
-:INTERRUPTED-SWAP (Task 5).  REBUILD is the caller's (lambda (name
-graph)) loader for :DERIVABLE stores (GH #171, spec R1/R2)."
+:INTERRUPTED-SWAP (a stranded rename pair; repair with
+REPAIR-INTERRUPTED-SWAP before retrying).  REBUILD is the caller's
+(lambda (name graph)) loader for :DERIVABLE stores (GH #171, spec
+R1/R2)."
   (multiple-value-bind (entries reasons)
       (%restore-plan-entries clock epoch rebuild)
     (when require-exact

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -6,7 +6,8 @@
 ;;; docs/superpowers/specs/2026-08-23-restore-171-design.md
 
 (defstruct (generation (:constructor %make-generation))
-  store location retired swap-epoch live-from journaled-p present-p policy)
+  store location retired swap-epoch live-from eras journaled-p present-p
+  policy)
 
 (define-condition swap-record-missing-warning (warning)
   ;; The #212 shape: renames landed, JOURNAL-APPEND did not.  Tolerated,
@@ -79,6 +80,44 @@ same way (GH #171)."
            (setf (gethash (%trimmed-namestring (getf r :from)) set) t)))))
     set))
 
+(defun %restore-promotions (clock)
+  "EQUAL hash STORE -> ((EPOCH . FROM-PATH) ...) ascending, one entry per
+:RESTORE record that promoted a retired directory back to live.  A
+:MODE :REBUILT restore carries no :FROM and makes no entry: its content
+is fresh, so it inherits nothing (GH #171)."
+  (let ((by-store (make-hash-table :test 'equal)))
+    (dolist (r (journal-records clock))
+      (when (and (eq (getf r :kind) :restore) (getf r :from))
+        (push (cons (getf r :epoch)
+                    (%trimmed-namestring (getf r :from)))
+              (gethash (getf r :store) by-store))))
+    (maphash (lambda (store prs)
+               (setf (gethash store by-store) (sort prs #'< :key #'car)))
+             by-store)
+    by-store))
+
+(defun %assign-generation-eras (gens promotions)
+  "Fill ERAS and LIVE-FROM for GENS -- one store, ascending SWAP-EPOCH,
+UNFILTERED.  A generation's ERAS is ((FROM . TO) ...): its own live
+window, plus, when a :RESTORE promoted a directory into the window that
+generation then closed, that directory's eras as well -- recursively
+through chains of restores.  Without inheritance a directory promoted by
+one restore and retired again by a later swap would have its original
+content era attributed to nobody (GH #171, fix round 3)."
+  (let ((by-path (make-hash-table :test 'equal))
+        (prev 0))
+    (dolist (g gens)
+      (let* ((to (generation-swap-epoch g))
+             (promo (find-if (lambda (p) (and (<= prev (car p))
+                                              (< (car p) to)))
+                             promotions))
+             (eras (cons (cons (if promo (car promo) prev) to)
+                         (and promo (gethash (cdr promo) by-path)))))
+        (setf (generation-eras g) eras
+              (generation-live-from g) (car (first (last eras)))
+              (gethash (generation-retired g) by-path) eras
+              prev to)))))
+
 (defun retired-generations (clock)
   "Every retired generation known to CLOCK's system, as GENERATION
 structs sorted by store then SWAP-EPOCH.  Filesystem is authoritative:
@@ -87,7 +126,9 @@ JOURNALED-P NIL and warned (SWAP-RECORD-MISSING-WARNING); a record
 without a directory is listed PRESENT-P NIL (GH #171, spec R4).  A
 generation PRUNE-RETIRED-GENERATIONS has deleted (:RETIRE) or a
 RESTORE-SYSTEM call has since consumed by promoting it back to live
-(:RESTORE :FROM) is omitted entirely, not merely marked absent."
+(:RESTORE :FROM) is omitted entirely, not merely marked absent -- but
+such a generation still contributes its ERAS to whichever generation
+inherited its content (see %ASSIGN-GENERATION-ERAS)."
   (let ((by-retired (make-hash-table :test 'equal))
         (locations (make-hash-table :test 'equal))
         (pruned (%pruned-retired-paths clock)))
@@ -151,20 +192,19 @@ RESTORE-SYSTEM call has since consumed by promoting it back to live
                           (and (string= sa sb)
                                (< (generation-swap-epoch a)
                                   (generation-swap-epoch b))))))))
-      ;; LIVE-FROM spans the FULL per-store event order, including a
+      ;; ERAS spans the FULL per-store event order, including a
       ;; generation a RESTORE has since consumed or PRUNE-RETIRED-
       ;; GENERATIONS has deleted -- dropping such a generation from the
       ;; returned list below must not erase what it taught its
-      ;; successor about when ITS OWN live interval began (GH #171,
-      ;; fix round 2; see %GENERATION-LIVE-AT).
-      (let ((prev-store nil) (prev-epoch nil))
-        (dolist (g all)
-          (setf (generation-live-from g)
-                (if (equal (generation-store g) prev-store)
-                    prev-epoch
-                    0))
-          (setf prev-store (generation-store g)
-                prev-epoch (generation-swap-epoch g))))
+      ;; successor about which eras that successor now covers (GH #171,
+      ;; fix rounds 2 and 3; see %GENERATION-LIVE-AT).
+      (let ((promotions (%restore-promotions clock))
+            (per-store (make-hash-table :test 'equal)))
+        (dolist (g all) (push g (gethash (generation-store g) per-store)))
+        (maphash (lambda (store gens)
+                   (%assign-generation-eras
+                    (nreverse gens) (gethash store promotions)))
+                 per-store))
       (remove-if (lambda (g) (gethash (generation-retired g) pruned))
                  all))))
 
@@ -245,18 +285,22 @@ returns what would go and touches nothing.  Each deletion journals
         0)))
 
 (defun %generation-live-at (gens epoch)
-  "Among GENS (one store), the generation whose live interval
-[LIVE-FROM, SWAP-EPOCH) contains EPOCH, or NIL when EPOCH is covered by
-the CURRENT generation instead (:UNCHANGED).  LIVE-FROM is the epoch
-the PREVIOUS retiring event for this store ended at -- 0 when there was
-none -- so this is interval containment, not just "earliest retired
-generation with SWAP-EPOCH > EPOCH": for a monotone swap chain the two
-rules agree exactly, but a RESTORE can promote an OLDER generation back
-to live, breaking monotonicity -- interval containment is what still
-gets it right (GH #171, fix round 2)."
-  (find-if (lambda (g) (and (<= (generation-live-from g) epoch)
-                            (< epoch (generation-swap-epoch g))))
-           gens))
+  "Among GENS (one store), the generation with a half-open era
+[FROM, TO) containing EPOCH, or NIL when EPOCH is covered by the
+CURRENT generation instead (:UNCHANGED).  Ties -- possible only while
+an ancestor a restore promoted is still listed -- go to the matching
+era with the LATEST FROM, i.e. the most recent directory holding that
+content.  Era containment, not merely the earliest generation whose
+SWAP-EPOCH exceeds EPOCH: those agree on a monotone swap chain, but a
+RESTORE promotes an OLDER generation back to live and a later swap
+retires it again, so a directory's content era is not always its own
+last live window (GH #171, fix rounds 2 and 3)."
+  (let ((best nil) (best-from nil))
+    (dolist (g gens best)
+      (dolist (era (generation-eras g))
+        (when (and (<= (car era) epoch) (< epoch (cdr era))
+                   (or (null best-from) (> (car era) best-from)))
+          (setq best g best-from (car era)))))))
 
 (defun %open-store-for-clock (name clock)
   "The graph registered as NAME if it is attached to CLOCK -- matched by
@@ -285,20 +329,28 @@ A store that needs a rename (:REWOUND or :REBUILT) but is not open
 under CLOCK right now is refused :NOT-OPEN -- RESTORE-SYSTEM can only
 quiesce and rename a live, attached graph, and this must be caught
 before ANY store is renamed, not partway through a multi-store restore
-(GH #171).  Likewise a MASTER-GRAPH/SLAVE-GRAPH/PEER-GRAPH target is
-refused :UNSUPPORTED-GRAPH rather than propagating
-DETACH-UNSUPPORTED-GRAPH-ERROR bare, so it lands in the same
-RESTORE-REFUSED-ERROR as every other refusal."
+(GH #171).  Likewise ANY open clocked MASTER-GRAPH/SLAVE-GRAPH/PEER-
+GRAPH is refused :UNSUPPORTED-GRAPH -- whatever this EPOCH would do to
+it -- rather than propagating DETACH-UNSUPPORTED-GRAPH-ERROR bare, so it
+lands in the same RESTORE-REFUSED-ERROR as every other refusal."
   (let ((by-store (make-hash-table :test 'equal))
+        (unsupported (make-hash-table :test 'equal))
         (entries nil) (reasons nil))
     (dolist (g (retired-generations clock))
       (push g (gethash (generation-store g) by-store)))
     ;; Open clocked stores with no generations at all are :UNCHANGED.
+    ;; The supported check runs on EVERY open clocked store, not only on
+    ;; the ones this EPOCH plans to touch: the cascade can rebuild a
+    ;; store the plan called :UNCHANGED, and that rebuild reopens it the
+    ;; same way a rewind would (GH #171).
     (maphash (lambda (name graph)
                (declare (ignore graph))
-               (when (%open-store-for-clock name clock)
-                 (unless (nth-value 1 (gethash name by-store))
-                   (setf (gethash name by-store) nil))))
+               (let ((open-graph (%open-store-for-clock name clock)))
+                 (when open-graph
+                   (unless (nth-value 1 (gethash name by-store))
+                     (setf (gethash name by-store) nil))
+                   (unless (%supported-for-restore-p open-graph)
+                     (setf (gethash name unsupported) t)))))
              *graphs*)
     (maphash
      (lambda (store gens)
@@ -306,16 +358,16 @@ RESTORE-REFUSED-ERROR as every other refusal."
               (target (%generation-live-at gens epoch))
               (open-graph (and target (%open-store-for-clock store clock))))
          (cond
+           ((gethash store unsupported)
+            (push (cons store :unsupported-graph) reasons)
+            (push (list :store store :action :refused
+                        :reason :unsupported-graph)
+                  entries))
            ((null target)
             (push (list :store store :action :unchanged) entries))
            ((null open-graph)
             (push (cons store :not-open) reasons)
             (push (list :store store :action :refused :reason :not-open)
-                  entries))
-           ((not (%supported-for-restore-p open-graph))
-            (push (cons store :unsupported-graph) reasons)
-            (push (list :store store :action :refused
-                        :reason :unsupported-graph)
                   entries))
            ((generation-present-p target)
             (let ((e0 (%generation-state-epoch (generation-retired target))))
@@ -416,6 +468,19 @@ holds elsewhere -- it never mutates the manifest (GH #171)."
                   unless (member k keys)
                     append (list k v)))))
 
+(defun %retired-path-for (clock live)
+  "<LIVE>-retired-<E> for an E no directory already uses.  Two retiring
+events with no commit between them -- two RESTORE-SYSTEM calls in a row,
+or a rewind the cascade then rebuilds -- otherwise compute the SAME name
+and the second rename fails on the non-empty directory: consume epochs
+until the name is free, so the journal record's own :EPOCH still matches
+the name (GH #171)."
+  (loop for path = (format nil "~A-retired-~D" live
+                           (clock-current-epoch clock))
+        while (probe-file (uiop:ensure-directory-pathname path))
+        do (clock-next-epoch clock)
+        finally (return path)))
+
 (defun %close-quiesced (graph timeout)
   "SWAP-IN-SHADOW's close sequence: quiesce as :RESTORING, close with
 snapshot, no writer can land in the doomed generation."
@@ -439,8 +504,7 @@ rename-back itself succeeds, a :RETIRE-LIVE-ABORTED record cancels it
   (let* ((graph (lookup-graph name))
          (live (%trimmed-namestring (location graph)))
          (from (getf entry :from))
-         (retired (format nil "~A-retired-~D" live
-                          (clock-current-epoch clock)))
+         (retired (%retired-path-for clock live))
          (done nil) (retire-live-ok nil))
     (%close-quiesced graph timeout)
     (handler-case
@@ -493,8 +557,7 @@ journal says what actually happened (GH #171)."
   (let* ((graph (lookup-graph name))
          (live (%trimmed-namestring (location graph)))
          (policy (store-recovery-policy live))
-         (retired (format nil "~A-retired-~D" live
-                          (clock-current-epoch clock))))
+         (retired (%retired-path-for clock live)))
     (%close-quiesced graph timeout)
     (handler-case
         (progn

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -1,0 +1,127 @@
+;;;; Whole-system restore across a shadow swap (GH #171).  Spec:
+;;;; docs/superpowers/specs/2026-08-23-restore-171-design.md
+(in-package #:graph-db/test)
+
+(def-suite system-restore-suite :in graph-db-suite
+  :description "RETIRED-GENERATIONS, PRUNE, PLAN/RESTORE-SYSTEM (GH #171).")
+(in-suite system-restore-suite)
+
+(defmacro with-restore-system ((g clock sys &key (policy :authored))
+                               &body body)
+  "WITH-CLOCKED-STORE's shape, with the store named :RESTORE-STORE-1 and a
+persisted recovery POLICY.  G is SETQ-able: tests rebind it to whatever
+SWAP-IN-SHADOW / RESTORE-SYSTEM return."
+  (let ((cdir (gensym)) (ddir (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,cdir)
+         (with-temp-directory (,ddir)
+           (let ((graph-db::*system-directory* (namestring ,sys))
+                 (graph-db::*store-registry* nil))
+             (let ((,clock (open-system-clock (namestring ,cdir))))
+               (unwind-protect
+                    (let ((,g (make-graph :restore-store-1
+                                          (namestring ,ddir)
+                                          :buffer-pool-size 1000
+                                          :system-clock ,clock
+                                          :recovery-policy ,policy)))
+                      (unwind-protect (progn ,@body)
+                        (when (graph-db::graph-open-p ,g)
+                          (let ((graph-db:*graph* ,g))
+                            (ignore-errors
+                             (close-graph ,g :snapshot-p nil))))
+                        (collect-garbage)))
+                 (close-system-clock ,clock)))))))))
+
+(defun %rs-write (g)
+  "One generic vertex into G; returns the epoch the commit used."
+  (with-transaction ((graph-db::transaction-manager g))
+    (graph-db:make-vertex :generic nil :graph g))
+  (graph-db::load-highest-transaction-id g))
+
+(defun %rs-count (g)
+  (length (graph-db:map-vertices #'identity g :collect-p t)))
+
+(defun %rs-swap (g clock &key (shadow-writes 1))
+  "Shadow G, write SHADOW-WRITES vertices into the shadow, swap it in.
+Returns (values NEW-GRAPH RETIRED-PATH)."
+  (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
+    (multiple-value-bind (start end) (graph-db:clock-lease-epochs clock 1000)
+      (let ((sg (graph-db:open-shadow-graph
+                 shadow-location :restore-store-1 :lease (cons start end))))
+        (dotimes (i shadow-writes)
+          (with-transaction ((graph-db::transaction-manager sg))
+            (graph-db:make-vertex :generic nil :graph sg)))
+        (let ((graph-db:*graph* sg)) (close-graph sg :snapshot-p nil))))
+    (graph-db:swap-in-shadow g2 shadow-location)))
+
+(test retired-generations-joins-directory-and-journal
+  "After one swap: exactly one generation for the store, PRESENT, JOURNALED,
+its SWAP-EPOCH equal to the :SWAP record's :epoch, POLICY read from the
+RETIRED directory's policy.dat."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng retired) (%rs-swap g clock)
+      (setq g ng)
+      (let ((gens (graph-db:retired-generations clock)))
+        (is (= 1 (length gens)))
+        (let ((gen (first gens))
+              (swap (find :swap (journal-records clock)
+                          :key (lambda (r) (getf r :kind)))))
+          (is (eq :restore-store-1 (graph-db:generation-store gen)))
+          (is (string= (string-right-trim "/" retired)
+                       (graph-db:generation-retired gen)))
+          (is (= (getf swap :epoch) (graph-db:generation-swap-epoch gen)))
+          (is-true (graph-db:generation-journaled-p gen))
+          (is-true (graph-db:generation-present-p gen))
+          (is (eq :authored (graph-db:generation-policy gen))))))))
+
+(test retired-generations-tolerates-a-missing-swap-record
+  "The #212 shape: the retired directory exists but its :SWAP record was
+never written.  The generation is still listed (JOURNALED NIL) and
+SWAP-RECORD-MISSING-WARNING names the path.  Ablation: a reader that trusts
+the journal alone lists nothing."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng retired) (%rs-swap g clock)
+      (setq g ng)
+      ;; Drop the :SWAP line from the journal file by rewriting it.
+      (let ((file (graph-db::%clock-journal-file
+                   (graph-db::system-clock-location clock)))
+            (kept (remove :swap (journal-records clock)
+                          :key (lambda (r) (getf r :kind)))))
+        (close-system-clock clock)
+        (with-open-file (out file :direction :output :if-exists :supersede)
+          (let ((*print-readably* nil) (*print-pretty* nil))
+            (dolist (r kept) (format out "~S~%" r))))
+        (setq clock (open-system-clock
+                     (namestring (graph-db::system-clock-location clock))))
+        (let* ((warned nil)
+               (gens (handler-bind
+                         ((graph-db:swap-record-missing-warning
+                            (lambda (w)
+                              (setq warned
+                                    (graph-db:swap-record-missing-path w))
+                              (muffle-warning w))))
+                       (graph-db:retired-generations clock))))
+          (is (= 1 (length gens)))
+          (is-false (graph-db:generation-journaled-p (first gens)))
+          (is (string= (string-right-trim "/" retired) warned))
+          (is (= (parse-integer retired
+                                :start (1+ (position #\- retired :from-end t)))
+                 (graph-db:generation-swap-epoch (first gens)))))))))
+
+(test retired-generations-reports-a-pruned-directory
+  "A :SWAP record whose directory is gone lists as PRESENT NIL."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng retired) (%rs-swap g clock)
+      (setq g ng)
+      (uiop:delete-directory-tree (uiop:ensure-directory-pathname retired)
+                                  :validate t)
+      (let ((gens (graph-db:retired-generations clock)))
+        (is (= 1 (length gens)))
+        (is-false (graph-db:generation-present-p (first gens)))
+        (is-true (graph-db:generation-journaled-p (first gens)))))))

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -125,3 +125,75 @@ the journal alone lists nothing."
         (is (= 1 (length gens)))
         (is-false (graph-db:generation-present-p (first gens)))
         (is-true (graph-db:generation-journaled-p (first gens)))))))
+
+(defun %rs-gen-epochs (clock)
+  (mapcar #'graph-db:generation-swap-epoch
+          (graph-db:retired-generations clock)))
+
+(test prune-deletes-generations-at-or-below-the-floor
+  "Two swaps; floor = first swap's epoch: the first generation goes, the
+second stays; a :RETIRE record names the deleted path."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (multiple-value-bind (ng2 r2) (%rs-swap g clock)
+        (setq g ng2)
+        (destructuring-bind (e1 e2) (%rs-gen-epochs clock)
+          (let ((gone (graph-db:prune-retired-generations clock e1)))
+            (is (= 1 (length gone)))
+            (is (= e1 (graph-db:generation-swap-epoch (first gone))))
+            (is-false (probe-file (uiop:ensure-directory-pathname r1)))
+            (is-true (probe-file (uiop:ensure-directory-pathname r2)))
+            (is (equal (list e2) (%rs-gen-epochs clock)))
+            (let ((retire (find :retire (journal-records clock)
+                                :key (lambda (r) (getf r :kind)))))
+              (is (string= (string-right-trim "/" r1)
+                           (getf retire :retired)))
+              (is (= e1 (getf retire :swap-epoch))))))))))
+
+(test prune-refuses-an-authored-generation-inside-the-window
+  "Floor below the swap epoch on an :AUTHORED store: RETENTION-REQUIRED-
+ERROR naming the generation, directory untouched.  Ablation: no guard
+deletes the only copy of authored data."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (let* ((e1 (first (%rs-gen-epochs clock)))
+             (c (handler-case
+                    (progn (graph-db:prune-retired-generations clock (1- e1))
+                           nil)
+                  (graph-db:retention-required-error (c) c))))
+        (is-true c)
+        (when c
+          (is (= 1 (length (graph-db:retention-required-generations c)))))
+        (is-true (probe-file (uiop:ensure-directory-pathname r1)))))))
+
+(test prune-deletes-a-derivable-generation-only-when-told
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (let ((e1 (first (%rs-gen-epochs clock))))
+        (is (null (graph-db:prune-retired-generations clock (1- e1))))
+        (is-true (probe-file (uiop:ensure-directory-pathname r1)))
+        (is (= 1 (length (graph-db:prune-retired-generations
+                          clock (1- e1) :discard-derivable t))))
+        (is-false (probe-file (uiop:ensure-directory-pathname r1)))))))
+
+(test prune-dry-run-deletes-nothing
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (setq g ng)
+      (let ((e1 (first (%rs-gen-epochs clock))))
+        (is (= 1 (length (graph-db:prune-retired-generations
+                          clock e1 :dry-run t))))
+        (is-true (probe-file (uiop:ensure-directory-pathname r1)))
+        (is-false (find :retire (journal-records clock)
+                        :key (lambda (r) (getf r :kind))))))))

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -25,10 +25,17 @@ SWAP-IN-SHADOW / RESTORE-SYSTEM return."
                                           :system-clock ,clock
                                           :recovery-policy ,policy)))
                       (unwind-protect (progn ,@body)
-                        (when (graph-db::graph-open-p ,g)
-                          (let ((graph-db:*graph* ,g))
-                            (ignore-errors
-                             (close-graph ,g :snapshot-p nil))))
+                        ;; Close whatever is actually registered, not the
+                        ;; stale local G -- a test that never re-SETQs G
+                        ;; after RESTORE-SYSTEM/SWAP-IN-SHADOW reopens a
+                        ;; new object under the same name, and closing the
+                        ;; old one is a no-op that leaks the store-id
+                        ;; across tests (GH #171).
+                        (let ((live (graph-db:lookup-graph :restore-store-1)))
+                          (when (and live (graph-db::graph-open-p live))
+                            (let ((graph-db:*graph* live))
+                              (ignore-errors
+                               (close-graph live :snapshot-p nil)))))
                         (collect-garbage)))
                  (close-system-clock ,clock)))))))))
 
@@ -297,6 +304,161 @@ NIL; without it, refused with reason :NO-REBUILD."
           (when c
             (is (equal '((:restore-store-1 . :no-rebuild))
                        (graph-db:restore-refused-reasons c)))))))))
+
+(test restore-puts-the-retained-generation-back-and-round-trips
+  "1 vertex, swap (+1), restore to before the swap: 1 vertex readable,
+store open and accepting; journal carries :RETIRE-LIVE then :RESTORE; the
+post-swap generation is itself retained, and a restore to NOW-1 of that
+state puts the 2-vertex generation back."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (is (= 2 (%rs-count g)))
+        (let ((after-swap (graph-db:clock-current-epoch clock)))
+          (let ((m (graph-db:restore-system clock e0)))
+            (setq g (graph-db:lookup-graph :restore-store-1))
+            (is (eq :rewound (getf (%rs-entry m :restore-store-1) :action)))
+            (is (= 1 (%rs-count g)))
+            (with-transaction ((graph-db::transaction-manager g))
+              (graph-db:make-vertex :generic nil :graph g))
+            (let ((kinds (mapcar (lambda (r) (getf r :kind))
+                                 (journal-records clock))))
+              (is-true (member :retire-live kinds))
+              (is-true (member :restore kinds))
+              (is (< (position :retire-live kinds)
+                     (position :restore kinds)))))
+          ;; Round trip: the 2-vertex generation was retired, not lost.
+          (graph-db:restore-system clock after-swap)
+          (setq g (graph-db:lookup-graph :restore-store-1))
+          (is (= 2 (%rs-count g))))))))
+
+(test restore-refuses-before-any-rename
+  ":REQUIRE-EXACT on an inexact plan: nothing moved, graph still open and
+accepting, no new journal records."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((t0 (%rs-write g)))
+      (%rs-write g)
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (let ((n (length (journal-records clock))))
+          (signals graph-db:restore-refused-error
+            (graph-db:restore-system clock t0 :require-exact t))
+          (is (= n (length (journal-records clock))))
+          (is-true (probe-file (uiop:ensure-directory-pathname r1)))
+          (is-true (graph-db::graph-open-p g))
+          (with-transaction ((graph-db::transaction-manager g))
+            (graph-db:make-vertex :generic nil :graph g)))))))
+
+(test restore-writes-a-readable-manifest-and-warns-when-inexact
+  (with-restore-system (g clock sys)
+    sys
+    (let ((t0 (%rs-write g)))
+      (%rs-write g)
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let* ((warned nil)
+               (m (handler-bind
+                      ((graph-db:restore-inexact-warning
+                         (lambda (w) (setq warned t) (muffle-warning w))))
+                    (graph-db:restore-system clock t0)))
+               (file (merge-pathnames
+                      (format nil "restore-~D.manifest" (getf m :at))
+                      (uiop:ensure-directory-pathname
+                       (graph-db::system-clock-location clock)))))
+          (is-true warned)
+          (is-true (probe-file file))
+          (is (equal m (graph-db:read-restore-manifest file))))))))
+
+(test restore-rebuilds-a-derivable-store-through-the-callback
+  "Generation pruned, :REBUILD supplied: the callback runs against a fresh
+empty graph at the live location; its writes are what the store holds
+afterwards; manifest :REBUILT."
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let* ((seen nil)
+               (m (handler-bind
+                      ((graph-db:restore-inexact-warning #'muffle-warning))
+                    (graph-db:restore-system
+                     clock e0
+                     :rebuild (lambda (name graph)
+                                (setq seen name)
+                                (is (= 0 (%rs-count graph)))
+                                (dotimes (i 3)
+                                  (with-transaction
+                                      ((graph-db::transaction-manager graph))
+                                    (graph-db:make-vertex :generic nil
+                                                          :graph graph))))))))
+          (setq g (graph-db:lookup-graph :restore-store-1))
+          (is (eq :restore-store-1 seen))
+          (is (eq :rebuilt (getf (%rs-entry m :restore-store-1) :action)))
+          (is (= 3 (%rs-count g)))
+          (is (eq :derivable (graph-db:store-recovery-policy
+                              (graph-db::location g)))))))))
+
+(defmacro with-second-store ((g2 clock name dir-var &key (policy :derivable))
+                             &body body)
+  `(with-temp-directory (,dir-var)
+     (let ((,g2 (make-graph ,name (namestring ,dir-var)
+                            :buffer-pool-size 1000 :system-clock ,clock
+                            :recovery-policy ,policy)))
+       (unwind-protect (progn ,@body)
+         (let ((live (graph-db:lookup-graph ,name)))
+           (when (and live (graph-db::graph-open-p live))
+             (let ((graph-db:*graph* live))
+               (ignore-errors (close-graph live :snapshot-p nil)))))))))
+
+(test restore-cascades-to-a-derivable-dependent-and-reports-an-authored-one
+  "Store A (derivable) is rebuilt.  Store B (derivable) holds an edge into
+A: B is rebuilt too (callback sees both names, A first).  Store C
+(authored) holds an edge into A: untouched, manifest :DANGLING 1."
+  (with-restore-system (ga clock sys :policy :derivable)
+    sys
+    (with-second-store (gb clock :restore-store-b bdir :policy :derivable)
+      (with-second-store (gc clock :restore-store-c cdir :policy :authored)
+        (let (a-id)
+          (with-transaction ((graph-db::transaction-manager ga))
+            (setq a-id (graph-db:id (graph-db:make-vertex :generic nil
+                                                           :graph ga))))
+          (dolist (gx (list gb gc))
+            (with-transaction ((graph-db::transaction-manager gx))
+              (let ((v (graph-db:make-vertex :generic nil :graph gx)))
+                (graph-db:make-edge :generic (graph-db:id v) a-id nil nil
+                                    :graph gx))))
+          (let ((e0 (graph-db:clock-current-epoch clock)))
+            (multiple-value-bind (ng r1) (%rs-swap ga clock)
+              (setq ga ng)
+              (uiop:delete-directory-tree
+               (uiop:ensure-directory-pathname r1) :validate t)
+              (let* ((order nil)
+                     (m (handler-bind
+                            ((graph-db:restore-inexact-warning
+                               #'muffle-warning))
+                          (graph-db:restore-system
+                           clock e0
+                           :rebuild (lambda (name graph)
+                                      (declare (ignore graph))
+                                      (push name order))))))
+                (is (equal '(:restore-store-1 :restore-store-b)
+                           (reverse order)))
+                (is (eq :rebuilt (getf (%rs-entry m :restore-store-b)
+                                       :action)))
+                (is (eq :restore-store-1
+                        (getf (%rs-entry m :restore-store-b)
+                              :cascade-from)))
+                (is (eq :unchanged (getf (%rs-entry m :restore-store-c)
+                                         :action)))
+                (is (= 1 (getf (%rs-entry m :restore-store-c)
+                               :dangling)))))))))))
 
 (test plan-handles-two-swaps-by-picking-the-generation-live-at-t
   "Swap twice.  T between the swaps selects the SECOND retired

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -378,7 +378,14 @@ accepting, no new journal records."
                        (graph-db::system-clock-location clock)))))
           (is-true warned)
           (is-true (probe-file file))
-          (is (equal m (graph-db:read-restore-manifest file))))))))
+          (is (equal m (graph-db:read-restore-manifest file)))
+          ;; *PACKAGE* must stay COMMON-LISP while writing, not KEYWORD
+          ;; -- otherwise :RESTORE prints as the bare, colon-less symbol
+          ;; RESTORE (GH #171).
+          (with-open-file (in file)
+            (let ((text (make-string (file-length in))))
+              (read-sequence text in)
+              (is-true (search ":RESTORE" text)))))))))
 
 (test restore-rebuilds-a-derivable-store-through-the-callback
   "Generation pruned, :REBUILD supplied: the callback runs against a fresh
@@ -974,6 +981,44 @@ genuinely gone, so the plan must still refuse :INTERRUPTED-SWAP (not
       (setq g (open-graph :restore-store-1 (concatenate 'string live "/")
                           :system-clock clock))
       (is (= 1 (%rs-count g))))))
+
+(test retry-after-a-retire-live-abort-mints-a-fresh-retired-path
+  "Round-trip of the #212 alias hazard: a rolled-back :RETIRE-LIVE-
+ABORTED already names <live>-retired-<E>, the CURRENT epoch; a retry's
+own :RETIRE-LIVE must not reuse E -- reusing it would let a genuinely
+stranded retry masquerade as the OLD abort's already-settled path, so
+REPAIR-INTERRUPTED-SWAP would wrongly answer :NOTHING-TO-DO instead of
+:REPAIRED (GH #171)."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (let* ((live (graph-db::%trimmed-namestring (graph-db::location g)))
+           (now (graph-db:clock-current-epoch clock))
+           (aliased (format nil "~A-retired-~D" live now)))
+      ;; Simulate the aborted first attempt: rollback already journaled
+      ;; a :RETIRE-LIVE-ABORTED naming the epoch a fresh mint would
+      ;; otherwise reuse -- no directory exists at ALIASED at all.
+      (journal-append clock :retire-live-aborted :store :restore-store-1
+                       :retired aliased)
+      ;; The retry: %RETIRED-PATH-FOR must skip the aliased name even
+      ;; though no directory occupies it.
+      (let ((minted (graph-db::%retired-path-for clock live)))
+        (is (string/= aliased minted))
+        ;; Simulate a hard crash between the retry's own two renames:
+        ;; live really moved to MINTED, :RETIRE-LIVE journaled, nothing
+        ;; else -- the shape a genuinely interrupted swap leaves.
+        (let ((graph-db:*graph* g)) (close-graph g :snapshot-p nil))
+        (graph-db::%posix-rename live minted)
+        (journal-append clock :retire-live :store :restore-store-1
+                         :retired minted)
+        (is (eq :repaired (graph-db:repair-interrupted-swap
+                           clock :restore-store-1 live)))
+        (is-true (probe-file (uiop:ensure-directory-pathname live)))
+        (is-false (probe-file (uiop:ensure-directory-pathname minted)))
+        (setq g (open-graph :restore-store-1
+                            (concatenate 'string live "/")
+                            :system-clock clock))
+        (is (= 1 (%rs-count g)))))))
 
 (test dangling-into-is-scoped-to-the-clock-and-guards-a-nil-tag
   "%DANGLING-INTO's two guards (C2, M3), unit-tested: a store attached to

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -940,6 +940,41 @@ to NOW is :UNCHANGED, not a refusal and not a phantom rewind."
                           :restore-store-1)))
         (is (eq :unchanged (getf e :action)))))))
 
+(test restore-refuses-when-a-failed-rebuild-left-the-live-directory-gone
+  "Review fix round 1: a :RETIRE-LIVE followed by a :RESTORE :FAILED T
+record naming that same path as :RETIRED-LIVE -- %REBUILD-ONE-STORE's
+own journal shape when MAKE-GRAPH itself never got far enough to
+create anything live.  The :RESTORE record's mere presence must NOT
+make %RETIRE-LIVE-COMPLETED-P call this settled: the live directory is
+genuinely gone, so the plan must still refuse :INTERRUPTED-SWAP (not
+:NOT-OPEN) and the repair tool must still find something to fix."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (let* ((live (graph-db::%trimmed-namestring (graph-db::location g)))
+           (now (graph-db:clock-current-epoch clock))
+           (retired (format nil "~A-retired-~D" live (+ now 50))))
+      (let ((graph-db:*graph* g)) (close-graph g :snapshot-p nil))
+      (graph-db::%posix-rename live retired)
+      (journal-append clock :retire-live :store :restore-store-1
+                       :retired retired)
+      (journal-append clock :restore :store :restore-store-1
+                       :mode :rebuilt :failed t :retired-live retired)
+      (let ((c (handler-case
+                   (progn (graph-db:plan-system-restore clock now) nil)
+                 (graph-db:restore-refused-error (c) c))))
+        (is-true c)
+        (when c
+          (is (equal '((:restore-store-1 . :interrupted-swap))
+                     (graph-db:restore-refused-reasons c)))))
+      (is (eq :repaired (graph-db:repair-interrupted-swap
+                         clock :restore-store-1 live)))
+      (is-true (probe-file (uiop:ensure-directory-pathname live)))
+      (is-false (probe-file (uiop:ensure-directory-pathname retired)))
+      (setq g (open-graph :restore-store-1 (concatenate 'string live "/")
+                          :system-clock clock))
+      (is (= 1 (%rs-count g))))))
+
 (test dangling-into-is-scoped-to-the-clock-and-guards-a-nil-tag
   "%DANGLING-INTO's two guards (C2, M3), unit-tested: a store attached to
 a DIFFERENT clock holding an edge into store A is invisible to a scan

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -460,6 +460,163 @@ A: B is rebuilt too (callback sees both names, A first).  Store C
                 (is (= 1 (getf (%rs-entry m :restore-store-c)
                                :dangling)))))))))))
 
+;;; Fix round 1 (GH #171): C1, C2, I4, I6.
+
+(test plan-refuses-a-store-that-is-not-open
+  "The target generation exists and would normally be REWOUND, but the
+store itself was closed (not detached): C1 refuses :NOT-OPEN before any
+rename -- not a LOCATION error on a NIL graph partway through a
+multi-store restore."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((graph-db:*graph* g))
+          (close-graph g :snapshot-p nil))
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock e0) nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :not-open))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-after-a-restore-does-not-see-the-consumed-generation
+  "Restore to T once; planning to the SAME T again must not refuse
+:AUTHORED-GENERATION-MISSING against a ghost entry for the generation
+the restore just consumed (I4).  Without the fix, the consumed
+generation's now-vanished directory still shows up (via its stale
+:SWAP record) as a PRESENT-P NIL :AUTHORED generation and the plan
+refuses.  With the fix that ghost entry is gone, but the remaining
+retired generation (the pre-restore live content, now :RETIRE-LIVE'd)
+still has a swap-epoch after T, so the plan comes back :REWOUND rather
+than :UNCHANGED -- this is a known scope limit (no generation-chain
+reasoning yet to recognize the CURRENT live directory as covering T);
+the test pins the actual behavior and, above all, the absence of the
+wrong refusal."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (handler-bind
+            ((graph-db:restore-inexact-warning #'muffle-warning))
+          (graph-db:restore-system clock e0))
+        (setq g (graph-db:lookup-graph :restore-store-1))
+        (is (= 1 (%rs-count g)))
+        (let* ((refused nil)
+               (m (handler-case
+                      (handler-bind
+                          ((graph-db:restore-inexact-warning
+                             #'muffle-warning))
+                        (graph-db:plan-system-restore clock e0))
+                    (graph-db:restore-refused-error (c) (setq refused c)
+                      nil))))
+          (is-false refused)
+          (when m
+            (is (eq :rewound
+                    (getf (%rs-entry m :restore-store-1) :action)))))))))
+
+(defmacro with-posix-rename-failing-when ((old-var new-var test-form)
+                                          &body body)
+  "Install a wrapper on GRAPH-DB::%POSIX-RENAME for BODY's dynamic
+extent that signals an error the FIRST time (OLD-VAR NEW-VAR) satisfies
+TEST-FORM and delegates every other call -- including later ones -- to
+the original.  Matched by PATH, not a raw call count: CLOSE-GRAPH's own
+snapshot promotes sidecar .tmp files via this same primitive, and a
+naive Nth-call counter would fail the WRONG rename depending on how
+many sidecars a graph happens to carry (I6's fault-injection mechanism,
+mirroring the FDEFINITION-swap idiom used throughout tests/, e.g.
+SEGMENT-TESTS' %POSIX-MMAP wrapper) (GH #171)."
+  (let ((orig (gensym "ORIG")) (fired (gensym "FIRED")))
+    `(let ((,orig (fdefinition 'graph-db::%posix-rename))
+           (,fired nil))
+       (unwind-protect
+            (progn
+              (setf (fdefinition 'graph-db::%posix-rename)
+                    (lambda (,old-var ,new-var)
+                      (declare (ignorable ,old-var ,new-var))
+                      (if (and (not ,fired) ,test-form)
+                          (progn
+                            (setq ,fired t)
+                            (error "injected rename failure for the ~
+test"))
+                          (funcall ,orig ,old-var ,new-var))))
+              ,@body)
+         (setf (fdefinition 'graph-db::%posix-rename) ,orig)))))
+
+(defmacro with-reopen-failing-once (&body body)
+  "Install a wrapper on GRAPH-DB::%REOPEN-AND-RESUME that fails its
+FIRST call and delegates every later call to the original (GH #171)."
+  (let ((orig (gensym "ORIG")) (fired (gensym "FIRED")))
+    `(let ((,orig (fdefinition 'graph-db::%reopen-and-resume))
+           (,fired nil))
+       (unwind-protect
+            (progn
+              (setf (fdefinition 'graph-db::%reopen-and-resume)
+                    (lambda (name location clock reason)
+                      (if ,fired
+                          (funcall ,orig name location clock reason)
+                          (progn
+                            (setq ,fired t)
+                            (error "injected reopen failure for the test")))))
+              ,@body)
+         (setf (fdefinition 'graph-db::%reopen-and-resume) ,orig)))))
+
+(test restore-second-rename-failure-restores-service
+  "The second rename (retained generation -> live) fails: the original
+error is resignalled, the live directory is renamed back, the store
+ends up open and accepting again, and the journal carries :RETIRE-LIVE
+followed by :RETIRE-LIVE-ABORTED (I3a, I6)."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((live (graph-db::%trimmed-namestring
+                     (graph-db::location g))))
+          (with-posix-rename-failing-when
+              (old new (string= (graph-db::%trimmed-namestring new) live))
+            (signals error (graph-db:restore-system clock e0))))
+        (setq g (graph-db:lookup-graph :restore-store-1))
+        (is-true (graph-db::graph-open-p g))
+        (is (eq t (graph-db:accepting-p
+                   (graph-db::transaction-manager g))))
+        (is (= 2 (%rs-count g)))
+        (with-transaction ((graph-db::transaction-manager g))
+          (graph-db:make-vertex :generic nil :graph g))
+        (let ((kinds (mapcar (lambda (r) (getf r :kind))
+                             (journal-records clock))))
+          (is-true (member :retire-live kinds))
+          (is-true (member :retire-live-aborted kinds))
+          (is (< (position :retire-live kinds)
+                 (position :retire-live-aborted kinds))))))))
+
+(test restore-recovers-onto-the-new-generation-after-a-reopen-failure
+  "Both renames land; the follow-up reopen fails once: SWAP-RECOVERED-
+WARNING is signalled (not a resignalled error), and the RESTORED
+generation ends up live (I6)."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((warned nil))
+          (with-reopen-failing-once
+            (handler-bind
+                ((graph-db:swap-recovered-warning
+                   (lambda (w) (setq warned t) (muffle-warning w))))
+              (graph-db:restore-system clock e0)))
+          (is-true warned))
+        (setq g (graph-db:lookup-graph :restore-store-1))
+        (is-true (graph-db::graph-open-p g))
+        (is (= 1 (%rs-count g)))))))
+
 (test plan-handles-two-swaps-by-picking-the-generation-live-at-t
   "Swap twice.  T between the swaps selects the SECOND retired
 generation (the one live at T), not the first."

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -197,3 +197,120 @@ deletes the only copy of authored data."
         (is-true (probe-file (uiop:ensure-directory-pathname r1)))
         (is-false (find :retire (journal-records clock)
                         :key (lambda (r) (getf r :kind))))))))
+
+(defun %rs-entry (manifest store)
+  (find store (getf manifest :stores)
+        :key (lambda (e) (getf e :store))))
+
+(test plan-selects-the-retained-generation-exactly
+  "Write at E0, swap at E3 > T >= E0: the plan is :REWOUND :EXACT T with
+:STATE-AT E0 and :FROM the retired path; nothing on disk changes."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (let* ((tt (1+ e0))
+               (m (graph-db:plan-system-restore clock tt))
+               (e (%rs-entry m :restore-store-1)))
+          (is (= tt (getf m :requested)))
+          (is (eq :rewound (getf e :action)))
+          (is (eq t (getf e :exact)))
+          (is (= e0 (getf e :state-at)))
+          (is (string= (string-right-trim "/" r1) (getf e :from)))
+          (is-true (graph-db::graph-open-p g)))))))
+
+(test plan-marks-inexact-when-writes-follow-t
+  "T before the generation's last commit: :EXACT NIL, :STATE-AT E0.  With
+:REQUIRE-EXACT the plan refuses with reason :INEXACT instead."
+  (with-restore-system (g clock sys)
+    sys
+    (let* ((t0 (%rs-write g))
+           (e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((e (%rs-entry (graph-db:plan-system-restore clock t0)
+                            :restore-store-1)))
+          (is (eq :rewound (getf e :action)))
+          (is (null (getf e :exact)))
+          (is (= e0 (getf e :state-at))))
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock t0
+                                                          :require-exact t)
+                            nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :inexact))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-leaves-an-unaffected-store-unchanged
+  "T after the swap: :UNCHANGED."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (declare (ignore r1))
+      (setq g ng)
+      (let* ((now (graph-db:clock-current-epoch clock))
+             (e (%rs-entry (graph-db:plan-system-restore clock now)
+                           :restore-store-1)))
+        (is (eq :unchanged (getf e :action)))))))
+
+(test plan-refuses-when-an-authored-generation-is-gone
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock e0) nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :authored-generation-missing))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-rebuilds-a-derivable-store-whose-generation-is-gone
+  "Derivable, generation pruned: with :REBUILD the plan is :REBUILT :EXACT
+NIL; without it, refused with reason :NO-REBUILD."
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let ((e (%rs-entry (graph-db:plan-system-restore
+                             clock e0 :rebuild (lambda (name graph)
+                                                 (declare (ignore name graph))))
+                            :restore-store-1)))
+          (is (eq :rebuilt (getf e :action)))
+          (is (null (getf e :exact))))
+        (let ((c (handler-case
+                     (progn (graph-db:plan-system-restore clock e0) nil)
+                   (graph-db:restore-refused-error (c) c))))
+          (is-true c)
+          (when c
+            (is (equal '((:restore-store-1 . :no-rebuild))
+                       (graph-db:restore-refused-reasons c)))))))))
+
+(test plan-handles-two-swaps-by-picking-the-generation-live-at-t
+  "Swap twice.  T between the swaps selects the SECOND retired
+generation (the one live at T), not the first."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (multiple-value-bind (ng r1) (%rs-swap g clock)
+      (declare (ignore r1))
+      (setq g ng)
+      (let ((mid (%rs-write g)))
+        (multiple-value-bind (ng2 r2) (%rs-swap g clock)
+          (setq g ng2)
+          (let ((e (%rs-entry (graph-db:plan-system-restore clock mid)
+                              :restore-store-1)))
+            (is (eq :rewound (getf e :action)))
+            (is (string= (string-right-trim "/" r2) (getf e :from)))))))))

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -881,6 +881,65 @@ reader the store is an exact instant when it is a rebuild."
                 (is (null (getf eb :exact)))
                 (is (eq :restore-store-1 (getf eb :cascade-from)))))))))))
 
+;;; Task 5 (GH #171): repair-interrupted-swap and the restore pre-check.
+
+(test restore-refuses-while-a-swap-is-interrupted
+  "Construct the between-renames layout by hand: live renamed away,
+nothing at the live location, and no journal record at all -- the
+shape a hard crash inside SWAP-IN-SHADOW's own rename pair leaves,
+since it journals nothing until AFTER both renames land.  The plan
+refuses with :INTERRUPTED-SWAP; the repair tool renames the stranded
+directory back, returns :REPAIRED, journals :SWAP-ABORTED, and is
+idempotent (:NOTHING-TO-DO on a second call)."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (let* ((live (graph-db::%trimmed-namestring (graph-db::location g)))
+           (now (graph-db:clock-current-epoch clock))
+           (stranded (format nil "~A-retired-~D" live (+ now 50))))
+      (let ((graph-db:*graph* g)) (close-graph g :snapshot-p nil))
+      (graph-db::%posix-rename live stranded)
+      (let ((c (handler-case
+                   (progn (graph-db:plan-system-restore clock now) nil)
+                 (graph-db:restore-refused-error (c) c))))
+        (is-true c)
+        (when c
+          (is (equal '((:restore-store-1 . :interrupted-swap))
+                     (graph-db:restore-refused-reasons c)))))
+      (is (eq :repaired (graph-db:repair-interrupted-swap
+                         clock :restore-store-1 live)))
+      (is-true (probe-file (uiop:ensure-directory-pathname live)))
+      (is-false (probe-file (uiop:ensure-directory-pathname stranded)))
+      (is-true (find :swap-aborted (journal-records clock)
+                     :key (lambda (r) (getf r :kind))))
+      (is (eq :nothing-to-do (graph-db:repair-interrupted-swap
+                              clock :restore-store-1 live)))
+      (setq g (open-graph :restore-store-1 (concatenate 'string live "/")
+                          :system-clock clock))
+      (is (= 1 (%rs-count g))))))
+
+(test plan-and-retired-generations-are-sane-after-a-repair
+  "After REPAIR-INTERRUPTED-SWAP, the store is an ordinary open store
+again: RETIRED-GENERATIONS lists no generation for it (the repair
+retired nothing -- :SWAP-ABORTED names no :RETIRED path), and planning
+to NOW is :UNCHANGED, not a refusal and not a phantom rewind."
+  (with-restore-system (g clock sys)
+    sys
+    (%rs-write g)
+    (let* ((live (graph-db::%trimmed-namestring (graph-db::location g)))
+           (now (graph-db:clock-current-epoch clock))
+           (stranded (format nil "~A-retired-~D" live (+ now 50))))
+      (let ((graph-db:*graph* g)) (close-graph g :snapshot-p nil))
+      (graph-db::%posix-rename live stranded)
+      (graph-db:repair-interrupted-swap clock :restore-store-1 live)
+      (setq g (open-graph :restore-store-1 (concatenate 'string live "/")
+                          :system-clock clock))
+      (is (null (graph-db:retired-generations clock)))
+      (let ((e (%rs-entry (graph-db:plan-system-restore
+                           clock (graph-db:clock-current-epoch clock))
+                          :restore-store-1)))
+        (is (eq :unchanged (getf e :action)))))))
+
 (test dangling-into-is-scoped-to-the-clock-and-guards-a-nil-tag
   "%DANGLING-INTO's two guards (C2, M3), unit-tested: a store attached to
 a DIFFERENT clock holding an edge into store A is invisible to a scan

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -486,16 +486,14 @@ multi-store restore."
 (test plan-after-a-restore-does-not-see-the-consumed-generation
   "Restore to T once; planning to the SAME T again must not refuse
 :AUTHORED-GENERATION-MISSING against a ghost entry for the generation
-the restore just consumed (I4).  Without the fix, the consumed
-generation's now-vanished directory still shows up (via its stale
-:SWAP record) as a PRESENT-P NIL :AUTHORED generation and the plan
-refuses.  With the fix that ghost entry is gone, but the remaining
-retired generation (the pre-restore live content, now :RETIRE-LIVE'd)
-still has a swap-epoch after T, so the plan comes back :REWOUND rather
-than :UNCHANGED -- this is a known scope limit (no generation-chain
-reasoning yet to recognize the CURRENT live directory as covering T);
-the test pins the actual behavior and, above all, the absence of the
-wrong refusal."
+the restore just consumed (I4), AND must come back :UNCHANGED, not
+:REWOUND (fix round 2): LIVE-FROM/%GENERATION-LIVE-AT's interval rule
+recognizes that the remaining retired generation's live interval
+starts AFTER T (at the original swap epoch), so it does not contain T
+-- the CURRENT live directory is what covers T now, exactly as it
+should after a completed restore.  Executing a :REWOUND plan here
+would have been a real regression: it would revert the just-completed
+restore back to the pre-restore (2-vertex) content."
   (with-restore-system (g clock sys)
     sys
     (let ((e0 (%rs-write g)))
@@ -517,8 +515,39 @@ wrong refusal."
                       nil))))
           (is-false refused)
           (when m
-            (is (eq :rewound
+            (is (eq :unchanged
                     (getf (%rs-entry m :restore-store-1) :action)))))))))
+
+(test plan-after-a-restore-selects-the-post-swap-generation-by-interval
+  "After restoring to T=e0, planning to an epoch INSIDE the retired
+post-swap generation's live interval selects THAT generation: :REWOUND
+with :FROM its path.  MID is a further write committed to the swapped-
+in generation AFTER the swap and BEFORE the restore -- a concrete
+epoch strictly between the swap's own epoch and the restore's later
+:RETIRE-LIVE epoch, unlike the epoch read immediately after the swap
+completes, which (nothing else advancing the clock in between) can
+land EXACTLY ON the :RETIRE-LIVE epoch -- the half-open interval's
+excluded upper boundary, which the companion test above already
+covers by landing there and getting :UNCHANGED."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((mid (%rs-write g)))
+          (let ((m0 (handler-bind
+                        ((graph-db:restore-inexact-warning
+                           #'muffle-warning))
+                      (graph-db:restore-system clock e0))))
+            (setq g (graph-db:lookup-graph :restore-store-1))
+            (let* ((post-swap-path
+                     (getf (%rs-entry m0 :restore-store-1) :retired-live))
+                   (e (%rs-entry (graph-db:plan-system-restore clock mid)
+                                 :restore-store-1)))
+              (is-true post-swap-path)
+              (is (eq :rewound (getf e :action)))
+              (is (string= post-swap-path (getf e :from))))))))))
 
 (defmacro with-posix-rename-failing-when ((old-var new-var test-form)
                                           &body body)

--- a/tests/system-restore-tests.lisp
+++ b/tests/system-restore-tests.lisp
@@ -48,13 +48,19 @@ SWAP-IN-SHADOW / RESTORE-SYSTEM return."
 (defun %rs-count (g)
   (length (graph-db:map-vertices #'identity g :collect-p t)))
 
-(defun %rs-swap (g clock &key (shadow-writes 1))
+(defun %rs-key-count (plist key)
+  "How many times KEY appears as an indicator in PLIST -- 1 is what a
+%ENTRY-WITH replacement must leave behind, 2 means a stale shadowed
+value survived (GH #171)."
+  (loop for (k nil) on plist by #'cddr count (eq k key)))
+
+(defun %rs-swap (g clock &key (shadow-writes 1) (name :restore-store-1))
   "Shadow G, write SHADOW-WRITES vertices into the shadow, swap it in.
 Returns (values NEW-GRAPH RETIRED-PATH)."
   (multiple-value-bind (shadow-location g2) (graph-db:shadow-store g)
     (multiple-value-bind (start end) (graph-db:clock-lease-epochs clock 1000)
       (let ((sg (graph-db:open-shadow-graph
-                 shadow-location :restore-store-1 :lease (cons start end))))
+                 shadow-location name :lease (cons start end))))
         (dotimes (i shadow-writes)
           (with-transaction ((graph-db::transaction-manager sg))
             (graph-db:make-vertex :generic nil :graph sg)))
@@ -662,3 +668,243 @@ generation (the one live at T), not the first."
                               :restore-store-1)))
             (is (eq :rewound (getf e :action)))
             (is (string= (string-right-trim "/" r2) (getf e :from)))))))))
+
+;;; Fix round 3 (GH #171): the ERAS model, and the guards round 2 left
+;;; unexercised.
+
+(test plan-selects-a-generation-by-an-inherited-era
+  "Three events: swap@E1 retires r1, restore-to-E0@E2 promotes r1 and
+retires r2, swap@E3 retires the promoted directory as r3.  E0's content
+now sits in r3, not in r1 (consumed) and not in r2 (a later era), so
+planning to E0 must be :REWOUND :FROM r3 -- the single-window model
+answered :UNCHANGED here and lost the generation.  :EXACT is NIL because
+the promoted generation took a further write after E2, which no rewind
+to r3 can undo (spec R2).  :STATE-AT is that write's own epoch, which
+also pins %REOPEN-AND-RESUME's location normalisation: unnormalised, the
+restored store wrote transaction-id.dat into its PARENT directory and
+the generation still reported the pre-restore watermark."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (handler-bind ((graph-db:restore-inexact-warning #'muffle-warning))
+          (graph-db:restore-system clock e0))
+        (setq g (graph-db:lookup-graph :restore-store-1))
+        (is (= 1 (%rs-count g)))
+        (let ((post (%rs-write g)))
+          (multiple-value-bind (ng2 r3) (%rs-swap g clock)
+            (setq g ng2)
+            (let ((e (%rs-entry (graph-db:plan-system-restore clock e0)
+                                :restore-store-1)))
+              (is (eq :rewound (getf e :action)))
+              (is (string= (string-right-trim "/" r3) (getf e :from)))
+              (is (= post (getf e :state-at)))
+              (is (null (getf e :exact))))))))))
+
+(test plan-follows-a-chain-of-two-restores
+  "Two consecutive restores: restore-to-E0 promotes r1 (retiring r2),
+then restore-to-MID promotes r2 back (retiring r1's content as r3).  E0's
+era is inherited through the chain, so planning to E0 selects r3, and
+executing that plan yields the 1-vertex content again; MID is covered by
+what is live now, so it plans :UNCHANGED."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((mid (%rs-write g)))
+          (is (= 3 (%rs-count g)))
+          (handler-bind ((graph-db:restore-inexact-warning #'muffle-warning))
+            (graph-db:restore-system clock e0))
+          (setq g (graph-db:lookup-graph :restore-store-1))
+          (is (= 1 (%rs-count g)))
+          (let ((m2 (handler-bind
+                        ((graph-db:restore-inexact-warning #'muffle-warning))
+                      (graph-db:restore-system clock mid))))
+            (setq g (graph-db:lookup-graph :restore-store-1))
+            (is (= 3 (%rs-count g)))
+            (let ((r3 (getf (%rs-entry m2 :restore-store-1) :retired-live))
+                  (e (%rs-entry (graph-db:plan-system-restore clock e0)
+                                :restore-store-1)))
+              (is-true r3)
+              (is (eq :rewound (getf e :action)))
+              (is (string= r3 (getf e :from)))
+              (is (eq :unchanged
+                      (getf (%rs-entry (graph-db:plan-system-restore clock mid)
+                                       :restore-store-1)
+                            :action)))
+              (handler-bind
+                  ((graph-db:restore-inexact-warning #'muffle-warning))
+                (graph-db:restore-system clock e0))
+              (setq g (graph-db:lookup-graph :restore-store-1))
+              (is (= 1 (%rs-count g))))))))))
+
+(test plan-refuses-a-replicated-graph-as-unsupported
+  "I5's refusal, exercised: a MASTER-GRAPH registered under the store's
+name is refused :UNSUPPORTED-GRAPH inside RESTORE-REFUSED-ERROR, not by
+a bare DETACH-UNSUPPORTED-GRAPH-ERROR.  Refused for an epoch this store
+would otherwise leave :UNCHANGED too -- the check runs on every open
+clocked store, because the cascade can rebuild one the plan did not
+name.  A bare MAKE-INSTANCE shell is enough (see DETACH-REFUSES-
+REPLICATED-GRAPHS): the check is a TYPEP."
+  (with-restore-system (g clock sys)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (declare (ignore r1))
+        (setq g ng)
+        (let ((shell (make-instance 'graph-db::master-graph
+                                    :graph-name :restore-store-1
+                                    :location (graph-db::location g)
+                                    :system-clock clock)))
+          (unwind-protect
+               (progn
+                 (setf (gethash :restore-store-1 graph-db::*graphs*) shell)
+                 (dolist (epoch (list e0 (graph-db:clock-current-epoch clock)))
+                   (let ((c (handler-case
+                                (progn (graph-db:plan-system-restore
+                                        clock epoch)
+                                       nil)
+                              (graph-db:restore-refused-error (c) c))))
+                     (is-true c)
+                     (when c
+                       (is (equal '((:restore-store-1 . :unsupported-graph))
+                                  (graph-db:restore-refused-reasons c)))))))
+            (setf (gethash :restore-store-1 graph-db::*graphs*) g)))))))
+
+(test rebuild-rolls-back-a-failed-retire-rename
+  "%REBUILD-ONE-STORE's PRE-MAKE-GRAPH branch: the retire rename fails,
+so nothing changed -- the live directory is renamed back and reopened
+fully accepting, the REBUILD callback never runs, and the original error
+is resignalled (I1)."
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (let ((live (graph-db::%trimmed-namestring (graph-db::location g)))
+              (ran nil))
+          (with-posix-rename-failing-when
+              (old new (string= (graph-db::%trimmed-namestring old) live))
+            (signals error
+              (graph-db:restore-system
+               clock e0
+               :rebuild (lambda (name graph)
+                          (declare (ignore name graph))
+                          (setq ran t)))))
+          (is-false ran))
+        (setq g (graph-db:lookup-graph :restore-store-1))
+        (is-true (graph-db::graph-open-p g))
+        (is (eq t (graph-db:accepting-p (graph-db::transaction-manager g))))
+        (is (= 2 (%rs-count g)))
+        (with-transaction ((graph-db::transaction-manager g))
+          (graph-db:make-vertex :generic nil :graph g))))))
+
+(test rebuild-journals-a-failed-callback
+  "%REBUILD-ONE-STORE's POST-MAKE-GRAPH branch: the callback signals, so
+the fresh (possibly half-populated) generation stays live by design and
+a :RESTORE :MODE :REBUILT :FAILED T record names it and its retired
+predecessor before the error propagates out of RESTORE-SYSTEM (I1)."
+  (with-restore-system (g clock sys :policy :derivable)
+    sys
+    (let ((e0 (%rs-write g)))
+      (multiple-value-bind (ng r1) (%rs-swap g clock)
+        (setq g ng)
+        (uiop:delete-directory-tree (uiop:ensure-directory-pathname r1)
+                                    :validate t)
+        (signals error
+          (graph-db:restore-system
+           clock e0
+           :rebuild (lambda (name graph)
+                      (declare (ignore name graph))
+                      (error "injected rebuild-callback failure"))))
+        (let ((r (find-if (lambda (r) (and (eq (getf r :kind) :restore)
+                                           (getf r :failed)))
+                          (journal-records clock))))
+          (is-true r)
+          (when r
+            (is (eq :rebuilt (getf r :mode)))
+            (is-true (getf r :retired-live))))
+        (setq g (graph-db:lookup-graph :restore-store-1))
+        (is-true (graph-db::graph-open-p g))
+        (is (= 0 (%rs-count g)))))))
+
+(test cascade-replaces-the-action-key-on-a-rewound-entry
+  "%ENTRY-WITH must REPLACE, not shadow: store B plans :REWOUND :EXACT T,
+then the cascade rebuilds it because it holds an edge into rebuilt store
+A.  Its manifest entry must carry exactly one :ACTION (:REBUILT) and one
+:EXACT (NIL) -- a shadowed :EXACT T behind the new one would tell a
+reader the store is an exact instant when it is a rebuild."
+  (with-restore-system (ga clock sys :policy :derivable)
+    sys
+    (with-second-store (gb clock :restore-store-b bdir :policy :derivable)
+      (let (a-id)
+        (with-transaction ((graph-db::transaction-manager ga))
+          (setq a-id (graph-db:id (graph-db:make-vertex :generic nil
+                                                        :graph ga))))
+        (with-transaction ((graph-db::transaction-manager gb))
+          (let ((v (graph-db:make-vertex :generic nil :graph gb)))
+            (graph-db:make-edge :generic (graph-db:id v) a-id nil nil
+                                :graph gb)))
+        (let ((e0 (graph-db:clock-current-epoch clock)))
+          (multiple-value-bind (ngb rb1) (%rs-swap gb clock
+                                                   :name :restore-store-b)
+            (declare (ignore rb1))
+            (setq gb ngb)
+            (let ((eb (%rs-entry (graph-db:plan-system-restore
+                                  clock e0
+                                  :rebuild (lambda (n g)
+                                             (declare (ignore n g))))
+                                 :restore-store-b)))
+              (is (eq :rewound (getf eb :action)))
+              (is (eq t (getf eb :exact))))
+            (multiple-value-bind (nga ra1) (%rs-swap ga clock)
+              (setq ga nga)
+              (uiop:delete-directory-tree
+               (uiop:ensure-directory-pathname ra1) :validate t)
+              (let* ((m (handler-bind
+                            ((graph-db:restore-inexact-warning
+                               #'muffle-warning))
+                          (graph-db:restore-system
+                           clock e0
+                           :rebuild (lambda (name graph)
+                                      (declare (ignore name graph))))))
+                     (eb (%rs-entry m :restore-store-b)))
+                (is (= 1 (%rs-key-count eb :action)))
+                (is (eq :rebuilt (getf eb :action)))
+                (is (= 1 (%rs-key-count eb :exact)))
+                (is (null (getf eb :exact)))
+                (is (eq :restore-store-1 (getf eb :cascade-from)))))))))))
+
+(test dangling-into-is-scoped-to-the-clock-and-guards-a-nil-tag
+  "%DANGLING-INTO's two guards (C2, M3), unit-tested: a store attached to
+a DIFFERENT clock holding an edge into store A is invisible to a scan
+scoped to A's clock and visible to a scan scoped to its own; and a NIL
+store tag matches nothing rather than every untagged legacy id."
+  (with-restore-system (ga clock sys)
+    sys
+    (with-temp-directory (cdir2)
+      (let ((clock2 (open-system-clock (namestring cdir2))))
+        (unwind-protect
+             (with-second-store (gb clock2 :restore-store-b bdir)
+               (let (a-id)
+                 (with-transaction ((graph-db::transaction-manager ga))
+                   (setq a-id (graph-db:id (graph-db:make-vertex
+                                            :generic nil :graph ga))))
+                 (with-transaction ((graph-db::transaction-manager gb))
+                   (let ((v (graph-db:make-vertex :generic nil :graph gb)))
+                     (graph-db:make-edge :generic (graph-db:id v) a-id nil nil
+                                         :graph gb)))
+                 (let ((tag (graph-db:store-registry-id-for
+                             :restore-store-1)))
+                   (is-true tag)
+                   (is (null (graph-db::%dangling-into clock tag nil)))
+                   (is (equal '((:restore-store-b . 1))
+                              (graph-db::%dangling-into clock2 tag nil)))
+                   (is (null (graph-db::%dangling-into clock2 nil nil))))))
+          (close-system-clock clock2))))))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -3159,7 +3159,13 @@ seeding rule: a peer-graph's pull cursor is a distinct number space from
 its local highest id (see PEER-OBSERVE-EPOCH's docstring), so both are
 watermarked, not just the local one.  Refuses -- signals
 ATTACH-WITH-ACTIVE-TRANSACTIONS -- while GRAPH has any in-flight
-transaction; see that condition for why."
+transaction; see that condition for why.
+
+The :ATTACH record also carries :LOCATION (a namestring): a swap-in-
+shadow crash between its two renames leaves no :SWAP record at all, so
+:ATTACH is the only surviving trace REPAIR-INTERRUPTED-SWAP's pre-check
+can use to find the store's live directory once the graph itself is no
+longer open (GH #171, spec R6)."
   (let ((tm (transaction-manager graph)))
     (with-transaction-manager-lock (tm)
       (when (minimum-start-transaction-id tm)
@@ -3169,7 +3175,8 @@ transaction; see that condition for why."
                                 (load-peer-pull-cursor graph)
                                 0))))
         (clock-observe-epoch clock watermark)
-        (journal-append clock :attach :store (graph-name graph))
+        (journal-append clock :attach :store (graph-name graph)
+                        :location (namestring (location graph)))
         (setf (graph-system-clock graph) clock))))
   graph)
 


### PR DESCRIPTION
Implements whole-system restore across a shadow swap — the last build unit of the namespaces epic (#110). Closes #171.

Spec: docs/superpowers/specs/2026-08-23-restore-171-design.md (rulings R1–R6 + R2a). Plan: docs/superpowers/plans/2026-08-23-restore-171.md.

## What ships
- **`retired-generations`** — filesystem-authoritative generation discovery joined to the clock journal, with ERAS: half-open content intervals inherited through `:restore` promotions, so restore-then-swap chains select correctly. Unjournaled dirs (the #212 shape) are listed and warned, not lost.
- **`prune-retired-generations`** — retention enforcement: `:authored` generations inside the restore window are refused by name (`retention-required-error`); `:derivable` needs `:discard-derivable`; `:dry-run`; every deletion journaled `:retire`.
- **`plan-system-restore` / `restore-system`** — generation-granularity restore to an epoch; every refusal (`:authored-generation-missing :no-rebuild :not-open :unsupported-graph :inexact :interrupted-swap`) fires in one `restore-refused-error` before any rename. Exactness reported per store (`:exact nil :state-at E0`), `:require-exact` refuses instead. Derivable rebuild via a caller `(lambda (name graph))` with fixpoint cascade over store-tag dangling edges; authored dependents get `:dangling N`. Manifest `(:restore t ...)` written to `restore-<epoch>.manifest`, read back `*read-eval*` NIL; `restore-inexact-warning` on any mixed instant. Per-store failure handling mirrors `swap-in-shadow` (commit = second rename; rollback + `:retire-live-aborted`, or reopen + `swap-recovered-warning`).
- **`repair-interrupted-swap`** — the explicit, idempotent tool for #170's crash-between-renames window (and restore's own); the plan refuses `:interrupted-swap` and names it. `:attach` journal records now carry `:location` so a closed, never-swapped store is discoverable.
- Docs: manual ch.17 section + ch.11 pointer, CHANGELOG, spec Built notes; namespaces spec §11 unit 6 → Done.

Answers the issue's open question: **shadow swap does not supersede `snapshot`/`replay`** — point-in-time inside a generation is a separate follow-up.

## Verification (SBCL; ECL demoted per standing policy)
- Definitive gate `(asdf:test-system :graph-db)` on final HEAD: **4450 checks / 4440 pass / 10 skips (GEOS, pre-existing) / 0 fail** (branch-start baseline 4294/4284/10/0).
- Focused: system-restore-suite 154/154 (33 tests incl. fault injection on both rename paths); detach-suite 150/150; system-clock-suite 75/75; zero-warning cold quickload.
- Process: 6 tasks, per-task review + 6 fix rounds, whole-branch review, final fix wave — all findings addressed.

Follow-ups filed, not blocking: #222 (open-graph slashless-location hazard, found here), note added to #212 (missing `:restore` record after post-rename failure), plus the pre-existing #208–#216 family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95