### PR TITLE
Namespaces unit 2: packages as namespaces (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
-- **A store adopts a foreign class at first write; re-declaring a class
-  moves its registration to its new default store** (#167). Writing a
+- **A store adopts a foreign class at first write; lookup of a class
+  registered in more than one store is deterministic** (#167). Writing a
   node of a class via an explicit `:graph` that names a store other
   than the class's declared default no longer requires that store to
   have seen the class before: the first such write finds the class's
@@ -45,11 +45,13 @@ between releases; cutting a release renames it to the new version and dates it.
   schema lock, and saves that store's `schema.dat` — the type is then
   durably part of that store, surviving close and reopen like any type
   declared there from the start. This is the mechanism behind "one
-  class, many stores" (cl-llm#20). A `def-vertex`/`def-edge` form
-  re-evaluated with a different trailing store argument now *moves*
-  the class's registration to the new store rather than leaving a
-  stale entry behind under the old one, matching ordinary CLOS
-  redefinition semantics.
+  class, many stores" (cl-llm#20; #186). Because a class can be
+  registered under more than one store simultaneously,
+  `%find-registered-node-type` takes an optional preferred store and
+  checks that store's own registration first before falling back to a
+  full scan, so `:graph`-directed lookups resolve to the calling
+  store's own meta rather than whichever store a hash-table scan
+  happens to visit first.
   Edge classes additionally maintain a store-occupancy hint,
   `edge-type-stores` (name) — the list of stores known to hold a given
   edge class, or `NIL` for "no hint, sweep everything." It is updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,33 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **A store adopts a foreign class at first write; re-declaring a class
+  moves its registration to its new default store** (#167). Writing a
+  node of a class via an explicit `:graph` that names a store other
+  than the class's declared default no longer requires that store to
+  have seen the class before: the first such write finds the class's
+  registered metadata, instantiates it into the target store under the
+  schema lock, and saves that store's `schema.dat` — the type is then
+  durably part of that store, surviving close and reopen like any type
+  declared there from the start. This is the mechanism behind "one
+  class, many stores" (cl-llm#20). A `def-vertex`/`def-edge` form
+  re-evaluated with a different trailing store argument now *moves*
+  the class's registration to the new store rather than leaving a
+  stale entry behind under the old one, matching ordinary CLOS
+  redefinition semantics.
+  Edge classes additionally maintain a store-occupancy hint,
+  `edge-type-stores` (name) — the list of stores known to hold a given
+  edge class, or `NIL` for "no hint, sweep everything." It is updated
+  at the same instantiation point that adoption uses, so both a
+  class's declared-store write and a lazy cross-store adoption keep it
+  current. The hint is a best-effort, append-only sidecar
+  (`edge-occupancy.dat`, beside the type registry) that fails safe: a
+  missing system directory, an unreadable or torn file, or a never-
+  written class all answer `NIL`, and a failed append degrades to
+  in-image-only for the session rather than aborting the write that
+  triggered it. Nothing in this change consumes the hint for query
+  routing — that is left to the ontology/cross-store query work.
+
 - **New node ids are tagged UUIDv8, carrying a 12-bit store field** for
   O(1) cross-store resolution; existing v5 ids are unchanged and a v5
   id still resolves via a per-open-store scan, so there is no flag
@@ -739,6 +766,25 @@ between releases; cutting a release renames it to the new version and dates it.
   per-record fsync was considered and rejected in the issue. (#191)
 
 ### Changed
+
+- **BREAKING: a `make-<type>` constructor's `:graph` default is now the
+  class's declared store, not the ambient `*graph*`** (#167). The
+  trailing argument to `def-vertex`/`def-edge` is documented from here
+  on as the class's *default store*; omitting `:graph` places the node
+  there, not wherever `*graph*` happens to be bound at the call site.
+  If that default store is not open and no `:graph` was passed, the
+  constructor now signals the new `default-store-not-open-error`
+  (naming the class and the store) rather than silently writing into
+  `*graph*` — placement determines recovery policy (which store's WAL,
+  backup schedule and detach boundary a node falls under), so a quiet
+  substitution would change a node's durability story without saying
+  so. Single-package/single-store code is unaffected: there, `*graph*`
+  already *is* the declared store on every call. The behaviour change
+  reaches only code that relied on `*graph*` differing from a class's
+  declared store to place nodes elsewhere without passing `:graph`.
+  `lookup-<type>` and the generic `make-vertex`/`make-edge` keep their
+  existing `*graph*` behaviour; they take ids or explicit types, not
+  class policy.
 
 - **BREAKING: peer wire protocol bumped 1 -> 2; a v1 device is now
   refused, not misparsed** (#206, #201). This is a wire-generation

--- a/docs/superpowers/plans/2026-08-23-packages-167.md
+++ b/docs/superpowers/plans/2026-08-23-packages-167.md
@@ -1,0 +1,483 @@
+# Packages as Namespaces (#167) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A class writes to its declared default store (overridable per
+write, refusing silent `*graph*` fallback), is adoptable by any store at
+first write, and edge classes maintain a store-occupancy hint.
+
+**Architecture:** All changes ride the existing schema machinery: the
+generated `make-<name>` constructors change their `:graph` default and
+route type lookup through a new `%ensure-type-in-store` that lazily calls
+the existing `instantiate-node-type` (which already handles
+registry-id assignment and `save-schema`). Occupancy is an append-only
+sidecar beside the type registry. No on-disk format changes.
+
+**Tech Stack:** Common Lisp (SBCL verified; ECL demoted), FiveAM.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-packages-167-design.md`
+(rulings R1–R6; read first). Epic spec:
+`docs/superpowers/specs/2026-08-20-namespaces-design.md` §2–§4.
+
+## Global Constraints
+
+- Spaces only, **hard 80-column limit**, terse comments citing `(GH #167)`.
+- R1 exactly: explicit `:graph` > open graph named by the class's declared
+  store > `default-store-not-open-error`. NEVER a silent `*graph*`
+  fallback. `lookup-<type>` and generic `make-vertex`/`make-edge` keep
+  `*graph*`.
+- R2: `*schema-node-metadata*`'s hash shape and key are unchanged.
+- Occupancy reads bind `*read-eval*` NIL; a lost/absent file means "no
+  hint" (NIL), never an error or a wrong answer (R4).
+- Test forms: `(with-transaction ((graph-db::transaction-manager g)) ...)`;
+  rebind `graph-db::*system-directory*` (temp dir) + `graph-db::*type-registry*`
+  NIL + reset `(gethash <name> graph-db::*schema-node-metadata*)` per
+  fixture; neutral names (public repo). Test system `:graph-db/test`,
+  package `graph-db/test`.
+- SBCL from the worktree with `--dynamic-space-size 16384`, FIRST eval
+  `(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))`.
+  Focused run: `(fiveam:run! 'package-namespace-suite)` under the
+  `*system-directory*`/`*type-registry*` binding. One SBCL at a time on
+  this host; never kill foreign processes.
+- Docs travel with code (Task 4).
+
+---
+
+### Task 1: R1 — constructor placement default + refusal
+
+**Files:**
+- Modify: `schema.lisp` (`def-node-type`'s generated constructor, ~line
+  437-465 of the macro body; new condition near
+  `divergent-node-type-redefinition`)
+- Modify: `package.lisp` (export `#:default-store-not-open-error
+  #:default-store-not-open-class #:default-store-not-open-store`)
+- Create: `tests/package-namespace-tests.lisp`
+- Modify: `graph-db.asd` test system (add
+  `(:file "package-namespace-tests")` after `system-restore-tests`)
+
+**Interfaces:**
+- Produces: condition `default-store-not-open-error` (readers
+  `default-store-not-open-class`, `default-store-not-open-store`);
+  helper `(%default-store-graph class-name store-name explicit)` →
+  graph, used verbatim by every generated constructor. Task 2 reroutes
+  the same constructors' type lookup.
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+;;;; Packages as namespaces (GH #167).  Spec:
+;;;; docs/superpowers/specs/2026-08-23-packages-167-design.md
+(in-package #:graph-db/test)
+
+(def-suite package-namespace-suite :in graph-db-suite
+  :description "Placement defaults, lazy adoption, occupancy (GH #167).")
+(in-suite package-namespace-suite)
+
+;; Two stores under one *SYSTEM-DIRECTORY* so type-ids come from one
+;; registry.  Classes are defined at load time below (DEF-VERTEX is a
+;; top-level macro); each test opens fresh store directories.
+(defparameter *pn-store-a* :pn-store-a)
+(defparameter *pn-store-b* :pn-store-b)
+
+(def-vertex pn-item () ((label :type string)) :pn-store-a)
+(def-edge pn-link () () :pn-store-b)
+
+(defmacro with-pn-stores ((ga gb) &body body)
+  "Two open stores :PN-STORE-A / :PN-STORE-B under a fresh system dir.
+Resets both metadata lists' instantiation state by reopening from empty
+directories each time; the DEF-VERTEX/DEF-EDGE above re-register their
+metas at load time, which is all the constructors need."
+  (let ((sys (gensym)) (da (gensym)) (db (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,da)
+         (with-temp-directory (,db)
+           (let ((graph-db::*system-directory* (namestring ,sys))
+                 (graph-db::*type-registry* nil))
+             (let ((,ga (make-graph :pn-store-a (namestring ,da)
+                                    :buffer-pool-size 1000))
+                   (,gb nil))
+               (unwind-protect
+                    (progn
+                      (setq ,gb (make-graph :pn-store-b (namestring ,db)
+                                            :buffer-pool-size 1000))
+                      ,@body)
+                 (dolist (name '(:pn-store-b :pn-store-a))
+                   (let ((live (graph-db:lookup-graph name)))
+                     (when (and live (graph-db::graph-open-p live))
+                       (let ((graph-db:*graph* live))
+                         (ignore-errors
+                          (close-graph live :snapshot-p nil))))))
+                 (collect-garbage)))))))))
+
+(test constructor-defaults-to-the-declared-store-not-graph
+  "R1 ablation: *GRAPH* bound to store B, no :GRAPH argument -- the
+PN-ITEM lands in store A (its declared store).  Under the old
+*GRAPH* default this vertex would land in B."
+  (with-pn-stores (ga gb)
+    (let ((graph-db:*graph* gb))
+      (with-transaction ((graph-db::transaction-manager ga))
+        (make-pn-item :label "in-a")))
+    (is (= 1 (length (graph-db:map-vertices #'identity ga :collect-p t
+                                            :vertex-type 'pn-item))))
+    (is (= 0 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                            :vertex-type 'pn-item))))))
+
+(test constructor-explicit-graph-overrides-the-default
+  (with-pn-stores (ga gb)
+    (declare (ignorable ga))
+    (with-transaction ((graph-db::transaction-manager gb))
+      (make-pn-item :label "in-b" :graph gb))
+    (is (= 1 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                            :vertex-type 'pn-item))))))
+
+(test constructor-refuses-when-the-default-store-is-closed
+  "R1's third clause: no :GRAPH and :PN-STORE-A closed -- refuse by
+name, never fall back to *GRAPH* (the spec-rejected behaviour)."
+  (with-pn-stores (ga gb)
+    (let ((graph-db:*graph* gb))
+      (let ((graph-db:*graph* ga)) (close-graph ga :snapshot-p nil))
+      (let ((c (handler-case (progn (make-pn-item :label "x") nil)
+                 (graph-db:default-store-not-open-error (e) e))))
+        (is-true c)
+        (when c
+          (is (eq 'pn-item (graph-db:default-store-not-open-class c)))
+          (is (eq :pn-store-a
+                  (graph-db:default-store-not-open-store c)))))
+      ;; And no vertex leaked into the ambient store B.
+      (is (= 0 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                              :vertex-type 'pn-item)))))))
+
+(test edge-places-by-its-own-class-default
+  "PN-LINK's declared store is B: with both endpoints in A and *GRAPH*
+bound to A, the edge still lands in B (spec 4: an edge is a node and is
+placed the same way)."
+  (with-pn-stores (ga gb)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (let ((graph-db:*graph* ga))
+        (with-transaction ((graph-db::transaction-manager gb))
+          (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2))))
+      (is (= 1 (length (graph-db:map-edges #'identity gb :collect-p t
+                                           :edge-type 'pn-link))))
+      (is (= 0 (length (graph-db:map-edges #'identity ga :collect-p t
+                                           :edge-type 'pn-link)))))))
+```
+
+Adapt `map-vertices`/`map-edges` keyword names to the real arglists
+(`edge.lisp:353`, vertex counterpart) — the intent is a typed count per
+store. If `map-vertices` has no `:vertex-type`, filter with `typep` in
+the function.
+
+- [ ] **Step 2: Run** — first two tests FAIL (vertex lands in `*graph*`),
+  refusal test FAILS (no such condition).
+- [ ] **Step 3: Implement** in `schema.lisp`:
+
+```lisp
+(define-condition default-store-not-open-error (error)
+  ;; R1: the spec REJECTED silently writing to *GRAPH* when the class's
+  ;; declared store is not open -- placement determines recovery policy,
+  ;; so a silent fallback quietly changes durability (GH #167).
+  ((class-name :initarg :class-name
+               :reader default-store-not-open-class)
+   (store :initarg :store :reader default-store-not-open-store))
+  (:report (lambda (c s)
+             (format s "MAKE-~A: no :GRAPH argument and the class's ~
+default store ~S is not open.  Open it, or pass :GRAPH explicitly ~
+(GH #167)."
+                     (default-store-not-open-class c)
+                     (default-store-not-open-store c)))))
+
+(defun %default-store-graph (class-name store-name explicit)
+  "R1 resolution: EXPLICIT graph if given, else the OPEN graph named
+STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
+  (or explicit
+      (lookup-graph store-name)
+      (error 'default-store-not-open-error
+             :class-name class-name :store store-name)))
+```
+
+In the generated constructor, change the lambda list's
+`(graph *graph*)` to `(graph nil)` (both the edge and vertex arms) and
+bind at the top of the body:
+
+```lisp
+(let ((graph (%default-store-graph ',name ',graph-name graph)))
+  ...)
+```
+
+wrapping the existing `slots`/`make-edge`/`make-vertex` forms.
+
+- [ ] **Step 4: Run** — 4 tests pass; then run `node-class-tests` (or
+  the nearest schema suite) + `system-restore-suite` to prove no
+  regression in one-to-one code, and compile the whole system clean.
+- [ ] **Step 5: Commit** `feat(schema): constructors place at the class's default store, refusing silent *graph* (#167)`
+
+---
+
+### Task 2: R3 — lazy adoption of a foreign type at first write
+
+**Files:**
+- Modify: `schema.lisp` (new `%find-registered-node-type`,
+  `%ensure-type-in-store`; reroute the generated constructors' type
+  lookup), `package.lisp` (no new exports — internal),
+  `tests/package-namespace-tests.lisp`
+
+**Interfaces:**
+- Consumes: Task 1's constructor shape; existing
+  `lookup-node-type-by-name (name parent &key graph)`,
+  `instantiate-node-type (meta graph)` (handles registry id +
+  `save-schema`), `schema-lock`.
+- Produces: `(%find-registered-node-type symbol kind)` → meta or NIL
+  (scan `*schema-node-metadata*` values for `node-type-name` EQ symbol
+  and matching `node-type-parent-type`); `(%ensure-type-in-store name
+  kind graph)` → meta, instantiating lazily. Task 3 hooks occupancy
+  into `instantiate-node-type`.
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test class-is-instantiable-in-a-second-store
+  "cl-llm#20's acceptance: PN-ITEM (declared store A) written into B via
+explicit :GRAPH -- B adopts the type at first write, both stores hold
+their own instances, and the type-id is the same system-wide id."
+  (with-pn-stores (ga gb)
+    (with-transaction ((graph-db::transaction-manager ga))
+      (make-pn-item :label "a1"))
+    (with-transaction ((graph-db::transaction-manager gb))
+      (make-pn-item :label "b1" :graph gb))
+    (is (= 1 (length (graph-db:map-vertices #'identity ga :collect-p t
+                                            :vertex-type 'pn-item))))
+    (is (= 1 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                            :vertex-type 'pn-item))))
+    (let ((ma (graph-db:lookup-node-type-by-name 'pn-item :vertex
+                                                 :graph ga))
+          (mb (graph-db:lookup-node-type-by-name 'pn-item :vertex
+                                                 :graph gb)))
+      (is (= (graph-db::node-type-id ma) (graph-db::node-type-id mb))))))
+
+(test adopted-type-survives-reopen
+  "The adoption persisted via the store's own schema.dat: close B,
+reopen it, and the foreign-typed node reads back typed."
+  (with-pn-stores (ga gb)
+    (declare (ignorable ga))
+    (let (id (loc (namestring (graph-db::location gb))))
+      (with-transaction ((graph-db::transaction-manager gb))
+        (setq id (graph-db:id (make-pn-item :label "b1" :graph gb))))
+      (let ((graph-db:*graph* gb)) (close-graph gb :snapshot-p nil))
+      (let ((gb2 (open-graph :pn-store-b loc)))
+        (let ((v (graph-db:lookup-vertex id :graph gb2)))
+          (is (typep v 'pn-item))
+          (is (string= "b1" (label v))))))))
+
+(test two-packages-share-a-symbol-name-without-collision
+  "Distinct packages, same symbol-name, both usable -- pinned end to
+end, not just at definition."
+  (with-pn-stores (ga gb)
+    (declare (ignorable gb))
+    ;; The classes are defined at load time below in two scratch
+    ;; packages; both declare store A.
+    (with-transaction ((graph-db::transaction-manager ga))
+      (funcall (intern "MAKE-TWIN" :pn-pkg-one) :graph ga)
+      (funcall (intern "MAKE-TWIN" :pn-pkg-two) :graph ga))
+    (let ((c1 (find-class (intern "TWIN" :pn-pkg-one)))
+          (c2 (find-class (intern "TWIN" :pn-pkg-two))))
+      (is (not (eq c1 c2))))
+    (is (= 1 (length (graph-db:map-vertices
+                      #'identity ga :collect-p t
+                      :vertex-type (intern "TWIN" :pn-pkg-one)))))
+    (is (= 1 (length (graph-db:map-vertices
+                      #'identity ga :collect-p t
+                      :vertex-type (intern "TWIN" :pn-pkg-two)))))))
+```
+
+Top-of-file scratch packages for the twin test (adapt from
+`tests/peer-type-table-tests.lisp`'s two-package fixtures):
+
+```lisp
+(defpackage #:pn-pkg-one (:use #:cl #:graph-db))
+(defpackage #:pn-pkg-two (:use #:cl #:graph-db))
+(in-package #:pn-pkg-one)
+(graph-db:def-vertex twin () () :pn-store-a)
+(in-package #:pn-pkg-two)
+(graph-db:def-vertex twin () () :pn-store-a)
+(in-package #:graph-db/test)
+```
+
+(`def-vertex` interns `MAKE-TWIN` in the defining package; check what
+package the generated names land in and adjust the `intern` calls.)
+
+- [ ] **Step 2: Run** — second-store test FAILS (type unknown to B).
+- [ ] **Step 3: Implement** in `schema.lisp`:
+
+```lisp
+(defun %find-registered-node-type (name kind)
+  "The registered META whose class symbol is NAME (EQ -- package-aware)
+and parent KIND, from any default store's list, or NIL (GH #167)."
+  (maphash (lambda (store metas)
+             (declare (ignore store))
+             (let ((hit (find-if (lambda (m)
+                                   (and (eq (node-type-name m) name)
+                                        (eq (node-type-parent-type m)
+                                            kind)))
+                                 metas)))
+               (when hit (return-from %find-registered-node-type hit))))
+           *schema-node-metadata*)
+  nil)
+
+(defun %ensure-type-in-store (name kind graph)
+  "NAME's meta in GRAPH's schema, adopting it lazily on first write: a
+store learns a foreign class the moment a node of it is written there,
+durably via INSTANTIATE-NODE-TYPE's own SAVE-SCHEMA (GH #167, R3)."
+  (or (lookup-node-type-by-name name kind :graph graph)
+      (let ((meta (%find-registered-node-type name kind)))
+        (unless meta
+          (error "Node type ~S (~S) is not registered anywhere." name kind))
+        (with-recursive-lock-held ((schema-lock (schema graph)))
+          (or (lookup-node-type-by-name name kind :graph graph)
+              (progn (instantiate-node-type meta graph)
+                     (lookup-node-type-by-name name kind :graph graph)))))))
+```
+
+Reroute the generated constructors:
+`(lookup-node-type-by-name ',name :vertex :graph graph)` →
+`(%ensure-type-in-store ',name :vertex graph)` (and `:edge` arm).
+Check `schema-lock`'s real accessor name on the `schema` struct before
+using it. `instantiate-node-type` mutates the shared META's `id` slot —
+verify that is idempotent for a meta already carrying the registry id
+(the "new TO THIS STORE" branch assigns unconditionally from the
+registry, which returns the same id for the same name; confirm and note
+in the report).
+
+- [ ] **Step 4: Run** — all Task 1+2 tests pass; run `type-id-seeding` /
+  `global-type-id` suites for registry regressions.
+- [ ] **Step 5: Commit** `feat(schema): a store adopts a foreign class at first write (#167)`
+
+---
+
+### Task 3: R4 — edge store-occupancy sidecar
+
+**Files:**
+- Modify: `schema.lisp` (hook in `instantiate-node-type`) or a new
+  small `type-occupancy.lisp` after `type-registry` in the `.asd`
+  (implementer's choice; prefer the new file — registry-adjacent
+  responsibility), `package.lisp` (export `#:edge-type-stores`),
+  `tests/package-namespace-tests.lisp`
+
+**Interfaces:**
+- Consumes: `instantiate-node-type` call sites; `*system-directory*`,
+  `type-registry-location`, `ensure-type-registry`,
+  `system-directory-required` condition.
+- Produces: `(edge-type-stores name)` → list of store names (graph
+  names) known to hold NAME edges, or NIL = no hint;
+  `(%note-edge-occupancy name store)` internal;
+  `edge-occupancy.dat` beside `type-registry.log`, one readable
+  `(NAME STORE)` line per new pair, `*read-eval*` NIL on read, torn
+  final line dropped silently (it is only a hint).
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test edge-occupancy-tracks-stores-and-defaults-to-no-hint
+  "PN-LINK instantiated into B (its default) and adopted by A: the
+occupancy set names both; an undefined class name yields NIL (= sweep,
+the fail-safe)."
+  (with-pn-stores (ga gb)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (with-transaction ((graph-db::transaction-manager gb))
+        (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2)))
+      (with-transaction ((graph-db::transaction-manager ga))
+        (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2)
+                      :graph ga))
+      (is (null (set-difference '(:pn-store-a :pn-store-b)
+                                (graph-db:edge-type-stores 'pn-link))))
+      (is (null (graph-db:edge-type-stores 'pn-no-such-edge))))))
+
+(test edge-occupancy-persists-and-tolerates-a-torn-tail
+  "A fresh image (simulated: clear the in-image cache) reloads the set
+from edge-occupancy.dat; a torn final line is dropped, not an error."
+  (with-pn-stores (ga gb)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (with-transaction ((graph-db::transaction-manager gb))
+        (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2)))
+      (graph-db::%clear-edge-occupancy-cache)
+      (is (member :pn-store-b (graph-db:edge-type-stores 'pn-link)))
+      (let ((file (graph-db::%edge-occupancy-file)))
+        (with-open-file (out file :direction :output
+                             :if-exists :append)
+          (format out "(PN-TORN"))
+        (graph-db::%clear-edge-occupancy-cache)
+        (is (member :pn-store-b
+                    (graph-db:edge-type-stores 'pn-link)))))))
+```
+
+- [ ] **Step 2: Run** — FAIL (undefined `edge-type-stores`).
+- [ ] **Step 3: Implement** (`type-occupancy.lisp`): an in-image EQUAL
+  hash `class-symbol → store-name list` + lock; `%edge-occupancy-file`
+  = `edge-occupancy.dat` in `(type-registry-location (ensure-type-registry))`,
+  with `system-directory-required` caught → in-image only (R4 fallback);
+  `%note-edge-occupancy` appends one `~S`-printed `(name store)` line
+  under the lock when the pair is new (load the file first on first
+  use); reader parses lines with `*read-eval*` NIL and `read-from-string`
+  wrapped in `handler-case` — a malformed (torn) line is skipped;
+  `%clear-edge-occupancy-cache` resets the in-image state (tests +
+  `*system-directory*` rebinding). Hook: in `instantiate-node-type`,
+  when `(eq (node-type-parent-type meta) :edge)`, call
+  `(%note-edge-occupancy (node-type-name meta) (graph-name graph))`.
+  Print symbols package-qualified (`~S` with `*package*` bound to
+  `(find-package :keyword)`? No — bind `*package*` to
+  `(find-package :common-lisp)` so class symbols print qualified, the
+  manifest's #171 discipline).
+- [ ] **Step 4: Run** — Task 3 tests pass; re-run the whole
+  `package-namespace-suite`.
+- [ ] **Step 5: Commit** `feat(schema): edge classes maintain a store-occupancy hint (#167)`
+
+---
+
+### Task 4: Docs
+
+**Files:**
+- Modify: `CHANGELOG.md` — `### Changed` **breaking** entry: constructor
+  `:graph` default is now the class's declared store; omitted `:graph`
+  with the declared store closed signals `default-store-not-open-error`
+  instead of writing to `*graph*`; plus `### Added` for lazy adoption +
+  `edge-type-stores`.
+- Modify: `docs/vivace-graph-v3-doc.org` — schema chapter: "The trailing
+  argument is the class's default store" (placement rules R1, the
+  two-`in-package` example from epic spec §3.2, lazy adoption, the
+  occupancy hint and its fail-safe, and the explicit statement that
+  packages express rather than enforce, pointing at the ontology work).
+- Modify: `docs/superpowers/specs/2026-08-23-packages-167-design.md` —
+  short `**Built (#167):**` note (deviations if any).
+- Modify: `docs/superpowers/specs/2026-08-20-namespaces-design.md` —
+  §3.2/§3.3/§4 get a `**Built (#167):**` note; §11 unit 2 → **Done**.
+
+- [ ] Steps: write, verify org SRC balance + function names against
+  `package.lisp`, commit
+  `docs(schema): default-store placement, lazy adoption, occupancy (#167)`.
+
+---
+
+## Self-review
+
+- Spec coverage: R1 → T1; R2 → no task (deliberately no change; T1/T2
+  tests exercise the hash as-is); R3 → T2; R4 → T3; R5 → T4 docstrings;
+  R6 guard respected (no query rewiring, no placement rules). Issue
+  acceptance: multi-store class (T2), same-symbol packages (T2 twin
+  test), namespace spanning stores (T1+T2), existing consumers
+  unchanged (full suite at the branch gate), cl-llm#20 (T2).
+- Type consistency: `%default-store-graph`, `%ensure-type-in-store`,
+  `%find-registered-node-type`, `edge-type-stores`,
+  `%note-edge-occupancy`, `%clear-edge-occupancy-cache`,
+  `%edge-occupancy-file` used consistently across tasks.
+- Known judgment points delegated with instructions: `map-vertices`
+  arglist, generated-name packages in the twin test, `schema-lock`
+  accessor, `instantiate-node-type` id idempotence (T2 must verify and
+  report).

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -68,6 +68,12 @@ existing trailing argument keeps its position and becomes the class's **default 
 Existing single-package/single-graph code is unchanged and *is* the one-to-one case.
 Decoupling is additive: obtained by writing a second `in-package`, never by accident.
 
+**Built (#167):** Shipped as designed, no syntax change. The trailing
+argument's documented meaning is now "default store" throughout
+`schema.lisp`'s docstrings and the manual (Chapter 17). A class is
+instantiable in any store from its first write via lazy adoption (§3.3);
+see that entry for how a foreign store learns a type.
+
 ### 3.3 A class is instantiable in any store
 
 Placement is a property of the node, not the class.
@@ -84,6 +90,16 @@ store instantiates the types it holds.
 
 **Guarded (#196):** divergent slot sets across stores now signal
 `divergent-node-type-redefinition`; identical sets stay silent.
+
+**Built (#167):** `*schema-node-metadata*` kept its hash-by-store shape
+(not re-keyed by class symbol — R2 of the unit spec judged the churn not
+worth it); its key's meaning changed from ownership to default store. A
+store adopts a foreign class lazily at first write
+(`%ensure-type-in-store`, under the schema lock, durable via that
+store's own `save-schema`) rather than requiring the type to be declared
+there in advance. Placement itself (which store a write targets when
+`:graph` is omitted) is §4's `default-store-not-open-error` rule, not a
+change to this section's uniqueness/registry mechanics.
 
 ### 3.4 The global type registry
 
@@ -194,6 +210,14 @@ Placement stays visible at the call site.
 store, but by its own class default. This answers "whose store holds a cross-store edge"
 with no special case, and places the relation by *policy*: a derived claim defaults to a
 disposable store while an authored assertion defaults to a durable one.
+
+**Built (#167):** `default-store-not-open-error` (readers: class name,
+store name) plus the R1 default in `def-node-type`'s generated
+`make-<name>`. `*graph*` is never consulted for this decision; an edge's
+own class default covers it with no separate code path, per the
+paragraph above. §5.4's store-occupancy set is also built here, as an
+edge-class sidecar (`edge-type-stores`, fail-safe `NIL`,
+`edge-occupancy.dat`) — see §5.4's own Built note.
 
 ## 5. Identity and resolution
 
@@ -558,7 +582,7 @@ before this ships. That is a release gate, not a design gate.
 |---|---|---|---|---|
 | 1a | Widen `type-id` to 32 bits, sparse type-index, v3 head codec, migration — **ids stay per-graph** | #166 | — | **Done** |
 | 1b | Global type-ids: canonical registry (D14), distribution, handshake guard (D15), delete the uniqueness check | #186 | 1a | In progress |
-| 2 | Packages as namespaces; store/namespace decoupling; placement defaults | #167 | **1b**, #190 | Blocked |
+| 2 | Packages as namespaces; store/namespace decoupling; placement defaults | #167 | **1b**, #190 | **Done** |
 | 3 | Image-level clock, system journal, epoch leases | #168 | — | **Done** |
 | 4 | Tagged UUIDv8 store field, resolver, detached-read marker | #169 | 3 | Not started |
 | 5 | Detach quiescence protocol and shadow bulk load | #170 | 3, 4, #191 | Blocked |

--- a/docs/superpowers/specs/2026-08-23-packages-167-design.md
+++ b/docs/superpowers/specs/2026-08-23-packages-167-design.md
@@ -130,6 +130,23 @@ share a transaction domain by construction (§2).
 6. Full suite green on SBCL (ECL demoted). Closes vivace-graph#167 and
    cl-llm#20 (a class instantiable in more than one store).
 
+**Built (#167):** Shipped as designed — R1-R5 landed unchanged, R6's
+scope guard held (no placement-rule function, no per-namespace default,
+no query rewiring). Two additions surfaced by review that the design
+above did not anticipate: (1) `def-node-type`'s registration-list
+maintenance now **moves** a redeclared class's meta to its new default
+store instead of leaving a stale copy under the old store name — without
+this, `%find-registered-node-type`'s cross-store scan would find two
+entries for one class symbol and pick whichever `maphash` visited first;
+see the `redeclaring-a-class-moves-its-meta-to-the-new-store` test. (2)
+`%note-edge-occupancy`'s sidecar append is now guarded by
+`handler-case`/`ignore-errors` around the file write, not just around the
+initial `%edge-occupancy-file` lookup — a disk-full or permission failure
+on the append must degrade to in-image-only for the session, never
+propagate into the caller's real edge write; see
+`edge-occupancy-append-failure-does-not-abort-the-write`. Full suite
+green on SBCL (ECL demoted per standing directive).
+
 ## 4. Acceptance mapping
 
 | Issue acceptance | Where |

--- a/docs/superpowers/specs/2026-08-23-packages-167-design.md
+++ b/docs/superpowers/specs/2026-08-23-packages-167-design.md
@@ -133,12 +133,18 @@ share a transaction domain by construction (§2).
 **Built (#167):** Shipped as designed — R1-R5 landed unchanged, R6's
 scope guard held (no placement-rule function, no per-namespace default,
 no query rewiring). Two additions surfaced by review that the design
-above did not anticipate: (1) `def-node-type`'s registration-list
-maintenance now **moves** a redeclared class's meta to its new default
-store instead of leaving a stale copy under the old store name — without
-this, `%find-registered-node-type`'s cross-store scan would find two
-entries for one class symbol and pick whichever `maphash` visited first;
-see the `redeclaring-a-class-moves-its-meta-to-the-new-store` test. (2)
+above did not anticipate: (1) a first attempt made `def-node-type`'s
+registration-list maintenance **move** a redeclared class's meta to its
+new default store; this broke the #186 pattern of one class registered
+in more than one store (a live pattern in `tests/global-type-id-
+tests.lisp`, ~150 cascading test failures + an fd exhaustion crash), so
+the sweep was reverted. `%find-registered-node-type` instead takes an
+optional `prefer-store` argument and checks that store's own list
+first, falling back to a full scan only when unset; `%ensure-type-in-
+store` passes `(graph-name graph)` so ambiguity resolves
+deterministically to the calling store's own meta without disturbing
+any other store's registration. See
+`a-class-registered-in-two-stores-keeps-both-metas`. (2)
 `%note-edge-occupancy`'s sidecar append is now guarded by
 `handler-case`/`ignore-errors` around the file write, not just around the
 initial `%edge-occupancy-file` lookup — a disk-full or permission failure

--- a/docs/superpowers/specs/2026-08-23-packages-167-design.md
+++ b/docs/superpowers/specs/2026-08-23-packages-167-design.md
@@ -1,0 +1,141 @@
+# Packages as namespaces (#167) — unit design
+
+Unit 2 of the namespaces epic (#110), the last build unit. Implements
+`2026-08-20-namespaces-design.md` §2, §3.1–3.3, §4 (decisions D1, D3,
+D4, D7) against the code as it stands after units 1a/1b/3–6. Public
+repo: neutral names throughout.
+
+## 1. What already holds
+
+- Type-ids are system-wide (#186); `%check-node-class-graph-unique` is
+  **already deleted** — `def-node-type` carries the comment saying so,
+  and `divergent-node-type-redefinition` (#196) is the remaining guard.
+  This unit's "delete the check" bullet is done; what remains is the
+  *placement* half.
+- `def-node-type` already records `:package (package-name *package*)`;
+  only `rest.lisp:507` reads it today.
+- `*schema-node-metadata*` is an EQUAL hash keyed by the trailing
+  `graph-name` argument, holding ordered meta lists; `update-schema`
+  instantiates exactly the metas under the graph's own name.
+  **~45 test fixtures reset it by that key** — the keyed shape is a de
+  facto seam.
+- `make-<type>` constructors default `:graph` to `*graph*` — precisely
+  the "omit it and you silently get `*graph*`" behaviour §4 rejects.
+- A store's `schema.dat` persists whatever types were instantiated into
+  it and re-instantiates them on open, independent of the metadata
+  hash's keying.
+
+## 2. Rulings
+
+**R1 — Constructor placement: explicit `:graph` > the class's default
+store (must be open) > refuse.** `make-<type>`'s `:graph` default stops
+being `*graph*` and becomes the open graph registered under the class's
+declared store name. If that store is not open and no `:graph` was
+passed, signal `default-store-not-open-error` naming class and store —
+never fall back to `*graph*` silently, per §4's explicit rejection.
+One-to-one code is unaffected: there, `*graph*` *is* the declared
+store. `lookup-<type>` and the generic `make-vertex`/`make-edge`
+(`:generic`) keep their current `*graph*` behaviour — they take ids or
+explicit types, not class policy. *Cost if wrong:* multi-graph code
+that deliberately wrote a class into `*graph*` ≠ its declared store now
+gets an error or the declared store instead of the ambient graph — a
+visible behaviour change, called out in CHANGELOG as breaking.
+
+**R2 — `*schema-node-metadata*` keeps its hash-by-store shape; its
+key's *meaning* changes from ownership to default store.** The spec
+sentence "stops being keyed by graph-name" is implemented semantically,
+not literally: the trailing argument now *is* a store attribute (the
+write default), so keying registration by it loses nothing — a class is
+no longer *owned* by that key, and nothing refuses instantiating it
+elsewhere. Literal re-keying (flat list by class symbol) would churn
+~45 test fixtures and every reset seam for zero observable gain.
+Same-named classes in two packages are distinct symbols and already
+coexist under any keying. *Cost if wrong:* an internal reshape later;
+no on-disk or API surface depends on the hash's shape.
+
+**R3 — A store learns a foreign type lazily, at first write, and keeps
+it durably.** When a constructor targets a store whose schema lacks the
+type (`lookup-node-type-by-name` miss), the engine finds the registered
+meta by class symbol across the metadata hash, instantiates it into the
+target under the schema lock (`instantiate-node-type` + `save-schema`),
+and proceeds. Thereafter the type is in that store's `schema.dat` and
+reopens normally — `update-schema` itself is unchanged (it still
+instantiates the metas registered under the store's own name; foreign
+types come back from the store's persisted schema, not from the hash).
+A miss with *no* registered meta anywhere stays the current error.
+*Cost if wrong:* first write into a foreign store pays one schema save;
+concurrent first-writers serialize on the schema lock.
+
+**R4 — Edges place by their own class default; the occupancy set is an
+image-level sidecar of the type registry.** No edge-specific placement
+code exists to change — R1 covers edges because `make-<type>` for an
+edge class flows through the same default. The **store-occupancy set**
+(spec: "maintain on write, the lookup hint for cross-store edge
+queries") is maintained at the moment an edge class is instantiated
+into a store — exactly the first-write event, one record per
+(class, store) pair, appended to `edge-occupancy.dat` beside the type
+registry, `*read-eval*` NIL on read, tolerant of a torn tail by the
+same rule as the registry files. Exposed as
+`edge-type-stores (name) → list of store names, or NIL for unknown` —
+NIL means "no hint, sweep everything", so a lost or stale file costs a
+wasted lookup, never a wrong answer. When no system directory/type
+registry is configured, occupancy is maintained in-image only (same
+fail-safe). **No query API is rewired in this unit** — the consumer is
+the ontology/query work (#109); this unit delivers the maintained set
+and the accessor. *Cost if wrong:* if a consumer needs per-store
+counts or removal records later, the append-only format grows fields —
+additive.
+
+**R5 — `node-type-graph-name` keeps its name and its persisted form;
+its documented meaning becomes "default store".** `schema.dat` files
+and the peer wire (#206 type-table rows are name/supers only) are
+untouched; renaming the accessor would be gratuitous churn on a
+persisted struct. Docstrings and the manual say "default store"
+wherever they said "the graph". *Cost if wrong:* naming only.
+
+**R6 — Scope guard.** Not in this unit: placement *rules*/functions
+(§4 rejected them), per-namespace defaults (rejected), semantic
+enforcement of cross-namespace references (#109, opt-in), cross-store
+edge *query* surface (consumer of R4's hint), and any change to
+`cross-graph-transaction-error` — two namespaces in one store already
+share a transaction domain by construction (§2).
+
+## 3. Deliverables
+
+1. `default-store-not-open-error` (readers: class name, store name) and
+   the R1 constructor default in `def-node-type`'s generated
+   `make-<name>` (schema.lisp).
+2. `%find-registered-node-type (symbol kind)` — global meta lookup by
+   class symbol across the hash — and the R3 lazy instantiation hook in
+   the constructor path.
+3. Occupancy: `%note-edge-occupancy (name store)` called from
+   `instantiate-node-type` (edge kinds only), `edge-type-stores (name)`,
+   `edge-occupancy.dat` beside the type registry, loaded lazily.
+4. Docs: manual (schema chapter: default store, lazy adoption,
+   occupancy hint; the "one class, many stores" example from §3.2 with
+   two `in-package` forms), CHANGELOG **Changed (breaking)** entry for
+   R1, spec Built notes here and in the namespaces spec (§11 unit 2 →
+   Done).
+5. Tests (FiveAM, `tests/package-namespace-tests.lisp`): two packages
+   defining same-named classes without collision and with distinct
+   data; one class written into two stores via explicit `:graph`;
+   default-store placement (constructor with no `:graph` writes to the
+   declared store while `*graph*` is bound to another — ablation of
+   R1); refusal when the default store is closed; lazy adoption
+   persists across reopen (write into foreign store, close, reopen,
+   read back); edge placed by its own class default with endpoints in
+   two other stores; occupancy set reflects both stores and
+   `edge-type-stores` returns NIL for a never-written class; divergent
+   slot warning still fires (#196 regression pin).
+6. Full suite green on SBCL (ECL demoted). Closes vivace-graph#167 and
+   cl-llm#20 (a class instantiable in more than one store).
+
+## 4. Acceptance mapping
+
+| Issue acceptance | Where |
+|---|---|
+| Class instantiable in >1 store (cl-llm#20) | R1+R3, tests 2–5 |
+| Two packages, same symbol-name, no collision | already true post-#186; pinned by test 1 |
+| One namespace spans stores | R1 explicit `:graph` + R3; test 2 |
+| Existing consumers compile and write unchanged | R1 one-to-one case; full suite is the proof |
+| Full suite green | gate |

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3023,6 +3023,119 @@ existed, the second definition silently replaced the first class's slots,
 leaving the first graph's stored data unreachable through the API while still
 on disk.
 
+*** A namespace is a package; a store is files (GH #167)
+
+A *namespace* is a Lisp package: a set of symbols, and the unit of naming and
+ontological scoping. A *store* is a set of files — the unit of durability,
+snapshot, backup and detach. The two are independent axes. ~def-vertex~ and
+~def-edge~ never grew a namespace argument because they did not need one: the
+package comes from the ambient ~in-package~, exactly as for any other Lisp
+form, and the trailing argument you already pass is a store name. As of #167
+that trailing argument is documented precisely as the class's **default
+store** — where a node of that class lands when nothing says otherwise —
+rather than "the graph this type belongs to." A class does not belong to a
+store; it merely defaults to one.
+
+**Placement: explicit ~:graph~, else the default store, else refuse.**
+~make-<type>~ used to default a missing ~:graph~ to the ambient ~*graph*~,
+which meant omitting the argument silently placed the node in whatever graph
+happened to be bound at the call site — not necessarily the one the class was
+declared against. As of #167 that default is gone. Placement now follows one
+rule:
+
+1. An explicit ~:graph~ argument always wins.
+2. Otherwise, the class's declared default store, *if it is open*.
+3. Otherwise, refuse: signal ~default-store-not-open-error~, naming the class
+   and the store it wanted.
+
+~*graph*~ is never consulted by this decision. That is deliberate, not an
+oversight: placement determines recovery policy — which store's WAL, which
+store's backup schedule, which store's detach boundary a node falls under —
+and a rule that quietly substitutes whatever graph is ambient would change a
+node's durability story without saying so at the call site. An error that
+names the class and the missing store is recoverable in a way a silent wrong
+answer is not: open the store, or pass ~:graph~ explicitly, and proceed.
+
+One-to-one code — a single package, a single store, ~:graph~ never passed —
+is completely unaffected: there, ~*graph*~ *is* the declared store, by
+construction, on every call. The behaviour change is visible only to code
+that deliberately writes a class into a graph other than the one it was
+declared against, without saying so via ~:graph~.
+
+**One namespace, several stores.** Decoupling naming from placement is
+obtained by writing a second ~in-package~, never by accident:
+
+#+BEGIN_SRC lisp
+  (in-package :fish)
+  (def-vertex species () ((latin-name :type string)) :taxonomy)
+#+END_SRC
+
+~fish::species~ and a same-named ~primate::species~ defined the same way are
+distinct CLOS classes that happen to share a symbol-name — see "Class names
+are global" above for what happens if you instead want *one* class shared
+across stores. A single namespace may equally *span* several stores: a
+package's authored nodes can default to a durable store and its derived
+nodes to a disposable one, without splitting the ontology across packages.
+Nothing about namespace membership constrains which store a node of that
+namespace ends up in; only the class's own default, and any explicit
+~:graph~, does that.
+
+**A store adopts a foreign class lazily, at first write.** Writing a node of
+a class whose default store is *not* the target graph — via explicit
+~:graph~ — no longer requires the class to have been declared against that
+store in advance. The first such write finds the class's registered metadata,
+instantiates it into the target store under its own schema lock, and saves
+that store's ~schema.dat~. From then on the type is durably part of that
+store: it survives a close and reopen exactly like a type declared there from
+the start, because it now *is* one, on disk. A ~make-<type>~ call that names
+a store with no registered metadata for that class anywhere in the image
+still errors, as before — adoption finds an existing declaration, it does
+not invent one.
+
+**Edges place by their own class default, not by an endpoint's store.** An
+edge is a node, so §4's rule covers it with no special case: a cross-store
+edge — endpoints living in two different stores, neither necessarily the
+edge's own — is placed by the edge class's declared default, the same as any
+vertex. This is a policy point, not an accident of implementation: a derived
+relationship can default to a disposable store while an authored one defaults
+to a durable one, independent of where its endpoints happen to live.
+
+**The store-occupancy hint, and why it is allowed to be wrong.** Sweeping
+every open store to find which one holds a given edge class is wasteful once
+a system has more than a couple of stores, so each edge class keeps an
+image-level occupancy hint, updated the moment it is instantiated into a
+store — declared-store instantiation and lazy adoption both go through the
+same path, so both update it:
+
+#+BEGIN_SRC lisp
+  (graph-db:edge-type-stores 'follows)
+  ;; => (:social-app :archive)   or NIL for "no hint, sweep everything"
+#+END_SRC
+
+The hint is durable — appended to ~edge-occupancy.dat~ beside the type
+registry under ~*system-directory*~ — and *fails safe*: a missing directory,
+an unreadable or torn file, or a class this image has never written all
+answer ~NIL~. Nothing here is a source of truth; a stale or absent hint costs
+one wasted lookup by a consumer, never a wrong answer. When no system
+directory is configured at all, the hint lives in-image only for the
+session, with the same fail-safe shape. Nothing in this unit *consumes* the
+hint for query routing — that is for the ontology/cross-store query work — it
+only maintains it and exposes ~edge-type-stores~ for a future or external
+consumer to read.
+
+**Packages express ontological separation; they do not enforce it.** Two
+namespaces sharing a store are already in one transaction domain at one
+clock — co-locating things that share an invariant is how you give them
+transactional consistency, and separating them into distinct packages when
+they should not be able to reach into each other is how you make that
+lexically visible. But ~::~ bypasses a package, and nothing stops a node
+holding a foreign class's id: the engine does not refuse a cross-namespace
+reference, it only makes one obvious at the call site. Semantic
+*enforcement* of namespace boundaries — refusing a reference that crosses an
+ontological line, not merely a lexical one — is the opt-in ontology subsystem
+(GH #109 and its units), layered on top of, and not part of, what packages
+give you here.
+
 *** ~*transaction*~ is NIL inside a read-only snapshot
 
 ~with-read-snapshot~ (and ~select~/~do-query~ with ~:snapshot t~) records its

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -539,6 +539,7 @@ cl-temporal-extent."
                (:file "store-resolver-tests")     ; GH #169
                (:file "detach-tests")             ; GH #170
                (:file "system-restore-tests")     ; GH #171
+               (:file "package-namespace-tests")  ; GH #167
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -63,6 +63,9 @@
                ;; The image-level store-id registry (GH #169).  Same shape
                ;; as type-registry; graph-class references +MAX-STORE-TAG+.
                (:file "store-registry" :depends-on ("type-registry"))
+               ;; The edge store-occupancy sidecar (GH #167, spec R4):
+               ;; registry-adjacent, no graph dependency of its own.
+               (:file "type-occupancy" :depends-on ("type-registry"))
                (:file "geometry" :depends-on ("serialize"))
                (:file "geometry-ops" :depends-on ("geometry"))
                (:file "geohash" :depends-on ("package"))
@@ -91,7 +94,7 @@
                ;; "type-registry" for ASSIGN-TYPE-ID / ENSURE-TYPE-REGISTRY
                ;; (#186); it only built before because that component happens
                ;; to precede this one in the list.
-               (:file "schema" :depends-on ("stats" "type-registry"))
+               (:file "schema" :depends-on ("stats" "type-registry" "type-occupancy"))
                ;; Reads a store's schema.dat and heap header, so it cannot
                ;; live in "type-registry" -- "schema" depends on THAT (#186).
                (:file "type-seeding"

--- a/package.lisp
+++ b/package.lisp
@@ -293,6 +293,11 @@
            #:divergent-type-name
            #:divergent-type-graph-name
            #:divergent-type-other-graphs
+
+           ;; packages as namespaces (GH #167)
+           #:default-store-not-open-error
+           #:default-store-not-open-class
+           #:default-store-not-open-store
            #:instantiate-node-type
            #:*schema-node-metadata*
            #:with-write-locked-class

--- a/package.lisp
+++ b/package.lisp
@@ -124,6 +124,8 @@
            #:*type-registry*
            #:system-directory-required
            #:system-directory-required-operation
+           ;; edge store-occupancy sidecar (GH #167)
+           #:edge-type-stores
            ;; image-level store-id registry (GH #169)
            #:ensure-store-registry
            #:store-registry-intern

--- a/rest.lisp
+++ b/rest.lisp
@@ -685,7 +685,10 @@ A malformed query or a resource-bound breach is a 400, a forbidden effect a 403.
                                                    params
                                                    :test 'string-equal))))
                                slots))
-                     (node (apply constructor slot-args)))
+                     ;; The URL's graph IS the explicit :graph -- without
+                     ;; it the node lands in the class's declared store,
+                     ;; not the store the request named (GH #167).
+                     (node (apply constructor :graph *graph* slot-args)))
                 (json-encode node))
               (json:encode-json-to-string
                (list (cons :error error-string)))))))))
@@ -746,7 +749,9 @@ A malformed query or a resource-bound breach is a 400, a forbidden effect a 403.
                                                    :test 'string-equal))))
                                slots)))
                 (if (and from to)
-                    (let ((node (apply constructor :from from :to to
+                    ;; :graph *graph* -- see rest-post-vertex (GH #167).
+                    (let ((node (apply constructor :graph *graph*
+                                       :from from :to to
                                        slot-args)))
                       (json-encode node))
                     (json:encode-json-to-string

--- a/schema.lisp
+++ b/schema.lisp
@@ -350,6 +350,35 @@ default store ~S is not open.  Open it, or pass :GRAPH explicitly ~
                      (default-store-not-open-class c)
                      (default-store-not-open-store c)))))
 
+(defun %find-registered-node-type (name kind)
+  "The registered META whose class symbol is NAME (EQ -- package-aware)
+and parent KIND, from any default store's list, or NIL (GH #167)."
+  (maphash (lambda (store metas)
+             (declare (ignore store))
+             (let ((hit (find-if (lambda (m)
+                                    (and (eq (node-type-name m) name)
+                                         (eq (node-type-parent-type m)
+                                             kind)))
+                                  metas)))
+               (when hit (return-from %find-registered-node-type hit))))
+           *schema-node-metadata*)
+  nil)
+
+(defun %ensure-type-in-store (name kind graph)
+  "NAME's meta in GRAPH's schema, adopting it lazily on first write: a
+store learns a foreign class the moment a node of it is written there,
+durably via INSTANTIATE-NODE-TYPE's own SAVE-SCHEMA (GH #167, R3)."
+  (or (lookup-node-type-by-name name kind :graph graph)
+      (let ((meta (%find-registered-node-type name kind)))
+        (unless meta
+          (error "Node type ~S (~S) is not registered anywhere."
+                 name kind))
+        (with-recursive-lock-held ((schema-lock (schema graph)))
+          (or (lookup-node-type-by-name name kind :graph graph)
+              (progn (instantiate-node-type meta graph)
+                     (lookup-node-type-by-name name kind
+                                                :graph graph)))))))
+
 (defun %default-store-graph (class-name store-name explicit)
   "R1 resolution: EXPLICIT graph if given, else the OPEN graph named
 STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
@@ -439,15 +468,15 @@ be defined before or after the graph is created."
                                    (data-slots (find-class ',name))))))
                       ,(if (eql (last1 parent-types) 'edge)
                            `(make-edge (node-type-id
-                                        (lookup-node-type-by-name ',name :edge
-                                                                  :graph graph))
+                                        (%ensure-type-in-store ',name :edge
+                                                                graph))
                                        from to weight
                                        slots ;(list ,@slots)
                                        :id id :revision revision :deleted-p deleted-p
                                        :graph graph)
                            `(make-vertex (node-type-id
-                                          (lookup-node-type-by-name ',name :vertex
-                                                                    :graph graph))
+                                          (%ensure-type-in-store ',name :vertex
+                                                                  graph))
                                          slots ;(list ,@slots)
                                          :id id :revision revision :deleted-p deleted-p
                                          :graph graph)))))

--- a/schema.lisp
+++ b/schema.lisp
@@ -336,6 +336,28 @@ evolution and is not this guard's business (GH #196)."
             :graph-name (node-type-graph-name meta)
             :other-graphs (nreverse divergent)))))
 
+(define-condition default-store-not-open-error (error)
+  ;; R1: the spec REJECTED silently writing to *GRAPH* when the class's
+  ;; declared store is not open -- placement determines recovery policy,
+  ;; so a silent fallback quietly changes durability (GH #167).
+  ((class-name :initarg :class-name
+               :reader default-store-not-open-class)
+   (store :initarg :store :reader default-store-not-open-store))
+  (:report (lambda (c s)
+             (format s "MAKE-~A: no :GRAPH argument and the class's ~
+default store ~S is not open.  Open it, or pass :GRAPH explicitly ~
+(GH #167)."
+                     (default-store-not-open-class c)
+                     (default-store-not-open-store c)))))
+
+(defun %default-store-graph (class-name store-name explicit)
+  "R1 resolution: EXPLICIT graph if given, else the OPEN graph named
+STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
+  (or explicit
+      (lookup-graph store-name)
+      (error 'default-store-not-open-error
+             :class-name class-name :store store-name)))
+
 (defmacro def-node-type (name parent-types slot-specs graph-name &key keep-revisions)
   "Define a persistent node type NAME for the graph named GRAPH-NAME.  This is
 the machinery behind DEF-VERTEX and DEF-EDGE; you normally use those instead.
@@ -400,11 +422,13 @@ be defined before or after the graph is created."
                  thing)))
            ,(let ((args (if (eql (last1 parent-types) 'edge)
                             '(&rest make-args
-                              &key (graph *graph*) id deleted-p revision from to weight &allow-other-keys)
+                              &key (graph nil) id deleted-p revision from to weight &allow-other-keys)
                             '(&rest make-args
-                              &key (graph *graph*) id deleted-p revision &allow-other-keys))))
+                              &key (graph nil) id deleted-p revision &allow-other-keys))))
                  `(defun ,constructor ,args
-                    (let ((slots (remove-if
+                    (let ((graph (%default-store-graph
+                                  ',name ',graph-name graph))
+                          (slots (remove-if
                                   'null
                                   (mapcar
                                    (lambda (slot-name)

--- a/schema.lisp
+++ b/schema.lisp
@@ -798,6 +798,13 @@ is the only point at which that ordering is guaranteed."
                              (ignore-errors (location graph))))))))
 
 (defmethod instantiate-node-type ((meta node-type) (graph graph))
+  ;; R4 (GH #167): edge classes maintain a store-occupancy hint at the
+  ;; moment they are instantiated into a store -- covers both the
+  ;; declared-store path and lazy cross-store adoption, since both flow
+  ;; through here.  Re-instantiation at UPDATE-SCHEMA/reopen is a no-op:
+  ;; %NOTE-EDGE-OCCUPANCY only appends when the (name, store) pair is new.
+  (when (eq (node-type-parent-type meta) :edge)
+    (%note-edge-occupancy (node-type-name meta) (graph-name graph)))
   (with-recursive-lock-held ((schema-lock (schema graph)))
     (let ((cl (find-class (node-type-name meta) nil)))
       ;; Drop EVERY memoized CLASS-SLOTS-derived answer for this class and its

--- a/schema.lisp
+++ b/schema.lisp
@@ -388,8 +388,11 @@ STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
              :class-name class-name :store store-name)))
 
 (defmacro def-node-type (name parent-types slot-specs graph-name &key keep-revisions)
-  "Define a persistent node type NAME for the graph named GRAPH-NAME.  This is
-the machinery behind DEF-VERTEX and DEF-EDGE; you normally use those instead.
+  "Define a persistent node type NAME whose default store is GRAPH-NAME.  This
+is the machinery behind DEF-VERTEX and DEF-EDGE; you normally use those
+instead.  NAME's package comes from the ambient *PACKAGE* at macroexpansion
+time, not from this form -- namespace and default store are independent axes
+(GH #167).
 
 PARENT-TYPES is a single-inheritance superclass list ending in VERTEX or EDGE.
 SLOT-SPECS are CLOS-style slot definitions (a bare symbol, or (name :type ...)
@@ -399,8 +402,12 @@ Expands to a (defclass ... (:metaclass node-class)) plus generated helpers:
 MAKE-<NAME> (constructor), LOOKUP-<NAME> (id -> node, skipping deleted unless
 :include-deleted-p), and <NAME>-P (predicate).  For edges it also defines the
 Prolog functors <NAME>/2 and <NAME>/3.  The type metadata is registered under
-GRAPH-NAME and instantiated into the graph if it already exists, so a type may
-be defined before or after the graph is created."
+GRAPH-NAME and instantiated into that store if it is already open, so a type
+may be defined before or after its default store is created.  MAKE-<NAME>
+places a new node in GRAPH-NAME when :GRAPH is omitted (open, or else
+DEFAULT-STORE-NOT-OPEN-ERROR); an explicit :GRAPH always overrides the
+default and adopts the type into that store lazily on first write if it is
+not already known there (GH #167, R1/R3)."
   (with-gensyms (meta graph metas pos)
     (let* ((constructor (intern (format nil "MAKE-~A" name)))
            (predicate (intern (format nil "~A-P" name)))
@@ -619,25 +626,29 @@ be defined before or after the graph is created."
            )))))
 
 (defmacro def-vertex (name parent-types slot-specs graph-name &key keep-revisions)
-  "Define a vertex (node) type NAME for the graph named GRAPH-NAME.
+  "Define a vertex (node) type NAME whose default store is GRAPH-NAME.
 
 PARENT-TYPES is a list of other vertex types to inherit from (often empty);
 VERTEX is appended automatically.  SLOT-SPECS are CLOS-style typed slots.
 Generates MAKE-NAME / LOOKUP-NAME / NAME-P and slot accessors.  Example:
   (def-vertex user () ((username :type string)) :social-app)
-:KEEP-REVISIONS N overrides, for this type, how many prior MVCC versions the
-reaper retains (NIL = inherit the graph default).
+MAKE-NAME places a new vertex in GRAPH-NAME when :GRAPH is omitted (it must
+be open), or in an explicit :GRAPH, adopting the type there lazily on first
+write (GH #167).  :KEEP-REVISIONS N overrides, for this type, how many prior
+MVCC versions the reaper retains (NIL = inherit the graph default).
 See DEF-NODE-TYPE for full details and DEF-EDGE for relationships."
   `(def-node-type ,name (,@parent-types vertex) ,slot-specs ,graph-name
      :keep-revisions ,keep-revisions))
 
 (defmacro def-edge (name parent-types slot-specs graph-name &key keep-revisions)
-  "Define an edge (relationship) type NAME for the graph named GRAPH-NAME.
+  "Define an edge (relationship) type NAME whose default store is GRAPH-NAME.
 
 Like DEF-VERTEX but the type inherits from EDGE, so its constructor also takes
 :FROM, :TO and :WEIGHT.  Generates MAKE-NAME / LOOKUP-NAME / NAME-P, slot
-accessors, and the Prolog query functors NAME/2 and NAME/3.  :KEEP-REVISIONS N
-overrides this type's retained-version count (NIL = inherit the graph default).
+accessors, and the Prolog query functors NAME/2 and NAME/3.  An edge is
+placed by its own class default exactly like a vertex, independent of which
+store its endpoints live in (GH #167).  :KEEP-REVISIONS N overrides this
+type's retained-version count (NIL = inherit the graph default).
 Example:
   (def-edge follows () () :social-app)
   ... (make-follows :from alice :to bob)"

--- a/schema.lisp
+++ b/schema.lisp
@@ -350,26 +350,35 @@ default store ~S is not open.  Open it, or pass :GRAPH explicitly ~
                      (default-store-not-open-class c)
                      (default-store-not-open-store c)))))
 
-(defun %find-registered-node-type (name kind)
+(defun %find-registered-node-type (name kind &optional prefer-store)
   "The registered META whose class symbol is NAME (EQ -- package-aware)
-and parent KIND, from any default store's list, or NIL (GH #167)."
-  (maphash (lambda (store metas)
-             (declare (ignore store))
-             (let ((hit (find-if (lambda (m)
-                                    (and (eq (node-type-name m) name)
-                                         (eq (node-type-parent-type m)
-                                             kind)))
-                                  metas)))
-               (when hit (return-from %find-registered-node-type hit))))
-           *schema-node-metadata*)
-  nil)
+and parent KIND. A class may be registered under more than one store
+(GH #186); PREFER-STORE's own list is checked first so the choice is
+deterministic, then every store is scanned as a fallback. NIL if
+nowhere (GH #167)."
+  (flet ((scan (metas)
+           (find-if (lambda (m)
+                      (and (eq (node-type-name m) name)
+                           (eq (node-type-parent-type m) kind)))
+                    metas)))
+    (when prefer-store
+      (let ((hit (scan (gethash prefer-store *schema-node-metadata*))))
+        (when hit (return-from %find-registered-node-type hit))))
+    (maphash (lambda (store metas)
+               (declare (ignore store))
+               (let ((hit (scan metas)))
+                 (when hit
+                   (return-from %find-registered-node-type hit))))
+             *schema-node-metadata*)
+    nil))
 
 (defun %ensure-type-in-store (name kind graph)
   "NAME's meta in GRAPH's schema, adopting it lazily on first write: a
 store learns a foreign class the moment a node of it is written there,
 durably via INSTANTIATE-NODE-TYPE's own SAVE-SCHEMA (GH #167, R3)."
   (or (lookup-node-type-by-name name kind :graph graph)
-      (let ((meta (%find-registered-node-type name kind)))
+      (let ((meta (%find-registered-node-type
+                   name kind (graph-name graph))))
         (unless meta
           (error "Node type ~S (~S) is not registered anywhere."
                  name kind))
@@ -456,11 +465,14 @@ not already known there (GH #167, R1/R3)."
                           (or include-deleted-p
                               (not (deleted-p thing))))
                  thing)))
-           ,(let ((args (if (eql (last1 parent-types) 'edge)
-                            '(&rest make-args
-                              &key (graph nil) id deleted-p revision from to weight &allow-other-keys)
-                            '(&rest make-args
-                              &key (graph nil) id deleted-p revision &allow-other-keys))))
+           ,(let ((args
+                   (if (eql (last1 parent-types) 'edge)
+                       '(&rest make-args
+                         &key (graph nil) id deleted-p revision
+                         from to weight &allow-other-keys)
+                       '(&rest make-args
+                         &key (graph nil) id deleted-p revision
+                         &allow-other-keys))))
                  `(defun ,constructor ,args
                     (let ((graph (%default-store-graph
                                   ',name ',graph-name graph))
@@ -599,16 +611,11 @@ not already known there (GH #167, R1/R3)."
                                          *graph*
                                          :edge-type ',name)))))
                   )
-           ;; A class has exactly one default store: re-declaring it under a
-           ;; different trailing GRAPH-NAME MOVES the meta, matching CLOS
-           ;; redefinition semantics.  Without this, the old store's list
-           ;; keeps a stale entry and %FIND-REGISTERED-NODE-TYPE's scan over
-           ;; every store picks whichever maphash visits first (GH #167).
-           (maphash (lambda (store metas)
-                      (unless (eq store ',graph-name)
-                        (setf (gethash store *schema-node-metadata*)
-                              (remove ',name metas :key #'node-type-name))))
-                    *schema-node-metadata*)
+           ;; A class may be registered under more than one store (#186);
+           ;; each store keeps its own meta entry independently.  Only
+           ;; GRAPH-NAME's own list is touched here -- %FIND-REGISTERED-
+           ;; NODE-TYPE resolves ambiguity deterministically via its
+           ;; preferred-store argument (GH #167).
            ;; Replace in place, preserving position.  The type-id reason is
            ;; historical: ids came from this list's order until #186 moved
            ;; assignment to the registry, which keys on the name.  Position

--- a/schema.lisp
+++ b/schema.lisp
@@ -592,6 +592,16 @@ be defined before or after the graph is created."
                                          *graph*
                                          :edge-type ',name)))))
                   )
+           ;; A class has exactly one default store: re-declaring it under a
+           ;; different trailing GRAPH-NAME MOVES the meta, matching CLOS
+           ;; redefinition semantics.  Without this, the old store's list
+           ;; keeps a stale entry and %FIND-REGISTERED-NODE-TYPE's scan over
+           ;; every store picks whichever maphash visits first (GH #167).
+           (maphash (lambda (store metas)
+                      (unless (eq store ',graph-name)
+                        (setf (gethash store *schema-node-metadata*)
+                              (remove ',name metas :key #'node-type-name))))
+                    *schema-node-metadata*)
            ;; Replace in place, preserving position.  The type-id reason is
            ;; historical: ids came from this list's order until #186 moved
            ;; assignment to the registry, which keys on the name.  Position

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -14,9 +14,11 @@
 
 (def-vertex pn-item () ((label :type string)) :pn-store-a)
 (def-edge pn-link () () :pn-store-b)
-;; Scratch class for the redeclare-moves-the-meta test below; never
-;; written to, so its own store need not be open.
-(def-vertex pn-redeclared () () :pn-store-a)
+;; Scratch class registered under BOTH stores (#186 pattern) for the
+;; preferred-store-determinism test below; never written to, so
+;; neither store need be open.
+(def-vertex pn-dual () () :pn-store-a)
+(def-vertex pn-dual () () :pn-store-b)
 
 ;; Two scratch packages, same symbol-name TWIN, both declared into
 ;; store A -- DEF-VERTEX interns MAKE-<NAME>/<NAME>-P in *PACKAGE* at
@@ -166,31 +168,30 @@ end, not just at definition."
                       #'identity ga :collect-p t
                       :vertex-type (intern "TWIN" :pn-pkg-two)))))))
 
-(test redeclaring-a-class-moves-its-meta-to-the-new-store
-  "A class has exactly one default store: re-declaring PN-REDECLARED
-with :PN-STORE-B as the trailing argument must MOVE its meta, not
-leave a stale copy under :PN-STORE-A -- else %FIND-REGISTERED-NODE-
-TYPE's cross-store scan is ambiguous (GH #167 review round 1)."
-  (unwind-protect
-       (progn
-         (eval '(def-vertex pn-redeclared () () :pn-store-b))
-         (is (not (find 'pn-redeclared
-                        (gethash :pn-store-a
-                                 graph-db::*schema-node-metadata*)
-                        :key #'graph-db::node-type-name)))
-         (let ((meta (find 'pn-redeclared
-                           (gethash :pn-store-b
-                                    graph-db::*schema-node-metadata*)
-                           :key #'graph-db::node-type-name)))
-           (is-true meta)
-           (when meta
-             (is (eq :pn-store-b (graph-db::node-type-graph-name meta)))
-             (is (eq meta
-                     (graph-db::%find-registered-node-type
-                      'pn-redeclared :vertex))))))
-    ;; Restore the load-time declaration so later tests (and later
-    ;; runs of this suite in the same image) see the original store.
-    (eval '(def-vertex pn-redeclared () () :pn-store-a))))
+(test a-class-registered-in-two-stores-keeps-both-metas
+  "PN-DUAL is declared under both :PN-STORE-A and :PN-STORE-B (#186):
+both metas survive, and %FIND-REGISTERED-NODE-TYPE's PREFER-STORE
+argument deterministically picks the requested store's own meta
+(GH #167 review round 1, reversed)."
+  (let ((meta-a (find 'pn-dual
+                      (gethash :pn-store-a
+                               graph-db::*schema-node-metadata*)
+                      :key #'graph-db::node-type-name))
+        (meta-b (find 'pn-dual
+                      (gethash :pn-store-b
+                               graph-db::*schema-node-metadata*)
+                      :key #'graph-db::node-type-name)))
+    (is-true meta-a)
+    (is-true meta-b)
+    (when (and meta-a meta-b)
+      (is (eq :pn-store-a (graph-db::node-type-graph-name meta-a)))
+      (is (eq :pn-store-b (graph-db::node-type-graph-name meta-b)))
+      (is (eq meta-a
+              (graph-db::%find-registered-node-type
+               'pn-dual :vertex :pn-store-a)))
+      (is (eq meta-b
+              (graph-db::%find-registered-node-type
+               'pn-dual :vertex :pn-store-b))))))
 
 (test edge-occupancy-tracks-stores-and-defaults-to-no-hint
   "PN-LINK instantiated into B (its default) and adopted by A: the
@@ -229,6 +230,23 @@ from edge-occupancy.dat; a torn final line is dropped, not an error."
         (graph-db::%clear-edge-occupancy-cache)
         (is (member :pn-store-b
                     (graph-db:edge-type-stores 'pn-link)))))))
+
+(test edge-occupancy-load-failure-degrades-to-no-hint
+  "%LOAD-EDGE-OCCUPANCY must never signal: point the sidecar path at a
+directory (PROBE-FILE succeeds, WITH-OPEN-FILE :INPUT does not) and
+confirm the lookup still returns cleanly with no hint (GH #167, final
+review I1)."
+  (with-pn-stores (ga gb)
+    ga gb
+    (let ((orig (fdefinition 'graph-db::%edge-occupancy-file)))
+      (unwind-protect
+           (progn
+             (setf (fdefinition 'graph-db::%edge-occupancy-file)
+                   (lambda () (uiop:temporary-directory)))
+             (graph-db::%clear-edge-occupancy-cache)
+             (is (null (graph-db:edge-type-stores 'pn-link))))
+        (setf (fdefinition 'graph-db::%edge-occupancy-file) orig)
+        (graph-db::%clear-edge-occupancy-cache)))))
 
 (test edge-occupancy-append-failure-does-not-abort-the-write
   "A failed sidecar append (disk full, permissions, fd exhaustion) must

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -1,0 +1,107 @@
+;;;; Packages as namespaces (GH #167).  Spec:
+;;;; docs/superpowers/specs/2026-08-23-packages-167-design.md
+(in-package #:graph-db/test)
+
+(def-suite package-namespace-suite :in graph-db-suite
+  :description "Placement defaults, lazy adoption, occupancy (GH #167).")
+(in-suite package-namespace-suite)
+
+;; Two stores under one *SYSTEM-DIRECTORY* so type-ids come from one
+;; registry.  Classes are defined at load time below (DEF-VERTEX is a
+;; top-level macro); each test opens fresh store directories.
+(defparameter *pn-store-a* :pn-store-a)
+(defparameter *pn-store-b* :pn-store-b)
+
+(def-vertex pn-item () ((label :type string)) :pn-store-a)
+(def-edge pn-link () () :pn-store-b)
+
+(defmacro with-pn-stores ((ga gb) &body body)
+  "Two open stores :PN-STORE-A / :PN-STORE-B under a fresh system dir.
+Resets both metadata lists' instantiation state by reopening from empty
+directories each time; the DEF-VERTEX/DEF-EDGE above re-register their
+metas at load time, which is all the constructors need."
+  (let ((sys (gensym)) (da (gensym)) (db (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,da)
+         (with-temp-directory (,db)
+           (let ((graph-db::*system-directory* (namestring ,sys))
+                 (graph-db::*type-registry* nil))
+             (let ((,ga (make-graph :pn-store-a (namestring ,da)
+                                    :buffer-pool-size 1000))
+                   (,gb nil))
+               (unwind-protect
+                    (progn
+                      (setq ,gb (make-graph :pn-store-b (namestring ,db)
+                                            :buffer-pool-size 1000))
+                      ,@body)
+                 (dolist (name '(:pn-store-b :pn-store-a))
+                   (let ((live (graph-db:lookup-graph name)))
+                     (when (and live (graph-db::graph-open-p live))
+                       (let ((graph-db:*graph* live))
+                         (ignore-errors
+                          (close-graph live :snapshot-p nil))))))
+                 (collect-garbage)))))))))
+
+(test constructor-defaults-to-the-declared-store-not-graph
+  "R1 ablation: *GRAPH* bound to store B, no :GRAPH argument -- the
+PN-ITEM lands in store A (its declared store).  Under the old
+*GRAPH* default this vertex would land in B."
+  (with-pn-stores (ga gb)
+    (let ((graph-db:*graph* gb))
+      (with-transaction ((graph-db::transaction-manager ga))
+        (make-pn-item :label "in-a")))
+    (is (= 1 (length (graph-db:map-vertices #'identity ga :collect-p t
+                                            :vertex-type 'pn-item))))
+    (is (= 0 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                            :vertex-type 'pn-item))))))
+
+(test constructor-explicit-graph-overrides-the-default
+  ;; Adaptation note (GH #167 task 1): PN-ITEM's type is only auto-
+  ;; instantiated into its DECLARED store (:PN-STORE-A) -- adopting it
+  ;; into a foreign store on first write is Task 3's lazy-adoption work,
+  ;; not this task's.  Instantiate it into GB by hand here so this test
+  ;; isolates R1 (does :GRAPH override the default?) from R3.
+  (with-pn-stores (ga gb)
+    ga
+    (let ((meta (find 'pn-item
+                       (gethash :pn-store-a graph-db::*schema-node-metadata*)
+                       :key #'graph-db::node-type-name)))
+      (graph-db:instantiate-node-type meta gb))
+    (with-transaction ((graph-db::transaction-manager gb))
+      (make-pn-item :label "in-b" :graph gb))
+    (is (= 1 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                            :vertex-type 'pn-item))))))
+
+(test constructor-refuses-when-the-default-store-is-closed
+  "R1's third clause: no :GRAPH and :PN-STORE-A closed -- refuse by
+name, never fall back to *GRAPH* (the spec-rejected behaviour)."
+  (with-pn-stores (ga gb)
+    (let ((graph-db:*graph* gb))
+      (let ((graph-db:*graph* ga)) (close-graph ga :snapshot-p nil))
+      (let ((c (handler-case (progn (make-pn-item :label "x") nil)
+                 (graph-db:default-store-not-open-error (e) e))))
+        (is-true c)
+        (when c
+          (is (eq 'pn-item (graph-db:default-store-not-open-class c)))
+          (is (eq :pn-store-a
+                  (graph-db:default-store-not-open-store c)))))
+      ;; And no vertex leaked into the ambient store B.
+      (is (= 0 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                              :vertex-type 'pn-item)))))))
+
+(test edge-places-by-its-own-class-default
+  "PN-LINK's declared store is B: with both endpoints in A and *GRAPH*
+bound to A, the edge still lands in B (spec 4: an edge is a node and is
+placed the same way)."
+  (with-pn-stores (ga gb)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (let ((graph-db:*graph* ga))
+        (with-transaction ((graph-db::transaction-manager gb))
+          (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2))))
+      (is (= 1 (length (graph-db:map-edges #'identity gb :collect-p t
+                                           :edge-type 'pn-link))))
+      (is (= 0 (length (graph-db:map-edges #'identity ga :collect-p t
+                                           :edge-type 'pn-link)))))))

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -14,6 +14,9 @@
 
 (def-vertex pn-item () ((label :type string)) :pn-store-a)
 (def-edge pn-link () () :pn-store-b)
+;; Scratch class for the redeclare-moves-the-meta test below; never
+;; written to, so its own store need not be open.
+(def-vertex pn-redeclared () () :pn-store-a)
 
 ;; Two scratch packages, same symbol-name TWIN, both declared into
 ;; store A -- DEF-VERTEX interns MAKE-<NAME>/<NAME>-P in *PACKAGE* at
@@ -162,3 +165,29 @@ end, not just at definition."
     (is (= 1 (length (graph-db:map-vertices
                       #'identity ga :collect-p t
                       :vertex-type (intern "TWIN" :pn-pkg-two)))))))
+
+(test redeclaring-a-class-moves-its-meta-to-the-new-store
+  "A class has exactly one default store: re-declaring PN-REDECLARED
+with :PN-STORE-B as the trailing argument must MOVE its meta, not
+leave a stale copy under :PN-STORE-A -- else %FIND-REGISTERED-NODE-
+TYPE's cross-store scan is ambiguous (GH #167 review round 1)."
+  (unwind-protect
+       (progn
+         (eval '(def-vertex pn-redeclared () () :pn-store-b))
+         (is (not (find 'pn-redeclared
+                        (gethash :pn-store-a
+                                 graph-db::*schema-node-metadata*)
+                        :key #'graph-db::node-type-name)))
+         (let ((meta (find 'pn-redeclared
+                           (gethash :pn-store-b
+                                    graph-db::*schema-node-metadata*)
+                           :key #'graph-db::node-type-name)))
+           (is-true meta)
+           (when meta
+             (is (eq :pn-store-b (graph-db::node-type-graph-name meta)))
+             (is (eq meta
+                     (graph-db::%find-registered-node-type
+                      'pn-redeclared :vertex))))))
+    ;; Restore the load-time declaration so later tests (and later
+    ;; runs of this suite in the same image) see the original store.
+    (eval '(def-vertex pn-redeclared () () :pn-store-a))))

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -229,3 +229,39 @@ from edge-occupancy.dat; a torn final line is dropped, not an error."
         (graph-db::%clear-edge-occupancy-cache)
         (is (member :pn-store-b
                     (graph-db:edge-type-stores 'pn-link)))))))
+
+(test edge-occupancy-append-failure-does-not-abort-the-write
+  "A failed sidecar append (disk full, permissions, fd exhaustion) must
+degrade to in-image-only, never abort the caller's real edge write --
+R4's fail-safe applies to the WRITE side too, not only reads (GH #167,
+review round 1).  PN-LINK's declared store (:PN-STORE-B) is already
+instantiated by the time this test's body runs (MAKE-GRAPH eagerly
+instantiates a store's OWN declared types), so the failure is injected
+around the lazy ADOPTION into :PN-STORE-A instead -- that is the write
+path that actually reaches %NOTE-EDGE-OCCUPANCY after this test starts."
+  (with-pn-stores (ga gb)
+    (let (v1 v2 (orig (fdefinition 'graph-db::%edge-occupancy-file)))
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (unwind-protect
+           (progn
+             ;; %EDGE-OCCUPANCY-FILE now names a path under a directory
+             ;; that does not exist, so the append inside
+             ;; %NOTE-EDGE-OCCUPANCY signals a file error.
+             (setf (fdefinition 'graph-db::%edge-occupancy-file)
+                   (lambda ()
+                     (merge-pathnames
+                      "edge-occupancy.dat"
+                      #P"/nonexistent-167-review-round-1/")))
+             (is (eq :made
+                     (with-transaction ((graph-db::transaction-manager ga))
+                       (make-pn-link :from (graph-db:id v1)
+                                     :to (graph-db:id v2)
+                                     :graph ga)
+                       :made)))
+             ;; Still answers from the in-image cache the PUSH populated
+             ;; before the append failed -- checked while the swap is
+             ;; still in effect, so no reload masks a real regression.
+             (is (member :pn-store-a (graph-db:edge-type-stores 'pn-link))))
+        (setf (fdefinition 'graph-db::%edge-occupancy-file) orig)))))

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -15,6 +15,17 @@
 (def-vertex pn-item () ((label :type string)) :pn-store-a)
 (def-edge pn-link () () :pn-store-b)
 
+;; Two scratch packages, same symbol-name TWIN, both declared into
+;; store A -- DEF-VERTEX interns MAKE-<NAME>/<NAME>-P in *PACKAGE* at
+;; expansion time, so each package gets its own MAKE-TWIN (GH #167).
+(defpackage #:pn-pkg-one (:use #:cl #:graph-db))
+(defpackage #:pn-pkg-two (:use #:cl #:graph-db))
+(in-package #:pn-pkg-one)
+(graph-db:def-vertex twin () () :pn-store-a)
+(in-package #:pn-pkg-two)
+(graph-db:def-vertex twin () () :pn-store-a)
+(in-package #:graph-db/test)
+
 (defmacro with-pn-stores ((ga gb) &body body)
   "Two open stores :PN-STORE-A / :PN-STORE-B under a fresh system dir.
 Resets both metadata lists' instantiation state by reopening from empty
@@ -56,17 +67,10 @@ PN-ITEM lands in store A (its declared store).  Under the old
                                             :vertex-type 'pn-item))))))
 
 (test constructor-explicit-graph-overrides-the-default
-  ;; Adaptation note (GH #167 task 1): PN-ITEM's type is only auto-
-  ;; instantiated into its DECLARED store (:PN-STORE-A) -- adopting it
-  ;; into a foreign store on first write is Task 3's lazy-adoption work,
-  ;; not this task's.  Instantiate it into GB by hand here so this test
-  ;; isolates R1 (does :GRAPH override the default?) from R3.
+  "R1: :GRAPH overrides the class's declared default store; PN-ITEM's
+type is adopted into GB lazily at this first write (R3)."
   (with-pn-stores (ga gb)
     ga
-    (let ((meta (find 'pn-item
-                       (gethash :pn-store-a graph-db::*schema-node-metadata*)
-                       :key #'graph-db::node-type-name)))
-      (graph-db:instantiate-node-type meta gb))
     (with-transaction ((graph-db::transaction-manager gb))
       (make-pn-item :label "in-b" :graph gb))
     (is (= 1 (length (graph-db:map-vertices #'identity gb :collect-p t
@@ -105,3 +109,56 @@ placed the same way)."
                                            :edge-type 'pn-link))))
       (is (= 0 (length (graph-db:map-edges #'identity ga :collect-p t
                                            :edge-type 'pn-link)))))))
+
+(test class-is-instantiable-in-a-second-store
+  "cl-llm#20's acceptance: PN-ITEM (declared store A) written into B via
+explicit :GRAPH -- B adopts the type at first write, both stores hold
+their own instances, and the type-id is the same system-wide id."
+  (with-pn-stores (ga gb)
+    (with-transaction ((graph-db::transaction-manager ga))
+      (make-pn-item :label "a1"))
+    (with-transaction ((graph-db::transaction-manager gb))
+      (make-pn-item :label "b1" :graph gb))
+    (is (= 1 (length (graph-db:map-vertices #'identity ga :collect-p t
+                                            :vertex-type 'pn-item))))
+    (is (= 1 (length (graph-db:map-vertices #'identity gb :collect-p t
+                                            :vertex-type 'pn-item))))
+    (let ((ma (graph-db:lookup-node-type-by-name 'pn-item :vertex
+                                                 :graph ga))
+          (mb (graph-db:lookup-node-type-by-name 'pn-item :vertex
+                                                 :graph gb)))
+      (is (= (graph-db::node-type-id ma) (graph-db::node-type-id mb))))))
+
+(test adopted-type-survives-reopen
+  "The adoption persisted via the store's own schema.dat: close B,
+reopen it, and the foreign-typed node reads back typed."
+  (with-pn-stores (ga gb)
+    ga
+    (let (id (loc (namestring (graph-db::location gb))))
+      (with-transaction ((graph-db::transaction-manager gb))
+        (setq id (graph-db:id (make-pn-item :label "b1" :graph gb))))
+      (let ((graph-db:*graph* gb)) (close-graph gb :snapshot-p nil))
+      (let ((gb2 (open-graph :pn-store-b loc)))
+        (let ((v (graph-db:lookup-vertex id :graph gb2)))
+          (is (typep v 'pn-item))
+          (is (string= "b1" (label v))))))))
+
+(test two-packages-share-a-symbol-name-without-collision
+  "Distinct packages, same symbol-name, both usable -- pinned end to
+end, not just at definition."
+  (with-pn-stores (ga gb)
+    gb
+    ;; The classes are defined at load time above in two scratch
+    ;; packages; both declare store A.
+    (with-transaction ((graph-db::transaction-manager ga))
+      (funcall (intern "MAKE-TWIN" :pn-pkg-one) :graph ga)
+      (funcall (intern "MAKE-TWIN" :pn-pkg-two) :graph ga))
+    (let ((c1 (find-class (intern "TWIN" :pn-pkg-one)))
+          (c2 (find-class (intern "TWIN" :pn-pkg-two))))
+      (is (not (eq c1 c2))))
+    (is (= 1 (length (graph-db:map-vertices
+                      #'identity ga :collect-p t
+                      :vertex-type (intern "TWIN" :pn-pkg-one)))))
+    (is (= 1 (length (graph-db:map-vertices
+                      #'identity ga :collect-p t
+                      :vertex-type (intern "TWIN" :pn-pkg-two)))))))

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -191,3 +191,41 @@ TYPE's cross-store scan is ambiguous (GH #167 review round 1)."
     ;; Restore the load-time declaration so later tests (and later
     ;; runs of this suite in the same image) see the original store.
     (eval '(def-vertex pn-redeclared () () :pn-store-a))))
+
+(test edge-occupancy-tracks-stores-and-defaults-to-no-hint
+  "PN-LINK instantiated into B (its default) and adopted by A: the
+occupancy set names both; an undefined class name yields NIL (= sweep,
+the fail-safe)."
+  (with-pn-stores (ga gb)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (with-transaction ((graph-db::transaction-manager gb))
+        (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2)))
+      (with-transaction ((graph-db::transaction-manager ga))
+        (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2)
+                      :graph ga))
+      (is (null (set-difference '(:pn-store-a :pn-store-b)
+                                (graph-db:edge-type-stores 'pn-link))))
+      (is (null (graph-db:edge-type-stores 'pn-no-such-edge))))))
+
+(test edge-occupancy-persists-and-tolerates-a-torn-tail
+  "A fresh image (simulated: clear the in-image cache) reloads the set
+from edge-occupancy.dat; a torn final line is dropped, not an error."
+  (with-pn-stores (ga gb)
+    (let (v1 v2)
+      (with-transaction ((graph-db::transaction-manager ga))
+        (setq v1 (make-pn-item :label "v1")
+              v2 (make-pn-item :label "v2")))
+      (with-transaction ((graph-db::transaction-manager gb))
+        (make-pn-link :from (graph-db:id v1) :to (graph-db:id v2)))
+      (graph-db::%clear-edge-occupancy-cache)
+      (is (member :pn-store-b (graph-db:edge-type-stores 'pn-link)))
+      (let ((file (graph-db::%edge-occupancy-file)))
+        (with-open-file (out file :direction :output
+                             :if-exists :append)
+          (format out "(PN-TORN"))
+        (graph-db::%clear-edge-occupancy-cache)
+        (is (member :pn-store-b
+                    (graph-db:edge-type-stores 'pn-link)))))))

--- a/tests/rest-tests.lisp
+++ b/tests/rest-tests.lisp
@@ -534,3 +534,58 @@ name and (values meta NIL) for a unique one."
           (graph-db::%rest-resolve-post-type "aliasUnique" :vertex)
         (is (graph-db::node-type-p meta))
         (is (null msg))))))
+
+;;; ---------------------------------------------------------------------------
+;;; POST places the node in the URL's graph, not the class's declared
+;;; default store (GH #167).
+;;; ---------------------------------------------------------------------------
+
+;; Declared default is store A; a POST to store B must still land there.
+(def-vertex rest-dual-item () ((label :type string)) :rest-dual-store-a)
+
+(defmacro with-rest-dual-stores ((ga gb) &body body)
+  "Two open stores, :REST-DUAL-STORE-A (REST-DUAL-ITEM's declared
+default) and :REST-DUAL-STORE-B (foreign to it), under a fresh system
+directory."
+  (let ((sys (gensym)) (da (gensym)) (db (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,da)
+         (with-temp-directory (,db)
+           (let ((graph-db::*system-directory* (namestring ,sys)))
+             (let ((,ga (make-graph :rest-dual-store-a (namestring ,da)
+                                    :buffer-pool-size 1000))
+                   (,gb nil))
+               (unwind-protect
+                    (progn
+                      (setq ,gb (make-graph :rest-dual-store-b
+                                            (namestring ,db)
+                                            :buffer-pool-size 1000))
+                      ,@body)
+                 (ignore-errors (close-graph ,ga :snapshot-p nil))
+                 (when ,gb
+                   (ignore-errors (close-graph ,gb :snapshot-p nil)))
+                 (collect-garbage)))))))))
+
+(test rest-post-vertex-honors-the-url-graph-over-the-class-default
+  "POST to store B for a class whose declared default is store A: the
+node must be created IN B (the URL's graph), not silently redirected
+to A.  %REST-RESOLVE-POST-TYPE only sees types already known to
+*GRAPH*'s own schema, so B first adopts REST-DUAL-ITEM the ordinary
+way (one direct write with an explicit :GRAPH); the REST POST that
+follows is the thing under test (GH #167)."
+  (with-rest-dual-stores (ga gb)
+    (with-transaction ((graph-db::transaction-manager gb))
+      (make-rest-dual-item :label "seed" :graph gb))
+    (with-rest-env ()
+      (let* ((out (graph-db::rest-post-vertex
+                   (list (cons "username" "u") (cons "password" "p")
+                         (cons :graph-name
+                               (json:lisp-to-camel-case
+                                (symbol-name :rest-dual-store-b)))
+                         (cons :type "restDualItem")
+                         (cons "label" "in-b"))))
+             (j (rest-decode out))
+             (id (cdr (assoc :id j))))
+        (is (string= "in-b" (cdr (assoc :label j))))
+        (is-true (lookup-vertex id :graph gb))
+        (is (null (lookup-vertex id :graph ga)))))))

--- a/type-occupancy.lisp
+++ b/type-occupancy.lisp
@@ -1,0 +1,111 @@
+(in-package :graph-db)
+
+;;; Edge store-occupancy sidecar (GH #167, spec R4).  An image-level HINT
+;;; of which stores hold which edge classes -- maintained on write, never
+;;; the source of truth.  Absent file, no registry, or unknown class all
+;;; answer NIL ("no hint, sweep everything"): a stale or missing sidecar
+;;; costs a wasted lookup, never a wrong answer.
+
+(defvar *edge-occupancy* (make-hash-table :test 'eq)
+  "CLASS-SYMBOL -> list of store names known to hold that edge class.
+Loaded lazily from EDGE-OCCUPANCY.DAT on first use in this image.")
+
+(defvar *edge-occupancy-loaded-p* nil
+  "T once *EDGE-OCCUPANCY* has been populated from disk this image.")
+
+(defvar *edge-occupancy-loaded-file* nil
+  "The pathname *EDGE-OCCUPANCY* was last loaded from (or NIL for
+in-image-only).  Mirrors ENSURE-TYPE-REGISTRY's own re-open-on-change
+check: tests rebind *SYSTEM-DIRECTORY* per store, and without this the
+cache would keep answering for whatever directory was current first.")
+
+(defvar *edge-occupancy-lock* (make-lock "edge occupancy"))
+
+(defun %edge-occupancy-file ()
+  "EDGE-OCCUPANCY.DAT beside the type registry, or NIL when no system
+directory is configured (R4 fallback: in-image only)."
+  (handler-case
+      (make-pathname :name "edge-occupancy" :type "dat"
+                     :defaults (type-registry-location
+                                (ensure-type-registry)))
+    (system-directory-required () nil)))
+
+(defun %edge-occupancy-print-package ()
+  ;; COMMON-LISP, not KEYWORD: class symbols must print package-qualified
+  ;; (the #171 manifest discipline), and KEYWORD cannot hold them.
+  (load-time-value (find-package "COMMON-LISP")))
+
+(defun %parse-edge-occupancy-line (line)
+  "Read LINE as a (NAME STORE) list.  *READ-EVAL* NIL: the file is data.
+Returns NIL on anything malformed -- a torn or corrupt line is only a
+lost hint, never an error."
+  (handler-case
+      (let ((*read-eval* nil))
+        (multiple-value-bind (form pos) (read-from-string line)
+          (when (and (= pos (length line))
+                     (consp form) (symbolp (first form))
+                     (= (length form) 2))
+            form)))
+    (error () nil)))
+
+(defun %load-edge-occupancy (file)
+  "Populate *EDGE-OCCUPANCY* from FILE, if it exists.  Caller holds
+*EDGE-OCCUPANCY-LOCK*."
+  (clrhash *edge-occupancy*)
+  (when (and file (probe-file file))
+    (with-open-file (s file :direction :input)
+      (loop
+        (let ((line (read-line s nil :eof)))
+          (when (eq line :eof) (return))
+          (let ((parsed (%parse-edge-occupancy-line line)))
+            (when parsed
+              (destructuring-bind (name store) parsed
+                (pushnew store (gethash name *edge-occupancy*)
+                         :test 'equal))))))))
+  (setf *edge-occupancy-loaded-file* file)
+  (setf *edge-occupancy-loaded-p* t))
+
+(defun %ensure-edge-occupancy-loaded ()
+  (let ((file (%edge-occupancy-file)))
+    (unless (and *edge-occupancy-loaded-p*
+                 (equal *edge-occupancy-loaded-file* file))
+      (%load-edge-occupancy file))))
+
+(defun %note-edge-occupancy (name store)
+  "Record that edge class NAME has been instantiated into STORE, if the
+pair is new.  Appends one `~S'-printed (NAME STORE) line to
+EDGE-OCCUPANCY.DAT when a system directory is configured; otherwise the
+hint lives in-image only for this session (R4 fallback)."
+  (with-lock-held (*edge-occupancy-lock*)
+    (%ensure-edge-occupancy-loaded)
+    (unless (member store (gethash name *edge-occupancy*) :test 'equal)
+      (push store (gethash name *edge-occupancy*))
+      (let ((file (%edge-occupancy-file)))
+        (when file
+          (with-open-file (s file :direction :output
+                                  :if-exists :append
+                                  :if-does-not-exist :create)
+            (let ((*print-readably* nil)
+                  (*print-pretty* nil)
+                  (*package* (%edge-occupancy-print-package)))
+              (format s "~S~%" (list name store)))
+            (finish-output s))))))
+  (values))
+
+(defun edge-type-stores (name)
+  "The store names known to hold NAME edges, or NIL when there is no
+hint -- meaning either NAME has never been instantiated in this image
+(or its sidecar), or NAME is not a known edge class.  Never signals: a
+missing/unreadable sidecar is exactly the fail-safe case (GH #167)."
+  (with-lock-held (*edge-occupancy-lock*)
+    (%ensure-edge-occupancy-loaded)
+    (copy-list (gethash name *edge-occupancy*))))
+
+(defun %clear-edge-occupancy-cache ()
+  "Reset the in-image occupancy state.  Tests use this after rebinding
+*SYSTEM-DIRECTORY* so the next lookup re-reads from the new location."
+  (with-lock-held (*edge-occupancy-lock*)
+    (clrhash *edge-occupancy*)
+    (setf *edge-occupancy-loaded-p* nil)
+    (setf *edge-occupancy-loaded-file* nil))
+  (values))

--- a/type-occupancy.lisp
+++ b/type-occupancy.lisp
@@ -82,14 +82,20 @@ hint lives in-image only for this session (R4 fallback)."
       (push store (gethash name *edge-occupancy*))
       (let ((file (%edge-occupancy-file)))
         (when file
-          (with-open-file (s file :direction :output
-                                  :if-exists :append
-                                  :if-does-not-exist :create)
-            (let ((*print-readably* nil)
-                  (*print-pretty* nil)
-                  (*package* (%edge-occupancy-print-package)))
-              (format s "~S~%" (list name store)))
-            (finish-output s))))))
+          ;; The in-image PUSH above already stands; a failed append (disk
+          ;; full, permissions, fd exhaustion) must not propagate into the
+          ;; caller's real edge write -- it only means the hint stays
+          ;; in-image-only for this session (GH #167, R4, review round 1).
+          (handler-case
+              (with-open-file (s file :direction :output
+                                      :if-exists :append
+                                      :if-does-not-exist :create)
+                (let ((*print-readably* nil)
+                      (*print-pretty* nil)
+                      (*package* (%edge-occupancy-print-package)))
+                  (format s "~S~%" (list name store)))
+                (finish-output s))
+            (error () nil))))))
   (values))
 
 (defun edge-type-stores (name)

--- a/type-occupancy.lisp
+++ b/type-occupancy.lisp
@@ -23,12 +23,13 @@ cache would keep answering for whatever directory was current first.")
 
 (defun %edge-occupancy-file ()
   "EDGE-OCCUPANCY.DAT beside the type registry, or NIL when no system
-directory is configured (R4 fallback: in-image only)."
+directory is configured, or any other failure (R4 fallback: in-image
+only -- this must never signal, GH #167)."
   (handler-case
       (make-pathname :name "edge-occupancy" :type "dat"
                      :defaults (type-registry-location
                                 (ensure-type-registry)))
-    (system-directory-required () nil)))
+    (error () nil)))
 
 (defun %edge-occupancy-print-package ()
   ;; COMMON-LISP, not KEYWORD: class symbols must print package-qualified
@@ -50,18 +51,23 @@ lost hint, never an error."
 
 (defun %load-edge-occupancy (file)
   "Populate *EDGE-OCCUPANCY* from FILE, if it exists.  Caller holds
-*EDGE-OCCUPANCY-LOCK*."
+*EDGE-OCCUPANCY-LOCK*.  Any read failure (FILE is a directory, a
+permission error, a race with an external deletion after PROBE-FILE)
+degrades to no-hint, matching R4 -- this must never signal into a real
+write (GH #167)."
   (clrhash *edge-occupancy*)
   (when (and file (probe-file file))
-    (with-open-file (s file :direction :input)
-      (loop
-        (let ((line (read-line s nil :eof)))
-          (when (eq line :eof) (return))
-          (let ((parsed (%parse-edge-occupancy-line line)))
-            (when parsed
-              (destructuring-bind (name store) parsed
-                (pushnew store (gethash name *edge-occupancy*)
-                         :test 'equal))))))))
+    (handler-case
+        (with-open-file (s file :direction :input)
+          (loop
+            (let ((line (read-line s nil :eof)))
+              (when (eq line :eof) (return))
+              (let ((parsed (%parse-edge-occupancy-line line)))
+                (when parsed
+                  (destructuring-bind (name store) parsed
+                    (pushnew store (gethash name *edge-occupancy*)
+                             :test 'equal)))))))
+      (error () (clrhash *edge-occupancy*))))
   (setf *edge-occupancy-loaded-file* file)
   (setf *edge-occupancy-loaded-p* t))
 


### PR DESCRIPTION
Implements packages as namespaces — unit 2 of the namespaces epic (#110). Closes #167. Also closes kraison/cl-llm#20 (a class instantiable in more than one store).

Spec: docs/superpowers/specs/2026-08-23-packages-167-design.md (rulings R1–R6 + Built note). Plan: docs/superpowers/plans/2026-08-23-packages-167.md.

## What ships
- **BREAKING — placement (R1):** `make-<type>` constructors' `:graph` default is the class's declared store (the `def-vertex`/`def-edge` trailing argument, now documented as the *default store*): explicit `:graph` > open declared store > `default-store-not-open-error`. `*graph*` is never silently substituted — placement determines recovery policy. One-to-one code unaffected. `lookup-<type>` and generic `make-vertex`/`make-edge` keep `*graph*`.
- **Lazy adoption (R3):** a store learns a foreign class at first write (`%ensure-type-in-store` under the schema lock), durably via its own `schema.dat`. A class registered under several stores resolves deterministically (`%find-registered-node-type` prefers the target store).
- **Edge occupancy hint (R4):** edge classes maintain `edge-type-stores` — an append-only, fail-safe sidecar (`edge-occupancy.dat`) beside the type registry; NIL = no hint = sweep; load/append failures degrade in-image-only and can never abort a caller's write. No query rewiring in this unit (consumer is #109).
- REST POST vertex/edge now pass `:graph *graph*` explicitly — without it, a POST would have written into the class's declared store instead of the URL's graph (caught by the whole-branch review; regression-tested).
- Docs: manual "A namespace is a package; a store is files" section, CHANGELOG breaking entry, spec Built notes; namespaces spec §11 unit 2 → Done.

Notable during execution: an initial "registration MOVE on re-declaration" ruling was **reversed** after the full-suite gate exposed it breaking the supported one-class-two-stores pattern (#186) with a ~150-test cascade; root-caused by a dedicated debug pass, replaced by preferred-store determinism. That hunt also surfaced a pre-existing engine defect, filed separately: an aborted `make-graph`/`open-graph` leaks its fds (plus usocket's FD_SETSIZE fragility).

## Verification (SBCL; ECL demoted per standing policy)
- Fresh-image `(asdf:test-system :graph-db)` on final HEAD: **4483 checks / 4473 pass / 10 skips (GEOS, pre-existing) / 0 fail**, zero test errors, REST-HTTP completed.
- Focused: package-namespace 30/30, global-type-id 23/23, keyword-alias 9/9, rest 80/80, node-class 55/55, graph 73/73, seeding 88/88.
- Process: 4 tasks, per-task review + 3 fix rounds, whole-branch review, gate-failure root-cause pass, one final fix wave — all findings addressed.

Epic status after this merges: **unit 7 (#172, runtime schema from persisted metadata) is unblocked and is the last build unit.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95