### PR TITLE
Namespaces unit 7: runtime schema from persisted metadata (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,80 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **A node type can now be defined at runtime, from data, and survive a
+  restart as a live class instead of only as metadata** (#172, unit 7 of
+  the namespaces epic, #110). `ENSURE-NAMESPACE` (name &key nicknames)
+  creates a package -- no files, no store -- as the functional twin of
+  writing a new `IN-PACKAGE`; `CREATE-VERTEX-TYPE` / `CREATE-EDGE-TYPE`
+  (name slot-specs &key parents default-store keep-revisions) are the
+  runtime twins of `DEF-VERTEX`/`DEF-EDGE`, building a class from a data
+  slot-spec list through the same `%INSTALL-NODE-TYPE` path a macro
+  expansion uses, so a runtime type is indistinguishable from a
+  source-defined one once built (redefining an existing name, runtime-
+  or source-defined, is ordinary CLOS redefinition, with the existing
+  #196 divergence warning on slot disagreement). `DEFAULT-STORE`
+  defaults to `NIL` -- "no default store" -- so a runtime type need not
+  commit to placement at creation; its generated constructor then
+  requires an explicit `:GRAPH`.
+
+  A system-level manifest, `schema-manifest.dat` beside the type
+  registry, records every namespace and type -- appended by both the
+  source and runtime installation paths, so it describes the WHOLE
+  schema, fail-safe like the #167 occupancy sidecar (no system
+  directory, or a torn/damaged file, degrades to in-image-only rather
+  than aborting a definition). `MATERIALIZE-SCHEMA` (dir &key
+  namespaces) is the load-order answer this manifest exists for: a
+  macro carrying its own `EVAL-WHEN`, placed in its own file between
+  the static schema and any file with methods on a runtime type, that
+  rebuilds every runtime-defined package and class from the manifest
+  before those methods compile -- the twenty-year blocker on this
+  feature. It is idempotent and **source wins**: a type whose class
+  already exists is left alone, with the #196 warning on divergence.
+  Nothing is evaluated -- the input is plists, the output is MOP
+  calls -- and it fails fast, before building anything, naming every
+  offender in one condition each: `MATERIALIZE-UNRESOLVED-FUNCTIONS`
+  for a `:CHECK` name the image does not provide, and
+  `MATERIALIZE-UNRESOLVED-PARENTS` for a row whose parent neither
+  exists nor is itself being built in this call (a half-built
+  materialization would otherwise leave stub classes that poison every
+  later attempt). Returns `(:NAMESPACES n :MATERIALIZED n
+  :SKIPPED-EXISTING n)`.
+
+  Behaviour is the one thing that never crosses the metadata boundary:
+  a closure does not serialize, so a runtime type that wants a
+  constraint names a function the image registers by code,
+  `REGISTER-SCHEMA-FUNCTION` (name fn) / `FIND-SCHEMA-FUNCTION` (name),
+  and the metadata stores only that name. The sole v1 consumer is a new
+  `:CHECK FN-NAME` slot option (accepted by `DEF-VERTEX`/`DEF-EDGE`
+  slot-specs too, for parity), enforced where value constraints already
+  are, NULL-exempt, violating with the existing condition's `:reason
+  :CHECK-FAILED`; presence is verified at `CREATE-*-TYPE` time and again
+  at `MATERIALIZE-SCHEMA` time, resolution happens at each check so a
+  re-registration takes effect immediately. Restart never evaluates
+  data -- this is the invariant the whole unit is built to hold.
+
+  Two read-only visibility tools close the opacity gap a runtime type
+  otherwise opens (a class with no source file, ungreppable): `DESCRIBE-
+  SCHEMA` (&key namespace store since stream) is a plain-text dump,
+  joining the manifest with live metas, grouped by namespace, one line
+  per type (kind, default store, a `[source]`/`[runtime YYYY-MM-DD]`
+  provenance tag) and one line per slot (name, type, `:CHECK` name);
+  `:SINCE` filters by record time, so the dump doubles as a change log.
+  `EXPORT-SCHEMA-SOURCE` (path &key namespace store) writes a generated-
+  header comment plus literal `DEFPACKAGE`/`DEF-VERTEX`/`DEF-EDGE` forms
+  reconstructed from the metadata -- a symbol foreign to the exported
+  namespace prints package-qualified so it re-reads to the SAME symbol
+  rather than interning a new one under the freshly created package,
+  which would silently break an EQ-keyed lookup like a `:CHECK` name.
+  This is the promotion path: loading the generated file is the
+  ordinary source path, idempotent (same names, same registry ids), and
+  turns a runtime type into a source-defined one for good. Export never
+  runs implicitly and the engine never reads the file back.
+
+  Not in this unit, deliberately: runtime type deletion/retraction,
+  runtime `DEF-VIEW`/index/unique definition (those macros stay
+  code-side), and an Emacs mode (the text dump is SLIME-usable as-is).
+
 - **A store adopts a foreign class at first write; lookup of a class
   registered in more than one store is deterministic** (#167). Writing a
   node of a class via an explicit `:graph` that names a store other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,23 @@ between releases; cutting a release renames it to the new version and dates it.
   runtime `DEF-VIEW`/index/unique definition (those macros stay
   code-side), and an Emacs mode (the text dump is SLIME-usable as-is).
 
+  Final-review fixes (#172, review round 3): the manifest dedup cache
+  is now seeded from the on-disk file on a fresh image's first write,
+  so a reopen no longer re-appends every type row with a new `:time`
+  (previously `DESCRIBE-SCHEMA :SINCE` listed the whole schema after
+  any reopen); `CREATE-VERTEX-TYPE`/`CREATE-EDGE-TYPE`'s symbol-argument
+  path now refuses a CL-homed name before interning any slot into it,
+  instead of hitting SBCL's raw package-lock error; `EXPORT-SCHEMA-
+  SOURCE` now qualifies a bare symbol whose name shadows an external
+  `COMMON-LISP`/`GRAPH-DB` symbol (e.g. a slot named `TYPE`), which
+  previously round-tripped to the wrong symbol silently; `DESCRIBE-
+  SCHEMA`'s `:SINCE` string now parses at UTC, matching the UTC dates
+  it prints; and `ENSURE-NAMESPACE` refuses `COMMON-LISP`/`KEYWORD` (or
+  a nickname of either) the same way `CREATE-*-TYPE` already does.
+  `REGISTER-SCHEMA-FUNCTION`'s docstring and the manual now say
+  explicitly that a `:CHECK` function must be pure: OCC retry can run
+  it more than once per logical write.
+
 - **A store adopts a foreign class at first write; lookup of a class
   registered in more than one store is deterministic** (#167). Writing a
   node of a class via an explicit `:graph` that names a store other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,10 +101,12 @@ between releases; cutting a release renames it to the new version and dates it.
   `:CHECK FN-NAME` slot option (accepted by `DEF-VERTEX`/`DEF-EDGE`
   slot-specs too, for parity), enforced where value constraints already
   are, NULL-exempt, violating with the existing condition's `:reason
-  :CHECK-FAILED`; presence is verified at `CREATE-*-TYPE` time and again
-  at `MATERIALIZE-SCHEMA` time, resolution happens at each check so a
-  re-registration takes effect immediately. Restart never evaluates
-  data -- this is the invariant the whole unit is built to hold.
+  :CHECK-FAILED`; presence is verified at `CREATE-*-TYPE` time
+  (signalling `SCHEMA-FUNCTION-UNRESOLVED` if the name is not yet
+  registered) and again at `MATERIALIZE-SCHEMA` time, resolution
+  happens at each check so a re-registration takes effect immediately.
+  Restart never evaluates data -- this is the invariant the whole unit
+  is built to hold.
 
   Two read-only visibility tools close the opacity gap a runtime type
   otherwise opens (a class with no source file, ungreppable): `DESCRIBE-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Changed
+
+- **`DEF-NODE-TYPE` now installs through a shared functional core**
+  (#172). The macro's expansion keeps only the literal `DEFCLASS`; the
+  generated helpers (`MAKE-<N>`, `LOOKUP-<N>`, `<N>-P`), the `<N>/2` and
+  `<N>/3` Prolog functors for edge types, the `*SCHEMA-NODE-METADATA*`
+  registration and the instantiation into an open default store all run
+  in `%INSTALL-NODE-TYPE`, so a later runtime path can build a class
+  from persisted metadata and get exactly the same installation. No
+  behaviour change for source-defined types: the helpers are closures
+  installed with `(SETF FDEFINITION)` instead of compiled `DEFUN`s, and
+  the functor symbols are now interned in the class symbol's own
+  package rather than the expansion-time `*PACKAGE*` — identical for
+  every ordinary `DEF-VERTEX` / `DEF-EDGE`, where the class symbol is
+  read into the defining package. Functors are still installed under
+  both `FDEFINITION` and `*PROLOG-GLOBAL-FUNCTORS*` and exported, as
+  `DEF-GLOBAL-PROLOG-FUNCTOR` did.
+
 ### Fixed
 
 - **`%POSIX-OPEN` created files with an arbitrary permission mode on Apple

--- a/docs/runtime-schema-example.lisp
+++ b/docs/runtime-schema-example.lisp
@@ -1,0 +1,310 @@
+;;;; Runtime schema: the intended developer experience (GH #172).
+;;;;
+;;;; This file is a DESIGN ARTIFACT, not loadable code.  It is the
+;;;; example application requested before implementation: every form
+;;;; below is written against the API #172 intends to build, and the
+;;;; commentary states the design decision each form embodies.  Read it
+;;;; top to bottom as three Lisp sessions separated by process restarts.
+;;;;
+;;;; The two problems this design must not dodge (Kevin, 2026-08-24):
+;;;;
+;;;;   1. OPACITY.  A runtime-created class has no source file.  The
+;;;;      developer who sits down tomorrow cannot grep for it, cannot
+;;;;      read a def-vertex form, cannot see the schema as Lisp.  VG's
+;;;;      founding bargain -- "write mostly ordinary CLOS and it
+;;;;      persists" -- cuts both ways: the schema has always BEEN the
+;;;;      source.  #172 breaks that unless the schema can be turned
+;;;;      back into source on demand.
+;;;;
+;;;;   2. LOAD ORDER.  Methods need their classes at compile time.  A
+;;;;      class that exists only as persisted metadata does not exist
+;;;;      when compile-file reaches (defmethod ... ((x sensor:reading))
+;;;;      in the next Lisp invocation.  This is the reason the feature
+;;;;      has waited twenty years.
+;;;;
+;;;; The design answers both with the same move: METADATA IS THE
+;;;; DURABLE TRUTH, AND SOURCE IS A VIEW OF IT -- derivable at any
+;;;; moment, in two directions:
+;;;;
+;;;;   - MATERIALIZE: metadata -> live classes, at load time, before
+;;;;     any method file compiles.  No eval, no load of runtime-written
+;;;;     code; the spec's invariant ("restart never evaluates data")
+;;;;     holds because building a class from a slots list is a
+;;;;     mechanical MOP operation on data.
+;;;;
+;;;;   - EXPORT: metadata -> def-vertex/def-edge text, for the human.
+;;;;     The developer can read it, diff it, and -- when a runtime type
+;;;;     has earned permanence -- check it in, at which point it stops
+;;;;     being a runtime type at all.  Loading exported source over an
+;;;;     existing runtime type is idempotent: same names, same registry
+;;;;     ids, same slots.  Promotion to source is a one-way door the
+;;;;     DEVELOPER walks through deliberately; the ENGINE never
+;;;;     persists source or loads it.
+
+;;;; ===================================================================
+;;;; SESSION 1 -- a running system grows a type at runtime
+;;;; ===================================================================
+
+(in-package :cl-user)
+
+;;; The application's static schema, exactly as today.  Nothing about
+;;; def-vertex changes; compiled files with methods on TICKET work as
+;;; they always have.  (:SUPPORT is TICKET's default store per #167.)
+
+(defpackage #:helpdesk (:use #:cl #:graph-db))
+(in-package #:helpdesk)
+
+(def-vertex ticket () ((title :type string)
+                       (severity :type integer))
+  :support)
+
+;;; ... the app runs; an operator (or the app itself, e.g. an ETL that
+;;; discovers a new record shape) needs a new node type WITHOUT a
+;;; deploy.  Two new functions -- functions, not macros, because the
+;;; type name and shape arrive as data at runtime:
+
+;; A runtime namespace is a package plus, later, metadata rows.  This
+;; allocates NO files and creates NO store (spec: schema creation must
+;; be cheap, store creation must not be).  Idempotent.
+(graph-db:ensure-namespace "TELEMETRY" :nicknames '("TLM"))
+
+;; The runtime twin of def-vertex.  NAME may be a symbol or a
+;; "PACKAGE:NAME" string (the caller may only have strings -- this is
+;; runtime).  Slot specs are the same data def-vertex takes.  The
+;; trailing :DEFAULT-STORE mirrors def-vertex's trailing argument.
+;;
+;; Returns the finalized CLOS class.  Under the hood this drives the
+;; SAME registration path def-vertex expands into -- one meta, one
+;; registry id keyed on the interned symbol, instantiated into the
+;; default store if open -- plus the one new primitive the spec names:
+;; class-from-metadata (defclass via the MOP, accessors and
+;; MAKE-/LOOKUP-/-P helpers interned in the symbol's package).
+(graph-db:create-vertex-type "TELEMETRY:READING"
+  '((sensor-id :type string)
+    (value     :type double-float)
+    (taken-at  :type integer))
+  :default-store :support)
+
+;; Behaviour cannot be data (a closure does not serialize).  A runtime
+;; type that wants a constraint NAMES a function registered by code
+;; that shipped in the image.  Registration is code-side and explicit;
+;; the metadata stores only the NAME.  At restart the name is resolved
+;; against this registry and materialization FAILS CLEANLY (a named
+;; condition listing the missing function) if the image no longer
+;; provides it -- restart still never evaluates data.
+(graph-db:register-schema-function 'telemetry-plausible-p
+  (lambda (v) (< -1d6 v 1d6)))
+
+(graph-db:create-vertex-type "TELEMETRY:CALIBRATION"
+  '((value :type double-float
+           :value-constraint telemetry-plausible-p))  ; a NAME, not a #'
+  :default-store :support)
+
+;;; From here the runtime type is indistinguishable from a static one.
+;;; The generated constructor exists, placement follows #167's rules,
+;;; transactions and views and indexes see an ordinary node-class:
+
+(with-transaction ((transaction-manager (lookup-graph :support)))
+  (funcall (intern "MAKE-READING" :telemetry)
+           :sensor-id "s-17" :value 22.5d0 :taken-at 3600))
+
+;;; ------------------------------------------------------------------
+;;; The opacity answer, part 1: the schema is always readable as text.
+;;; ------------------------------------------------------------------
+;;;
+;;; DESCRIBE-SCHEMA is the REPL/Emacs tool.  Plain text on a stream, so
+;;; it works today in SLIME (C-c C-d equivalent: just call it), and a
+;;; ten-line schema.el can later put it in a dedicated buffer.  Every
+;;; type row says WHERE IT CAME FROM -- source or runtime -- because
+;;; that provenance is precisely what the developer cannot currently
+;;; see:
+
+(graph-db:describe-schema :namespace :telemetry)
+;; =>
+;; Namespace TELEMETRY (runtime, created 2026-08-24T18:02:11Z)
+;;   READING (vertex) default-store :SUPPORT   [runtime 2026-08-24]
+;;     SENSOR-ID  string
+;;     VALUE      double-float
+;;     TAKEN-AT   integer
+;;   CALIBRATION (vertex) default-store :SUPPORT [runtime 2026-08-24]
+;;     VALUE      double-float  :value-constraint TELEMETRY-PLAUSIBLE-P
+;;
+;; (describe-schema)               -- everything, grouped by namespace
+;; (describe-schema :store :support) -- what one store's schema holds
+;; Static types print the same way tagged [source], so ONE tool shows
+;; the whole schema, not only the runtime part.
+
+;;; ------------------------------------------------------------------
+;;; The opacity answer, part 2: the schema is exportable as SOURCE.
+;;; ------------------------------------------------------------------
+
+(graph-db:export-schema-source "src/generated-schema.lisp"
+                               :namespace :telemetry)
+;; Writes, verbatim def-vertex syntax, with a provenance header:
+;;
+;;   ;;; Generated by graph-db:export-schema-source 2026-08-24.
+;;   ;;; Source of truth remains the persisted metadata until this
+;;   ;;; file is loaded as part of the system; loading it is
+;;   ;;; idempotent (same names -> same registry ids).
+;;   (defpackage #:telemetry (:use #:cl #:graph-db)
+;;     (:nicknames #:tlm)
+;;     (:export #:reading #:calibration))
+;;   (in-package #:telemetry)
+;;   (def-vertex reading ()
+;;     ((sensor-id :type string)
+;;      (value     :type double-float)
+;;      (taken-at  :type integer))
+;;     :support)
+;;   (def-vertex calibration ()
+;;     ((value :type double-float
+;;             :value-constraint telemetry-plausible-p))
+;;     :support)
+;;
+;; This is how a runtime type is PROMOTED: the developer reviews the
+;; file, adds it to the .asd before their method files, commits.  The
+;; type is now source-defined; the persisted metadata agrees with it
+;; and stays agreeing (def-vertex re-registration is the existing
+;; replace-in-place).  The engine itself NEVER loads this file --
+;; export is for humans and their build systems only.
+
+;;; Session 1 ends: the process exits.  Everything above survives as
+;;; metadata: node-type rows (name, parents, slots, package, default
+;;; store, constraint NAMES) in each holding store's schema.dat, plus
+;;; -- new in #172 -- a system-level namespace+type manifest beside the
+;;; type registry, so the full schema is enumerable WITHOUT opening
+;;; every store.  No source anywhere.
+
+;;; ===================================================================
+;;; SESSION 2 -- a fresh Lisp: the load-order problem, solved at load
+;;; ===================================================================
+
+;;; The developer writes ordinary methods against the runtime class.
+;;; THE PROBLEM in one line: compile-file cannot compile
+;;;
+;;;   (defmethod plot ((r telemetry:reading)) ...)
+;;;
+;;; when TELEMETRY:READING exists only in schema.dat -- the package
+;;; does not even exist to read the symbol.  The answer is one form,
+;;; placed where schema has always had to live: BEFORE the code that
+;;; uses it.
+
+;;; --- helpdesk.asd ---------------------------------------------------
+;; (defsystem "helpdesk"
+;;   :depends-on ("graph-db")
+;;   :components
+;;   ((:file "package")
+;;    ;; Static schema, as always:
+;;    (:file "schema"        :depends-on ("package"))
+;;    ;; NEW: materialize every runtime-defined namespace and type from
+;;    ;; the persisted metadata -- packages interned, classes built via
+;;    ;; the MOP, accessors and constructors generated -- exactly as if
+;;    ;; a schema.lisp had been loaded, except nothing is evaluated:
+;;    ;; the input is the metadata rows, pure data.
+;;    (:file "runtime-schema" :depends-on ("schema"))
+;;    ;; Methods compile AFTER both, so every class -- source-defined
+;;    ;; or runtime-defined -- exists at compile time:
+;;    (:file "plotting"      :depends-on ("runtime-schema"))))
+
+;;; --- runtime-schema.lisp -------------------------------------------
+(in-package :helpdesk)
+
+;; Reads the system manifest at LOAD TIME (including during
+;; compile-file's load of this file), creates packages and classes for
+;; every runtime-defined type.  Idempotent; a type whose class already
+;; exists (e.g. defined by schema.lisp above) is left alone -- source
+;; wins, and a slot-set disagreement between source and metadata
+;; signals the #196 divergence warning rather than silently picking.
+;;
+;; EVAL-WHEN matters and the macro carries it so users cannot get it
+;; wrong: (:compile-toplevel :load-toplevel :execute).
+(graph-db:materialize-schema "/var/db/helpdesk-system/")
+
+;; A closed variant for deployments that fix their schema at build
+;; time exists as an option rather than a second function:
+;;   (graph-db:materialize-schema DIR :namespaces '(:telemetry))
+
+;;; --- plotting.lisp -------------------------------------------------
+(in-package :helpdesk)
+
+;; Compiles because materialize-schema ran first.  This is ordinary
+;; CLOS on an ordinary class; the founding bargain holds again.
+(defmethod plot ((r telemetry:reading))
+  (draw-point (telemetry:taken-at r) (telemetry:value r)))
+
+;; And the constraint function the metadata names must be provided by
+;; the image before any write touches CALIBRATION; a missing name is a
+;; clean, named error at materialize time (listing every unresolved
+;; function), not a mystery at first write:
+(graph-db:register-schema-function 'telemetry-plausible-p
+  (lambda (v) (< -1d6 v 1d6)))
+
+;;; Runtime use, session 2 -- note ordinary reader syntax now works,
+;;; no intern/funcall gymnastics, because the package and accessors
+;;; exist before this file was even compiled:
+
+(open-graph :support "/var/db/helpdesk/support/")
+(with-transaction ((transaction-manager (lookup-graph :support)))
+  (telemetry:make-reading :sensor-id "s-17" :value 21.9d0
+                          :taken-at 7200))
+
+(mapcar #'plot
+        (map-vertices #'identity (lookup-graph :support)
+                      :collect-p t
+                      :vertex-type 'telemetry:reading))
+
+;;; ===================================================================
+;;; SESSION 3 -- schema evolution at runtime, still visible
+;;; ===================================================================
+
+(in-package :helpdesk)
+
+;; Adding a slot to a live runtime type is the same function again --
+;; CREATE-VERTEX-TYPE on an existing name is redefinition, exactly as
+;; re-evaluating a def-vertex form is today (same replace-in-place,
+;; same CLOS class-redefinition semantics for live instances):
+(graph-db:create-vertex-type "TELEMETRY:READING"
+  '((sensor-id :type string)
+    (value     :type double-float)
+    (taken-at  :type integer)
+    (unit      :type keyword))       ; new slot
+  :default-store :support)
+
+;; The developer arriving after that change asks the schema, not grep:
+(graph-db:describe-schema :namespace :telemetry :since "2026-08-24")
+;; => shows READING with UNIT marked [runtime 2026-08-25], i.e. the
+;;    text dump doubles as a change log because every meta row carries
+;;    its definition timestamp.
+
+;; What is DELIBERATELY NOT PROVIDED, so the boundary stays sharp:
+;;  - no runtime defmethod, no persisted functions, no lambda in any
+;;    slot option: behaviour ships in the image, structure in the data;
+;;  - no automatic loading of exported source by the engine, ever;
+;;  - no runtime DELETION of a type in this unit (retraction interacts
+;;    with on-disk instances and stays out of scope, as today).
+
+;;; ===================================================================
+;;; Summary of the API this example commits #172 to
+;;; ===================================================================
+;;;
+;;;   ensure-namespace          name &key nicknames        -> package
+;;;   create-vertex-type        name slot-specs
+;;;                             &key parents default-store
+;;;                                  keep-revisions        -> class
+;;;   create-edge-type          name slot-specs &key ...   -> class
+;;;   register-schema-function  name function              -> name
+;;;   materialize-schema        system-dir &key namespaces -> summary
+;;;     (load-time safe; :compile-toplevel; idempotent; source wins;
+;;;      unresolved function names -> one named condition, clean)
+;;;   describe-schema           &key namespace store since stream
+;;;   export-schema-source      path &key namespace store  -> truename
+;;;
+;;; Open design points to settle in the unit spec (flagged, not hidden):
+;;;   A. Where materialize-schema reads from: a new system-level
+;;;      manifest beside the type registry (proposed -- enumerable
+;;;      without opening stores, appended on every registration), vs
+;;;      scanning registered stores' schema.dat files.
+;;;   B. Whether create-*-type on a SOURCE-defined name is allowed
+;;;      (proposed: yes with the #196 divergence warning, since
+;;;      re-evaluating def-vertex already is) or refused.
+;;;   C. Constraint-name resolution time: at materialize (fail fast,
+;;;      proposed) vs at first write (lazier, mirrors adoption).

--- a/docs/runtime-schema-example.lisp
+++ b/docs/runtime-schema-example.lisp
@@ -178,14 +178,13 @@
 ;;   (in-package #:telemetry)
 ;;
 ;;   (def-vertex calibration ()
-;;       ((value :type double-float
-;;               :check helpdesk::telemetry-plausible-p))
+;;       ((value :type double-float :check helpdesk::telemetry-plausible-p))
 ;;       :support)
 ;;
 ;;   (def-vertex reading ()
 ;;       ((sensor-id :type string)
-;;        (value     :type double-float)
-;;        (taken-at  :type integer))
+;;        (value :type double-float)
+;;        (taken-at :type integer))
 ;;       :support)
 ;;
 ;; Two things worth noticing that only show up once real metadata goes

--- a/docs/runtime-schema-example.lisp
+++ b/docs/runtime-schema-example.lisp
@@ -1,10 +1,15 @@
 ;;;; Runtime schema: the intended developer experience (GH #172).
 ;;;;
-;;;; This file is a DESIGN ARTIFACT, not loadable code.  It is the
-;;;; example application requested before implementation: every form
-;;;; below is written against the API #172 intends to build, and the
-;;;; commentary states the design decision each form embodies.  Read it
-;;;; top to bottom as three Lisp sessions separated by process restarts.
+;;;; This file is DOCUMENTATION, not loadable code.  It is the example
+;;;; application written before implementation as the design artifact
+;;;; (Kevin-approved 2026-08-24) and reconciled here, after #172
+;;;; shipped, against the actual signatures and output shapes in
+;;;; `runtime-schema.lisp` and `schema-tools.lisp` -- every form below
+;;;; is checked against the source, and the three open points (A/B/C)
+;;;; the original draft flagged are resolved below, not left hanging.
+;;;; Read it top to bottom as three Lisp sessions separated by process
+;;;; restarts; Kevin reads this file, so the design commentary and the
+;;;; session structure are kept, not stripped to a bare reference.
 ;;;;
 ;;;; The two problems this design must not dodge (Kevin, 2026-08-24):
 ;;;;
@@ -28,9 +33,9 @@
 ;;;;
 ;;;;   - MATERIALIZE: metadata -> live classes, at load time, before
 ;;;;     any method file compiles.  No eval, no load of runtime-written
-;;;;     code; the spec's invariant ("restart never evaluates data")
-;;;;     holds because building a class from a slots list is a
-;;;;     mechanical MOP operation on data.
+;;;;     code; the invariant ("restart never evaluates data") holds
+;;;;     because building a class from a slots list is a mechanical MOP
+;;;;     operation on data.
 ;;;;
 ;;;;   - EXPORT: metadata -> def-vertex/def-edge text, for the human.
 ;;;;     The developer can read it, diff it, and -- when a runtime type
@@ -63,22 +68,28 @@
 ;;; deploy.  Two new functions -- functions, not macros, because the
 ;;; type name and shape arrive as data at runtime:
 
-;; A runtime namespace is a package plus, later, metadata rows.  This
+;; A runtime namespace is a package plus, later, manifest rows.  This
 ;; allocates NO files and creates NO store (spec: schema creation must
 ;; be cheap, store creation must not be).  Idempotent.
 (graph-db:ensure-namespace "TELEMETRY" :nicknames '("TLM"))
 
 ;; The runtime twin of def-vertex.  NAME may be a symbol or a
 ;; "PACKAGE:NAME" string (the caller may only have strings -- this is
-;; runtime).  Slot specs are the same data def-vertex takes.  The
-;; trailing :DEFAULT-STORE mirrors def-vertex's trailing argument.
+;; runtime); the package must already exist (ENSURE-NAMESPACE first --
+;; a missing package is an error, not an implicit creation).  Slot
+;; specs are the same data def-vertex takes.  :DEFAULT-STORE mirrors
+;; def-vertex's trailing store argument, but as a keyword, and it
+;; defaults to NIL: a runtime type need not commit to placement at
+;; creation, at the cost that its generated constructor then requires
+;; an explicit :GRAPH.
 ;;
 ;; Returns the finalized CLOS class.  Under the hood this drives the
-;; SAME registration path def-vertex expands into -- one meta, one
-;; registry id keyed on the interned symbol, instantiated into the
-;; default store if open -- plus the one new primitive the spec names:
-;; class-from-metadata (defclass via the MOP, accessors and
-;; MAKE-/LOOKUP-/-P helpers interned in the symbol's package).
+;; SAME installation path def-vertex's expansion uses
+;; (%INSTALL-NODE-TYPE) -- one meta, one registry id keyed on the
+;; interned symbol, instantiated into the default store if open -- via
+;; the one new primitive the spec names: class-from-metadata (a
+;; DEFCLASS built through the MOP, with accessors and MAKE-/LOOKUP-/-P
+;; helpers interned in the symbol's own package).
 (graph-db:create-vertex-type "TELEMETRY:READING"
   '((sensor-id :type string)
     (value     :type double-float)
@@ -87,17 +98,22 @@
 
 ;; Behaviour cannot be data (a closure does not serialize).  A runtime
 ;; type that wants a constraint NAMES a function registered by code
-;; that shipped in the image.  Registration is code-side and explicit;
-;; the metadata stores only the NAME.  At restart the name is resolved
-;; against this registry and materialization FAILS CLEANLY (a named
-;; condition listing the missing function) if the image no longer
-;; provides it -- restart still never evaluates data.
+;; that shipped in the image, via a slot option: :CHECK NAME (not
+;; :VALUE-CONSTRAINT -- that is a different, existing mechanism,
+;; DEF-VALUE-CONSTRAINT; :CHECK is the new, minimal, function-by-name
+;; seam #172 adds beside it).  Registration is code-side and explicit;
+;; the metadata stores only the NAME.  Presence is verified twice: at
+;; CREATE-VERTEX-TYPE time (this call would itself signal
+;; SCHEMA-FUNCTION-UNRESOLVED if the name were not yet registered) and
+;; again at MATERIALIZE-SCHEMA time in a later session; resolution
+;; itself happens at each check, so a re-registration takes effect
+;; immediately -- restart still never evaluates data.
 (graph-db:register-schema-function 'telemetry-plausible-p
   (lambda (v) (< -1d6 v 1d6)))
 
 (graph-db:create-vertex-type "TELEMETRY:CALIBRATION"
   '((value :type double-float
-           :value-constraint telemetry-plausible-p))  ; a NAME, not a #'
+           :check telemetry-plausible-p))  ; a NAME, not a #'
   :default-store :support)
 
 ;;; From here the runtime type is indistinguishable from a static one.
@@ -114,25 +130,31 @@
 ;;;
 ;;; DESCRIBE-SCHEMA is the REPL/Emacs tool.  Plain text on a stream, so
 ;;; it works today in SLIME (C-c C-d equivalent: just call it), and a
-;;; ten-line schema.el can later put it in a dedicated buffer.  Every
-;;; type row says WHERE IT CAME FROM -- source or runtime -- because
-;;; that provenance is precisely what the developer cannot currently
-;;; see:
+;;; ten-line schema.el could later put it in a dedicated buffer -- out
+;;; of scope for #172 itself (R7), but the text dump is SLIME-usable
+;;; as-is.  Every type row says WHERE IT CAME FROM -- source or
+;;; runtime -- because that provenance is precisely what the developer
+;;; cannot currently see:
 
 (graph-db:describe-schema :namespace :telemetry)
 ;; =>
-;; Namespace TELEMETRY (runtime, created 2026-08-24T18:02:11Z)
-;;   READING (vertex) default-store :SUPPORT   [runtime 2026-08-24]
-;;     SENSOR-ID  string
-;;     VALUE      double-float
-;;     TAKEN-AT   integer
-;;   CALIBRATION (vertex) default-store :SUPPORT [runtime 2026-08-24]
-;;     VALUE      double-float  :value-constraint TELEMETRY-PLAUSIBLE-P
+;; Namespace TELEMETRY
+;;   CALIBRATION (vertex) default-store :support   [runtime 2026-08-24]
+;;     VALUE  DOUBLE-FLOAT  :check TELEMETRY-PLAUSIBLE-P
+;;   READING (vertex) default-store :support   [runtime 2026-08-24]
+;;     SENSOR-ID  STRING
+;;     VALUE  DOUBLE-FLOAT
+;;     TAKEN-AT  INTEGER
 ;;
-;; (describe-schema)               -- everything, grouped by namespace
+;; (types within a namespace print sorted by name, hence CALIBRATION
+;; before READING here.)
+;;
+;; (describe-schema)                 -- everything, grouped by namespace
 ;; (describe-schema :store :support) -- what one store's schema holds
 ;; Static types print the same way tagged [source], so ONE tool shows
-;; the whole schema, not only the runtime part.
+;; the whole schema, not only the runtime part.  :SINCE (a universal
+;; time, or a "YYYY-MM-DD" string) filters by each row's recorded
+;; time, so the dump doubles as a change log -- see session 3.
 
 ;;; ------------------------------------------------------------------
 ;;; The opacity answer, part 2: the schema is exportable as SOURCE.
@@ -146,19 +168,47 @@
 ;;   ;;; Source of truth remains the persisted metadata until this
 ;;   ;;; file is loaded as part of the system; loading it is
 ;;   ;;; idempotent (same names -> same registry ids).
+;;
 ;;   (defpackage #:telemetry (:use #:cl #:graph-db)
 ;;     (:nicknames #:tlm)
-;;     (:export #:reading #:calibration))
+;;     (:export
+;;      #:calibration
+;;      #:reading
+;;      ))
 ;;   (in-package #:telemetry)
-;;   (def-vertex reading ()
-;;     ((sensor-id :type string)
-;;      (value     :type double-float)
-;;      (taken-at  :type integer))
-;;     :support)
+;;
 ;;   (def-vertex calibration ()
-;;     ((value :type double-float
-;;             :value-constraint telemetry-plausible-p))
-;;     :support)
+;;       ((value :type double-float
+;;               :check helpdesk::telemetry-plausible-p))
+;;       :support)
+;;
+;;   (def-vertex reading ()
+;;       ((sensor-id :type string)
+;;        (value     :type double-float)
+;;        (taken-at  :type integer))
+;;       :support)
+;;
+;; Two things worth noticing that only show up once real metadata goes
+;; through the exporter:
+;;
+;;   - The :EXPORT list is one name per line.  A ten-plus-type
+;;     namespace's export clause is the known column-80 offender when
+;;     run together on one line, so EXPORT-SCHEMA-SOURCE always breaks
+;;     it out.
+;;
+;;   - TELEMETRY-PLAUSIBLE-P prints package-qualified
+;;     (HELPDESK::TELEMETRY-PLAUSIBLE-P), not bare, even though this
+;;     file's IN-PACKAGE is :TELEMETRY.  The symbol was read where
+;;     REGISTER-SCHEMA-FUNCTION was called above -- ambient package
+;;     :HELPDESK, not :TELEMETRY -- and the exporter qualifies any
+;;     symbol whose home package a bare token would NOT resolve back
+;;     to: printing it bare here would, on load, INTERN A NEW SYMBOL
+;;     under :TELEMETRY instead of finding the original one, silently
+;;     breaking the EQ-keyed lookup against *SCHEMA-FUNCTIONS*.  A
+;;     symbol homed in the exported namespace itself, or in
+;;     COMMON-LISP or GRAPH-DB (which the generated DEFPACKAGE always
+;;     :USEs), prints bare -- see SENSOR-ID/VALUE/TAKEN-AT and the
+;;     type names above.
 ;;
 ;; This is how a runtime type is PROMOTED: the developer reviews the
 ;; file, adds it to the .asd before their method files, commits.  The
@@ -170,9 +220,9 @@
 ;;; Session 1 ends: the process exits.  Everything above survives as
 ;;; metadata: node-type rows (name, parents, slots, package, default
 ;;; store, constraint NAMES) in each holding store's schema.dat, plus
-;;; -- new in #172 -- a system-level namespace+type manifest beside the
-;;; type registry, so the full schema is enumerable WITHOUT opening
-;;; every store.  No source anywhere.
+;;; -- new in #172 -- a system-level namespace+type manifest
+;;; (schema-manifest.dat) beside the type registry, so the full schema
+;;; is enumerable WITHOUT opening every store.  No source anywhere.
 
 ;;; ===================================================================
 ;;; SESSION 2 -- a fresh Lisp: the load-order problem, solved at load
@@ -186,7 +236,13 @@
 ;;; when TELEMETRY:READING exists only in schema.dat -- the package
 ;;; does not even exist to read the symbol.  The answer is one form,
 ;;; placed where schema has always had to live: BEFORE the code that
-;;; uses it.
+;;; uses it.  A second constraint follows from the same load-order
+;;; discipline: MATERIALIZE-SCHEMA fails fast
+;;; (MATERIALIZE-UNRESOLVED-FUNCTIONS) on any :CHECK name the image
+;;; does not yet provide, so REGISTER-SCHEMA-FUNCTION must run BEFORE
+;;; it, not after -- the earlier draft of this example registered the
+;;; function in plotting.lisp, loaded AFTER runtime-schema.lisp; under
+;;; the shipped fail-fast behaviour that load order aborts the build.
 
 ;;; --- helpdesk.asd ---------------------------------------------------
 ;; (defsystem "helpdesk"
@@ -195,11 +251,12 @@
 ;;   ((:file "package")
 ;;    ;; Static schema, as always:
 ;;    (:file "schema"        :depends-on ("package"))
-;;    ;; NEW: materialize every runtime-defined namespace and type from
-;;    ;; the persisted metadata -- packages interned, classes built via
-;;    ;; the MOP, accessors and constructors generated -- exactly as if
-;;    ;; a schema.lisp had been loaded, except nothing is evaluated:
-;;    ;; the input is the metadata rows, pure data.
+;;    ;; NEW: registers the functions runtime :CHECK slots name, then
+;;    ;; materializes every runtime-defined namespace and type from the
+;;    ;; persisted metadata -- packages interned, classes built via the
+;;    ;; MOP, accessors and constructors generated -- exactly as if a
+;;    ;; schema.lisp had been loaded, except nothing is evaluated: the
+;;    ;; input is the metadata rows, pure data.
 ;;    (:file "runtime-schema" :depends-on ("schema"))
 ;;    ;; Methods compile AFTER both, so every class -- source-defined
 ;;    ;; or runtime-defined -- exists at compile time:
@@ -207,6 +264,16 @@
 
 ;;; --- runtime-schema.lisp -------------------------------------------
 (in-package :helpdesk)
+
+;; The constraint function MATERIALIZE-SCHEMA's :CHECK rows will name,
+;; provided by code that ships in the image.  Registering it here,
+;; before the MATERIALIZE-SCHEMA call below, is not a style choice: a
+;; missing name at materialize time aborts the WHOLE call before
+;; anything is built (one condition naming every unresolved name), by
+;; design (approved point C, R3/R5) -- fail fast at load, not at first
+;; write three files later.
+(graph-db:register-schema-function 'telemetry-plausible-p
+  (lambda (v) (< -1d6 v 1d6)))
 
 ;; Reads the system manifest at LOAD TIME (including during
 ;; compile-file's load of this file), creates packages and classes for
@@ -217,6 +284,10 @@
 ;;
 ;; EVAL-WHEN matters and the macro carries it so users cannot get it
 ;; wrong: (:compile-toplevel :load-toplevel :execute).
+;;
+;; Returns (:NAMESPACES n :MATERIALIZED n :SKIPPED-EXISTING n) -- the
+;; REPL summary; not used here, MATERIALIZE-SCHEMA is a top-level form
+;; run for effect.
 (graph-db:materialize-schema "/var/db/helpdesk-system/")
 
 ;; A closed variant for deployments that fix their schema at build
@@ -226,17 +297,11 @@
 ;;; --- plotting.lisp -------------------------------------------------
 (in-package :helpdesk)
 
-;; Compiles because materialize-schema ran first.  This is ordinary
+;; Compiles because materialize-schema ran first, and TELEMETRY-
+;; PLAUSIBLE-P was already registered before it ran.  This is ordinary
 ;; CLOS on an ordinary class; the founding bargain holds again.
 (defmethod plot ((r telemetry:reading))
   (draw-point (telemetry:taken-at r) (telemetry:value r)))
-
-;; And the constraint function the metadata names must be provided by
-;; the image before any write touches CALIBRATION; a missing name is a
-;; clean, named error at materialize time (listing every unresolved
-;; function), not a mystery at first write:
-(graph-db:register-schema-function 'telemetry-plausible-p
-  (lambda (v) (< -1d6 v 1d6)))
 
 ;;; Runtime use, session 2 -- note ordinary reader syntax now works,
 ;;; no intern/funcall gymnastics, because the package and accessors
@@ -261,7 +326,9 @@
 ;; Adding a slot to a live runtime type is the same function again --
 ;; CREATE-VERTEX-TYPE on an existing name is redefinition, exactly as
 ;; re-evaluating a def-vertex form is today (same replace-in-place,
-;; same CLOS class-redefinition semantics for live instances):
+;; same CLOS class-redefinition semantics for live instances), whether
+;; the existing name was itself runtime- or source-defined (approved
+;; point B):
 (graph-db:create-vertex-type "TELEMETRY:READING"
   '((sensor-id :type string)
     (value     :type double-float)
@@ -270,41 +337,63 @@
   :default-store :support)
 
 ;; The developer arriving after that change asks the schema, not grep:
-(graph-db:describe-schema :namespace :telemetry :since "2026-08-24")
-;; => shows READING with UNIT marked [runtime 2026-08-25], i.e. the
-;;    text dump doubles as a change log because every meta row carries
-;;    its definition timestamp.
+(graph-db:describe-schema :namespace :telemetry :since "2026-08-25")
+;; => shows READING with UNIT, tagged [runtime 2026-08-25]: the text
+;;    dump doubles as a change log because every meta row carries its
+;;    definition time, and :SINCE filters rows recorded at or after
+;;    it (a "YYYY-MM-DD" string is parsed as local midnight).
 
 ;; What is DELIBERATELY NOT PROVIDED, so the boundary stays sharp:
 ;;  - no runtime defmethod, no persisted functions, no lambda in any
 ;;    slot option: behaviour ships in the image, structure in the data;
 ;;  - no automatic loading of exported source by the engine, ever;
 ;;  - no runtime DELETION of a type in this unit (retraction interacts
-;;    with on-disk instances and stays out of scope, as today).
+;;    with on-disk instances and stays out of scope, as today);
+;;  - no runtime def-view/index/unique definition (those macros stay
+;;    code-side; R7) and no Emacs mode (the text dump is SLIME-usable
+;;    as-is, R6).
 
 ;;; ===================================================================
-;;; Summary of the API this example commits #172 to
+;;; Summary of the API this example commits #172 to, as shipped
 ;;; ===================================================================
 ;;;
-;;;   ensure-namespace          name &key nicknames        -> package
+;;;   ensure-namespace          name &key nicknames
+;;;                                  record-p (T)          -> package
+;;;     (RECORD-P NIL is MATERIALIZE-SCHEMA's own internal replay
+;;;      knob, suppressing a manifest re-append for an unchanged row;
+;;;      an ordinary caller never passes it.)
 ;;;   create-vertex-type        name slot-specs
 ;;;                             &key parents default-store
 ;;;                                  keep-revisions        -> class
 ;;;   create-edge-type          name slot-specs &key ...   -> class
 ;;;   register-schema-function  name function              -> name
-;;;   materialize-schema        system-dir &key namespaces -> summary
+;;;   find-schema-function      name                       -> function or NIL
+;;;   materialize-schema        system-dir &key namespaces
+;;;     -> (:namespaces n :materialized n :skipped-existing n)
 ;;;     (load-time safe; :compile-toplevel; idempotent; source wins;
-;;;      unresolved function names -> one named condition, clean)
+;;;      an unresolved :CHECK function, or an unbuildable parent, each
+;;;      abort the WHOLE call with one condition naming every offender
+;;;      -- MATERIALIZE-UNRESOLVED-FUNCTIONS / MATERIALIZE-UNRESOLVED-
+;;;      PARENTS -- before anything is built)
 ;;;   describe-schema           &key namespace store since stream
 ;;;   export-schema-source      path &key namespace store  -> truename
 ;;;
-;;; Open design points to settle in the unit spec (flagged, not hidden):
-;;;   A. Where materialize-schema reads from: a new system-level
-;;;      manifest beside the type registry (proposed -- enumerable
-;;;      without opening stores, appended on every registration), vs
-;;;      scanning registered stores' schema.dat files.
-;;;   B. Whether create-*-type on a SOURCE-defined name is allowed
-;;;      (proposed: yes with the #196 divergence warning, since
-;;;      re-evaluating def-vertex already is) or refused.
-;;;   C. Constraint-name resolution time: at materialize (fail fast,
-;;;      proposed) vs at first write (lazier, mirrors adoption).
+;;; The three open points the original draft flagged, as resolved by
+;;; the unit spec's rulings (docs/superpowers/specs/2026-08-24-runtime-
+;;; schema-172-design.md):
+;;;
+;;;   A. Where MATERIALIZE-SCHEMA reads from: a system-level manifest,
+;;;      schema-manifest.dat, beside the type registry under
+;;;      *SYSTEM-DIRECTORY* -- append-only, enumerable without opening
+;;;      any store, fail-safe (no system directory or a torn/damaged
+;;;      file degrades to in-image-only, never aborts) (R2).
+;;;
+;;;   B. CREATE-*-TYPE on an existing name, source- or runtime-defined,
+;;;      IS allowed: ordinary CLOS class redefinition, with the #196
+;;;      divergence warning on slot disagreement, exactly like
+;;;      re-evaluating DEF-VERTEX (R4) -- session 3 above.
+;;;
+;;;   C. Constraint-name resolution: PRESENCE is verified fail-fast, at
+;;;      CREATE-*-TYPE time and again at MATERIALIZE-SCHEMA time;
+;;;      RESOLUTION to the actual function happens at each check, so a
+;;;      re-registration takes effect immediately (R5).

--- a/docs/superpowers/plans/2026-08-24-runtime-schema-172.md
+++ b/docs/superpowers/plans/2026-08-24-runtime-schema-172.md
@@ -1,0 +1,650 @@
+# Runtime Schema From Persisted Metadata (#172) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A schema defined at runtime survives restart and materialises as
+live CLOS classes at load time — before method files compile — with the
+schema always viewable as text and exportable as source.
+
+**Architecture:** Refactor `def-node-type` so everything except the literal
+`defclass` flows through one functional core (`%install-node-type`); the
+runtime path is MOP `ensure-class` + that same core. A system-level
+append-only manifest (`schema-manifest.dat`, beside the type registry)
+records every namespace and type with provenance; `materialize-schema`
+reads it under `eval-when` and rebuilds packages and classes with no
+evaluation of data. `describe-schema`/`export-schema-source` are read-only
+views of the same metadata.
+
+**Tech Stack:** Common Lisp (SBCL verified; ECL demoted), MOP (`sb-mop`
+on SBCL — the package is already `:use`d by `graph-db`), FiveAM.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md`
+(R1–R7) arguing from `docs/runtime-schema-example.lisp` (Kevin-approved —
+the example's API is the contract; update the example in Task 5 if any
+shipped signature drifts, and say so).
+
+## Global Constraints
+
+- Spaces only, **hard 80-column limit**, terse comments citing `(GH #172)`.
+- **Restart never evaluates data**: no `eval`, no `load`, no
+  `read` with `*read-eval*` on any persisted schema; classes are built via
+  `ensure-class`/MOP calls on plists, helpers installed via
+  `(setf fdefinition)` closures.
+- Manifest discipline = the #167 occupancy sidecar's: printed with
+  `*package*` bound to CL (symbols package-qualified), read with
+  `*read-eval*` NIL, torn/malformed lines skipped, a failed append never
+  aborts the caller, no system directory ⇒ in-image-only degradation.
+- Source wins over metadata at materialize; slot divergence signals the
+  existing `divergent-node-type-redefinition` (#196) style-warning.
+- Test forms: `(with-transaction ((graph-db::transaction-manager g)) ...)`;
+  fixtures rebind `graph-db::*system-directory*` (temp dir) +
+  `graph-db::*type-registry*` NIL; neutral names (public repo). Test
+  system `:graph-db/test`, package `graph-db/test`.
+- SBCL from the worktree, `--dynamic-space-size 16384`, FIRST eval
+  `(asdf:initialize-source-registry (list :source-registry (list :tree (truename ".")) :inherit-configuration))`.
+  Focused run: `(let ((graph-db::*system-directory* (namestring (make-temp-directory))) (graph-db::*type-registry* nil)) (fiveam:run! 'runtime-schema-suite))`.
+  One SBCL at a time on this host; never kill foreign processes.
+- Docs travel with code (Task 5).
+
+---
+
+### Task 1: R1 — the shared `%install-node-type` path
+
+**Files:**
+- Modify: `schema.lisp` (`def-node-type` macro ~lines 399–632; new
+  functions above it)
+- Modify: `prolog-functors.lisp` only if a helper must live there
+  (prefer keeping everything in `schema.lisp`)
+- Test: `tests/runtime-schema-tests.lisp` (new; register in
+  `graph-db.asd` after `package-namespace-tests`)
+
+**Interfaces:**
+- Produces (all internal, consumed by Tasks 2–3):
+  - `(%normalize-slot-specs slot-specs)` → the accessor/initarg-filled
+    list (extracted verbatim from the macro's existing `setq slot-specs`
+    mapcar).
+  - `(%install-node-type meta)` → meta. Everything the macro's expansion
+    did EXCEPT the `defclass`: install `MAKE-<N>`/`LOOKUP-<N>`/`<N>-P`
+    via `(setf (fdefinition (intern ...)))` closures; for `:edge`
+    parents install the `<N>/2` and `<N>/3` functors; call
+    `%warn-if-divergent-across-stores`; `finalize-inheritance`;
+    replace-in-place registration into `*schema-node-metadata*`;
+    `instantiate-node-type` into the open default store, if any.
+  - `(%install-edge-functors name)` → installs two closures into
+    `*prolog-global-functors*` under `(intern "<N>/2" pkg)` /
+    `(intern "<N>/3" pkg)` where pkg = `(symbol-package name)`,
+    with bodies identical in behaviour to the current macro-generated
+    functors (the four map-edges dispatch arms; parameterised by NAME).
+- The macro `def-node-type` shrinks to: normalize specs at expansion →
+  `(defclass ...)` literal → `(let ((meta (make-node-type ...)))
+  (%install-node-type meta))`. Its docstring and def-vertex/def-edge
+  are unchanged.
+
+Key implementation notes (read the current macro in full first):
+- The constructor closure mirrors the current generated `defun`:
+
+```lisp
+(defun %make-constructor-closure (name graph-name kind)
+  (if (eq kind :edge)
+      (lambda (&rest make-args
+               &key graph id deleted-p revision from to weight
+               &allow-other-keys)
+        (let ((graph (%default-store-graph name graph-name graph))
+              (slots (%collect-constructor-slots name make-args)))
+          (make-edge (node-type-id
+                      (%ensure-type-in-store name :edge graph))
+                     from to weight slots
+                     :id id :revision revision :deleted-p deleted-p
+                     :graph graph)))
+      (lambda (&rest make-args
+               &key graph id deleted-p revision &allow-other-keys)
+        (let ((graph (%default-store-graph name graph-name graph))
+              (slots (%collect-constructor-slots name make-args)))
+          (make-vertex (node-type-id
+                        (%ensure-type-in-store name :vertex graph))
+                       slots
+                       :id id :revision revision :deleted-p deleted-p
+                       :graph graph)))))
+```
+
+  with `%collect-constructor-slots` extracted from the current
+  `remove-if/mapcar` over `(data-slots (find-class name))` — evaluated
+  at CALL time, so slot changes are picked up exactly as today.
+- `lookup-<N>` closure: `(lookup-vertex id)`/`(lookup-edge id)` +
+  `typep` + deleted-p, as generated today. `<N>-P` closure: `typep`.
+- The functor bodies move from the macro into `%install-edge-functors`
+  verbatim (the `*prolog-trace*` prints included); the macro arm that
+  emitted `def-global-prolog-functor` forms now just relies on
+  `%install-node-type` calling `%install-edge-functors`. NOTE
+  `def-global-prolog-functor` also `(export ',name)`s — the runtime
+  path must export the functor symbols from their package the same way
+  (guard: only when the package is not CL/KEYWORD).
+- `make-node-type` gains no new fields in this task.
+- Constructor/lookup/predicate names remain interned in
+  `(symbol-package name)` — TODAY they intern in `*package*` at
+  expansion time, which for source code is the defining package.
+  Switching to `symbol-package` of the class name is the correct
+  generalization (identical for every existing use, where the class
+  symbol is interned in the defining package); state this in the
+  report if any test disagrees.
+
+- [ ] **Step 1: Failing test** (equivalence pin — the only new test this
+  task; the real net is the existing full suite):
+
+```lisp
+;;;; Runtime schema (GH #172).  Spec:
+;;;; docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
+(in-package #:graph-db/test)
+
+(def-suite runtime-schema-suite :in graph-db-suite
+  :description "Class-from-metadata, manifest, materialize (GH #172).")
+(in-suite runtime-schema-suite)
+
+(def-vertex rs-static () ((label :type string)) :rs-store)
+(def-edge rs-knows () () :rs-store)
+
+(defmacro with-rs-store ((g) &body body)
+  (let ((sys (gensym)) (d (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,d)
+         (let ((graph-db::*system-directory* (namestring ,sys))
+               (graph-db::*type-registry* nil))
+           (let ((,g (make-graph :rs-store (namestring ,d)
+                                 :buffer-pool-size 1000)))
+             (unwind-protect (progn ,@body)
+               (let ((live (graph-db:lookup-graph :rs-store)))
+                 (when (and live (graph-db::graph-open-p live))
+                   (let ((graph-db:*graph* live))
+                     (ignore-errors
+                      (close-graph live :snapshot-p nil)))))
+               (collect-garbage))))))))
+
+(test source-types-behave-unchanged-through-the-shared-path
+  "R1 equivalence pin: after the refactor a def-vertex/def-edge type
+still constructs, looks up, predicates, and answers its Prolog functor.
+The full suite is the broad net; this is the focused canary."
+  (with-rs-store (g)
+    (let (a b e)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq a (make-rs-static :label "a")
+              b (make-rs-static :label "b")
+              e (make-rs-knows :from (graph-db:id a)
+                               :to (graph-db:id b))))
+      (is (rs-static-p a))
+      (is (typep (lookup-rs-static (graph-db:id a)) 'rs-static))
+      (is (rs-knows-p e))
+      ;; The functor was installed (macro path now goes through
+      ;; %install-edge-functors).
+      (is-true (gethash (intern "RS-KNOWS/2" :graph-db/test)
+                        graph-db::*prolog-global-functors*))
+      (let ((hits (select (?x ?y) (rs-knows ?x ?y))))
+        (is (= 1 (length hits)))))))
+```
+
+  Adjust the functor-package assertion to wherever the symbol really
+  lands (see the interning note above) and the `select` form to this
+  test package's Prolog conventions (see `tests/index-prolog-tests.lisp`
+  for the working pattern).
+
+- [ ] **Step 2: Run** — fails only until the refactor compiles; the
+  purpose is catching behavioural drift, so run it BEFORE the refactor
+  too (against the old macro it must PASS except the
+  `%install-edge-functors`-specific assertion — note the baseline).
+- [ ] **Step 3: Refactor** as specified above. No behaviour change.
+- [ ] **Step 4: Run** `runtime-schema-suite`, then the broad net:
+  `package-namespace-suite`, `keyword-alias-suite`, `node-class-suite`,
+  `index-prolog` suite, `global-type-id-suite`, and the full
+  `(asdf:test-system :graph-db)` — this task touches every constructor
+  in the image; the full gate is worth it HERE, not only at the end.
+- [ ] **Step 5: Commit** `refactor(schema): def-node-type installs through %install-node-type (#172)`
+
+---
+
+### Task 2: R2+R4 — the manifest, `ensure-namespace`, `create-*-type`
+
+**Files:**
+- Create: `runtime-schema.lisp` (add to `graph-db.asd` after `schema`:
+  `(:file "runtime-schema" :depends-on ("schema"))`)
+- Modify: `schema.lisp` (`%install-node-type` appends a manifest record;
+  a special `*schema-provenance*` defaults `:source`, bound `:runtime`
+  by the create functions)
+- Modify: `package.lisp` (export `#:ensure-namespace
+  #:create-vertex-type #:create-edge-type`)
+- Test: `tests/runtime-schema-tests.lisp`
+
+**Interfaces:**
+- Consumes: `%normalize-slot-specs`, `%install-node-type` (Task 1);
+  `type-registry-location`, `ensure-type-registry`,
+  `system-directory-required` (type-registry.lisp); the sidecar
+  discipline patterns in `type-occupancy.lisp`.
+- Produces:
+  - `(ensure-namespace name &key nicknames)` → package. `name` string
+    or symbol; creates via `make-package` (`:use` NIL — a schema
+    namespace holds class/accessor symbols, it is not a code package;
+    the example's `(:use #:cl #:graph-db)` applies to SOURCE packages a
+    developer writes, and `export-schema-source` emits those — note
+    this in the docstring) — idempotent; appends
+    `(:namespace NAME :nicknames (...) :time T)`.
+  - `(create-vertex-type name slot-specs &key parents default-store
+    keep-revisions)` → class; `(create-edge-type ...)` same. `name`
+    symbol or `"PKG:NAME"` string (parse with `*read-eval*` NIL is NOT
+    enough — do NOT read; split on `:` and `intern`/`find-package`
+    manually; missing package = error naming `ensure-namespace`).
+    Builds the class via `ensure-class`:
+
+```lisp
+(defun %ensure-node-class (name parents kind normalized-slots)
+  (ensure-class
+   name
+   :direct-superclasses
+   (append parents (list (ecase kind (:vertex 'vertex) (:edge 'edge))))
+   :direct-slots
+   (mapcar (lambda (spec)
+             (destructuring-bind (sname &key accessor initarg type
+                                        &allow-other-keys)
+                 spec
+               (append
+                (list :name sname
+                      :initargs (list initarg)
+                      :readers (list accessor)
+                      :writers (list (list 'setf accessor)))
+                (when type (list :type type)))))
+           normalized-slots)
+   :metaclass (find-class 'node-class)))
+```
+
+    then `make-node-type` + `%install-node-type` with
+    `*schema-provenance*` = `:runtime`. Redefinition (existing class,
+    source or runtime) is allowed — same replace/divergence semantics
+    as re-evaluating def-vertex (spec R4/point B). `:default-store NIL`
+    is legal: `%default-store-graph` already errors cleanly when
+    `lookup-graph` of NIL returns NIL — verify the error message reads
+    sanely for a NIL store and special-case the report string if not.
+  - Manifest I/O in `runtime-schema.lisp`:
+    `(%schema-manifest-file)` → path or NIL (same guard shape as
+    `%edge-occupancy-file`); `(%append-schema-manifest-record plist)`
+    (locked, guarded append; never signals);
+    `(read-schema-manifest dir)` → `(values namespace-records
+    type-records)` — last-record-per-name wins, `*read-eval*` NIL,
+    malformed lines skipped. Record shapes exactly as spec R2.
+    `%install-node-type` appends
+    `(:type NAME :kind K :parents (...) :slots NORMALIZED :default-store
+    S :keep-revisions KR :provenance *schema-provenance* :time
+    (get-universal-time))`.
+- NOTE the slots in the manifest are the NORMALIZED specs (accessor +
+  initarg filled) so materialize needs no re-derivation.
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test ensure-namespace-is-cheap-and-idempotent
+  (with-rs-store (g)
+    g
+    (let ((p1 (graph-db:ensure-namespace "RS-TLM" :nicknames '("RST")))
+          (p2 (graph-db:ensure-namespace "RS-TLM")))
+      (is (eq p1 p2))
+      (is (packagep p1))
+      ;; No files, no store: the store registry did not grow.
+      (is (null (graph-db:lookup-graph :rs-tlm))))))
+
+(test create-vertex-type-yields-a-working-class
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (let ((class (graph-db:create-vertex-type
+                  "RS-TLM:READING"
+                  '((sensor-id :type string)
+                    (value :type double-float))
+                  :default-store :rs-store)))
+      (is (typep class 'graph-db::node-class))
+      (with-transaction ((graph-db::transaction-manager g))
+        (funcall (intern "MAKE-READING" :rs-tlm)
+                 :sensor-id "s1" :value 1.5d0))
+      (let* ((sym (intern "READING" :rs-tlm))
+             (hits (graph-db:map-vertices #'identity g :collect-p t
+                                          :vertex-type sym)))
+        (is (= 1 (length hits)))
+        (is (string= "s1"
+                     (funcall (intern "SENSOR-ID" :rs-tlm)
+                              (first hits))))))))
+
+(test create-edge-type-installs-functors-and-places-by-default
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (graph-db:create-edge-type "RS-TLM:FEEDS" '()
+                               :default-store :rs-store)
+    (let (a b)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq a (funcall (intern "MAKE-READING" :rs-tlm) :value 1d0)
+              b (funcall (intern "MAKE-READING" :rs-tlm) :value 2d0))
+        (funcall (intern "MAKE-FEEDS" :rs-tlm)
+                 :from (graph-db:id a) :to (graph-db:id b)))
+      (is-true (gethash (intern "FEEDS/2" :rs-tlm)
+                        graph-db::*prolog-global-functors*)))))
+
+(test manifest-records-both-provenances-and-tolerates-damage
+  (with-rs-store (g)
+    g  ; RS-STATIC/RS-KNOWS registered at load time = :source rows
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (multiple-value-bind (ns types)
+        (graph-db::read-schema-manifest graph-db::*system-directory*)
+      (is (find "RS-TLM" ns :key (lambda (r) (getf r :namespace))
+                :test #'string-equal))
+      (let ((row (find (intern "READING" :rs-tlm) types
+                       :key (lambda (r) (getf r :type)))))
+        (is-true row)
+        (is (eq :runtime (getf row :provenance)))
+        (is (eq :rs-store (getf row :default-store))))
+      (is (eq :source
+              (getf (find 'rs-static types
+                          :key (lambda (r) (getf r :type)))
+                    :provenance))))
+    ;; Torn tail: append garbage, read again, intact rows survive.
+    (with-open-file (s (graph-db::%schema-manifest-file)
+                       :direction :output :if-exists :append)
+      (format s "(:type RS-TORN"))
+    (multiple-value-bind (ns types)
+        (graph-db::read-schema-manifest graph-db::*system-directory*)
+      ns
+      (is (find (intern "READING" :rs-tlm) types
+                :key (lambda (r) (getf r :type)))))))
+```
+
+- [ ] **Step 2: Run** — undefined functions.
+- [ ] **Step 3: Implement** per the interface block.
+- [ ] **Step 4: Run** `runtime-schema-suite` + `package-namespace-suite`.
+- [ ] **Step 5: Commit** `feat(schema): runtime namespaces and types, recorded in the system manifest (#172)`
+
+---
+
+### Task 3: R3+R5 — `materialize-schema`, the function registry, `:check`
+
+**Files:**
+- Modify: `runtime-schema.lisp`, `value-constraint.lisp` (the `:check`
+  enforcement point), `package.lisp` (export `#:materialize-schema
+  #:register-schema-function #:find-schema-function
+  #:materialize-unresolved-functions`)
+- Test: `tests/runtime-schema-tests.lisp`
+
+**Interfaces:**
+- Consumes: `read-schema-manifest`, `ensure-namespace`,
+  `%ensure-node-class`, `%install-node-type`, `%normalize-slot-specs`.
+- Produces:
+  - `(register-schema-function name fn)` → name; `(find-schema-function
+    name)` → fn or NIL; EQ hash + lock in `runtime-schema.lisp`.
+  - Slot option `:check FN-NAME` accepted in slot-specs (runtime AND
+    `def-vertex` — the normalizer passes unknown options through to the
+    meta's slots already; enforcement reads it): at commit, wherever
+    `validate-value-constraints` runs, a slot with `:check` calls
+    `(funcall (or (find-schema-function fn-name)
+                  (error 'schema-function-unresolved ...)) value)`
+    and a NIL result signals the existing
+    `value-constraint-violation` shape (read
+    `value-constraint.lisp:106` `%value-constraint-violations` and add
+    the `:check` pass beside it, same condition class, NULL-exempt like
+    `:one-of`). KEEP THIS SMALL — one option, one enforcement point.
+  - `(materialize-schema dir &key namespaces)` — a MACRO expanding to
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (%materialize-schema ,dir :namespaces ,namespaces))`.
+    `%materialize-schema`: read manifest → ensure namespaces → for each
+    type row (filtered by `:namespaces` when given, by the symbol's
+    package name) with `(find-class name nil)` absent, build via
+    `%ensure-node-class` + `make-node-type` + `%install-node-type`
+    (`*schema-provenance*` `:runtime` — materialized types keep their
+    runtime provenance; do NOT re-append rows for types already in the
+    manifest unchanged: skip the append when an identical last row
+    exists, or accept benign duplicate rows — implementer's choice,
+    say which and why). A class that EXISTS is skipped (source wins;
+    divergence → `%warn-if-divergent-across-stores` fires via the
+    normal path — verify a warning actually reaches the user in the
+    skip case and add a direct check if not). Before building anything:
+    scan every row's slot `:check` names, collect unregistered ones,
+    and signal ONE `materialize-unresolved-functions` (reader
+    `unresolved-function-names`) listing all — fail fast, nothing half
+    built. Returns `(:namespaces N :materialized M :skipped-source S)`.
+    Dependency order: parents before children (rows sorted so a row
+    whose `:parents` include a not-yet-built runtime type builds after
+    it; manifest append order already guarantees this for types created
+    through the API — a simple stable topological pass is still
+    required for redefinition-reordered manifests).
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(defun %rs-wipe-runtime-state ()
+  "Simulate a fresh image for the RS-TLM namespace: unintern the
+classes, delete the package, drop the metas.  A real restart is a
+different process; this is the closest single-image ablation and it
+proves materialize rebuilds everything it needs."
+  (let ((pkg (find-package :rs-tlm)))
+    (when pkg
+      (do-symbols (s pkg)
+        (when (find-class s nil) (setf (find-class s) nil)))
+      (delete-package pkg)))
+  (maphash (lambda (store metas)
+             (setf (gethash store graph-db::*schema-node-metadata*)
+                   (remove-if (lambda (m)
+                                (null (symbol-package
+                                       (graph-db::node-type-name m))))
+                              metas)))
+           graph-db::*schema-node-metadata*))
+
+(test materialize-rebuilds-a-runtime-type-in-a-fresh-image
+  "THE acceptance test: create at runtime, write, wipe the in-image
+state, materialize from the manifest, and both the CLASS and the DATA
+come back -- and a method compiles against the class."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (let (id)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq id (graph-db:id (funcall (intern "MAKE-READING" :rs-tlm)
+                                       :value 3.5d0))))
+      (%rs-wipe-runtime-state)
+      (is (null (find-package :rs-tlm)))
+      (let ((summary (graph-db:materialize-schema
+                      graph-db::*system-directory*)))
+        (is (plusp (getf summary :materialized))))
+      (let* ((sym (intern "READING" :rs-tlm))
+             (class (find-class sym nil)))
+        (is-true class)
+        ;; A method compiles against the materialized class -- the
+        ;; twenty-year problem, pinned.
+        (let ((m (compile nil `(lambda (r)
+                                 (declare (type ,sym r))
+                                 (funcall ',(intern "VALUE" :rs-tlm)
+                                          r)))))
+          (is (= 3.5d0 (funcall m (graph-db:lookup-vertex
+                                   id :graph g)))))))))
+
+(test materialize-skips-source-defined-classes
+  "Source wins: RS-STATIC is defined by def-vertex in this image; its
+manifest row must be skipped, not rebuilt, and the summary says so."
+  (with-rs-store (g)
+    g
+    (let ((summary (graph-db:materialize-schema
+                    graph-db::*system-directory*)))
+      (is (plusp (getf summary :skipped-source)))
+      (is (typep (make-instance 'rs-static) 'rs-static)))))
+
+(test materialize-fails-fast-on-an-unresolved-check-function
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:register-schema-function 'rs-plausible-p
+                                       (lambda (v) (< 0 v 100)))
+    (graph-db:create-vertex-type
+     "RS-TLM:CAL" '((value :type double-float :check rs-plausible-p))
+     :default-store :rs-store)
+    (%rs-wipe-runtime-state)
+    ;; Fresh image forgot to register the function:
+    (graph-db::%unregister-schema-function 'rs-plausible-p)
+    (let ((c (handler-case
+                 (progn (graph-db:materialize-schema
+                         graph-db::*system-directory*)
+                        nil)
+               (graph-db:materialize-unresolved-functions (e) e))))
+      (is-true c)
+      (when c
+        (is (member 'rs-plausible-p
+                    (graph-db:unresolved-function-names c))))
+      ;; Fail fast: nothing half-built.
+      (is (null (find-class (and (find-package :rs-tlm)
+                                 (intern "CAL" :rs-tlm))
+                            nil))))))
+
+(test check-constraint-enforces-at-commit
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:register-schema-function 'rs-plausible-p
+                                       (lambda (v) (< 0 v 100)))
+    (graph-db:create-vertex-type
+     "RS-TLM:CAL" '((value :type double-float :check rs-plausible-p))
+     :default-store :rs-store)
+    (with-transaction ((graph-db::transaction-manager g))
+      (funcall (intern "MAKE-CAL" :rs-tlm) :value 50d0))
+    (signals graph-db:value-constraint-violation
+      (with-transaction ((graph-db::transaction-manager g))
+        (funcall (intern "MAKE-CAL" :rs-tlm) :value 5000d0)))))
+```
+
+  (Add the tiny `%unregister-schema-function` internal for the test.)
+  Adapt the constraint-violation condition name/signal point to what
+  `value-constraint.lisp` really signals (read
+  `%value-constraint-violations` and its caller first).
+
+- [ ] **Step 2: Run** — undefined functions.
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run** `runtime-schema-suite` + `value-constraint` suite.
+- [ ] **Step 5: Commit** `feat(schema): materialize-schema rebuilds runtime classes at load time (#172)`
+
+---
+
+### Task 4: R6 — `describe-schema` and `export-schema-source`
+
+**Files:**
+- Create: `schema-tools.lisp` (`.asd` after `runtime-schema`, depends on
+  it), `package.lisp` exports (`#:describe-schema
+  #:export-schema-source`)
+- Test: `tests/runtime-schema-tests.lisp`
+
+**Interfaces:**
+- Consumes: `read-schema-manifest`, live metas, `node-type-*` readers.
+- Produces:
+  - `(describe-schema &key namespace store since
+    (stream *standard-output*))` → no value; plain text grouped by
+    namespace (package name of each type symbol), each type line:
+    name, kind, default store, `[source]`/`[runtime <ISO-date>]` from
+    its manifest row (a type with no manifest row — pre-#172 store —
+    prints `[source]`); slot lines: name, type, `:check` name if any.
+    `:since` (universal time or "YYYY-MM-DD" string) filters rows by
+    `:time`. `:store` limits to types instantiated in that open store.
+  - `(export-schema-source path &key namespace store)` → truename.
+    Emits: generated-header comment (tool name + date + the
+    idempotence note from the example), one `defpackage` per exported
+    namespace (`(:use #:cl #:graph-db)` + `:export` of the class
+    names — this IS the source-package shape, per Task 2's
+    ensure-namespace docstring note), `in-package`, and
+    `def-vertex`/`def-edge` forms rebuilt from metas: slot specs
+    printed WITHOUT the auto-filled `:accessor`/`:initarg` when they
+    match the defaults (so the output looks hand-written), keeping
+    `:type`/`:check`/other options; trailing default-store argument
+    (`nil` prints as `nil`); `:keep-revisions` when non-NIL. Printed
+    with `*print-case* :downcase`, `*package*` bound per-namespace so
+    symbols read back correctly, ≤80 columns via the pretty printer
+    (`*print-right-margin*` 79).
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test describe-schema-shows-provenance-and-slots
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (let ((text (with-output-to-string (s)
+                  (graph-db:describe-schema :stream s))))
+      (is (search "RS-TLM" text))
+      (is (search "READING" text))
+      (is (search "[runtime" text))
+      (is (search "RS-STATIC" text :test #'char-equal))
+      (is (search "[source]" text)))))
+
+(test export-schema-source-round-trips
+  "The promotion path: export the runtime namespace, wipe the image
+state, LOAD the exported file (the ordinary source path -- the ENGINE
+never does this, the developer's build does), and the type is back
+with the SAME registry id."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (let ((id-before (graph-db::node-type-id
+                      (graph-db::%find-registered-node-type
+                       (intern "READING" :rs-tlm) :vertex)))
+          (path (merge-pathnames
+                 "exported-schema.lisp"
+                 (uiop:ensure-directory-pathname
+                  graph-db::*system-directory*))))
+      (graph-db:export-schema-source path :namespace :rs-tlm)
+      (%rs-wipe-runtime-state)
+      (load path)
+      (let ((meta (graph-db::%find-registered-node-type
+                   (intern "READING" :rs-tlm) :vertex)))
+        (is-true meta)
+        (is (= id-before (graph-db::node-type-id meta)))))))
+```
+
+- [ ] **Step 2: Run** — undefined. **Step 3: Implement.**
+- [ ] **Step 4: Run** the suite. **Step 5: Commit**
+  `feat(schema): describe-schema and export-schema-source (#172)`
+
+---
+
+### Task 5: Docs and the example reconciled
+
+**Files:**
+- Modify: `CHANGELOG.md` (`### Added`: the whole unit, one entry —
+  runtime schema, materialize, tooling, the behaviour boundary),
+  `docs/vivace-graph-v3-doc.org` (new schema-chapter section: the three
+  sessions from the example, the `.asd` ordering recipe, the boundary,
+  describe/export), `docs/runtime-schema-example.lisp` (reconcile every
+  form with the shipped signatures; keep the design commentary; note
+  at top it is now DOCUMENTATION of shipped behaviour),
+  `docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md`
+  (Built note), `docs/superpowers/specs/2026-08-20-namespaces-design.md`
+  (§3.5 Built note; §11 unit 7 → **Done**; if every unit row is now
+  Done, say so where §11 introduces the table).
+- Sanity pass: exported names exist in `package.lisp`; org SRC balance;
+  Lisp examples ≤80 cols. ONE commit
+  `docs(schema): runtime schema -- manual, CHANGELOG, example reconciled (#172)`.
+
+---
+
+## Self-review
+
+- Spec coverage: R1→T1, R2→T2, R3→T3, R4→T2, R5→T3, R6→T4, R7 honoured
+  (no deletion, no runtime views/indexes, no Emacs mode); acceptance
+  table's five rows → T3 tests + branch gate; example promises → T2–T4
+  + T5 reconciliation.
+- Type consistency: `%install-node-type`, `%normalize-slot-specs`,
+  `%ensure-node-class`, `read-schema-manifest`,
+  `%append-schema-manifest-record`, `%schema-manifest-file`,
+  `register-schema-function`/`find-schema-function`,
+  `materialize-unresolved-functions`/`unresolved-function-names`,
+  `describe-schema`, `export-schema-source` used consistently.
+- Judgment points named for implementers: helper-symbol interning
+  package (T1), NIL-default-store error message (T2), duplicate
+  manifest rows at materialize (T3), constraint condition name (T3),
+  export slot-spec minimization (T4).

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -197,6 +197,20 @@ Slots, types, indexes, unique constraints and value constraints are data. Functi
 schema options are not — a closure cannot be serialised. A runtime-defined type that needs
 a function **names a pre-registered one**. Invariant: *restart never evaluates data.*
 
+**Built (#172):** `ensure-namespace`/`create-vertex-type`/`create-edge-type` build a
+namespace and a class from data through the same `%install-node-type` path a `def-vertex`
+expansion drives (R1); a system-level `schema-manifest.dat` beside the type registry
+records every namespace and type row, fail-safe like the #167 occupancy sidecar (R2); the
+`materialize-schema` macro is the load-order answer, rebuilding runtime packages and
+classes from the manifest at load time, idempotent, source-wins, and failing fast — before
+building anything — on an unresolved `:check` function name or an unbuildable parent
+(`materialize-unresolved-functions`/`materialize-unresolved-parents`, R3); `:check
+FN-NAME` is the one function-by-name slot option, resolved against
+`register-schema-function`/`find-schema-function` (R5); `describe-schema` and
+`export-schema-source` are the read-only visibility/promotion tools (R6). Full detail and
+the unit's own review-round additions: `docs/superpowers/specs/2026-08-24-runtime-
+schema-172-design.md`.
+
 ## 4. Placement
 
 The class's declared store is a **default**, overridable at any individual write.
@@ -581,13 +595,16 @@ before this ships. That is a release gate, not a design gate.
 | # | Unit | Issue | Depends on | Status |
 |---|---|---|---|---|
 | 1a | Widen `type-id` to 32 bits, sparse type-index, v3 head codec, migration — **ids stay per-graph** | #166 | — | **Done** |
-| 1b | Global type-ids: canonical registry (D14), distribution, handshake guard (D15), delete the uniqueness check | #186 | 1a | In progress |
+| 1b | Global type-ids: canonical registry (D14), distribution, handshake guard (D15), delete the uniqueness check | #186 | 1a | **Done** |
 | 2 | Packages as namespaces; store/namespace decoupling; placement defaults | #167 | **1b**, #190 | **Done** |
 | 3 | Image-level clock, system journal, epoch leases | #168 | — | **Done** |
-| 4 | Tagged UUIDv8 store field, resolver, detached-read marker | #169 | 3 | Not started |
-| 5 | Detach quiescence protocol and shadow bulk load | #170 | 3, 4, #191 | Blocked |
+| 4 | Tagged UUIDv8 store field, resolver, detached-read marker | #169 | 3 | **Done** |
+| 5 | Detach quiescence protocol and shadow bulk load | #170 | 3, 4, #191 | **Done** |
 | 6 | Restore: retention policy, algorithm, manifest, cascade | #171 | 5, #191 | **Done** |
-| 7 | Runtime schema from persisted metadata | #172 | 1b, 2 | Blocked |
+| 7 | Runtime schema from persisted metadata | #172 | 1b, 2 | **Done** |
+
+Every build unit in this table is now **Done** — #172 (unit 7) was the last. Follow-ups
+this epic surfaced along the way stay open as their own issues rather than rows here.
 
 Defects found while building the units above, which gate later ones: #187 (memory-image
 narrowing, **done**), #182 (clock had no cross-process exclusion, **done**), #190

--- a/docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
+++ b/docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
@@ -1,0 +1,163 @@
+# Runtime schema from persisted metadata (#172) — unit design
+
+Unit 7 of the namespaces epic (#110), the last build unit. Implements
+`2026-08-20-namespaces-design.md` §3.5 (decision D6). The developer
+experience is fixed by `docs/runtime-schema-example.lisp` (Kevin-approved
+2026-08-24, including open points A/B/C) — this spec argues from that
+example; where they disagree, the example wins unless a ruling below
+says otherwise. Public repo: neutral names.
+
+## 1. What already holds
+
+- `node-type` metas persist everything a `defclass` needs (name,
+  parent-type, slots, package, constructor name, keep-revisions), but
+  `instantiate-node-type` assumes `(find-class name)` exists — the
+  engine cannot rebuild a class from disk.
+- `def-node-type` expands to: `defclass` (metaclass `node-class`) +
+  `defun`s for `make-/lookup-/-p` + two `def-global-prolog-functor`s
+  for edges + registration into `*schema-node-metadata*`. The functor
+  macro just installs into `*prolog-global-functors*` — a runtime path
+  can install closures the same way.
+- Value constraints (`def-value-constraint`) are already pure data
+  (`:one-of` lists, `:required`) — no closure crosses the boundary
+  today. The function-by-name seam is therefore built for *new*
+  function-valued options, not to retrofit existing ones.
+- Placement, adoption and the occupancy hint (#167) apply to any
+  registered type; runtime types ride them unchanged.
+
+## 2. Rulings
+
+**R1 — One installation path for source and runtime types.**
+`def-node-type` is refactored so its expansion becomes: the literal
+`defclass` form (kept — the compiler must see the class) plus a call to
+a new shared functional core, `%install-node-type (meta)`, which does
+everything else — helper functions installed via `(setf fdefinition)`
+closures (constructor, lookup, predicate), edge Prolog functors
+installed as closures into `*prolog-global-functors*`, registration,
+instantiation into an open default store. The runtime path is then
+`ensure-class` (metaclass `node-class`, accessors/initargs derived from
+the same slot-spec normalization) + the *same* `%install-node-type`.
+Equivalence between a source-defined and a runtime-defined type is a
+property of sharing the path, pinned by a test, not a promise.
+*Cost if wrong:* generated helpers become closures instead of compiled
+`defun`s for source types too — they only parse args and call
+`make-vertex`/`make-edge`, so the cost is negligible; if profiling ever
+disagrees, the macro can go back to emitting `defun`s while still
+delegating their bodies to shared builders.
+
+**R2 — The system manifest (approved point A).**
+`schema-manifest.dat` lives beside the type registry under
+`*system-directory*`, append-only, one readable line per record,
+printed with `*package*` = CL (symbols package-qualified), read with
+`*read-eval*` NIL, torn/malformed tail lines skipped. Two record kinds:
+`(:namespace NAME :nicknames (...) :time T)` and
+`(:type NAME :kind :vertex|:edge :parents (...) :slots (...)
+:default-store S :keep-revisions K :provenance :source|:runtime
+:time T)`. Appended by `%install-node-type` (both paths — so the
+manifest describes the WHOLE schema, giving `describe-schema` its
+`[source]`/`[runtime]` provenance) and by `ensure-namespace`.
+Last-record-per-name wins on read. No system directory ⇒ manifest
+skipped, fail-safe: runtime types then live for the session only and
+`materialize-schema` of that directory later finds nothing — the same
+in-image-only degradation as the occupancy sidecar. A failed append
+must never abort the definition (guarded like #167's sidecar).
+*Cost if wrong:* the manifest duplicates what stores' schema.dat hold;
+divergence is impossible for slots (same meta object writes both) and
+tolerable for provenance (advisory).
+
+**R3 — `materialize-schema` (the load-order answer).** A macro wrapping
+`eval-when (:compile-toplevel :load-toplevel :execute)` around a
+functional core: read the manifest at DIR; `ensure-namespace` every
+namespace record; for each type record whose class does NOT exist,
+build it via the runtime path; a class that already exists (defined by
+source earlier in the load) is left alone — **source wins** — with the
+#196 divergence warning when slot sets disagree. Restart never
+evaluates data: inputs are plists, outputs are MOP calls. Collect every
+schema-function name the manifest references that is unregistered and
+signal ONE `materialize-unresolved-functions` error naming all of them
+(approved point C: fail fast at materialize, not first write).
+Idempotent; `:namespaces` keyword narrows. Returns a summary plist
+(counts by provenance) for the REPL.
+*Cost if wrong:* fail-fast means an image that never touches the
+constrained type still refuses to materialize — deliberate (a deploy
+missing behaviour its schema names is broken, loudly).
+
+**R4 — Runtime definition API.** `ensure-namespace (name &key
+nicknames)` → package, no files, no store, idempotent, manifest-logged.
+`create-vertex-type` / `create-edge-type (name slot-specs &key parents
+default-store keep-revisions)` → finalized class; NAME a symbol or
+"PACKAGE:NAME" string (package must exist — `ensure-namespace` first;
+a missing package is an error, not an implicit creation). Redefinition
+of an existing name — runtime OR source-defined (approved point B) —
+follows CLOS redefinition semantics with the #196 warning on slot
+divergence, exactly like re-evaluating `def-vertex`. `default-store`
+defaults to NIL meaning "no default store": constructors then REQUIRE
+an explicit `:graph` (`default-store-not-open-error` names NIL) — a
+runtime type need not commit to placement at creation.
+*Cost if wrong:* the no-default-store shape is new; if it confuses, a
+required `default-store` is a one-line tightening.
+
+**R5 — The behaviour boundary.** `register-schema-function (name fn)` →
+name, into an image-level EQ registry; `find-schema-function (name)` →
+fn or NIL. The only v1 consumer: a slot option `:check FN-NAME` on
+runtime slot-specs (and accepted by `def-vertex` slot-specs for parity)
+that registers a function-backed value constraint enforced where
+`validate-value-constraints` already runs, resolving the name at check
+time but *verified present* at materialize (R3) and at
+`create-*-type` time. The metadata stores only the name. No runtime
+`defmethod`, no persisted closures, no engine loading of exported
+source, no type deletion in this unit.
+*Cost if wrong:* `:check` overlaps `def-value-constraint`'s territory;
+kept minimal (one option, one enforcement point) so a later
+consolidation is a refactor, not a migration.
+
+**R6 — Visibility tooling.** `describe-schema (&key namespace store
+since (stream *standard-output*))` — plain-text dump from the manifest
+joined with live metas: grouped by namespace, per-type provenance tag
+and timestamp, slots with types and `:check` names; `:since` filters by
+record time (the dump doubles as a change log). `export-schema-source
+(path &key namespace store)` — writes a generated-header comment,
+`defpackage`+`in-package`, and literal `def-vertex`/`def-edge` forms
+reconstructed from metas; loading the file is the ordinary source path
+and therefore idempotent. Export never runs implicitly and the engine
+never reads the file back. An Emacs wrapper is out of scope (the text
+dump is SLIME-usable as-is); noted as follow-up.
+*Cost if wrong:* none structural — both are read-only views.
+
+**R7 — Scope guard.** Not in this unit: type deletion/retraction;
+runtime `def-view`/index/unique definition (their macros stay
+code-side; follow-ups if wanted); high-cardinality shared-type-id
+types (spec §3.5's "note on scale"); the Emacs mode; peer-wire
+changes (the type table already carries qualified names — a runtime
+type replicates like any other once instantiated in a store).
+
+## 3. Acceptance mapping (issue → here)
+
+| Issue acceptance | Where |
+|---|---|
+| Runtime type survives restart, materialises as live class | R2+R3 |
+| Restart performs no load/eval/read-with-eval of schema | R3 (plists → MOP; `*read-eval*` NIL) |
+| Function resolves by name, fails cleanly when unregistered | R5 + R3's one-error-naming-all |
+| Namespace creation allocates no files, no store | R4 |
+| Full suite green | branch gate |
+| Example-program promises (describe/export/asd flow) | R3, R6; example updated if any form drifts |
+
+## 4. Deliverables
+
+1. `%install-node-type` refactor of `def-node-type` (R1) — no
+   behaviour change for source types; equivalence test.
+2. `runtime-schema.lisp`: manifest read/write (R2), `ensure-namespace`,
+   `create-vertex-type`/`create-edge-type` (R4),
+   `register-schema-function`/`find-schema-function` + `:check` (R5),
+   `materialize-schema` (R3).
+3. `schema-tools.lisp`: `describe-schema`, `export-schema-source` (R6).
+4. Tests (`tests/runtime-schema-tests.lisp`): create → write → close →
+   NEW image simulated by dropping the classes/packages → materialize →
+   class exists, methods compile (`compile` a defmethod form), data
+   reads back typed; source-wins + divergence warning; unresolved
+   `:check` name → one error naming it; no-manifest degradation;
+   describe/export round-trip (export → load → same registry ids);
+   torn manifest tail; edge functors work for a runtime edge type.
+5. Docs: manual section (developer workflow = the example's three
+   sessions), CHANGELOG, example file updated to match shipped
+   signatures, epic spec §3.5 Built note + §11 unit 7 → Done.

--- a/docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
+++ b/docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
@@ -161,3 +161,25 @@ type replicates like any other once instantiated in a store).
 5. Docs: manual section (developer workflow = the example's three
    sessions), CHANGELOG, example file updated to match shipped
    signatures, epic spec §3.5 Built note + §11 unit 7 → Done.
+
+**Built (#172):** All of R1–R7 shipped, on `experiment`, in the order
+above; `tests/runtime-schema-tests.lisp` is the acceptance evidence.
+Review rounds added three things this spec did not originally name:
+`materialize-unresolved-parents` (a row whose parent neither exists
+nor is being built in the same call is refused, not built as a
+`forward-referenced-class` stub that would poison every later
+materialization — R3, review round 1, I-2); `*record-manifest-rows*`
+binding `materialize-schema`'s own install calls to skip the manifest
+append entirely, since every row it builds already came FROM the
+manifest, so replaying it must not grow the file (M-1); and
+`:skipped-existing` in the summary plist, counting rows left alone
+because the class was already present. `export-schema-source` gained
+mid-build hardening beyond the R6 sketch: every symbol foreign to the
+exported namespace prints package-qualified (not only the type and
+slot names — a `:check` name registered in some other package is the
+concrete case that forced this), and an unreachable-in-practice
+uninterned symbol warns and falls back to a bare token rather than
+signalling, so export never errors on live data. `ensure-namespace`
+shipped a `:record-p` keyword (default `T`) purely for
+`materialize-schema`'s own replay — an ordinary caller never passes
+it. The docs deliverable is Task 5, covered separately.

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3202,7 +3202,9 @@ Presence — not resolution — of the named function is verified at
 ~create-*-type~ time (signalling ~schema-function-unresolved~ if the name
 is not yet registered) and again at ~materialize-schema~ time below; the
 function itself is looked up at each check, so re-registering it takes
-effect immediately.
+effect immediately. The check function runs inside a transaction's OCC
+validation, so a conflict-triggered retry can run it more than once for
+one logical write; it must be pure and side-effect-free.
 
 From here the runtime type is indistinguishable from a static one: the
 generated constructor exists, placement follows #167's rules, transactions

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3136,6 +3136,256 @@ ontological line, not merely a lexical one — is the opt-in ontology subsystem
 (GH #109 and its units), layered on top of, and not part of, what packages
 give you here.
 
+*** Runtime schema: metadata is the durable truth (GH #172)
+
+~def-vertex~/~def-edge~ define a type from a Lisp form the compiler sees.
+Sometimes the type's name and shape only exist at runtime — an ETL that
+discovers a new record shape, an operator adding a type without a deploy —
+and a macro cannot help, because the data is not there yet when the form
+would need to be read. #172 adds a functional twin of the same machinery:
+~ensure-namespace~ and ~create-vertex-type~/~create-edge-type~ build a
+namespace and a class from data, driving the *same* installation path
+(~%install-node-type~) a ~def-vertex~ expansion drives, so a runtime type is
+indistinguishable from a source-defined one once built.
+
+This section is a developer workflow in three sessions — the same shape as
+~docs/runtime-schema-example.lisp~, which stays in the repository as the
+worked example this section summarizes.
+
+**** Session 1: a running system grows a type
+
+A namespace is a package, created cheaply and idempotently, with no files
+and no store allocated:
+
+#+BEGIN_SRC lisp
+  (graph-db:ensure-namespace "TELEMETRY" :nicknames '("TLM"))
+#+END_SRC
+
+~create-vertex-type~/~create-edge-type~ take a name — a symbol, or a
+~"PACKAGE:NAME"~ string, since the caller may only have strings — the same
+slot-spec data ~def-vertex~ takes, and the same trailing store keyword as a
+keyword argument, ~:default-store~ (default ~NIL~, meaning "no default
+store": the generated constructor then requires an explicit ~:graph~, since
+a runtime type need not commit to placement at creation):
+
+#+BEGIN_SRC lisp
+  (graph-db:create-vertex-type "TELEMETRY:READING"
+    '((sensor-id :type string)
+      (value     :type double-float)
+      (taken-at  :type integer))
+    :default-store :support)
+#+END_SRC
+
+Redefining an existing name — runtime- or source-defined — is ordinary CLOS
+class redefinition, with the existing #196 divergence warning when the slot
+sets disagree, exactly like re-evaluating a ~def-vertex~ form.
+
+A closure cannot serialize, so behaviour never crosses into the metadata: a
+runtime type that wants a constraint names a function the image registers
+by code, and the metadata stores only the name:
+
+#+BEGIN_SRC lisp
+  (graph-db:register-schema-function 'telemetry-plausible-p
+    (lambda (v) (< -1d6 v 1d6)))
+
+  (graph-db:create-vertex-type "TELEMETRY:CALIBRATION"
+    '((value :type double-float
+             :check telemetry-plausible-p))   ; a NAME, not a #'
+    :default-store :support)
+#+END_SRC
+
+~:check FN-NAME~ is a slot option accepted by ~def-vertex~/~def-edge~ too,
+for parity. It is enforced wherever value constraints already run
+(~value-constraint.lisp~), NULL-exempt; a violation signals the existing
+~value-constraint-violation~ condition with reason ~:check-failed~.
+Presence — not resolution — of the named function is verified at
+~create-*-type~ time and again at ~materialize-schema~ time below; the
+function itself is looked up at each check, so re-registering it takes
+effect immediately.
+
+From here the runtime type is indistinguishable from a static one: the
+generated constructor exists, placement follows #167's rules, transactions
+and views and indexes see an ordinary ~node-class~.
+
+**** The system manifest
+
+Every namespace and type — installed by ~def-vertex~/~def-edge~ or by
+~create-*-type~ — is appended as one readable line to ~schema-manifest.dat~,
+beside the type registry under ~*system-directory*~, so the full schema is
+enumerable without opening every store. It fails safe like the #167
+occupancy sidecar: no system directory, or a torn or damaged tail, degrades
+to in-image-only for the session rather than aborting a definition; the
+last record for a given name wins on read.
+
+**** Session 2: a fresh Lisp — the load-order problem
+
+A method cannot compile against a class that exists only as persisted
+metadata:
+
+#+BEGIN_SRC lisp
+  (defmethod plot ((r telemetry:reading)) ...)
+#+END_SRC
+
+fails outright in a new image — the ~telemetry~ package does not even exist
+to read the symbol. ~materialize-schema~ is the answer, placed where schema
+has always had to live: before the code that uses it.
+
+#+BEGIN_SRC lisp
+  ;; --- helpdesk.asd ---
+  (defsystem "helpdesk"
+    :depends-on ("graph-db")
+    :components
+    ((:file "package")
+     (:file "schema"         :depends-on ("package"))
+     (:file "runtime-schema" :depends-on ("schema"))
+     (:file "plotting"       :depends-on ("runtime-schema"))))
+
+  ;; --- runtime-schema.lisp ---
+  (in-package :helpdesk)
+
+  ;; Register every function a :CHECK slot names FIRST: materialize
+  ;; fails fast on an unresolved name, by design (see below), so
+  ;; registering it after this form -- e.g. in plotting.lisp, loaded
+  ;; next -- aborts the build.
+  (graph-db:register-schema-function 'telemetry-plausible-p
+    (lambda (v) (< -1d6 v 1d6)))
+
+  (graph-db:materialize-schema "/var/db/helpdesk-system/")
+#+END_SRC
+
+~materialize-schema~ is a macro carrying its own
+~(eval-when (:compile-toplevel :load-toplevel :execute))~, so a caller
+cannot get that part wrong. It reads the manifest at the given directory,
+~ensure-namespace~s every namespace row, and builds a class via the MOP for
+every type row whose class does not already exist. It is idempotent, and
+**source wins**: a type already defined by source earlier in the load (e.g.
+by ~schema.lisp~ above) is left alone, with the #196 divergence warning if
+the manifest's slot set disagrees with the live class. Nothing is
+evaluated — the input is plists, the output is MOP calls — which is what
+makes the restart-never-evaluates-data invariant hold.
+
+It fails fast, before building anything, and names every offender in one
+condition each:
+
+- ~materialize-unresolved-functions~ — a manifest row names a ~:check~
+  function this image does not provide. Register it first, as above.
+- ~materialize-unresolved-parents~ — a row's parent neither exists as a
+  finalized class nor appears among the rows being materialized (building
+  it anyway would leave a forward-referenced-class stub that poisons every
+  later materialization attempt). Widen ~:namespaces~, or load the source
+  that defines the parent first.
+
+A half-built materialization is worse than none, so either condition
+aborts the whole call with nothing built. On success it returns a summary
+plist for the REPL: ~(:namespaces n :materialized n :skipped-existing n)~.
+~:namespaces~ narrows a call to specific packages:
+
+#+BEGIN_SRC lisp
+  (graph-db:materialize-schema "/var/db/helpdesk-system/"
+                               :namespaces '(:telemetry))
+#+END_SRC
+
+Once ~runtime-schema.lisp~ has loaded, ordinary reader syntax works with no
+~intern~/~funcall~ gymnastics, because the package and accessors existed
+before ~plotting.lisp~ was even compiled.
+
+**** Session 3: schema evolution at runtime, still visible
+
+Adding a slot to a live runtime type is ~create-vertex-type~ again — the
+same replace-in-place, same CLOS redefinition semantics as re-evaluating
+~def-vertex~:
+
+#+BEGIN_SRC lisp
+  (graph-db:create-vertex-type "TELEMETRY:READING"
+    '((sensor-id :type string)
+      (value     :type double-float)
+      (taken-at  :type integer)
+      (unit      :type keyword))        ; new slot
+    :default-store :support)
+#+END_SRC
+
+**** Visibility: describe and export
+
+~describe-schema~ is the REPL/SLIME tool — plain text on a stream, grouped
+by namespace, one line per type (kind, default store, and a provenance tag:
+~[source]~ or ~[runtime YYYY-MM-DD]~; a type with no manifest row, from a
+pre-#172 store, always prints ~[source]~), then one line per slot (name,
+type, and its ~:check~ name if any):
+
+#+BEGIN_SRC lisp
+  (graph-db:describe-schema :namespace :telemetry)
+  ;; =>
+  ;; Namespace TELEMETRY
+  ;;   CALIBRATION (vertex) default-store :support   [runtime 2026-08-24]
+  ;;     VALUE  DOUBLE-FLOAT  :check TELEMETRY-PLAUSIBLE-P
+  ;;   READING (vertex) default-store :support   [runtime 2026-08-24]
+  ;;     SENSOR-ID  STRING
+  ;;     VALUE  DOUBLE-FLOAT
+  ;;     TAKEN-AT  INTEGER
+#+END_SRC
+
+~:namespace~ restricts to one namespace; ~:store~ restricts to types
+instantiated in one open store; ~:since~ (a universal time, or a
+~"YYYY-MM-DD"~ string, parsed at local midnight) filters by each row's
+recorded time, so the dump doubles as a change log. Static, source-defined
+types print the same way, tagged ~[source]~, so one tool shows the whole
+schema. ~describe-schema~ never signals on a missing or damaged manifest —
+it degrades to live metadata only.
+
+~export-schema-source~ is the promotion path: it writes literal
+~def-vertex~/~def-edge~ forms, reconstructed from the metadata, to a file:
+
+#+BEGIN_SRC lisp
+  (graph-db:export-schema-source "src/generated-schema.lisp"
+                                 :namespace :telemetry)
+  ;; =>
+  ;;   (defpackage #:telemetry (:use #:cl #:graph-db)
+  ;;     (:nicknames #:tlm)
+  ;;     (:export
+  ;;      #:calibration
+  ;;      #:reading
+  ;;      ))
+  ;;   (in-package #:telemetry)
+  ;;
+  ;;   (def-vertex reading ()
+  ;;       ((sensor-id :type string)
+  ;;        (value     :type double-float)
+  ;;        (taken-at  :type integer))
+  ;;       :support)
+  ;;   ...
+#+END_SRC
+
+A symbol foreign to the namespace being exported — including a ~:check~
+name registered under some other package — prints package-qualified, so it
+re-reads to the *same* symbol at load time rather than interning a new one
+under the freshly (re)created namespace package, which would silently break
+an EQ-keyed lookup like a ~:check~ name against the schema-function
+registry.
+
+Loading the generated file is the ordinary source path, and is idempotent
+(same names, same registry ids): this is how a runtime type earns
+permanence. The developer reviews the file, adds it to the ~.asd~ before
+their method files, and commits — the type is now source-defined, and the
+persisted metadata already agrees with it and stays agreeing (a
+~def-vertex~ re-registration is the existing replace-in-place). Export
+never runs implicitly, and the engine never reads the generated file back;
+it is for the developer's build only.
+
+**** What #172 deliberately does not provide
+
+- No runtime type deletion or retraction — retraction interacts with
+  on-disk instances and stays out of scope, as it does for source types
+  today.
+- No runtime ~def-view~, index, or ~:unique~ definition — those macros stay
+  code-side; a runtime type that needs one is a candidate for the
+  export/promote path above.
+- No Emacs mode — the ~describe-schema~ text dump is SLIME-usable as-is.
+- Functors and helper functions (~make-<name>~, ~lookup-<name>~,
+  ~<name>-p~) intern into the *type's* package, not the caller's. A query
+  or method written in another package must qualify the symbol
+  (~telemetry:reading~) or ~:use~ the namespace, exactly as for a
+  source-defined type in a package you have not ~:use~d.
+
 *** ~*transaction*~ is NIL inside a read-only snapshot
 
 ~with-read-snapshot~ (and ~select~/~do-query~ with ~:snapshot t~) records its

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3199,7 +3199,8 @@ for parity. It is enforced wherever value constraints already run
 (~value-constraint.lisp~), NULL-exempt; a violation signals the existing
 ~value-constraint-violation~ condition with reason ~:check-failed~.
 Presence — not resolution — of the named function is verified at
-~create-*-type~ time and again at ~materialize-schema~ time below; the
+~create-*-type~ time (signalling ~schema-function-unresolved~ if the name
+is not yet registered) and again at ~materialize-schema~ time below; the
 function itself is looked up at each check, so re-registering it takes
 effect immediately.
 

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -95,6 +95,9 @@
                ;; (#186); it only built before because that component happens
                ;; to precede this one in the list.
                (:file "schema" :depends-on ("stats" "type-registry" "type-occupancy"))
+               ;; ENSURE-NAMESPACE / CREATE-VERTEX-TYPE / CREATE-EDGE-TYPE
+               ;; (GH #172, R4): the runtime twins of DEF-VERTEX/DEF-EDGE.
+               (:file "runtime-schema" :depends-on ("schema"))
                ;; Reads a store's schema.dat and heap header, so it cannot
                ;; live in "type-registry" -- "schema" depends on THAT (#186).
                (:file "type-seeding"

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -98,6 +98,9 @@
                ;; ENSURE-NAMESPACE / CREATE-VERTEX-TYPE / CREATE-EDGE-TYPE
                ;; (GH #172, R4): the runtime twins of DEF-VERTEX/DEF-EDGE.
                (:file "runtime-schema" :depends-on ("schema"))
+               ;; DESCRIBE-SCHEMA / EXPORT-SCHEMA-SOURCE (GH #172, R6):
+               ;; read-only visibility tooling over the manifest+metas.
+               (:file "schema-tools" :depends-on ("runtime-schema"))
                ;; Reads a store's schema.dat and heap header, so it cannot
                ;; live in "type-registry" -- "schema" depends on THAT (#186).
                (:file "type-seeding"

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -543,6 +543,7 @@ cl-temporal-extent."
                (:file "detach-tests")             ; GH #170
                (:file "system-restore-tests")     ; GH #171
                (:file "package-namespace-tests")  ; GH #167
+               (:file "runtime-schema-tests")     ; GH #172
                (:file "posix-tests")              ; GH #182
                (:file "rest-tests")
                (:file "rest-http-tests")

--- a/node-class.lisp
+++ b/node-class.lisp
@@ -36,7 +36,14 @@
    ;; Max cells cap for this geometry slot's spatial index, or NIL for the graph
    ;; default.  Declared via the :SPATIAL-MAX-CELLS slot option.
    (spatial-max-cells :accessor spatial-max-cells-spec :initarg :spatial-max-cells
-                      :initform nil :allocation :instance)))
+                      :initform nil :allocation :instance)
+   ;; Function-backed value constraint (GH #172, R5): the NAME of a
+   ;; function in the schema-function registry (runtime-schema.lisp),
+   ;; resolved and applied at commit by %VALUE-CONSTRAINT-VIOLATIONS.
+   ;; A name, never a closure -- behaviour ships in the image, structure
+   ;; in the data.
+   (check :accessor check-function-name :initarg :check :initform nil
+          :allocation :instance)))
 
 (defmethod persistent-p (slot-def)
   nil)
@@ -57,6 +64,9 @@
   nil)
 
 (defmethod spatial-max-cells-spec (slot-def)
+  nil)
+
+(defmethod check-function-name (slot-def)
   nil)
 
 (defmethod ephemeral-p (slot-def)
@@ -97,18 +107,23 @@
   (persistent-names nil :type list)
   (ephemeral-names nil :type list)
   (meta-names nil :type list)
-  (data-names nil :type list))
+  (data-names nil :type list)
+  ;; (SLOT-NAME . CHECK-FUNCTION-NAME) for every :CHECK slot (GH #172).
+  (check-slots nil :type list))
 
 (defun %compute-node-slot-info (class)
   "Build CLASS's NODE-SLOT-INFO.  Each list is filtered independently, exactly
 as the separate walks it replaces did, so a slot carrying more than one flag
 still appears in each list it qualifies for."
   (let ((keywords (make-hash-table :test 'eq))
-        (persistent '()) (ephemeral '()) (meta '()) (data '()))
+        (persistent '()) (ephemeral '()) (meta '()) (data '())
+        (checks '()))
     (dolist (slot (class-slots class))
       (let ((name (slot-definition-name slot))
             (persistentp (persistent-p slot))
-            (ephemeralp (ephemeral-p slot)))
+            (ephemeralp (ephemeral-p slot))
+            (check (check-function-name slot)))
+        (when check (push (cons name check) checks))
         (when persistentp
           (push name persistent)
           (setf (gethash name keywords) (intern (symbol-name name) :keyword)))
@@ -119,7 +134,8 @@ still appears in each list it qualifies for."
                          :persistent-names (nreverse persistent)
                          :ephemeral-names (nreverse ephemeral)
                          :meta-names (nreverse meta)
-                         :data-names (nreverse data))))
+                         :data-names (nreverse data)
+                         :check-slots (nreverse checks))))
 
 (defun %node-slot-info (class)
   "CLASS's cached slot categorization, computing it on first use.
@@ -258,7 +274,22 @@ test in tests/node-class-tests.lisp."
         (setf (slot-value slot 'spatial-max-cells)
               (or (spatial-max-cells-spec slot)
                   (and smc (spatial-max-cells-spec smc))))))
+    ;; Inherit :CHECK from the declaring direct slot, so a constraint on
+    ;; a parent slot is enforced across its subclasses (GH #172, R5).
+    (let ((ck (find-if #'check-function-name direct-slots)))
+      (when (or (check-function-name slot) ck)
+        (setf (slot-value slot 'check)
+              (or (check-function-name slot)
+                  (and ck (check-function-name ck))))
+        ;; One image-wide flag so VALIDATE-VALUE-CONSTRAINTS' fast path
+        ;; stays free for schemas that use no :CHECK at all (GH #172).
+        (setf *schema-check-slots-present-p* t)))
     slot))
+
+(defun node-check-slots (class)
+  "CLASS's (SLOT-NAME . CHECK-FUNCTION-NAME) pairs, cached with the rest
+of its slot categorization.  Read-only (GH #172, R5)."
+  (%nsi-check-slots (%node-slot-info class)))
 
 (defun %indexed-slot-owner-name (class slot-name)
   "The most-general node-class in CLASS's precedence list that declares SLOT-NAME as

--- a/package.lisp
+++ b/package.lisp
@@ -305,6 +305,12 @@
            #:ensure-namespace
            #:create-vertex-type
            #:create-edge-type
+           #:materialize-schema
+           #:register-schema-function
+           #:find-schema-function
+           #:schema-function-unresolved
+           #:materialize-unresolved-functions
+           #:unresolved-function-names
            #:instantiate-node-type
            #:*schema-node-metadata*
            #:with-write-locked-class

--- a/package.lisp
+++ b/package.lisp
@@ -300,6 +300,11 @@
            #:default-store-not-open-error
            #:default-store-not-open-class
            #:default-store-not-open-store
+
+           ;; runtime schema definition API (GH #172)
+           #:ensure-namespace
+           #:create-vertex-type
+           #:create-edge-type
            #:instantiate-node-type
            #:*schema-node-metadata*
            #:with-write-locked-class

--- a/package.lisp
+++ b/package.lisp
@@ -315,6 +315,11 @@
            #:unresolved-parent-names
            #:instantiate-node-type
            #:*schema-node-metadata*
+           #:read-schema-manifest
+
+           ;; visibility tooling (GH #172, R6)
+           #:describe-schema
+           #:export-schema-source
            #:with-write-locked-class
            #:with-read-locked-class
            #:schema-class-locks

--- a/package.lisp
+++ b/package.lisp
@@ -311,6 +311,8 @@
            #:schema-function-unresolved
            #:materialize-unresolved-functions
            #:unresolved-function-names
+           #:materialize-unresolved-parents
+           #:unresolved-parent-names
            #:instantiate-node-type
            #:*schema-node-metadata*
            #:with-write-locked-class

--- a/prolog-functors.lisp
+++ b/prolog-functors.lisp
@@ -1060,18 +1060,23 @@ the edge weight (GH #172)."
   "Install <NAME>/2 and <NAME>/3 for edge type NAME exactly as
 DEF-GLOBAL-PROLOG-FUNCTOR would: FDEFINITION (the compiler's fallback),
 export, and *PROLOG-GLOBAL-FUNCTORS* (what COMPILE-CALL reads).  The
-symbols are interned in NAME's own package (GH #172)."
+symbols are interned in NAME's own package.  Skipped, with a warning
+naming NAME, when that package is COMMON-LISP or KEYWORD -- neither
+tolerates new symbols (GH #172)."
   (let ((pkg (%schema-symbol-package name)))
-    (flet ((install (suffix fn)
-             (let ((sym (intern (concatenate 'string (symbol-name name)
-                                             suffix)
-                                pkg)))
-               (setf (fdefinition sym) fn)
-               (unless (member pkg (list (find-package :common-lisp)
-                                         (find-package :keyword)))
-                 (export sym pkg))
-               (setf (gethash sym *prolog-global-functors*) fn)
-               sym)))
-      (install "/2" (%edge-functor/2 name))
-      (install "/3" (%edge-functor/3 name))
-      name)))
+    (if (member pkg (list (find-package :common-lisp)
+                          (find-package :keyword)))
+        (warn "Skipping edge functor install for ~S: its package ~A ~
+is locked (GH #172)." name (package-name pkg))
+        (flet ((install (suffix fn)
+                 (let ((sym (intern (concatenate 'string
+                                                 (symbol-name name)
+                                                 suffix)
+                                    pkg)))
+                   (setf (fdefinition sym) fn)
+                   (export sym pkg)
+                   (setf (gethash sym *prolog-global-functors*) fn)
+                   sym)))
+          (install "/2" (%edge-functor/2 name))
+          (install "/3" (%edge-functor/3 name))))
+    name))

--- a/prolog-functors.lisp
+++ b/prolog-functors.lisp
@@ -963,3 +963,115 @@ geometry ?AREA.  ?LON/?LAT must be bound numbers and ?AREA a bound geometry."
     (when (and (numberp lon) (numberp lat) (geometryp area))
       (when (geometry-contains-point-p area lon lat)
         (funcall cont)))))
+
+;;; Generated edge functors (GH #172, R1).  DEF-NODE-TYPE used to inline
+;;; two DEF-GLOBAL-PROLOG-FUNCTOR forms per edge type; they live here as
+;;; closure builders so the runtime schema path installs the identical
+;;; behaviour.  They belong in this file, not schema.lisp: VAR-DEREF is a
+;;; macro defined in prologc.lisp, which schema.lisp precedes.
+
+(defun %edge-functor/2 (name)
+  "The <NAME>/2 functor for edge type NAME: solve (from to) over NAME
+edges, whichever of FROM/TO is bound (GH #172)."
+  (let ((label (format nil "~A/2" (symbol-name name))))
+    (lambda (from to cont)
+      (setq from (var-deref from)
+            to (var-deref to))
+      (when *prolog-trace*
+        (format t "TRACE: ~A(~S ~S)~%" label from to))
+      (flet ((both (edge)
+               (let ((old-trail (fill-pointer *trail*)))
+                 (let ((v1 (lookup-vertex (from edge))))
+                   (when (unify from v1)
+                     (let ((v2 (lookup-vertex (to edge))))
+                       (when (unify to v2)
+                         (funcall cont)))))
+                 (undo-bindings old-trail)))
+             (bind-to (edge)
+               (let ((old-trail (fill-pointer *trail*)))
+                 (let ((v2 (lookup-vertex (to edge))))
+                   (when (unify to v2)
+                     (funcall cont)))
+                 (undo-bindings old-trail)))
+             (bind-from (edge)
+               (let ((old-trail (fill-pointer *trail*)))
+                 (let ((v2 (lookup-vertex (from edge))))
+                   (when (unify from v2)
+                     (funcall cont)))
+                 (undo-bindings old-trail))))
+        (cond ((and (not (var-p from)) (not (var-p to)))
+               (map-edges #'both *graph* :from-vertex from
+                          :to-vertex to :edge-type name))
+              ((not (var-p from))
+               (map-edges #'bind-to *graph* :vertex from
+                          :direction :out :edge-type name))
+              ((not (var-p to))
+               (map-edges #'bind-from *graph* :vertex to
+                          :direction :in :edge-type name))
+              (t
+               (map-edges #'both *graph* :edge-type name)))))))
+
+(defun %edge-functor/3 (name)
+  "The <NAME>/3 functor for edge type NAME: as <NAME>/2, also unifying
+the edge weight (GH #172)."
+  (let ((label (format nil "~A/3" (symbol-name name))))
+    (lambda (from to weight cont)
+      (setq from (var-deref from)
+            to (var-deref to)
+            weight (var-deref weight))
+      (when *prolog-trace*
+        (format t "TRACE: ~A(~S ~S ~S)~%" label from to weight))
+      (flet ((both (edge)
+               (let ((old-trail (fill-pointer *trail*)))
+                 (let ((v1 (lookup-vertex (from edge))))
+                   (when (unify from v1)
+                     (let ((v2 (lookup-vertex (to edge))))
+                       (when (unify to v2)
+                         (when (unify weight (weight edge))
+                           (funcall cont))))))
+                 (undo-bindings old-trail)))
+             (bind-to (edge)
+               (let ((old-trail (fill-pointer *trail*)))
+                 (let ((v2 (lookup-vertex (to edge))))
+                   (when (unify to v2)
+                     (when (unify weight (weight edge))
+                       (funcall cont))))
+                 (undo-bindings old-trail)))
+             (bind-from (edge)
+               (let ((old-trail (fill-pointer *trail*)))
+                 (let ((v2 (lookup-vertex (from edge))))
+                   (when (unify from v2)
+                     (when (unify weight (weight edge))
+                       (funcall cont))))
+                 (undo-bindings old-trail))))
+        (cond ((and (not (var-p from)) (not (var-p to)))
+               (map-edges #'both *graph* :from-vertex from
+                          :to-vertex to :edge-type name))
+              ((not (var-p from))
+               (map-edges #'bind-to *graph* :vertex from
+                          :direction :out :edge-type name))
+              ((not (var-p to))
+               (map-edges #'bind-from *graph* :vertex to
+                          :direction :in :edge-type name))
+              (t
+               (map-edges #'both *graph* :edge-type name)))))))
+
+(defun %install-edge-functors (name)
+  "Install <NAME>/2 and <NAME>/3 for edge type NAME exactly as
+DEF-GLOBAL-PROLOG-FUNCTOR would: FDEFINITION (the compiler's fallback),
+export, and *PROLOG-GLOBAL-FUNCTORS* (what COMPILE-CALL reads).  The
+symbols are interned in NAME's own package (GH #172)."
+  (let ((pkg (%schema-symbol-package name)))
+    (flet ((install (suffix fn)
+             (let ((sym (intern (concatenate 'string (symbol-name name)
+                                             suffix)
+                                pkg)))
+               (setf (fdefinition sym) fn)
+               (unless (member pkg (list (find-package :common-lisp)
+                                         (find-package :keyword)))
+                 (export sym pkg))
+               (setf (gethash sym *prolog-global-functors*) fn)
+               sym)))
+      (install "/2" (%edge-functor/2 name))
+      (install "/3" (%edge-functor/3 name))
+      name)))

--- a/runtime-schema.lisp
+++ b/runtime-schema.lisp
@@ -119,6 +119,20 @@ skipped, a missing file yields two empty lists (GH #172, R2)."
 ;;; ENSURE-NAMESPACE (R4)
 ;;; ---------------------------------------------------------------------
 
+(defun %refused-schema-package-p (pkg)
+  "COMMON-LISP and KEYWORD tolerate no new symbols and must never be
+RENAME-PACKAGE'd; neither a schema type nor a schema namespace can be
+homed in either (GH #172, R4; review round 3, M-7)."
+  (and (member pkg (list (find-package :common-lisp)
+                         (find-package :keyword)))
+       t))
+
+(defun %refuse-schema-package (designator pkg)
+  (error "~A: refusing to touch ~A -- it is locked and cannot hold ~
+schema symbols; use ENSURE-NAMESPACE to create a namespace package ~
+first (GH #172)."
+         designator (package-name pkg)))
+
 (defun ensure-namespace (name &key nicknames (record-p t))
   "Ensure a package for a runtime schema namespace, idempotent and
 manifest-logged.  NAME and each of NICKNAMES may be a string or a
@@ -131,27 +145,32 @@ emits for one, not what this creates.  Allocates no files and no store.
 RECORD-P NIL suppresses the manifest append: MATERIALIZE-SCHEMA is
 replaying rows the manifest already holds, and re-appending an
 unchanged namespace row on every load would grow the file forever
-(GH #172, R4)."
+(GH #172, R4).  Refuses NAME (or a NICKNAME) that resolves to COMMON-
+LISP or KEYWORD -- without this, :NICKNAMES on either would reach
+RENAME-PACKAGE and hit SBCL's raw package-lock error instead of this
+condition (GH #172, review round 3, M-7)."
   (let* ((pkg-name (string name))
          (nick-strings (mapcar #'string nicknames))
-         (pkg (find-package pkg-name))
-         ;; The set actually applied to the package -- review round 1,
-         ;; I1: the manifest row must record THIS, not just this call's
-         ;; own NICK-STRINGS, or a later no-nickname call's last-wins
-         ;; row would drop every nickname a prior call had established.
-         (wanted (if pkg
-                    (union (package-nicknames pkg) nick-strings
-                          :test #'string=)
-                    nick-strings)))
-    (if pkg
-        (unless (= (length wanted) (length (package-nicknames pkg)))
-          (rename-package pkg pkg-name wanted))
-        (setf pkg (make-package pkg-name :nicknames wanted :use nil)))
-    (when record-p
-      (%append-schema-manifest-record
-       (list :namespace pkg-name :nicknames wanted
-             :time (get-universal-time))))
-    pkg))
+         (pkg (find-package pkg-name)))
+    (when (%refused-schema-package-p pkg)
+      (%refuse-schema-package 'ensure-namespace pkg))
+    ;; The set actually applied to the package -- review round 1, I1:
+    ;; the manifest row must record THIS, not just this call's own
+    ;; NICK-STRINGS, or a later no-nickname call's last-wins row would
+    ;; drop every nickname a prior call had established.
+    (let ((wanted (if pkg
+                      (union (package-nicknames pkg) nick-strings
+                            :test #'string=)
+                      nick-strings)))
+      (if pkg
+          (unless (= (length wanted) (length (package-nicknames pkg)))
+            (rename-package pkg pkg-name wanted))
+          (setf pkg (make-package pkg-name :nicknames wanted :use nil)))
+      (when record-p
+        (%append-schema-manifest-record
+         (list :namespace pkg-name :nicknames wanted
+               :time (get-universal-time))))
+      pkg)))
 
 ;;; ---------------------------------------------------------------------
 ;;; Schema functions and the :CHECK slot option (R5)
@@ -169,11 +188,10 @@ unchanged namespace row on every load would grow the file forever
 
 (defvar *schema-functions-lock* (make-lock "schema functions"))
 
-(defvar *schema-check-slots-present-p* nil
-  "T once any class in this image has a :CHECK slot.  Set by
-COMPUTE-EFFECTIVE-SLOT-DEFINITION (node-class.lisp); read by
-VALIDATE-VALUE-CONSTRAINTS so a schema with no :CHECK pays nothing
-(GH #172, R5).")
+;; *SCHEMA-CHECK-SLOTS-PRESENT-P* moved to schema.lisp (review round 3,
+;; M-4): NODE-CLASS.LISP SETFs it and depends only on "schema" in the
+;; .asd, not "runtime-schema", so it compiled that reference against no
+;; DEFVAR at all before this move.
 
 (define-condition schema-function-unresolved (error)
   ((names :initarg :names :reader unresolved-function-names))
@@ -209,7 +227,11 @@ would then skip those names as \"already defined\".  Widen ~
 
 (defun register-schema-function (name fn)
   "Register FN under NAME for the :CHECK slot option.  Returns NAME.
-Re-registering replaces (GH #172, R5)."
+Re-registering replaces (GH #172, R5).  FN runs inside a transaction's
+OCC validation and MUST BE PURE: a conflict retries the transaction, so
+FN can run several times for one logical write, and must never itself
+mutate state or have other side effects (GH #172, review round 3,
+M-5)."
   (check-type name symbol)
   (with-lock-held (*schema-functions-lock*)
     (setf (gethash name *schema-functions*) fn))
@@ -247,22 +269,6 @@ deduplicated, in order of appearance (GH #172, R5)."
       (dolist (name (%slot-check-names specs))
         (unless (or (find-schema-function name) (member name missing))
           (push name missing))))))
-
-;;; ---------------------------------------------------------------------
-;;; CREATE-VERTEX-TYPE / CREATE-EDGE-TYPE (R4)
-;;; ---------------------------------------------------------------------
-
-(defun %refused-schema-package-p (pkg)
-  "COMMON-LISP and KEYWORD tolerate no new symbols; a schema type can
-never be homed in either (GH #172, R4)."
-  (and (member pkg (list (find-package :common-lisp)
-                         (find-package :keyword)))
-       t))
-
-(defun %refuse-schema-package (designator pkg)
-  (error "~A: cannot define a schema type in ~A -- use ~
-ENSURE-NAMESPACE to create a namespace package first (GH #172)."
-         designator (package-name pkg)))
 
 (defun %parse-schema-type-name (name)
   "NAME as a symbol.  A string is split on ':' by hand -- NEVER READ,
@@ -352,29 +358,34 @@ SLOTS are %NORMALIZE-SLOT-SPECS output; only :TYPE is forwarded to
   "Shared body of CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE.  %ENSURE-NODE-CLASS
 must run before %INSTALL-NODE-TYPE -- the latter requires the class to
 already exist, since it calls FINALIZE-INHERITANCE (GH #172, R4)."
-  (let* ((sym (%parse-schema-type-name name))
-         (specs (%retarget-slot-specs (%normalize-slot-specs slot-specs)
-                                      (symbol-package sym))))
+  (let ((sym (%parse-schema-type-name name)))
+    ;; Before %RETARGET-SLOT-SPECS: the SYMBOL-argument path (a bare CL-
+    ;; homed symbol) skips %PARSE-SCHEMA-TYPE-NAME's own string-path
+    ;; package check, so interning slot names into SYM's package first
+    ;; would hit SBCL's raw package-lock error instead of this refusal
+    ;; (GH #172, review round 3, M-1).
     (%check-schema-name-package sym)
-    ;; Fail fast, like MATERIALIZE-SCHEMA: a :CHECK naming a function
-    ;; this image does not provide is a broken definition, not a
-    ;; surprise at first write (GH #172, R5).
-    (let ((missing (%unresolved-check-names (list specs))))
-      (when missing
-        (error 'schema-function-unresolved :names missing)))
-    (%ensure-node-class sym parents kind specs)
-    (let ((*schema-provenance* :runtime))
-      (%install-node-type
-       (make-node-type
-        :name sym
-        :parent-type kind
-        :graph-name default-store
-        :slots specs
-        :package (package-name (symbol-package sym))
-        :constructor (intern (format nil "MAKE-~A" (symbol-name sym))
-                             (%schema-symbol-package sym))
-        :keep-revisions keep-revisions)))
-    (find-class sym)))
+    (let ((specs (%retarget-slot-specs (%normalize-slot-specs slot-specs)
+                                       (symbol-package sym))))
+      ;; Fail fast, like MATERIALIZE-SCHEMA: a :CHECK naming a function
+      ;; this image does not provide is a broken definition, not a
+      ;; surprise at first write (GH #172, R5).
+      (let ((missing (%unresolved-check-names (list specs))))
+        (when missing
+          (error 'schema-function-unresolved :names missing)))
+      (%ensure-node-class sym parents kind specs)
+      (let ((*schema-provenance* :runtime))
+        (%install-node-type
+         (make-node-type
+          :name sym
+          :parent-type kind
+          :graph-name default-store
+          :slots specs
+          :package (package-name (symbol-package sym))
+          :constructor (intern (format nil "MAKE-~A" (symbol-name sym))
+                               (%schema-symbol-package sym))
+          :keep-revisions keep-revisions)))
+      (find-class sym))))
 
 (defun create-vertex-type (name slot-specs &key parents default-store
                                                 keep-revisions)

--- a/runtime-schema.lisp
+++ b/runtime-schema.lisp
@@ -1,0 +1,255 @@
+(in-package :graph-db)
+
+;;; Runtime schema definition API (GH #172, R2+R4).  ENSURE-NAMESPACE and
+;;; CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE are the functional twins of
+;;; DEF-VERTEX/DEF-EDGE: they build a class from data arriving at runtime
+;;; instead of a macro form, then hand off to %INSTALL-NODE-TYPE (schema.lisp)
+;;; -- the same path DEF-NODE-TYPE's expansion uses, so a runtime type is
+;;; indistinguishable from a source one once built.  Spec:
+;;; docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
+
+;;; ---------------------------------------------------------------------
+;;; The system manifest (R2): schema-manifest.dat beside the type
+;;; registry.  Append-only, one readable line per record, mirroring
+;;; type-occupancy.lisp's sidecar discipline -- a failed append never
+;;; aborts the definition, and no system directory degrades to
+;;; in-image-only for this session.
+;;; ---------------------------------------------------------------------
+
+(defvar *schema-manifest-lock* (make-lock "schema manifest"))
+
+(defun %schema-manifest-path (dir)
+  (make-pathname :name "schema-manifest" :type "dat" :defaults dir))
+
+(defun %schema-manifest-file ()
+  "SCHEMA-MANIFEST.DAT beside the type registry, or NIL when no system
+directory is configured, or any other failure -- fallback: in-image
+only (GH #172, mirrors %EDGE-OCCUPANCY-FILE)."
+  (handler-case
+      (%schema-manifest-path (type-registry-location (ensure-type-registry)))
+    (error () nil)))
+
+(defun %schema-manifest-print-package ()
+  ;; COMMON-LISP, not KEYWORD: class symbols must print package-qualified
+  ;; (the #167 manifest discipline; see %EDGE-OCCUPANCY-PRINT-PACKAGE).
+  (load-time-value (find-package "COMMON-LISP")))
+
+(defun %append-schema-manifest-record (plist)
+  "Append PLIST as one ~S-printed, package-qualified line to the schema
+manifest.  Locked; never signals -- a failed append (disk full, no
+system directory, permissions) leaves the definition itself intact and
+the record in-image-only for this session (GH #172, R2)."
+  (with-lock-held (*schema-manifest-lock*)
+    (let ((file (%schema-manifest-file)))
+      (when file
+        (handler-case
+            (with-open-file (s file :direction :output
+                                    :if-exists :append
+                                    :if-does-not-exist :create)
+              (let ((*print-readably* nil)
+                    (*print-pretty* nil)
+                    (*package* (%schema-manifest-print-package)))
+                (format s "~S~%" plist))
+              (finish-output s))
+          (error () nil)))))
+  (values))
+
+(defun %parse-schema-manifest-line (line)
+  "Read LINE as a plist headed by a keyword.  *READ-EVAL* NIL: the file
+is data.  Returns NIL on anything malformed -- a torn or corrupt line is
+only a lost record, never an error (GH #172)."
+  (handler-case
+      (let ((*read-eval* nil)
+            (*package* (%schema-manifest-print-package)))
+        (multiple-value-bind (form pos) (read-from-string line)
+          (when (and (= pos (length line))
+                     (consp form) (keywordp (first form)))
+            form)))
+    (error () nil)))
+
+(defun read-schema-manifest (dir)
+  "Read schema-manifest.dat under DIR.  Returns (VALUES NAMESPACE-RECORDS
+TYPE-RECORDS); last record per name wins, malformed/torn lines are
+skipped, a missing file yields two empty lists (GH #172, R2)."
+  (let ((file (ignore-errors (%schema-manifest-path dir)))
+        (ns-table (make-hash-table :test 'equal))
+        (ns-order nil)
+        (type-table (make-hash-table :test 'eq))
+        (type-order nil))
+    (when (and file (probe-file file))
+      (handler-case
+          (with-open-file (s file :direction :input)
+            (loop
+              (let ((line (read-line s nil :eof)))
+                (when (eq line :eof) (return))
+                (let ((rec (%parse-schema-manifest-line line)))
+                  (when rec
+                    (cond
+                      ((getf rec :namespace)
+                       (let ((key (getf rec :namespace)))
+                         (unless (nth-value 1 (gethash key ns-table))
+                           (push key ns-order))
+                         (setf (gethash key ns-table) rec)))
+                      ((getf rec :type)
+                       (let ((key (getf rec :type)))
+                         (unless (nth-value 1 (gethash key type-table))
+                           (push key type-order))
+                         (setf (gethash key type-table) rec)))))))))
+        (error () nil)))
+    (values (mapcar (lambda (k) (gethash k ns-table)) (nreverse ns-order))
+            (mapcar (lambda (k) (gethash k type-table))
+                    (nreverse type-order)))))
+
+;;; ---------------------------------------------------------------------
+;;; ENSURE-NAMESPACE (R4)
+;;; ---------------------------------------------------------------------
+
+(defun ensure-namespace (name &key nicknames)
+  "Ensure a package for a runtime schema namespace, idempotent and
+manifest-logged.  NAME and each of NICKNAMES may be a string or a
+symbol.  Created with MAKE-PACKAGE :USE NIL -- a schema namespace only
+holds the class and accessor symbols CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE
+intern into it, it is not a code package; (:use #:cl #:graph-db) is what
+a hand-written SOURCE package uses, and is what EXPORT-SCHEMA-SOURCE
+emits for one, not what this creates.  Allocates no files and no store
+(GH #172, R4)."
+  (let* ((pkg-name (string name))
+         (nick-strings (mapcar #'string nicknames))
+         (pkg (find-package pkg-name)))
+    (if pkg
+        (let ((wanted (union (package-nicknames pkg) nick-strings
+                             :test #'string=)))
+          (unless (= (length wanted) (length (package-nicknames pkg)))
+            (rename-package pkg pkg-name wanted)))
+        (setf pkg (make-package pkg-name :nicknames nick-strings :use nil)))
+    (%append-schema-manifest-record
+     (list :namespace pkg-name :nicknames nick-strings
+           :time (get-universal-time)))
+    pkg))
+
+;;; ---------------------------------------------------------------------
+;;; CREATE-VERTEX-TYPE / CREATE-EDGE-TYPE (R4)
+;;; ---------------------------------------------------------------------
+
+(defun %parse-schema-type-name (name)
+  "NAME as a symbol.  A string is split on ':' by hand -- NEVER READ,
+since NAME is untrusted runtime data and *READ-EVAL* NIL alone does not
+rule out reader-macro side effects on an arbitrary token.  Handles both
+NAME:SYM and NAME::SYM.  A missing package errors naming ENSURE-NAMESPACE
+(GH #172, R4)."
+  (if (symbolp name)
+      name
+      (let* ((s (string name))
+             (c1 (position #\: s)))
+        (unless c1
+          (error "~S is not a symbol or a \"PACKAGE:NAME\" string ~
+(GH #172)." name))
+        (let* ((c2 (position #\: s :start (1+ c1)))
+               (name-start (if (and c2 (= c2 (1+ c1))) (1+ c2) (1+ c1)))
+               (pkg-name (subseq s 0 c1))
+               (sym-name (subseq s name-start))
+               (pkg (find-package pkg-name)))
+          (unless pkg
+            (error "No package named ~A -- call ENSURE-NAMESPACE first ~
+(GH #172)." pkg-name))
+          (intern sym-name pkg)))))
+
+(defun %check-schema-name-package (sym)
+  "Refuse to define a schema type whose home package is COMMON-LISP or
+KEYWORD -- neither tolerates new symbols; the package-lock guard in
+%INSTALL-NODE-HELPERS/%INSTALL-EDGE-FUNCTORS is the same rule applied to
+the generated helpers (GH #172, R4)."
+  (let ((pkg (symbol-package sym)))
+    (when (member pkg (list (find-package :common-lisp)
+                            (find-package :keyword)))
+      (error "~S: cannot define a schema type in ~A -- use ~
+ENSURE-NAMESPACE to create a namespace package first (GH #172)."
+             sym (package-name pkg)))))
+
+(defun %retarget-slot-specs (specs pkg)
+  "Re-intern each spec's slot NAME and :ACCESSOR into PKG.  Runtime
+SLOT-SPECS arrive as data, read in the CALLER's package; the generated
+accessor must live with the class's own symbols, exactly as
+DEF-VERTEX's slot symbols already do -- both read from one source form
+there, so no retargeting is needed on that path (GH #172, R4)."
+  (mapcar
+   (lambda (spec)
+     (destructuring-bind (name &rest plist &key accessor &allow-other-keys)
+         spec
+       (list* (intern (symbol-name name) pkg)
+              :accessor (intern (symbol-name accessor) pkg)
+              (let ((copy (copy-list plist)))
+                (remf copy :accessor)
+                copy))))
+   specs))
+
+(defun %ensure-node-class (name parents kind normalized-slots)
+  "Build or redefine NAME's CLOS class from data via the MOP.  NORMALIZED-
+SLOTS are %NORMALIZE-SLOT-SPECS output; only :TYPE is forwarded to
+:DIRECT-SLOTS (GH #172, R4)."
+  (ensure-class
+   name
+   :direct-superclasses
+   (append parents (list (ecase kind (:vertex 'vertex) (:edge 'edge))))
+   :direct-slots
+   (mapcar (lambda (spec)
+             (destructuring-bind (sname &key accessor initarg type
+                                        &allow-other-keys)
+                 spec
+               (append
+                (list :name sname
+                      :initargs (list initarg)
+                      :readers (list accessor)
+                      :writers (list (list 'setf accessor)))
+                (when type (list :type type)))))
+           normalized-slots)
+   :metaclass (find-class 'node-class)))
+
+(defun %create-node-type (name slot-specs kind &key parents default-store
+                                                    keep-revisions)
+  "Shared body of CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE.  %ENSURE-NODE-CLASS
+must run before %INSTALL-NODE-TYPE -- the latter requires the class to
+already exist, since it calls FINALIZE-INHERITANCE (GH #172, R4)."
+  (let* ((sym (%parse-schema-type-name name))
+         (specs (%retarget-slot-specs (%normalize-slot-specs slot-specs)
+                                      (symbol-package sym))))
+    (%check-schema-name-package sym)
+    (%ensure-node-class sym parents kind specs)
+    (let ((*schema-provenance* :runtime))
+      (%install-node-type
+       (make-node-type
+        :name sym
+        :parent-type kind
+        :graph-name default-store
+        :slots specs
+        :package (package-name (symbol-package sym))
+        :constructor (intern (format nil "MAKE-~A" (symbol-name sym))
+                             (%schema-symbol-package sym))
+        :keep-revisions keep-revisions)))
+    (find-class sym)))
+
+(defun create-vertex-type (name slot-specs &key parents default-store
+                                                keep-revisions)
+  "Runtime twin of DEF-VERTEX: build and register a vertex type from data
+instead of a macro form.  NAME is a symbol or a \"PACKAGE:NAME\" string --
+the package must already exist (see ENSURE-NAMESPACE); a missing one
+errors.  SLOT-SPECS are the same CLOS-style specs DEF-VERTEX takes.
+DEFAULT-STORE defaults to NIL, meaning \"no default store\": the generated
+constructor then requires an explicit :GRAPH argument, since a runtime
+type need not commit to placement at creation.  Redefining an existing
+name -- runtime- or source-defined -- follows ordinary CLOS class
+redefinition, with the #196 divergence warning when slot sets disagree
+across stores, exactly like re-evaluating DEF-VERTEX.  Returns the
+finalized class (GH #172, R4)."
+  (%create-node-type name slot-specs :vertex :parents parents
+                     :default-store default-store
+                     :keep-revisions keep-revisions))
+
+(defun create-edge-type (name slot-specs &key parents default-store
+                                              keep-revisions)
+  "Runtime twin of DEF-EDGE; see CREATE-VERTEX-TYPE for the shared
+semantics.  Also installs the NAME/2 and NAME/3 Prolog functors
+(GH #172, R4)."
+  (%create-node-type name slot-specs :edge :parents parents
+                     :default-store default-store
+                     :keep-revisions keep-revisions))

--- a/runtime-schema.lisp
+++ b/runtime-schema.lisp
@@ -115,15 +115,21 @@ emits for one, not what this creates.  Allocates no files and no store
 (GH #172, R4)."
   (let* ((pkg-name (string name))
          (nick-strings (mapcar #'string nicknames))
-         (pkg (find-package pkg-name)))
+         (pkg (find-package pkg-name))
+         ;; The set actually applied to the package -- review round 1,
+         ;; I1: the manifest row must record THIS, not just this call's
+         ;; own NICK-STRINGS, or a later no-nickname call's last-wins
+         ;; row would drop every nickname a prior call had established.
+         (wanted (if pkg
+                    (union (package-nicknames pkg) nick-strings
+                          :test #'string=)
+                    nick-strings)))
     (if pkg
-        (let ((wanted (union (package-nicknames pkg) nick-strings
-                             :test #'string=)))
-          (unless (= (length wanted) (length (package-nicknames pkg)))
-            (rename-package pkg pkg-name wanted)))
-        (setf pkg (make-package pkg-name :nicknames nick-strings :use nil)))
+        (unless (= (length wanted) (length (package-nicknames pkg)))
+          (rename-package pkg pkg-name wanted))
+        (setf pkg (make-package pkg-name :nicknames wanted :use nil)))
     (%append-schema-manifest-record
-     (list :namespace pkg-name :nicknames nick-strings
+     (list :namespace pkg-name :nicknames wanted
            :time (get-universal-time)))
     pkg))
 
@@ -131,12 +137,28 @@ emits for one, not what this creates.  Allocates no files and no store
 ;;; CREATE-VERTEX-TYPE / CREATE-EDGE-TYPE (R4)
 ;;; ---------------------------------------------------------------------
 
+(defun %refused-schema-package-p (pkg)
+  "COMMON-LISP and KEYWORD tolerate no new symbols; a schema type can
+never be homed in either (GH #172, R4)."
+  (and (member pkg (list (find-package :common-lisp)
+                         (find-package :keyword)))
+       t))
+
+(defun %refuse-schema-package (designator pkg)
+  (error "~A: cannot define a schema type in ~A -- use ~
+ENSURE-NAMESPACE to create a namespace package first (GH #172)."
+         designator (package-name pkg)))
+
 (defun %parse-schema-type-name (name)
   "NAME as a symbol.  A string is split on ':' by hand -- NEVER READ,
 since NAME is untrusted runtime data and *READ-EVAL* NIL alone does not
 rule out reader-macro side effects on an arbitrary token.  Handles both
-NAME:SYM and NAME::SYM.  A missing package errors naming ENSURE-NAMESPACE
-(GH #172, R4)."
+NAME:SYM and NAME::SYM.  A missing package errors naming ENSURE-NAMESPACE.
+The COMMON-LISP/KEYWORD refusal is checked on the PACKAGE NAME here,
+before INTERN -- review round 1, I2: checking only the interned symbol's
+package afterward is too late, since INTERN into COMMON-LISP itself
+signals SBCL's own package-lock error first, and INTERN into KEYWORD
+just silently succeeds (GH #172, R4)."
   (if (symbolp name)
       name
       (let* ((s (string name))
@@ -152,19 +174,21 @@ NAME:SYM and NAME::SYM.  A missing package errors naming ENSURE-NAMESPACE
           (unless pkg
             (error "No package named ~A -- call ENSURE-NAMESPACE first ~
 (GH #172)." pkg-name))
+          (when (%refused-schema-package-p pkg)
+            (%refuse-schema-package s pkg))
           (intern sym-name pkg)))))
 
 (defun %check-schema-name-package (sym)
   "Refuse to define a schema type whose home package is COMMON-LISP or
 KEYWORD -- neither tolerates new symbols; the package-lock guard in
 %INSTALL-NODE-HELPERS/%INSTALL-EDGE-FUNCTORS is the same rule applied to
-the generated helpers (GH #172, R4)."
+the generated helpers.  Covers the SYMBOL-argument path; the
+\"PACKAGE:NAME\" string path is checked earlier, in
+%PARSE-SCHEMA-TYPE-NAME, before the symbol is even interned (GH #172,
+R4)."
   (let ((pkg (symbol-package sym)))
-    (when (member pkg (list (find-package :common-lisp)
-                            (find-package :keyword)))
-      (error "~S: cannot define a schema type in ~A -- use ~
-ENSURE-NAMESPACE to create a namespace package first (GH #172)."
-             sym (package-name pkg)))))
+    (when (%refused-schema-package-p pkg)
+      (%refuse-schema-package sym pkg))))
 
 (defun %retarget-slot-specs (specs pkg)
   "Re-intern each spec's slot NAME and :ACCESSOR into PKG.  Runtime

--- a/runtime-schema.lisp
+++ b/runtime-schema.lisp
@@ -34,25 +34,40 @@ only (GH #172, mirrors %EDGE-OCCUPANCY-FILE)."
   ;; (the #167 manifest discipline; see %EDGE-OCCUPANCY-PRINT-PACKAGE).
   (load-time-value (find-package "COMMON-LISP")))
 
-(defun %append-schema-manifest-record (plist)
-  "Append PLIST as one ~S-printed, package-qualified line to the schema
-manifest.  Locked; never signals -- a failed append (disk full, no
-system directory, permissions) leaves the definition itself intact and
-the record in-image-only for this session (GH #172, R2)."
-  (with-lock-held (*schema-manifest-lock*)
-    (let ((file (%schema-manifest-file)))
-      (when file
+(defun %write-schema-manifest-record (plist)
+  "The UNLOCKED write: append PLIST as one ~S-printed, package-qualified
+line.  Returns T on a successful write, NIL when it degraded (no file,
+or the write itself failed) -- never signals.  Callers take
+*SCHEMA-MANIFEST-LOCK* themselves; this must not lock on its own, so a
+caller that also needs to update a cache under the same critical
+section (see %SCHEMA-MANIFEST-APPEND-IF-CHANGED, schema.lisp) can take
+the lock exactly once (GH #172, review round 2)."
+  (let ((file (%schema-manifest-file)))
+    (and file
         (handler-case
-            (with-open-file (s file :direction :output
-                                    :if-exists :append
-                                    :if-does-not-exist :create)
-              (let ((*print-readably* nil)
-                    (*print-pretty* nil)
-                    (*package* (%schema-manifest-print-package)))
-                (format s "~S~%" plist))
-              (finish-output s))
+            (progn
+              (with-open-file (s file :direction :output
+                                      :if-exists :append
+                                      :if-does-not-exist :create)
+                (let ((*print-readably* nil)
+                      (*print-pretty* nil)
+                      (*package* (%schema-manifest-print-package)))
+                  (format s "~S~%" plist))
+                (finish-output s))
+              t)
           (error () nil)))))
-  (values))
+
+(defun %append-schema-manifest-record (plist)
+  "Append PLIST to the schema manifest, under *SCHEMA-MANIFEST-LOCK*.
+Never signals.  Returns T on a successful write, NIL when it degraded
+to in-image-only (no system directory, or the write itself failed) --
+GH #172, R2.  The T/NIL contract is what
+%SCHEMA-MANIFEST-APPEND-IF-CHANGED needs: caching a row as written
+before the outcome is known would let one transient failure (disk
+full, unwritable directory) silently drop it for the rest of the
+session (review round 2)."
+  (with-lock-held (*schema-manifest-lock*)
+    (%write-schema-manifest-record plist)))
 
 (defun %parse-schema-manifest-line (line)
   "Read LINE as a plist headed by a keyword.  *READ-EVAL* NIL: the file

--- a/runtime-schema.lisp
+++ b/runtime-schema.lisp
@@ -195,6 +195,18 @@ function(s)~{ ~S~} that this image does not provide.  Nothing was ~
 built.  Register them before materializing (GH #172, R3)."
              (unresolved-function-names c)))))
 
+(define-condition materialize-unresolved-parents (error)
+  ((names :initarg :names :reader unresolved-parent-names))
+  (:report
+   (lambda (c s)
+     (format s "MATERIALIZE-SCHEMA: the manifest names parent type(s)~
+~{ ~S~} that neither exist as finalized classes nor appear among the ~
+rows being materialized.  Nothing was built: building them would leave ~
+FORWARD-REFERENCED-CLASSes behind, and every later materialization ~
+would then skip those names as \"already defined\".  Widen ~
+:NAMESPACES, or load the source that defines them first (GH #172, R3)."
+             (unresolved-parent-names c)))))
+
 (defun register-schema-function (name fn)
   "Register FN under NAME for the :CHECK slot option.  Returns NAME.
 Re-registering replaces (GH #172, R5)."
@@ -461,6 +473,31 @@ than crashing: the manifest is data, and may have been hand-edited
              (member (package-name (symbol-package name)) filter
                      :test #'string-equal))))))
 
+(defun %materialized-class-present-p (name)
+  "Does NAME already name a REAL class?  A FORWARD-REFERENCED-CLASS is
+absent, not present: it is the stub ENSURE-CLASS leaves behind for an
+unknown superclass, and treating it as \"source wins\" is exactly how a
+half-built materialization poisons every later one (GH #172, R3,
+review round 1, I-2)."
+  (let ((class (find-class name nil)))
+    (and class (not (typep class 'forward-referenced-class)))))
+
+(defun %unresolved-parent-names (rows)
+  "Every parent named by ROWS that is neither a real class already nor
+a row in ROWS itself, deduplicated in order of appearance.  ROWS is the
+whole build set, skipped rows included: a skipped row's class exists,
+so it is a legitimate parent (GH #172, R3, review round 1, I-2)."
+  (let ((known (make-hash-table :test 'eq))
+        (missing nil))
+    (dolist (row rows)
+      (setf (gethash (getf row :type) known) t))
+    (dolist (row rows (nreverse missing))
+      (dolist (parent (getf row :parents))
+        (unless (or (gethash parent known)
+                    (%materialized-class-present-p parent)
+                    (member parent missing))
+          (push parent missing))))))
+
 (defun %materialize-sort (rows)
   "ROWS reordered so a row builds after any parent of it that is also
 in ROWS; manifest order is the tiebreak.  Redefinition re-appends a
@@ -549,21 +586,30 @@ methods below it compile (GH #172, R3)."
                  (nth-value 1 (read-schema-manifest dir))))
           (pending nil))
       ;; Fail fast, before anything is built: ONE error naming every
-      ;; unresolved :CHECK function (approved point C).
+      ;; unresolved :CHECK function (approved point C), and one naming
+      ;; every unbuildable parent (I-2).  Half a materialization is
+      ;; worse than none: the stub classes it leaves behind make every
+      ;; later attempt skip those names as already defined.
       (let ((missing (%unresolved-check-names
                       (mapcar (lambda (r) (getf r :slots)) rows))))
         (when missing
           (error 'materialize-unresolved-functions :names missing)))
+      (let ((orphans (%unresolved-parent-names rows)))
+        (when orphans
+          (error 'materialize-unresolved-parents :names orphans)))
       (dolist (row rows)
-        (if (find-class (getf row :type) nil)
+        (if (%materialized-class-present-p (getf row :type))
             (progn (%warn-if-row-diverges row) (incf skipped))
             (push row pending)))
-      (dolist (row (%materialize-sort (nreverse pending)))
-        (%materialize-row row)
-        (incf materialized)))
+      ;; Nothing this call installs may touch the manifest: every row
+      ;; came out of it (M-1).
+      (let ((*record-manifest-rows* nil))
+        (dolist (row (%materialize-sort (nreverse pending)))
+          (%materialize-row row)
+          (incf materialized))))
     (list :namespaces namespace-count
           :materialized materialized
-          :skipped-source skipped)))
+          :skipped-existing skipped)))
 
 (defmacro materialize-schema (dir &key namespaces)
   "Rebuild every runtime-defined package and class recorded in DIR's
@@ -573,13 +619,20 @@ file with methods on a runtime type; the EVAL-WHEN is carried here so a
 caller cannot get it wrong.
 
 Idempotent, and SOURCE WINS: a type whose class already exists is left
-alone and counted under :SKIPPED-SOURCE, with the #196 divergence
-warning when the manifest's slot set disagrees with the live class.
+alone, with the #196 divergence warning when the manifest's slot set
+disagrees with the live class.
 :NAMESPACES narrows to the named packages.  Nothing is evaluated --
 the input is plists and the output is MOP calls -- and a :CHECK
 function the image does not provide aborts the whole call before
 anything is built (MATERIALIZE-UNRESOLVED-FUNCTIONS, naming all of
-them).  Returns (:NAMESPACES n :MATERIALIZED n :SKIPPED-SOURCE n)
-(GH #172, R3)."
+them), as does a row whose parent neither exists nor is being built
+(MATERIALIZE-UNRESOLVED-PARENTS).
+
+Returns (:NAMESPACES n :MATERIALIZED n :SKIPPED-EXISTING n).
+:NAMESPACES counts packages ensured, :MATERIALIZED classes built by
+THIS call, and :SKIPPED-EXISTING rows left alone because the class was
+already present -- whatever defined it, source or an earlier
+materialization (under compile-then-load, the load pass sees the
+compile pass's work here) (GH #172, R3)."
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (%materialize-schema ,dir :namespaces ,namespaces)))

--- a/runtime-schema.lisp
+++ b/runtime-schema.lisp
@@ -119,14 +119,18 @@ skipped, a missing file yields two empty lists (GH #172, R2)."
 ;;; ENSURE-NAMESPACE (R4)
 ;;; ---------------------------------------------------------------------
 
-(defun ensure-namespace (name &key nicknames)
+(defun ensure-namespace (name &key nicknames (record-p t))
   "Ensure a package for a runtime schema namespace, idempotent and
 manifest-logged.  NAME and each of NICKNAMES may be a string or a
 symbol.  Created with MAKE-PACKAGE :USE NIL -- a schema namespace only
 holds the class and accessor symbols CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE
 intern into it, it is not a code package; (:use #:cl #:graph-db) is what
 a hand-written SOURCE package uses, and is what EXPORT-SCHEMA-SOURCE
-emits for one, not what this creates.  Allocates no files and no store
+emits for one, not what this creates.  Allocates no files and no store.
+
+RECORD-P NIL suppresses the manifest append: MATERIALIZE-SCHEMA is
+replaying rows the manifest already holds, and re-appending an
+unchanged namespace row on every load would grow the file forever
 (GH #172, R4)."
   (let* ((pkg-name (string name))
          (nick-strings (mapcar #'string nicknames))
@@ -143,10 +147,94 @@ emits for one, not what this creates.  Allocates no files and no store
         (unless (= (length wanted) (length (package-nicknames pkg)))
           (rename-package pkg pkg-name wanted))
         (setf pkg (make-package pkg-name :nicknames wanted :use nil)))
-    (%append-schema-manifest-record
-     (list :namespace pkg-name :nicknames wanted
-           :time (get-universal-time)))
+    (when record-p
+      (%append-schema-manifest-record
+       (list :namespace pkg-name :nicknames wanted
+             :time (get-universal-time))))
     pkg))
+
+;;; ---------------------------------------------------------------------
+;;; Schema functions and the :CHECK slot option (R5)
+;;;
+;;; Behaviour cannot be data: a closure does not serialize.  A runtime
+;;; type that wants a constraint stores the NAME of a function the image
+;;; provides, and the name is resolved against this registry -- at
+;;; CREATE-*-TYPE time, at MATERIALIZE-SCHEMA time, and again at each
+;;; check.  Enforcement lives beside the other value constraints; see
+;;; %VALUE-CONSTRAINT-VIOLATIONS (value-constraint.lisp).
+;;; ---------------------------------------------------------------------
+
+(defvar *schema-functions* (make-hash-table :test 'eq)
+  "NAME (symbol) -> function, for the :CHECK slot option (GH #172, R5).")
+
+(defvar *schema-functions-lock* (make-lock "schema functions"))
+
+(defvar *schema-check-slots-present-p* nil
+  "T once any class in this image has a :CHECK slot.  Set by
+COMPUTE-EFFECTIVE-SLOT-DEFINITION (node-class.lisp); read by
+VALIDATE-VALUE-CONSTRAINTS so a schema with no :CHECK pays nothing
+(GH #172, R5).")
+
+(define-condition schema-function-unresolved (error)
+  ((names :initarg :names :reader unresolved-function-names))
+  (:report
+   (lambda (c s)
+     (format s "No schema function is registered under~{ ~S~}.  ~
+Behaviour ships in the image, not in the metadata: call ~
+REGISTER-SCHEMA-FUNCTION before the schema that names it is used ~
+(GH #172)."
+             (unresolved-function-names c)))))
+
+(define-condition materialize-unresolved-functions
+    (schema-function-unresolved)
+  ()
+  (:report
+   (lambda (c s)
+     (format s "MATERIALIZE-SCHEMA: the manifest names schema ~
+function(s)~{ ~S~} that this image does not provide.  Nothing was ~
+built.  Register them before materializing (GH #172, R3)."
+             (unresolved-function-names c)))))
+
+(defun register-schema-function (name fn)
+  "Register FN under NAME for the :CHECK slot option.  Returns NAME.
+Re-registering replaces (GH #172, R5)."
+  (check-type name symbol)
+  (with-lock-held (*schema-functions-lock*)
+    (setf (gethash name *schema-functions*) fn))
+  name)
+
+(defun find-schema-function (name)
+  "The function registered under NAME, or NIL (GH #172, R5)."
+  (with-lock-held (*schema-functions-lock*)
+    (values (gethash name *schema-functions*))))
+
+(defun %unregister-schema-function (name)
+  "Withdraw NAME's registration.  T if one was withdrawn.  Exists for
+tests simulating an image that no longer provides it (GH #172)."
+  (with-lock-held (*schema-functions-lock*)
+    (remhash name *schema-functions*)))
+
+(defun %resolve-schema-function (name)
+  "NAME's function, or SCHEMA-FUNCTION-UNRESOLVED.  Resolution is at
+CHECK time so a re-registration takes effect immediately; presence is
+verified far earlier (GH #172, R5)."
+  (or (find-schema-function name)
+      (error 'schema-function-unresolved :names (list name))))
+
+(defun %slot-check-names (slot-specs)
+  "The :CHECK names declared by SLOT-SPECS (normalized or raw)."
+  (loop for spec in slot-specs
+        for name = (and (consp spec) (getf (rest spec) :check))
+        when name collect name))
+
+(defun %unresolved-check-names (slot-spec-lists)
+  "Every :CHECK name in SLOT-SPEC-LISTS with no registered function,
+deduplicated, in order of appearance (GH #172, R5)."
+  (let ((missing nil))
+    (dolist (specs slot-spec-lists (nreverse missing))
+      (dolist (name (%slot-check-names specs))
+        (unless (or (find-schema-function name) (member name missing))
+          (push name missing))))))
 
 ;;; ---------------------------------------------------------------------
 ;;; CREATE-VERTEX-TYPE / CREATE-EDGE-TYPE (R4)
@@ -232,7 +320,7 @@ SLOTS are %NORMALIZE-SLOT-SPECS output; only :TYPE is forwarded to
    (append parents (list (ecase kind (:vertex 'vertex) (:edge 'edge))))
    :direct-slots
    (mapcar (lambda (spec)
-             (destructuring-bind (sname &key accessor initarg type
+             (destructuring-bind (sname &key accessor initarg type check
                                         &allow-other-keys)
                  spec
                (append
@@ -240,7 +328,10 @@ SLOTS are %NORMALIZE-SLOT-SPECS output; only :TYPE is forwarded to
                       :initargs (list initarg)
                       :readers (list accessor)
                       :writers (list (list 'setf accessor)))
-                (when type (list :type type)))))
+                (when type (list :type type))
+                ;; R5: the only other slot option a runtime type may
+                ;; carry.  NODE-CLASS's slot definitions accept it.
+                (when check (list :check check)))))
            normalized-slots)
    :metaclass (find-class 'node-class)))
 
@@ -253,6 +344,12 @@ already exist, since it calls FINALIZE-INHERITANCE (GH #172, R4)."
          (specs (%retarget-slot-specs (%normalize-slot-specs slot-specs)
                                       (symbol-package sym))))
     (%check-schema-name-package sym)
+    ;; Fail fast, like MATERIALIZE-SCHEMA: a :CHECK naming a function
+    ;; this image does not provide is a broken definition, not a
+    ;; surprise at first write (GH #172, R5).
+    (let ((missing (%unresolved-check-names (list specs))))
+      (when missing
+        (error 'schema-function-unresolved :names missing)))
     (%ensure-node-class sym parents kind specs)
     (let ((*schema-provenance* :runtime))
       (%install-node-type
@@ -292,3 +389,197 @@ semantics.  Also installs the NAME/2 and NAME/3 Prolog functors
   (%create-node-type name slot-specs :edge :parents parents
                      :default-store default-store
                      :keep-revisions keep-revisions))
+
+;;; ---------------------------------------------------------------------
+;;; MATERIALIZE-SCHEMA (R3): the load-order answer
+;;; ---------------------------------------------------------------------
+
+(defun %materialize-namespace-filter (namespaces)
+  "NAMESPACES as a list of package-name strings, or NIL for \"all\"."
+  (when namespaces
+    (mapcar (lambda (n) (string-upcase (string n)))
+            (if (listp namespaces) namespaces (list namespaces)))))
+
+(defun %manifest-type-row-package (line)
+  "The package-name prefix of a (:TYPE PKG::NAME ...) manifest line, or
+NIL.  Textual on purpose: READ interns, and interning needs the very
+package this is trying to discover -- a type row whose namespace record
+was hand-trimmed away would otherwise read as a missing-package error
+and vanish (GH #172, R3)."
+  (let ((trimmed (string-left-trim '(#\Space #\Tab) line)))
+    (when (and (> (length trimmed) 6)
+               (string-equal "(:TYPE" (subseq trimmed 0 6)))
+      (let* ((rest (string-left-trim '(#\Space #\Tab) (subseq trimmed 6)))
+             (end (or (position-if
+                       (lambda (c) (member c '(#\Space #\Tab #\)))) rest)
+                      (length rest)))
+             (token (subseq rest 0 end))
+             (colon (position #\: token)))
+        (when (and colon (plusp colon))
+          (subseq token 0 colon))))))
+
+(defun %materialize-orphan-packages (dir filter)
+  "Create a package for every type row in DIR's manifest whose package
+does not exist and has no namespace record.  Warns: a manifest that
+lost its namespace rows still materializes, but not silently
+(GH #172, R3)."
+  (let ((file (ignore-errors (%schema-manifest-path dir))))
+    (when (and file (probe-file file))
+      (handler-case
+          (with-open-file (s file :direction :input)
+            (loop
+              (let ((line (read-line s nil :eof)))
+                (when (eq line :eof) (return))
+                (let ((pkg (%manifest-type-row-package line)))
+                  (when (and pkg
+                             (or (null filter)
+                                 (member pkg filter :test #'string-equal))
+                             (not (find-package pkg)))
+                    (warn "Schema manifest: type row names package ~A ~
+with no namespace record; creating it with no nicknames (GH #172)." pkg)
+                    (ensure-namespace pkg))))))
+        (error () nil)))))
+
+(defun %materialize-row-wanted-p (row filter)
+  "Is ROW a type row this materialization should consider?  A row naming
+a locked package or an unknown kind is skipped with a warning rather
+than crashing: the manifest is data, and may have been hand-edited
+(GH #172, R3)."
+  (let ((name (getf row :type))
+        (kind (getf row :kind)))
+    (cond
+      ((not (and (symbolp name) (symbol-package name))) nil)
+      ((%refused-schema-package-p (symbol-package name))
+       (warn "Schema manifest: ignoring type row ~S in locked package ~
+~A (GH #172)." name (package-name (symbol-package name)))
+       nil)
+      ((not (member kind '(:vertex :edge)))
+       (warn "Schema manifest: ignoring type row ~S with kind ~S ~
+(GH #172)." name kind)
+       nil)
+      (t (or (null filter)
+             (member (package-name (symbol-package name)) filter
+                     :test #'string-equal))))))
+
+(defun %materialize-sort (rows)
+  "ROWS reordered so a row builds after any parent of it that is also
+in ROWS; manifest order is the tiebreak.  Redefinition re-appends a
+row, so append order alone can put a parent after its child.  A cycle
+-- impossible through the API, reachable by hand-editing -- falls back
+to manifest order for what remains (GH #172, R3)."
+  (let ((pending (copy-list rows))
+        (built (make-hash-table :test 'eq))
+        (out nil))
+    (loop while pending do
+      (let ((progressed nil))
+        (dolist (row pending)
+          (when (every (lambda (p)
+                         (or (gethash p built)
+                             (not (find p pending
+                                        :key (lambda (r) (getf r :type))))))
+                       (getf row :parents))
+            (push row out)
+            (setf (gethash (getf row :type) built) t)
+            (setf pending (remove row pending))
+            (setf progressed t)))
+        (unless progressed
+          (dolist (row pending) (push row out))
+          (setf pending nil))))
+    (nreverse out)))
+
+(defun %warn-if-row-diverges (row)
+  "Source wins on the skip path, but not silently.  %WARN-IF-DIVERGENT-
+ACROSS-STORES never runs here -- nothing is installed -- so compare the
+row against the registered meta and signal the #196 condition directly
+(GH #172, R3)."
+  (let* ((name (getf row :type))
+         (meta (%find-registered-node-type name (getf row :kind)
+                                           (getf row :default-store))))
+    (when (and meta (not (equal (node-type-slots meta) (getf row :slots))))
+      (warn 'divergent-node-type-redefinition
+            :name name
+            :graph-name (getf row :default-store)
+            :other-graphs (list (node-type-graph-name meta))))))
+
+(defun %materialize-row (row)
+  "Build ROW's class and install it through the shared path.  ROW's
+slots are already normalized and retargeted (the manifest records what
+%INSTALL-NODE-TYPE registered), so no re-normalization is needed.  No
+evaluation: plists in, MOP calls out (GH #172, R3)."
+  (let ((name (getf row :type))
+        (kind (getf row :kind))
+        (slots (getf row :slots)))
+    (%ensure-node-class name (getf row :parents) kind slots)
+    ;; The row's own provenance, defaulting to :RUNTIME -- never the
+    ;; :SOURCE default of *SCHEMA-PROVENANCE*, which would relabel every
+    ;; materialized runtime type as source-defined (GH #172, R2).
+    (let ((*schema-provenance* (or (getf row :provenance) :runtime)))
+      (%install-node-type
+       (make-node-type
+        :name name
+        :parent-type kind
+        :graph-name (getf row :default-store)
+        :slots slots
+        :package (package-name (symbol-package name))
+        :constructor (intern (format nil "MAKE-~A" (symbol-name name))
+                             (%schema-symbol-package name))
+        :keep-revisions (getf row :keep-revisions))))
+    name))
+
+(defun %materialize-schema (dir &key namespaces)
+  "The functional core of MATERIALIZE-SCHEMA; see that macro.  Use the
+macro in a file: it carries the EVAL-WHEN this needs to run before the
+methods below it compile (GH #172, R3)."
+  (let ((filter (%materialize-namespace-filter namespaces))
+        (namespace-count 0)
+        (materialized 0)
+        (skipped 0))
+    (dolist (rec (read-schema-manifest dir))
+      (let ((name (string (getf rec :namespace))))
+        (when (or (null filter) (member name filter :test #'string-equal))
+          ;; :RECORD-P NIL -- this row is already in the manifest.
+          (ensure-namespace name :nicknames (getf rec :nicknames)
+                                 :record-p nil)
+          (incf namespace-count))))
+    ;; Packages first, and not only from namespace rows: a type row
+    ;; cannot even be READ until its package exists.
+    (%materialize-orphan-packages dir filter)
+    (let ((rows (remove-if-not
+                 (lambda (r) (%materialize-row-wanted-p r filter))
+                 (nth-value 1 (read-schema-manifest dir))))
+          (pending nil))
+      ;; Fail fast, before anything is built: ONE error naming every
+      ;; unresolved :CHECK function (approved point C).
+      (let ((missing (%unresolved-check-names
+                      (mapcar (lambda (r) (getf r :slots)) rows))))
+        (when missing
+          (error 'materialize-unresolved-functions :names missing)))
+      (dolist (row rows)
+        (if (find-class (getf row :type) nil)
+            (progn (%warn-if-row-diverges row) (incf skipped))
+            (push row pending)))
+      (dolist (row (%materialize-sort (nreverse pending)))
+        (%materialize-row row)
+        (incf materialized)))
+    (list :namespaces namespace-count
+          :materialized materialized
+          :skipped-source skipped)))
+
+(defmacro materialize-schema (dir &key namespaces)
+  "Rebuild every runtime-defined package and class recorded in DIR's
+schema manifest, so methods compiled after this form see their classes.
+Put it in its own file, loaded after the static schema and before any
+file with methods on a runtime type; the EVAL-WHEN is carried here so a
+caller cannot get it wrong.
+
+Idempotent, and SOURCE WINS: a type whose class already exists is left
+alone and counted under :SKIPPED-SOURCE, with the #196 divergence
+warning when the manifest's slot set disagrees with the live class.
+:NAMESPACES narrows to the named packages.  Nothing is evaluated --
+the input is plists and the output is MOP calls -- and a :CHECK
+function the image does not provide aborts the whole call before
+anything is built (MATERIALIZE-UNRESOLVED-FUNCTIONS, naming all of
+them).  Returns (:NAMESPACES n :MATERIALIZED n :SKIPPED-SOURCE n)
+(GH #172, R3)."
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (%materialize-schema ,dir :namespaces ,namespaces)))

--- a/schema-tools.lisp
+++ b/schema-tools.lisp
@@ -99,7 +99,10 @@ so this degrades to live-metas-only rather than erroring (GH #172, R6)."
 
 (defun %schema-since-universal-time (since)
   "SINCE as a universal time: an integer as-is, or a \"YYYY-MM-DD\"
-string parsed at local midnight.  NIL passes through (GH #172, R6)."
+string parsed at UTC midnight -- matching %SCHEMA-ISO-DATE, which
+decodes each row's :TIME at UTC too, so the two agree instead of one
+using the local zone and the other UTC (GH #172, review round 3, M-6).
+NIL passes through."
   (etypecase since
     (null nil)
     (integer since)
@@ -107,7 +110,8 @@ string parsed at local midnight.  NIL passes through (GH #172, R6)."
      (encode-universal-time 0 0 0
                             (parse-integer since :start 8 :end 10)
                             (parse-integer since :start 5 :end 7)
-                            (parse-integer since :start 0 :end 4)))))
+                            (parse-integer since :start 0 :end 4)
+                            0))))
 
 (defun %filter-schema-entries (entries namespace store since)
   "ENTRIES restricted to NAMESPACE's package, to types live in STORE,
@@ -148,12 +152,29 @@ entries within a group sorted by type name -- deterministic output
 ;;; forms).
 ;;; ---------------------------------------------------------------------
 
+(defun %schema-name-shadowed-p (name)
+  "T when NAME (a string) already names an EXTERNAL symbol of COMMON-
+LISP or GRAPH-DB -- the two packages the generated file's DEFPACKAGE
+always :USEs.  A symbol homed in the target namespace but sharing NAME
+with one of these (e.g. a slot named TYPE) needs a :SHADOW clause in
+the generated DEFPACKAGE (%SCHEMA-NAMESPACE-SHADOW-NAMES): INTERN --
+which is what both a bare token AND an explicit NS::NAME qualification
+reduce to -- returns the INHERITED symbol whenever the name is merely
+accessible via :USE, so qualification ALONE cannot recover a distinct
+local symbol; only :SHADOW makes the local one accessible instead
+(GH #172, review round 3, M-2)."
+  (or (eq :external (nth-value 1 (find-symbol name (find-package :cl))))
+      (eq :external (nth-value 1 (find-symbol name (find-package
+                                                     :graph-db))))))
+
 (defun %schema-symbol-prints-bare-p (sym target-pkg-name)
   "T when SYM's home package is one the generated file's DEFPACKAGE
 makes a bare token resolve to the SAME symbol under: the namespace
 itself (matched by NAME -- the export-time package and the one the
 generated file's IN-PACKAGE creates at load time are different OBJECTS
-with the same name), or COMMON-LISP/GRAPH-DB, which the generated
+with the same name; a colliding name is safe to print bare too, since
+%WRITE-SCHEMA-NAMESPACE adds a :SHADOW clause for it -- see
+%SCHEMA-NAME-SHADOWED-P), or COMMON-LISP/GRAPH-DB, which the generated
 DEFPACKAGE always :USEs.  Any OTHER home package must be qualified:
 printing it bare would, at load time, INTERN A NEW SYMBOL under the
 namespace package instead of finding the original one, silently
@@ -262,7 +283,9 @@ NAMESPACE restricts to one namespace's package (a string, symbol, or
 keyword).  STORE restricts to types instantiated in that open store (a
 graph designator or a graph object).  SINCE (a universal time, or a
 \"YYYY-MM-DD\" string) filters by each row's record time, so the dump
-doubles as a change log.  Never signals on a missing or damaged
+doubles as a change log; a \"YYYY-MM-DD\" string is parsed at UTC
+midnight, matching the UTC dates printed in [runtime YYYY-MM-DD] tags
+(GH #172, review round 3, M-6).  Never signals on a missing or damaged
 manifest -- degrades to live metas only, all tagged [source]
 (GH #172, R6)."
   (let ((groups (%group-schema-entries-by-namespace
@@ -333,14 +356,42 @@ R6, review round 1)."
              :test #'string-equal)
         :nicknames))
 
+(defun %schema-namespace-shadow-names (pkg-name entries)
+  "Every symbol NAME (a type name, a parent, or a slot/accessor name --
+any leaf ENTRIES prints) that is homed in PKG-NAME and shares its name
+with an external COMMON-LISP or GRAPH-DB symbol, deduplicated.  The
+generated DEFPACKAGE must :SHADOW these: %SCHEMA-NAME-SHADOWED-P's
+docstring explains why qualification alone cannot recover the local
+symbol once the namespace package itself :USEs CL/GRAPH-DB (GH #172,
+review round 3, M-2)."
+  (let ((pkg-name (string-upcase pkg-name)) (out nil))
+    (labels ((consider (sym)
+               (when (and (symbolp sym) (symbol-package sym)
+                         (string= (package-name (symbol-package sym))
+                                 pkg-name)
+                         (%schema-name-shadowed-p (symbol-name sym))
+                         (not (member (symbol-name sym) out
+                                     :test #'string=)))
+                 (push (symbol-name sym) out)))
+             (walk (x) (if (consp x) (progn (walk (car x)) (walk (cdr x)))
+                          (consider x))))
+      (dolist (e entries)
+        (consider (getf e :name))
+        (mapc #'consider (getf e :parents))
+        (dolist (spec (getf e :slots)) (walk (%minimize-slot-spec spec)))))
+    (nreverse out)))
+
 (defun %write-schema-namespace (group ns-rows stream)
   (let* ((pkg-name (car group))
          (entries (cdr group))
-         (nicks (%schema-namespace-nicknames pkg-name ns-rows)))
+         (nicks (%schema-namespace-nicknames pkg-name ns-rows))
+         (shadows (%schema-namespace-shadow-names pkg-name entries)))
     (format stream "(defpackage #:~(~A~) (:use #:cl #:graph-db)~%"
             pkg-name)
     (when nicks
       (format stream "  (:nicknames~{ #:~(~A~)~})~%" nicks))
+    (when shadows
+      (format stream "  (:shadow~{ #:~(~A~)~})~%" shadows))
     ;; One name per line (MINOR 1, review round 1): a ten-plus-type
     ;; namespace's :EXPORT list is the known >80-column offender when
     ;; run together on one line.

--- a/schema-tools.lisp
+++ b/schema-tools.lisp
@@ -1,0 +1,305 @@
+(in-package :graph-db)
+
+;;; Visibility tooling (GH #172, R6): DESCRIBE-SCHEMA (a plain-text dump
+;;; joining the manifest with live metas) and EXPORT-SCHEMA-SOURCE (the
+;;; promotion path -- metadata back into def-vertex/def-edge text).  Both
+;;; are READ-ONLY: neither binds *RECORD-MANIFEST-ROWS* nor appends to the
+;;; manifest.  Spec: docs/superpowers/specs/2026-08-24-runtime-schema-172-
+;;; design.md, R6.
+
+;;; ---------------------------------------------------------------------
+;;; Joining the manifest with live metas
+;;; ---------------------------------------------------------------------
+
+(defun %schema-entry-parents (name kind row)
+  "Direct superclasses of NAME's live class, minus the VERTEX/EDGE base --
+the same computation %SCHEMA-MANIFEST-TYPE-RECORD makes.  Falls back to
+ROW's own :PARENTS when the class no longer exists (GH #172, R6)."
+  (let ((class (find-class name nil)))
+    (if class
+        (let ((base (ecase kind (:vertex (find-class 'vertex))
+                           (:edge (find-class 'edge)))))
+          (mapcar #'class-name
+                  (remove base (class-direct-superclasses class))))
+        (getf row :parents))))
+
+(defun %describe-schema-entries ()
+  "Every known node type as one plist: (:NAME :KIND :DEFAULT-STORE
+:SLOTS :PARENTS :KEEP-REVISIONS :PROVENANCE :TIME).  Joins the system
+manifest with every live META across every open store; a type with no
+manifest row (a pre-#172 store) gets :PROVENANCE :SOURCE and :TIME NIL
+-- describe/export must never signal on a missing or damaged manifest,
+so this degrades to live-metas-only rather than erroring (GH #172, R6)."
+  (let ((rows (nth-value 1 (ignore-errors
+                            (read-schema-manifest *system-directory*))))
+        (seen (make-hash-table :test 'equal))
+        (entries nil))
+    (flet ((key (name kind) (cons name kind))
+           (add (name kind default-store slots parents keep-revisions
+                 provenance time)
+             (push (list :name name :kind kind
+                        :default-store default-store :slots slots
+                        :parents parents :keep-revisions keep-revisions
+                        :provenance provenance :time time)
+                   entries)))
+      (dolist (row rows)
+        (let ((name (getf row :type)) (kind (getf row :kind)))
+          (when (and (symbolp name) (symbol-package name)
+                    (member kind '(:vertex :edge)))
+            (let ((meta (%find-registered-node-type
+                        name kind (getf row :default-store))))
+              (setf (gethash (key name kind) seen) t)
+              (add name kind (getf row :default-store)
+                   (if meta (node-type-slots meta) (getf row :slots))
+                   (%schema-entry-parents name kind row)
+                   (getf row :keep-revisions)
+                   (or (getf row :provenance) :source)
+                   (getf row :time))))))
+      (maphash
+       (lambda (store metas)
+         (declare (ignore store))
+         (dolist (meta metas)
+           (let* ((name (node-type-name meta))
+                  (kind (node-type-parent-type meta))
+                  (k (key name kind)))
+             (unless (gethash k seen)
+               (setf (gethash k seen) t)
+               (add name kind (node-type-graph-name meta)
+                    (node-type-slots meta)
+                    (%schema-entry-parents name kind nil)
+                    (node-type-keep-revisions meta)
+                    :source nil)))))
+       *schema-node-metadata*))
+    (nreverse entries)))
+
+(defun %normalize-namespace-designator (namespace)
+  (and namespace (string-upcase (string namespace))))
+
+(defun %normalize-store-designator (store)
+  (cond ((null store) nil)
+        ((typep store 'graph) (graph-name store))
+        (t store)))
+
+(defun %entry-live-in-store-p (entry store-key)
+  (find-if (lambda (m)
+             (and (eq (node-type-name m) (getf entry :name))
+                 (eq (node-type-parent-type m) (getf entry :kind))))
+           (gethash store-key *schema-node-metadata*)))
+
+(defun %schema-since-universal-time (since)
+  "SINCE as a universal time: an integer as-is, or a \"YYYY-MM-DD\"
+string parsed at local midnight.  NIL passes through (GH #172, R6)."
+  (etypecase since
+    (null nil)
+    (integer since)
+    (string
+     (encode-universal-time 0 0 0
+                            (parse-integer since :start 8 :end 10)
+                            (parse-integer since :start 5 :end 7)
+                            (parse-integer since :start 0 :end 4)))))
+
+(defun %filter-schema-entries (entries namespace store since)
+  "ENTRIES restricted to NAMESPACE's package, to types live in STORE,
+and (via SINCE) to rows recorded at or after that time -- an entry with
+no manifest row has no :TIME and is dropped whenever SINCE is given,
+since there is nothing to compare (GH #172, R6)."
+  (let ((ns (%normalize-namespace-designator namespace))
+        (store-key (%normalize-store-designator store))
+        (since-ut (%schema-since-universal-time since)))
+    (remove-if-not
+     (lambda (e)
+       (and (or (null ns)
+               (string-equal ns (package-name
+                                  (symbol-package (getf e :name)))))
+           (or (null store-key) (%entry-live-in-store-p e store-key))
+           (or (null since-ut)
+               (and (getf e :time) (>= (getf e :time) since-ut)))))
+     entries)))
+
+(defun %group-schema-entries-by-namespace (entries)
+  "ENTRIES as an alist of (PACKAGE-NAME . ENTRIES), package names sorted,
+entries within a group sorted by type name -- deterministic output
+(GH #172, R6)."
+  (let ((table (make-hash-table :test 'equal)) (order nil))
+    (dolist (e entries)
+      (let ((pkg (package-name (symbol-package (getf e :name)))))
+        (unless (nth-value 1 (gethash pkg table)) (push pkg order))
+        (push e (gethash pkg table))))
+    (mapcar (lambda (pkg)
+              (cons pkg
+                    (sort (gethash pkg table) #'string<
+                          :key (lambda (e) (symbol-name (getf e :name))))))
+            (sort (nreverse order) #'string<))))
+
+;;; ---------------------------------------------------------------------
+;;; Bare, downcased text for the generated source -- shared by
+;;; DESCRIBE-SCHEMA (default-store) and EXPORT-SCHEMA-SOURCE (whole
+;;; forms).
+;;; ---------------------------------------------------------------------
+
+(defun %schema-source-token (x)
+  "X as generated-source text: symbols print bare and downcased, with
+no package prefix -- the generated file's own IN-PACKAGE supplies the
+reader context that makes a bare token resolve correctly, so printing
+a home package here would only add noise (GH #172, R6)."
+  (cond
+    ((null x) "nil")
+    ((eq x t) "t")
+    ((keywordp x) (format nil ":~(~A~)" (symbol-name x)))
+    ((symbolp x) (string-downcase (symbol-name x)))
+    ((stringp x) (prin1-to-string x))
+    ((integerp x) (princ-to-string x))
+    (t (string-downcase (princ-to-string x)))))
+
+(defun %schema-source-form (form)
+  "FORM (nested lists of symbols/keywords/literals only, as produced by
+NODE-TYPE-SLOTS) as downcased source text (GH #172, R6)."
+  (if (consp form)
+      (format nil "(~{~A~^ ~})" (mapcar #'%schema-source-form form))
+      (%schema-source-token form)))
+
+;;; ---------------------------------------------------------------------
+;;; DESCRIBE-SCHEMA
+;;; ---------------------------------------------------------------------
+
+(defun %schema-iso-date (universal-time)
+  (multiple-value-bind (sec min hr day month year)
+      (decode-universal-time universal-time 0)
+    (declare (ignore sec min hr))
+    (format nil "~4,'0D-~2,'0D-~2,'0D" year month day)))
+
+(defun %schema-provenance-tag (provenance time)
+  (if (eq provenance :runtime)
+      (format nil "[runtime~@[ ~A~]]" (and time (%schema-iso-date time)))
+      "[source]"))
+
+(defun %describe-schema-slot (spec stream)
+  (destructuring-bind (name &key type check &allow-other-keys) spec
+    (format stream "    ~A" (symbol-name name))
+    (when type (format stream "  ~A" (princ-to-string type)))
+    (when check (format stream "  :check ~A" (symbol-name check)))
+    (terpri stream)))
+
+(defun describe-schema (&key namespace store since
+                        (stream *standard-output*))
+  "Plain-text dump of the schema, joining the system manifest with every
+live node-type meta: grouped by namespace (the package name of each
+type symbol), one line per type -- name, kind, default store, and a
+provenance tag ([source] or [runtime YYYY-MM-DD]; a type with no
+manifest row, a pre-#172 store, always prints [source]) -- then one
+line per slot: name, type, and its :CHECK name if any.
+
+NAMESPACE restricts to one namespace's package (a string, symbol, or
+keyword).  STORE restricts to types instantiated in that open store (a
+graph designator or a graph object).  SINCE (a universal time, or a
+\"YYYY-MM-DD\" string) filters by each row's record time, so the dump
+doubles as a change log.  Never signals on a missing or damaged
+manifest -- degrades to live metas only, all tagged [source]
+(GH #172, R6)."
+  (let ((groups (%group-schema-entries-by-namespace
+                (%filter-schema-entries (%describe-schema-entries)
+                                        namespace store since))))
+    (dolist (group groups)
+      (format stream "Namespace ~A~%" (car group))
+      (dolist (e (cdr group))
+        (format stream "  ~A (~(~A~)) default-store ~A   ~A~%"
+                (symbol-name (getf e :name))
+                (getf e :kind)
+                (%schema-source-token (getf e :default-store))
+                (%schema-provenance-tag (getf e :provenance)
+                                        (getf e :time)))
+        (dolist (spec (getf e :slots))
+          (%describe-schema-slot spec stream)))))
+  (values))
+
+;;; ---------------------------------------------------------------------
+;;; EXPORT-SCHEMA-SOURCE
+;;; ---------------------------------------------------------------------
+
+(defun %minimize-slot-spec (spec)
+  "SPEC (a normalized, retargeted slot spec, as NODE-TYPE-SLOTS stores
+it) with :ACCESSOR/:INITARG dropped when they are exactly what
+%NORMALIZE-SLOT-SPECS would have supplied -- so the exported form reads
+the way a developer would have written it, not the way the engine
+expanded it (GH #172, R6)."
+  (destructuring-bind (name &rest plist &key accessor initarg
+                            &allow-other-keys)
+      spec
+    (let ((rest (copy-list plist)))
+      (remf rest :accessor)
+      (remf rest :initarg)
+      (unless (eq accessor name)
+        (setf rest (list* :accessor accessor rest)))
+      (unless (eq initarg (intern (symbol-name name) :keyword))
+        (setf rest (list* :initarg initarg rest)))
+      (if rest (list* name rest) name))))
+
+(defun %write-schema-def-form (entry stream)
+  (let ((macro (ecase (getf entry :kind)
+                (:vertex "def-vertex") (:edge "def-edge")))
+        (slots (mapcar #'%minimize-slot-spec (getf entry :slots))))
+    (format stream "(~A ~A (~{~A~^ ~})~%    ("
+            macro
+            (%schema-source-token (getf entry :name))
+            (mapcar #'%schema-source-token (getf entry :parents)))
+    (loop for spec in slots
+          for firstp = t then nil
+          do (unless firstp (format stream "~%     "))
+             (write-string (%schema-source-form spec) stream))
+    (format stream ")~%    ~A"
+            (%schema-source-token (getf entry :default-store)))
+    (when (getf entry :keep-revisions)
+      (format stream "~%    :keep-revisions ~A"
+              (getf entry :keep-revisions)))
+    (format stream ")~%~%")))
+
+(defun %schema-namespace-nicknames (pkg-name ns-rows)
+  (getf (find pkg-name ns-rows :key (lambda (r) (getf r :namespace))
+             :test #'string-equal)
+        :nicknames))
+
+(defun %write-schema-namespace (group ns-rows stream)
+  (let* ((pkg-name (car group))
+         (entries (cdr group))
+         (nicks (%schema-namespace-nicknames pkg-name ns-rows)))
+    (format stream "(defpackage #:~(~A~) (:use #:cl #:graph-db)~%"
+            pkg-name)
+    (when nicks
+      (format stream "  (:nicknames~{ #:~(~A~)~})~%" nicks))
+    (format stream "  (:export~{ #:~(~A~)~}))~%"
+            (mapcar (lambda (e) (symbol-name (getf e :name))) entries))
+    (format stream "(in-package #:~(~A~))~%~%" pkg-name)
+    (dolist (e entries) (%write-schema-def-form e stream))))
+
+(defun export-schema-source (path &key namespace store)
+  "Write PATH: a generated-header comment, one DEFPACKAGE per exported
+namespace ((:use #:cl #:graph-db) plus :export of its class names --
+the SOURCE-package shape, per ENSURE-NAMESPACE's docstring; the runtime
+package it actually creates uses :USE NIL instead), IN-PACKAGE, and
+DEF-VERTEX/DEF-EDGE forms rebuilt from metadata.  NAMESPACE/STORE
+restrict exactly as in DESCRIBE-SCHEMA.
+
+This is the promotion path: loading the file is the ordinary source
+path, and is idempotent (same names -> same registry ids, per
+REGISTRY-INTERN). Export never runs implicitly, and the engine never
+reads the file back -- it is for the developer's build only.  Returns
+the file's truename (GH #172, R6)."
+  (let* ((entries (%filter-schema-entries (%describe-schema-entries)
+                                          namespace store nil))
+         (groups (%group-schema-entries-by-namespace entries))
+         (ns-rows (nth-value 0 (ignore-errors
+                                (read-schema-manifest *system-directory*)))))
+    (with-open-file (out path :direction :output
+                              :if-exists :supersede
+                              :if-does-not-exist :create)
+      (let ((*print-right-margin* 79))
+        (format out ";;; Generated by graph-db:export-schema-source ~A.~%"
+                (%schema-iso-date (get-universal-time)))
+        (format out ";;; Source of truth remains the persisted metadata ~
+until this~%")
+        (format out ";;; file is loaded as part of the system; loading ~
+it is~%")
+        (format out ";;; idempotent (same names -> same registry ids).~%~%")
+        (dolist (group groups)
+          (%write-schema-namespace group ns-rows out))))
+    (truename path)))

--- a/schema-tools.lisp
+++ b/schema-tools.lisp
@@ -23,6 +23,18 @@ ROW's own :PARENTS when the class no longer exists (GH #172, R6)."
                   (remove base (class-direct-superclasses class))))
         (getf row :parents))))
 
+(defun %read-schema-manifest-safe (dir)
+  "(VALUES NAMESPACE-ROWS TYPE-ROWS), like READ-SCHEMA-MANIFEST, but
+never signals: an error (a malformed DIR, an unreadable file despite
+READ-SCHEMA-MANIFEST's own guards) degrades to two empty lists, exactly
+like a missing manifest -- HANDLER-CASE, not IGNORE-ERRORS, because
+IGNORE-ERRORS's error branch returns (VALUES NIL CONDITION), and a
+caller taking this function's SECOND value would get the CONDITION
+object where it expects the type-row list (GH #172, R6, review round
+1)."
+  (handler-case (read-schema-manifest dir)
+    (error () (values nil nil))))
+
 (defun %describe-schema-entries ()
   "Every known node type as one plist: (:NAME :KIND :DEFAULT-STORE
 :SLOTS :PARENTS :KEEP-REVISIONS :PROVENANCE :TIME).  Joins the system
@@ -30,8 +42,7 @@ manifest with every live META across every open store; a type with no
 manifest row (a pre-#172 store) gets :PROVENANCE :SOURCE and :TIME NIL
 -- describe/export must never signal on a missing or damaged manifest,
 so this degrades to live-metas-only rather than erroring (GH #172, R6)."
-  (let ((rows (nth-value 1 (ignore-errors
-                            (read-schema-manifest *system-directory*))))
+  (let ((rows (nth-value 1 (%read-schema-manifest-safe *system-directory*)))
         (seen (make-hash-table :test 'equal))
         (entries nil))
     (flet ((key (name kind) (cons name kind))
@@ -137,26 +148,63 @@ entries within a group sorted by type name -- deterministic output
 ;;; forms).
 ;;; ---------------------------------------------------------------------
 
-(defun %schema-source-token (x)
-  "X as generated-source text: symbols print bare and downcased, with
-no package prefix -- the generated file's own IN-PACKAGE supplies the
-reader context that makes a bare token resolve correctly, so printing
-a home package here would only add noise (GH #172, R6)."
+(defun %schema-symbol-prints-bare-p (sym target-pkg-name)
+  "T when SYM's home package is one the generated file's DEFPACKAGE
+makes a bare token resolve to the SAME symbol under: the namespace
+itself (matched by NAME -- the export-time package and the one the
+generated file's IN-PACKAGE creates at load time are different OBJECTS
+with the same name), or COMMON-LISP/GRAPH-DB, which the generated
+DEFPACKAGE always :USEs.  Any OTHER home package must be qualified:
+printing it bare would, at load time, INTERN A NEW SYMBOL under the
+namespace package instead of finding the original one, silently
+breaking any EQ-keyed lookup on it -- e.g. a :CHECK name against
+*SCHEMA-FUNCTIONS* (GH #172, R6, review round 1)."
+  (let ((home (symbol-package sym)))
+    (and home
+        (or (and target-pkg-name
+                (string-equal (package-name home) target-pkg-name))
+            (eq home (find-package :common-lisp))
+            (eq home (find-package :graph-db))))))
+
+(defun %schema-qualified-symbol (sym)
+  "SYM as PACKAGE:NAME (external) or PACKAGE::NAME (internal), downcased
+(GH #172, R6, review round 1)."
+  (let* ((pkg (symbol-package sym))
+         (external-p (eq :external
+                        (nth-value 1
+                                   (find-symbol (symbol-name sym) pkg)))))
+    (format nil "~(~A~)~:[::~;:~]~(~A~)"
+            (package-name pkg) external-p (symbol-name sym))))
+
+(defun %schema-source-token (x &optional target-pkg-name)
+  "X as generated-source text.  A symbol prints bare and downcased only
+when %SCHEMA-SYMBOL-PRINTS-BARE-P says a bare token will resolve back
+to the SAME symbol under TARGET-PKG-NAME (the namespace the caller is
+printing this form for); otherwise it prints package-qualified.
+TARGET-PKG-NAME NIL (DESCRIBE-SCHEMA's callers, and any keyword/literal
+value) never qualifies -- describe-schema's output is not reloaded
+(GH #172, R6)."
   (cond
     ((null x) "nil")
     ((eq x t) "t")
     ((keywordp x) (format nil ":~(~A~)" (symbol-name x)))
-    ((symbolp x) (string-downcase (symbol-name x)))
+    ((symbolp x)
+     (if (%schema-symbol-prints-bare-p x target-pkg-name)
+         (string-downcase (symbol-name x))
+         (%schema-qualified-symbol x)))
     ((stringp x) (prin1-to-string x))
     ((integerp x) (princ-to-string x))
     (t (string-downcase (princ-to-string x)))))
 
-(defun %schema-source-form (form)
+(defun %schema-source-form (form &optional target-pkg-name)
   "FORM (nested lists of symbols/keywords/literals only, as produced by
-NODE-TYPE-SLOTS) as downcased source text (GH #172, R6)."
+NODE-TYPE-SLOTS) as downcased source text, package-qualifying any
+symbol foreign to TARGET-PKG-NAME (GH #172, R6)."
   (if (consp form)
-      (format nil "(~{~A~^ ~})" (mapcar #'%schema-source-form form))
-      (%schema-source-token form)))
+      (format nil "(~{~A~^ ~})"
+              (mapcar (lambda (f) (%schema-source-form f target-pkg-name))
+                      form))
+      (%schema-source-token form target-pkg-name)))
 
 ;;; ---------------------------------------------------------------------
 ;;; DESCRIBE-SCHEMA
@@ -234,18 +282,24 @@ expanded it (GH #172, R6)."
         (setf rest (list* :initarg initarg rest)))
       (if rest (list* name rest) name))))
 
-(defun %write-schema-def-form (entry stream)
+(defun %write-schema-def-form (entry pkg-name stream)
+  "Write ENTRY's DEF-VERTEX/DEF-EDGE form for the namespace PKG-NAME
+(a string): every symbol not homed in PKG-NAME/COMMON-LISP/GRAPH-DB is
+package-qualified so it re-reads to the SAME symbol later, not a new
+one interned into the freshly (re)created namespace package (GH #172,
+R6, review round 1)."
   (let ((macro (ecase (getf entry :kind)
                 (:vertex "def-vertex") (:edge "def-edge")))
         (slots (mapcar #'%minimize-slot-spec (getf entry :slots))))
     (format stream "(~A ~A (~{~A~^ ~})~%    ("
             macro
-            (%schema-source-token (getf entry :name))
-            (mapcar #'%schema-source-token (getf entry :parents)))
+            (%schema-source-token (getf entry :name) pkg-name)
+            (mapcar (lambda (p) (%schema-source-token p pkg-name))
+                    (getf entry :parents)))
     (loop for spec in slots
           for firstp = t then nil
           do (unless firstp (format stream "~%     "))
-             (write-string (%schema-source-form spec) stream))
+             (write-string (%schema-source-form spec pkg-name) stream))
     (format stream ")~%    ~A"
             (%schema-source-token (getf entry :default-store)))
     (when (getf entry :keep-revisions)
@@ -266,10 +320,15 @@ expanded it (GH #172, R6)."
             pkg-name)
     (when nicks
       (format stream "  (:nicknames~{ #:~(~A~)~})~%" nicks))
-    (format stream "  (:export~{ #:~(~A~)~}))~%"
-            (mapcar (lambda (e) (symbol-name (getf e :name))) entries))
+    ;; One name per line (MINOR 1, review round 1): a ten-plus-type
+    ;; namespace's :EXPORT list is the known >80-column offender when
+    ;; run together on one line.
+    (format stream "  (:export~%")
+    (dolist (e entries)
+      (format stream "   #:~(~A~)~%" (symbol-name (getf e :name))))
+    (format stream "   ))~%")
     (format stream "(in-package #:~(~A~))~%~%" pkg-name)
-    (dolist (e entries) (%write-schema-def-form e stream))))
+    (dolist (e entries) (%write-schema-def-form e pkg-name stream))))
 
 (defun export-schema-source (path &key namespace store)
   "Write PATH: a generated-header comment, one DEFPACKAGE per exported
@@ -287,19 +346,19 @@ the file's truename (GH #172, R6)."
   (let* ((entries (%filter-schema-entries (%describe-schema-entries)
                                           namespace store nil))
          (groups (%group-schema-entries-by-namespace entries))
-         (ns-rows (nth-value 0 (ignore-errors
-                                (read-schema-manifest *system-directory*)))))
+         (ns-rows (nth-value 0
+                             (%read-schema-manifest-safe
+                              *system-directory*))))
     (with-open-file (out path :direction :output
                               :if-exists :supersede
                               :if-does-not-exist :create)
-      (let ((*print-right-margin* 79))
-        (format out ";;; Generated by graph-db:export-schema-source ~A.~%"
-                (%schema-iso-date (get-universal-time)))
-        (format out ";;; Source of truth remains the persisted metadata ~
+      (format out ";;; Generated by graph-db:export-schema-source ~A.~%"
+              (%schema-iso-date (get-universal-time)))
+      (format out ";;; Source of truth remains the persisted metadata ~
 until this~%")
-        (format out ";;; file is loaded as part of the system; loading ~
+      (format out ";;; file is loaded as part of the system; loading ~
 it is~%")
-        (format out ";;; idempotent (same names -> same registry ids).~%~%")
-        (dolist (group groups)
-          (%write-schema-namespace group ns-rows out))))
+      (format out ";;; idempotent (same names -> same registry ids).~%~%")
+      (dolist (group groups)
+        (%write-schema-namespace group ns-rows out)))
     (truename path)))

--- a/schema-tools.lisp
+++ b/schema-tools.lisp
@@ -176,6 +176,30 @@ breaking any EQ-keyed lookup on it -- e.g. a :CHECK name against
     (format nil "~(~A~)~:[::~;:~]~(~A~)"
             (package-name pkg) external-p (symbol-name sym))))
 
+(defun %schema-source-symbol-token (sym target-pkg-name)
+  "SYM as source text under TARGET-PKG-NAME: bare when
+%SCHEMA-SYMBOL-PRINTS-BARE-P allows it, package-qualified otherwise --
+except an UNINTERNED symbol (no home package at all), which
+%SCHEMA-QUALIFIED-SYMBOL cannot name.  Unreachable through the ordinary
+CREATE-*-TYPE/DEF-VERTEX APIs (their slot data always comes from a real
+interned symbol), but EXPORT-SCHEMA-SOURCE must never signal an ERROR
+regardless: fall back to the bare, downcased name -- the closest-to-
+correct readable text, since it will still intern into whatever package
+the generated file's IN-PACKAGE is active under -- and WARN, so the
+file is flagged for hand review rather than silently wrong (GH #172,
+R6, review round 2)."
+  (if (symbol-package sym)
+      (if (%schema-symbol-prints-bare-p sym target-pkg-name)
+          (string-downcase (symbol-name sym))
+          (%schema-qualified-symbol sym))
+      (progn
+        (warn "EXPORT-SCHEMA-SOURCE: symbol ~S~@[, exporting namespace ~
+~A,~] has no home package (uninterned) -- printing it bare.  The ~
+generated file will intern a NEW symbol under its own IN-PACKAGE; ~
+review this output by hand (GH #172, R6, review round 2)."
+              sym target-pkg-name)
+        (string-downcase (symbol-name sym)))))
+
 (defun %schema-source-token (x &optional target-pkg-name)
   "X as generated-source text.  A symbol prints bare and downcased only
 when %SCHEMA-SYMBOL-PRINTS-BARE-P says a bare token will resolve back
@@ -188,10 +212,7 @@ value) never qualifies -- describe-schema's output is not reloaded
     ((null x) "nil")
     ((eq x t) "t")
     ((keywordp x) (format nil ":~(~A~)" (symbol-name x)))
-    ((symbolp x)
-     (if (%schema-symbol-prints-bare-p x target-pkg-name)
-         (string-downcase (symbol-name x))
-         (%schema-qualified-symbol x)))
+    ((symbolp x) (%schema-source-symbol-token x target-pkg-name))
     ((stringp x) (prin1-to-string x))
     ((integerp x) (princ-to-string x))
     (t (string-downcase (princ-to-string x)))))

--- a/schema.lisp
+++ b/schema.lisp
@@ -583,6 +583,14 @@ I3).")
     (remf copy :time)
     copy))
 
+(defvar *record-manifest-rows* t
+  "NIL suppresses every manifest type-row append.  Bound NIL by
+%MATERIALIZE-SCHEMA: the rows it installs came OUT of the manifest, so
+re-appending them would add one identical row per type on every boot,
+with a fresh :TIME that lies to DESCRIBE-SCHEMA's :SINCE (GH #172,
+review round 1, M-1).  ENSURE-NAMESPACE's :RECORD-P is the same rule
+for namespace rows.")
+
 (defun %schema-manifest-append-if-changed (name record)
   "Append RECORD unless it is EQUAL, ignoring :TIME, to the last row
 this image wrote for NAME under the current *SYSTEM-DIRECTORY* -- a
@@ -595,13 +603,16 @@ updated ONLY when the write actually lands: caching before the outcome
 is known would let one transient failure (disk full, unwritable
 directory) silently drop the row for the rest of the session -- before
 this fix, every reopen kept retrying instead (GH #172, review round
-2)."
-  (with-lock-held (*schema-manifest-lock*)
-    (let* ((key (cons name *system-directory*))
-           (sans-time (%schema-manifest-record-sans-time record)))
-      (unless (equal sans-time (gethash key *schema-manifest-type-cache*))
-        (when (%write-schema-manifest-record record)
-          (setf (gethash key *schema-manifest-type-cache*) sans-time))))))
+2).  *RECORD-MANIFEST-ROWS* NIL skips the append outright (M-1)."
+  (when *record-manifest-rows*
+    (with-lock-held (*schema-manifest-lock*)
+      (let* ((key (cons name *system-directory*))
+             (sans-time (%schema-manifest-record-sans-time record)))
+        (unless (equal sans-time
+                       (gethash key *schema-manifest-type-cache*))
+          (when (%write-schema-manifest-record record)
+            (setf (gethash key *schema-manifest-type-cache*)
+                  sans-time)))))))
 
 (defun %install-node-type (meta)
   "Everything DEF-NODE-TYPE's expansion does except the DEFCLASS: warn on

--- a/schema.lisp
+++ b/schema.lisp
@@ -415,6 +415,11 @@ STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
 ;; Defined in runtime-schema.lisp: manifest I/O lives with READ-SCHEMA-
 ;; MANIFEST so both sides of the file agree on record shape (GH #172, R2).
 (declaim (ftype (function (list) t) %append-schema-manifest-record))
+;; The unlocked writer %SCHEMA-MANIFEST-APPEND-IF-CHANGED calls directly,
+;; and the lock it and %APPEND-SCHEMA-MANIFEST-RECORD both take -- taken
+;; exactly once per call, never nested (GH #172, review round 2).
+(declaim (ftype (function (list) t) %write-schema-manifest-record))
+(declaim (special *schema-manifest-lock*))
 
 (defvar *schema-provenance* :source
   "Bound to :RUNTIME around CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE so
@@ -582,12 +587,21 @@ I3).")
   "Append RECORD unless it is EQUAL, ignoring :TIME, to the last row
 this image wrote for NAME under the current *SYSTEM-DIRECTORY* -- a
 reopen storm must not keep growing the manifest (GH #172, review round
-1, I3)."
-  (let* ((key (cons name *system-directory*))
-         (sans-time (%schema-manifest-record-sans-time record)))
-    (unless (equal sans-time (gethash key *schema-manifest-type-cache*))
-      (setf (gethash key *schema-manifest-type-cache*) sans-time)
-      (%append-schema-manifest-record record))))
+1, I3).  The whole check-write-cache sequence runs under
+*SCHEMA-MANIFEST-LOCK*, taken ONCE here (calling
+%WRITE-SCHEMA-MANIFEST-RECORD directly, not %APPEND-SCHEMA-MANIFEST-
+RECORD, which would nest the same non-recursive lock).  The cache is
+updated ONLY when the write actually lands: caching before the outcome
+is known would let one transient failure (disk full, unwritable
+directory) silently drop the row for the rest of the session -- before
+this fix, every reopen kept retrying instead (GH #172, review round
+2)."
+  (with-lock-held (*schema-manifest-lock*)
+    (let* ((key (cons name *system-directory*))
+           (sans-time (%schema-manifest-record-sans-time record)))
+      (unless (equal sans-time (gethash key *schema-manifest-type-cache*))
+        (when (%write-schema-manifest-record record)
+          (setf (gethash key *schema-manifest-type-cache*) sans-time))))))
 
 (defun %install-node-type (meta)
   "Everything DEF-NODE-TYPE's expansion does except the DEFCLASS: warn on

--- a/schema.lisp
+++ b/schema.lisp
@@ -420,11 +420,23 @@ STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
 ;; exactly once per call, never nested (GH #172, review round 2).
 (declaim (ftype (function (list) t) %write-schema-manifest-record))
 (declaim (special *schema-manifest-lock*))
+;; %SEED-SCHEMA-MANIFEST-CACHE (I-1, review round 3) reads the manifest
+;; back through the same file this file also writes.
+(declaim (ftype (function (t) (values list list)) read-schema-manifest))
 
 (defvar *schema-provenance* :source
   "Bound to :RUNTIME around CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE so
 %INSTALL-NODE-TYPE's manifest record captures who defined the type;
 DEF-VERTEX/DEF-EDGE leave it at the default (GH #172, R2).")
+
+;; Homed here, not runtime-schema.lisp, so NODE-CLASS.LISP's SETF sees a
+;; real DEFVAR: node-class.lisp depends only on "schema" in the .asd
+;; (review round 3, M-4).
+(defvar *schema-check-slots-present-p* nil
+  "T once any class in this image has a :CHECK slot.  Set by
+COMPUTE-EFFECTIVE-SLOT-DEFINITION (node-class.lisp); read by
+VALIDATE-VALUE-CONSTRAINTS so a schema with no :CHECK pays nothing
+(GH #172, R5).")
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
 (defun %normalize-slot-specs (slot-specs)
@@ -583,6 +595,39 @@ I3).")
     (remf copy :time)
     copy))
 
+;; I-1 (review round 3): the cache above is per-IMAGE, so a fresh image's
+;; first call for each name always misses -- without this, INSTANTIATE-
+;; NODE-TYPE would re-append every type row on every boot, forever, and
+;; DESCRIBE-SCHEMA's :SINCE would list the whole schema after any reopen.
+(defvar *schema-manifest-seeded-directories* (make-hash-table :test 'equal)
+  "*SYSTEM-DIRECTORY* values whose on-disk rows have already been loaded
+into *SCHEMA-MANIFEST-TYPE-CACHE* this image (GH #172, review round 3,
+I-1).  One %READ-SCHEMA-MANIFEST per directory suffices: seeding fills
+the cache for every name the file already has a row for, so a fresh
+image's first write for each name compares against the FILE, not
+against an empty cache.")
+
+(defun %seed-schema-manifest-cache ()
+  "Populate *SCHEMA-MANIFEST-TYPE-CACHE* from schema-manifest.dat under
+*SYSTEM-DIRECTORY*, once per directory per image.  Caller holds
+*SCHEMA-MANIFEST-LOCK* (GH #172, review round 3, I-1)."
+  (unless (gethash *system-directory* *schema-manifest-seeded-directories*)
+    (dolist (record (nth-value 1 (read-schema-manifest *system-directory*)))
+      (setf (gethash (cons (getf record :type) *system-directory*)
+                     *schema-manifest-type-cache*)
+           (%schema-manifest-record-sans-time record)))
+    (setf (gethash *system-directory* *schema-manifest-seeded-directories*)
+         t)))
+
+(defun %clear-schema-manifest-cache ()
+  "Reset the in-image manifest-dedup cache and its seeded-directory set.
+Tests use this to simulate a fresh image without restarting SBCL
+(GH #172, review round 3, I-1)."
+  (with-lock-held (*schema-manifest-lock*)
+    (clrhash *schema-manifest-type-cache*)
+    (clrhash *schema-manifest-seeded-directories*))
+  (values))
+
 (defvar *record-manifest-rows* t
   "NIL suppresses every manifest type-row append.  Bound NIL by
 %MATERIALIZE-SCHEMA: the rows it installs came OUT of the manifest, so
@@ -603,9 +648,13 @@ updated ONLY when the write actually lands: caching before the outcome
 is known would let one transient failure (disk full, unwritable
 directory) silently drop the row for the rest of the session -- before
 this fix, every reopen kept retrying instead (GH #172, review round
-2).  *RECORD-MANIFEST-ROWS* NIL skips the append outright (M-1)."
+2).  *RECORD-MANIFEST-ROWS* NIL skips the append outright (M-1).  A
+directory not yet seen this image is seeded from its on-disk rows
+first, so a fresh image's first call compares against the FILE, not an
+empty cache (review round 3, I-1)."
   (when *record-manifest-rows*
     (with-lock-held (*schema-manifest-lock*)
+      (%seed-schema-manifest-cache)
       (let* ((key (cons name *system-directory*))
              (sans-time (%schema-manifest-record-sans-time record)))
         (unless (equal sans-time

--- a/schema.lisp
+++ b/schema.lisp
@@ -344,11 +344,16 @@ evolution and is not this guard's business (GH #196)."
                :reader default-store-not-open-class)
    (store :initarg :store :reader default-store-not-open-store))
   (:report (lambda (c s)
-             (format s "MAKE-~A: no :GRAPH argument and the class's ~
-default store ~S is not open.  Open it, or pass :GRAPH explicitly ~
-(GH #167)."
-                     (default-store-not-open-class c)
-                     (default-store-not-open-store c)))))
+             (let ((store (default-store-not-open-store c)))
+               (if store
+                   (format s "MAKE-~A: no :GRAPH argument and the ~
+class's default store ~S is not open.  Open it, or pass :GRAPH ~
+explicitly (GH #167)."
+                           (default-store-not-open-class c) store)
+                   (format s "MAKE-~A: no :GRAPH argument and the ~
+class has no default store (:DEFAULT-STORE NIL).  Pass :GRAPH ~
+explicitly (GH #172)."
+                           (default-store-not-open-class c)))))))
 
 (defun %find-registered-node-type (name kind &optional prefer-store)
   "The registered META whose class symbol is NAME (EQ -- package-aware)
@@ -406,6 +411,15 @@ STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
 ;; Defined in prolog-functors.lisp: the functor bodies need VAR-DEREF,
 ;; which is a macro there, so they cannot live in this file (GH #172).
 (declaim (ftype (function (symbol) t) %install-edge-functors))
+
+;; Defined in runtime-schema.lisp: manifest I/O lives with READ-SCHEMA-
+;; MANIFEST so both sides of the file agree on record shape (GH #172, R2).
+(declaim (ftype (function (list) t) %append-schema-manifest-record))
+
+(defvar *schema-provenance* :source
+  "Bound to :RUNTIME around CREATE-VERTEX-TYPE/CREATE-EDGE-TYPE so
+%INSTALL-NODE-TYPE's manifest record captures who defined the type;
+DEF-VERTEX/DEF-EDGE leave it at the default (GH #172, R2).")
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
 (defun %normalize-slot-specs (slot-specs)
@@ -488,15 +502,23 @@ GRAPH-NAME (GH #172)."
 
 (defun %install-node-helpers (name kind graph-name)
   "Install <NAME>-P, LOOKUP-<NAME> and MAKE-<NAME> as functions in
-NAME's own package (GH #172)."
+NAME's own package.  Skipped, with a warning naming NAME, when that
+package is COMMON-LISP or KEYWORD -- neither tolerates new symbols
+(GH #172)."
   (let ((pkg (%schema-symbol-package name)))
-    (flet ((helper (string fn)
-             (setf (fdefinition
-                    (intern (format nil string (symbol-name name)) pkg))
-                   fn)))
-      (helper "~A-P" (lambda (thing) (typep thing name)))
-      (helper "LOOKUP-~A" (%make-lookup-closure name kind))
-      (helper "MAKE-~A" (%make-constructor-closure name graph-name kind)))
+    (if (member pkg (list (find-package :common-lisp)
+                          (find-package :keyword)))
+        (warn "Skipping helper install for ~S: its package ~A is ~
+locked (GH #172)." name (package-name pkg))
+        (flet ((helper (string fn)
+                 (setf (fdefinition
+                        (intern (format nil string (symbol-name name))
+                                pkg))
+                       fn)))
+          (helper "~A-P" (lambda (thing) (typep thing name)))
+          (helper "LOOKUP-~A" (%make-lookup-closure name kind))
+          (helper "MAKE-~A"
+                  (%make-constructor-closure name graph-name kind))))
     name))
 
 (defun %register-node-type-meta (meta)
@@ -514,6 +536,31 @@ still governs UPDATE-SCHEMA's instantiation order (GH #53, #167)."
               (append metas (list meta))))
     meta))
 
+(defvar *node-type-provenance* (make-hash-table :test 'eq)
+  "TYPE-NAME -> :SOURCE/:RUNTIME, set by %INSTALL-NODE-TYPE.  Consulted by
+INSTANTIATE-NODE-TYPE, which re-asserts a manifest row under whatever
+*SYSTEM-DIRECTORY* is current every time a store (re)opens with this
+type -- a source type defined once at load time, before any store or
+system directory existed, otherwise could never appear in a manifest
+written later (GH #172, R2).")
+
+(defun %schema-manifest-type-record (meta provenance)
+  "The (:TYPE ...) manifest plist for META, tagged with PROVENANCE
+(GH #172, R2)."
+  (let* ((name (node-type-name meta))
+         (kind (node-type-parent-type meta))
+         (base (ecase kind (:vertex (find-class 'vertex))
+                          (:edge (find-class 'edge)))))
+    (list :type name :kind kind
+          :parents (mapcar #'class-name
+                           (remove base (class-direct-superclasses
+                                         (find-class name))))
+          :slots (node-type-slots meta)
+          :default-store (node-type-graph-name meta)
+          :keep-revisions (node-type-keep-revisions meta)
+          :provenance provenance
+          :time (get-universal-time))))
+
 (defun %install-node-type (meta)
   "Everything DEF-NODE-TYPE's expansion does except the DEFCLASS: warn on
 cross-store divergence, finalize the class, install the generated
@@ -530,6 +577,13 @@ named by META must already exist.  Returns META (GH #172)."
     (when (eq kind :edge)
       (%install-edge-functors name))
     (%register-node-type-meta meta)
+    (setf (gethash name *node-type-provenance*) *schema-provenance*)
+    ;; R2: the manifest describes the WHOLE schema, source and runtime
+    ;; alike -- both paths funnel through here.  A type whose default
+    ;; store is not open (or NIL, R4) still gets this one row; see
+    ;; INSTANTIATE-NODE-TYPE for the re-assertion on store open.
+    (%append-schema-manifest-record
+     (%schema-manifest-type-record meta *schema-provenance*))
     (let ((graph (lookup-graph (node-type-graph-name meta))))
       (when graph
         (instantiate-node-type meta graph)))
@@ -772,6 +826,15 @@ is the only point at which that ordering is guaranteed."
   ;; %NOTE-EDGE-OCCUPANCY only appends when the (name, store) pair is new.
   (when (eq (node-type-parent-type meta) :edge)
     (%note-edge-occupancy (node-type-name meta) (graph-name graph)))
+  ;; R2 (GH #172): a store's own graph-open re-asserts its schema rows
+  ;; into whatever *SYSTEM-DIRECTORY* is current -- the only way a type
+  ;; defined once, before any system directory existed, still shows up
+  ;; in a manifest read later.  Last-record-per-name wins on read, so
+  ;; repeated re-assertion across opens is harmless.
+  (%append-schema-manifest-record
+   (%schema-manifest-type-record
+    meta (or (gethash (node-type-name meta) *node-type-provenance*)
+            :source)))
   (with-recursive-lock-held ((schema-lock (schema graph)))
     (let ((cl (find-class (node-type-name meta) nil)))
       ;; Drop EVERY memoized CLASS-SLOTS-derived answer for this class and its

--- a/schema.lisp
+++ b/schema.lisp
@@ -396,12 +396,153 @@ STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
       (error 'default-store-not-open-error
              :class-name class-name :store store-name)))
 
-(defmacro def-node-type (name parent-types slot-specs graph-name &key keep-revisions)
+;;; R1 (GH #172): one installation path for source- and runtime-defined
+;;; types.  DEF-NODE-TYPE's expansion keeps only the literal DEFCLASS and
+;;; hands everything else to %INSTALL-NODE-TYPE, so a class built from
+;;; persisted metadata gets the identical helpers, functors, registration
+;;; and instantiation.  Spec:
+;;; docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
+
+;; Defined in prolog-functors.lisp: the functor bodies need VAR-DEREF,
+;; which is a macro there, so they cannot live in this file (GH #172).
+(declaim (ftype (function (symbol) t) %install-edge-functors))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defun %normalize-slot-specs (slot-specs)
+  "Supply a default :ACCESSOR and :INITARG for every CLOS-style spec in
+SLOT-SPECS (a bare symbol becomes a one-element list).  Returns the
+normalized specs; both DEF-NODE-TYPE and the runtime path use it so the
+two agree on slot shape (GH #172)."
+  (mapcar
+   (lambda (spec)
+     (let ((s1 (if (listp spec)
+                   (if (find :accessor spec)
+                       spec
+                       (append spec (list :accessor (first spec))))
+                   (list spec :accessor spec))))
+       (if (find :initarg s1)
+           s1
+           (append s1 (list :initarg (intern (symbol-name (first s1))
+                                             :keyword))))))
+   slot-specs))
+
+
+(defun %schema-symbol-package (name)
+  "The package NAME's generated helpers and functors are interned in.
+DEF-NODE-TYPE used to intern them in the expansion-time *PACKAGE*, which
+for source code is the package NAME itself was read into (GH #172)."
+  (or (symbol-package name) *package*))
+) ; eval-when: both are called at DEF-NODE-TYPE expansion time
+
+(defun %collect-constructor-slots (name make-args)
+  "The (:SLOT . value) alist MAKE-<NAME> hands to MAKE-VERTEX/MAKE-EDGE:
+NAME's data slots that appear in MAKE-ARGS.  Read at call time, so a
+redefined class takes effect immediately (GH #172)."
+  (remove-if
+   'null
+   (mapcar (lambda (slot-name)
+             (let* ((key (intern (symbol-name slot-name) :keyword))
+                    (pos (position key make-args)))
+               (when pos
+                 (cons key (nth (1+ pos) make-args)))))
+           (data-slots (find-class name)))))
+
+(defun %make-constructor-closure (name graph-name kind)
+  "The MAKE-<NAME> function for node type NAME of KIND in store
+GRAPH-NAME (GH #172)."
+  (if (eq kind :edge)
+      (lambda (&rest make-args
+               &key (graph nil) id deleted-p revision from to weight
+               &allow-other-keys)
+        (let ((graph (%default-store-graph name graph-name graph)))
+          (make-edge (node-type-id
+                      (%ensure-type-in-store name :edge graph))
+                     from to weight
+                     (%collect-constructor-slots name make-args)
+                     :id id :revision revision :deleted-p deleted-p
+                     :graph graph)))
+      (lambda (&rest make-args
+               &key (graph nil) id deleted-p revision
+               &allow-other-keys)
+        (let ((graph (%default-store-graph name graph-name graph)))
+          (make-vertex (node-type-id
+                        (%ensure-type-in-store name :vertex graph))
+                       (%collect-constructor-slots name make-args)
+                       :id id :revision revision :deleted-p deleted-p
+                       :graph graph)))))
+
+(defun %make-lookup-closure (name kind)
+  "The LOOKUP-<NAME> function: id -> node, skipping deleted nodes unless
+:INCLUDE-DELETED-P (GH #172)."
+  (if (eq kind :edge)
+      (lambda (id &key include-deleted-p)
+        (let ((thing (lookup-edge id)))
+          (when (and (typep thing name)
+                     (or include-deleted-p (not (deleted-p thing))))
+            thing)))
+      (lambda (id &key include-deleted-p)
+        (let ((thing (lookup-vertex id)))
+          (when (and (typep thing name)
+                     (or include-deleted-p (not (deleted-p thing))))
+            thing)))))
+
+(defun %install-node-helpers (name kind graph-name)
+  "Install <NAME>-P, LOOKUP-<NAME> and MAKE-<NAME> as functions in
+NAME's own package (GH #172)."
+  (let ((pkg (%schema-symbol-package name)))
+    (flet ((helper (string fn)
+             (setf (fdefinition
+                    (intern (format nil string (symbol-name name)) pkg))
+                   fn)))
+      (helper "~A-P" (lambda (thing) (typep thing name)))
+      (helper "LOOKUP-~A" (%make-lookup-closure name kind))
+      (helper "MAKE-~A" (%make-constructor-closure name graph-name kind)))
+    name))
+
+(defun %register-node-type-meta (meta)
+  "Put META in *SCHEMA-NODE-METADATA* under its own store, replacing any
+entry for the same class IN PLACE.  A class may be registered under more
+than one store (#186); only this store's list is touched, and position
+still governs UPDATE-SCHEMA's instantiation order (GH #53, #167)."
+  (let* ((graph-name (node-type-graph-name meta))
+         (metas (gethash graph-name *schema-node-metadata*))
+         (pos (position (node-type-name meta) metas
+                        :key #'node-type-name)))
+    (if pos
+        (setf (nth pos metas) meta)
+        (setf (gethash graph-name *schema-node-metadata*)
+              (append metas (list meta))))
+    meta))
+
+(defun %install-node-type (meta)
+  "Everything DEF-NODE-TYPE's expansion does except the DEFCLASS: warn on
+cross-store divergence, finalize the class, install the generated
+helpers and (for edges) the Prolog functors, register META, and
+instantiate it into its default store if that store is open.  The class
+named by META must already exist.  Returns META (GH #172)."
+  (let* ((name (node-type-name meta))
+         (kind (node-type-parent-type meta)))
+    (%warn-if-divergent-across-stores meta)
+    ;; FIXME: why is this necessary when inheriting from another node
+    ;; subclass?
+    (finalize-inheritance (find-class name))
+    (%install-node-helpers name kind (node-type-graph-name meta))
+    (when (eq kind :edge)
+      (%install-edge-functors name))
+    (%register-node-type-meta meta)
+    (let ((graph (lookup-graph (node-type-graph-name meta))))
+      (when graph
+        (instantiate-node-type meta graph)))
+    meta))
+
+(defmacro def-node-type (name parent-types slot-specs graph-name
+                         &key keep-revisions)
   "Define a persistent node type NAME whose default store is GRAPH-NAME.  This
 is the machinery behind DEF-VERTEX and DEF-EDGE; you normally use those
 instead.  NAME's package comes from the ambient *PACKAGE* at macroexpansion
 time, not from this form -- namespace and default store are independent axes
-(GH #167).
+(GH #167); the generated helpers and functors are interned in NAME's own
+package (GH #172).
 
 PARENT-TYPES is a single-inheritance superclass list ending in VERTEX or EDGE.
 SLOT-SPECS are CLOS-style slot definitions (a bare symbol, or (name :type ...)
@@ -417,220 +558,28 @@ places a new node in GRAPH-NAME when :GRAPH is omitted (open, or else
 DEFAULT-STORE-NOT-OPEN-ERROR); an explicit :GRAPH always overrides the
 default and adopts the type into that store lazily on first write if it is
 not already known there (GH #167, R1/R3)."
-  (with-gensyms (meta graph metas pos)
-    (let* ((constructor (intern (format nil "MAKE-~A" name)))
-           (predicate (intern (format nil "~A-P" name)))
-           (lookup-fn (intern (format nil "LOOKUP-~A" name))))
-      (setq slot-specs
-            (mapcar (lambda (spec)
-                      (let ((s1
-                             (if (listp spec)
-                                 (if (find :accessor spec)
-                                     spec
-                                     (append spec (list :accessor (first spec))))
-                                 (list spec :accessor spec))))
-                        (if (find :initarg s1)
-                            s1
-                            (append s1 (list :initarg (intern (symbol-name (first s1)) :keyword))))))
-                    slot-specs))
-      `(progn
-         ;; No cross-graph uniqueness check: type-ids are system-wide as of
-         ;; #186, so one class may be instantiated in more than one store.
-         ;; Divergent slot sets across stores warn instead (GH #196).
-         (defclass ,name (,@parent-types)
-           (,@slot-specs)
-           (:metaclass node-class))
-         (let* ((,meta
-                 (make-node-type
-                  :name ',name
-                  :parent-type
-                  ',(intern (symbol-name (last1 parent-types)) :keyword)
-                  :graph-name ',graph-name
-                  :slots ',slot-specs
-                  :package (package-name *package*)
-                  :constructor ',constructor
-                  :keep-revisions ,keep-revisions)))
-           (%warn-if-divergent-across-stores ,meta)
-           ;; FIXME: why is this necessary when inheriting from another node subclass?
-           ;;(unless (class-finalized-p (find-class ',name))
-           (finalize-inheritance (find-class ',name))
-           ;;)
-           (defun ,predicate (thing)
-             (typep thing ',name))
-           (defun ,lookup-fn (id &key include-deleted-p)
-             (let ((thing ,(if (eql (last1 parent-types) 'edge)
-                               `(lookup-edge id)
-                               `(lookup-vertex id))))
-               (when (and (typep thing ',name)
-                          (or include-deleted-p
-                              (not (deleted-p thing))))
-                 thing)))
-           ,(let ((args
-                   (if (eql (last1 parent-types) 'edge)
-                       '(&rest make-args
-                         &key (graph nil) id deleted-p revision
-                         from to weight &allow-other-keys)
-                       '(&rest make-args
-                         &key (graph nil) id deleted-p revision
-                         &allow-other-keys))))
-                 `(defun ,constructor ,args
-                    (let ((graph (%default-store-graph
-                                  ',name ',graph-name graph))
-                          (slots (remove-if
-                                  'null
-                                  (mapcar
-                                   (lambda (slot-name)
-                                     (let ((key (intern (symbol-name slot-name) :keyword)))
-                                       (let ((pos (position key make-args)))
-                                         (when pos
-                                           (cons key (nth (1+ pos) make-args))))))
-                                   (data-slots (find-class ',name))))))
-                      ,(if (eql (last1 parent-types) 'edge)
-                           `(make-edge (node-type-id
-                                        (%ensure-type-in-store ',name :edge
-                                                                graph))
-                                       from to weight
-                                       slots ;(list ,@slots)
-                                       :id id :revision revision :deleted-p deleted-p
-                                       :graph graph)
-                           `(make-vertex (node-type-id
-                                          (%ensure-type-in-store ',name :vertex
-                                                                  graph))
-                                         slots ;(list ,@slots)
-                                         :id id :revision revision :deleted-p deleted-p
-                                         :graph graph)))))
-           ,(when (eql (last1 parent-types) 'edge)
-                  (let ((functor-name (intern (format nil "~A/2" name))))
-                    `(def-global-prolog-functor ,functor-name (from to cont)
-                       (setq from (var-deref from)
-                             to (var-deref to))
-                       (when *prolog-trace*
-                         (format t "TRACE: ~A(~S ~S)~%" ',functor-name from to))
-                       (cond ((and (not (graph-db::var-p from)) (not (graph-db::var-p to)))
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v1 (lookup-vertex (from edge))))
-                                               (when (unify from v1)
-                                                 (let ((v2 (lookup-vertex (to edge))))
-                                                   (when (unify to v2)
-                                                     (funcall cont)))))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :from-vertex from
-                                         :to-vertex to
-                                         :edge-type ',name))
-                             ((not (graph-db::var-p from))
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v2 (lookup-vertex (to edge))))
-                                               (when (unify to v2)
-                                                 (funcall cont)))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :vertex from
-                                         :direction :out
-                                         :edge-type ',name))
-                             ((not (graph-db::var-p to))
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v2 (lookup-vertex (from edge))))
-                                               (when (unify from v2)
-                                                 (funcall cont)))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :vertex to
-                                         :direction :in
-                                         :edge-type ',name))
-                             (t
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v1 (lookup-vertex (from edge))))
-                                               (when (unify from v1)
-                                                 (let ((v2 (lookup-vertex (to edge))))
-                                                   (when (unify to v2)
-                                                     (funcall cont)))))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :edge-type ',name))))))
-           ,(when (eql (last1 parent-types) 'edge)
-                  (let ((functor-name (intern (format nil "~A/3" name))))
-                    `(def-global-prolog-functor ,functor-name (from to weight cont)
-                       (setq from (var-deref from)
-                             to (var-deref to)
-                             weight (var-deref weight))
-                       (when *prolog-trace*
-                         (format t "TRACE: ~A(~S ~S ~S)~%" ',functor-name from to weight))
-                       (cond ((and (not (graph-db::var-p from)) (not (graph-db::var-p to)))
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v1 (lookup-vertex (from edge))))
-                                               (when (unify from v1)
-                                                 (let ((v2 (lookup-vertex (to edge))))
-                                                   (when (unify to v2)
-                                                     (when (unify weight (weight edge))
-                                                       (funcall cont))))))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :from-vertex from
-                                         :to-vertex to
-                                         :edge-type ',name))
-                             ((not (graph-db::var-p from))
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v2 (lookup-vertex (to edge))))
-                                               (when (unify to v2)
-                                                 (when (unify weight (weight edge))
-                                                   (funcall cont))))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :vertex from
-                                         :direction :out
-                                         :edge-type ',name))
-                             ((not (graph-db::var-p to))
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v2 (lookup-vertex (from edge))))
-                                               (when (unify from v2)
-                                                 (when (unify weight (weight edge))
-                                                   (funcall cont))))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :vertex to
-                                         :direction :in
-                                         :edge-type ',name))
-                             (t
-                              (map-edges (lambda (edge)
-                                           (let ((old-trail (fill-pointer *trail*)))
-                                             (let ((v1 (lookup-vertex (from edge))))
-                                               (when (unify from v1)
-                                                 (let ((v2 (lookup-vertex (to edge))))
-                                                   (when (unify to v2)
-                                                     (when (unify weight (weight edge))
-                                                       (funcall cont))))))
-                                             (undo-bindings old-trail)))
-                                         *graph*
-                                         :edge-type ',name)))))
-                  )
-           ;; A class may be registered under more than one store (#186);
-           ;; each store keeps its own meta entry independently.  Only
-           ;; GRAPH-NAME's own list is touched here -- %FIND-REGISTERED-
-           ;; NODE-TYPE resolves ambiguity deterministically via its
-           ;; preferred-store argument (GH #167).
-           ;; Replace in place, preserving position.  The type-id reason is
-           ;; historical: ids came from this list's order until #186 moved
-           ;; assignment to the registry, which keys on the name.  Position
-           ;; still governs the order UPDATE-SCHEMA instantiates types in, so
-           ;; a moved entry reorders schema replay (GH #53).
-           (let* ((,metas (gethash ',graph-name *schema-node-metadata*))
-                  (,pos (position ',name ,metas :key #'node-type-name)))
-             (if ,pos
-                 (setf (nth ,pos ,metas) ,meta)
-                 (setf (gethash ',graph-name *schema-node-metadata*)
-                       (append ,metas (list ,meta)))))
-           (let ((,graph (lookup-graph ',graph-name)))
-             (when ,graph
-               (instantiate-node-type ,meta ,graph)))
-           )))))
+  (let ((specs (%normalize-slot-specs slot-specs))
+        (kind (intern (symbol-name (last1 parent-types)) :keyword)))
+    `(progn
+       ;; No cross-graph uniqueness check: type-ids are system-wide as of
+       ;; #186, so one class may be instantiated in more than one store.
+       ;; Divergent slot sets across stores warn instead (GH #196).
+       (defclass ,name (,@parent-types)
+         (,@specs)
+         (:metaclass node-class))
+       ;; Everything else -- helpers, edge functors, registration,
+       ;; instantiation -- is the shared path the runtime schema builder
+       ;; uses too (GH #172, R1).
+       (%install-node-type
+        (make-node-type
+         :name ',name
+         :parent-type ',kind
+         :graph-name ',graph-name
+         :slots ',specs
+         :package (package-name *package*)
+         :constructor ',(intern (format nil "MAKE-~A" (symbol-name name))
+                                (%schema-symbol-package name))
+         :keep-revisions ,keep-revisions)))))
 
 (defmacro def-vertex (name parent-types slot-specs graph-name &key keep-revisions)
   "Define a vertex (node) type NAME whose default store is GRAPH-NAME.

--- a/schema.lisp
+++ b/schema.lisp
@@ -561,6 +561,34 @@ written later (GH #172, R2).")
           :provenance provenance
           :time (get-universal-time))))
 
+;; Review round 1, I3: keyed on (NAME . *SYSTEM-DIRECTORY*), not just
+;; NAME -- tests (and any image) rebind *SYSTEM-DIRECTORY* per store, and
+;; a cache hit against a PRIOR directory must never suppress the real
+;; write to a new one (mirrors *EDGE-OCCUPANCY-LOADED-FILE*'s reasoning).
+(defvar *schema-manifest-type-cache* (make-hash-table :test 'equal)
+  "(NAME . SYSTEM-DIRECTORY) -> the last %SCHEMA-MANIFEST-TYPE-RECORD
+plist appended for NAME under that directory, WITH :TIME REMOVED (which
+always differs and so must not defeat the comparison).  Lets
+INSTANTIATE-NODE-TYPE's re-append skip a redundant write on repeated
+opens/redefinitions with an unchanged row (GH #172, review round 1,
+I3).")
+
+(defun %schema-manifest-record-sans-time (record)
+  (let ((copy (copy-list record)))
+    (remf copy :time)
+    copy))
+
+(defun %schema-manifest-append-if-changed (name record)
+  "Append RECORD unless it is EQUAL, ignoring :TIME, to the last row
+this image wrote for NAME under the current *SYSTEM-DIRECTORY* -- a
+reopen storm must not keep growing the manifest (GH #172, review round
+1, I3)."
+  (let* ((key (cons name *system-directory*))
+         (sans-time (%schema-manifest-record-sans-time record)))
+    (unless (equal sans-time (gethash key *schema-manifest-type-cache*))
+      (setf (gethash key *schema-manifest-type-cache*) sans-time)
+      (%append-schema-manifest-record record))))
+
 (defun %install-node-type (meta)
   "Everything DEF-NODE-TYPE's expansion does except the DEFCLASS: warn on
 cross-store divergence, finalize the class, install the generated
@@ -582,8 +610,8 @@ named by META must already exist.  Returns META (GH #172)."
     ;; alike -- both paths funnel through here.  A type whose default
     ;; store is not open (or NIL, R4) still gets this one row; see
     ;; INSTANTIATE-NODE-TYPE for the re-assertion on store open.
-    (%append-schema-manifest-record
-     (%schema-manifest-type-record meta *schema-provenance*))
+    (%schema-manifest-append-if-changed
+     name (%schema-manifest-type-record meta *schema-provenance*))
     (let ((graph (lookup-graph (node-type-graph-name meta))))
       (when graph
         (instantiate-node-type meta graph)))
@@ -829,12 +857,24 @@ is the only point at which that ordering is guaranteed."
   ;; R2 (GH #172): a store's own graph-open re-asserts its schema rows
   ;; into whatever *SYSTEM-DIRECTORY* is current -- the only way a type
   ;; defined once, before any system directory existed, still shows up
-  ;; in a manifest read later.  Last-record-per-name wins on read, so
-  ;; repeated re-assertion across opens is harmless.
-  (%append-schema-manifest-record
-   (%schema-manifest-type-record
-    meta (or (gethash (node-type-name meta) *node-type-provenance*)
-            :source)))
+  ;; in a manifest read later.  Sourced from the REGISTERED meta for
+  ;; META's own declared store, not META itself: a #186 cross-store
+  ;; adoption or a stale on-disk read can hand this method a META that
+  ;; was never %REGISTER-NODE-TYPE-META'd under its claimed store, and
+  ;; that stray must never overwrite the canonical row a #196-divergent
+  ;; variant elsewhere would otherwise clobber it with (review round 1,
+  ;; I3).  %SCHEMA-MANIFEST-APPEND-IF-CHANGED then skips the write
+  ;; entirely when it would be a no-op, so a reopen storm does not keep
+  ;; growing the manifest.
+  (let* ((name (node-type-name meta))
+         (registered (or (%find-registered-node-type
+                          name (node-type-parent-type meta)
+                          (node-type-graph-name meta))
+                         meta)))
+    (%schema-manifest-append-if-changed
+     name
+     (%schema-manifest-type-record
+      registered (or (gethash name *node-type-provenance*) :source))))
   (with-recursive-lock-held ((schema-lock (schema graph)))
     (let ((cl (find-class (node-type-name meta) nil)))
       ;; Drop EVERY memoized CLASS-SLOTS-derived answer for this class and its

--- a/tests/keyword-alias-tests.lisp
+++ b/tests/keyword-alias-tests.lisp
@@ -16,9 +16,11 @@
   (:export #:alias-species))
 
 ;;; Both ALIAS-SPECIES types land in ONE store's schema -- that is the
-;;; collision.  The generated MAKE-/LOOKUP-/-P helpers intern in THIS
-;;; package, so the second definition redefines the first's helpers; the
-;;; tests below use only LOOKUP-NODE-TYPE-BY-NAME, never those helpers.
+;;; collision, and it is a schema-name collision only.  The generated
+;;; MAKE-/LOOKUP-/-P helpers intern in the CLASS SYMBOL's own package
+;;; (GH #172), so each ALIAS-SPECIES keeps its own helpers and neither
+;;; definition clobbers the other's.  The ambiguity surface these tests
+;;; exercise is LOOKUP-NODE-TYPE-BY-NAME; they never call the helpers.
 (def-vertex graph-db-alias-pkg-a:alias-species () ((label :type string))
   :alias-two-store)
 (def-vertex graph-db-alias-pkg-b:alias-species () ((label :type string))

--- a/tests/package-namespace-tests.lisp
+++ b/tests/package-namespace-tests.lisp
@@ -21,8 +21,8 @@
 (def-vertex pn-dual () () :pn-store-b)
 
 ;; Two scratch packages, same symbol-name TWIN, both declared into
-;; store A -- DEF-VERTEX interns MAKE-<NAME>/<NAME>-P in *PACKAGE* at
-;; expansion time, so each package gets its own MAKE-TWIN (GH #167).
+;; store A -- DEF-VERTEX interns MAKE-<NAME>/<NAME>-P in the class
+;; symbol's own package, so each gets its own MAKE-TWIN (GH #167, #172).
 (defpackage #:pn-pkg-one (:use #:cl #:graph-db))
 (defpackage #:pn-pkg-two (:use #:cl #:graph-db))
 (in-package #:pn-pkg-one)

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -264,3 +264,245 @@ poison the cache into skipping it for the rest of the session
         (let ((row (find name types :key (lambda (r) (getf r :type)))))
           (is-true row)
           (is (= 2 (length (getf row :slots)))))))))
+
+;;; ---------------------------------------------------------------------
+;;; Task 3 (R3+R5): MATERIALIZE-SCHEMA, the schema-function registry and
+;;; the :CHECK slot option.
+;;; ---------------------------------------------------------------------
+
+(defun %rs-wipe-runtime-state (&optional graph)
+  "Simulate a fresh image for the RS-TLM namespace: unintern the
+classes, delete the package, drop the metas, and empty GRAPH's node
+cache -- a fresh image has no cached instances either, and a cache hit
+would serve the pre-wipe object of the old class.  A real restart is a
+different process; this is the closest single-image ablation and it
+proves materialize rebuilds everything it needs."
+  (when graph (clrhash (graph-db::cache graph)))
+  (let ((pkg (find-package :rs-tlm)))
+    (when pkg
+      (do-symbols (s pkg)
+        (when (find-class s nil) (setf (find-class s) nil)))
+      (delete-package pkg)))
+  (%rs-drop-orphaned-metas))
+
+(defun %rs-drop-orphaned-metas ()
+  "Drop every registered meta whose class symbol lost its home package
+-- DELETE-PACKAGE uninterns them, and a later UPDATE-SCHEMA would then
+FIND-CLASS a symbol nothing can name."
+  (maphash (lambda (store metas)
+             (setf (gethash store graph-db::*schema-node-metadata*)
+                   (remove-if (lambda (m)
+                                (null (symbol-package
+                                       (graph-db::node-type-name m))))
+                              metas)))
+           graph-db::*schema-node-metadata*))
+
+(test materialize-rebuilds-a-runtime-type-in-a-fresh-image
+  "THE acceptance test: create at runtime, write, wipe the in-image
+state, materialize from the manifest, and both the CLASS and the DATA
+come back -- and a method compiles against the class."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (let (id)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq id (graph-db:id (funcall (intern "MAKE-READING" :rs-tlm)
+                                       :value 3.5d0))))
+      (%rs-wipe-runtime-state g)
+      (is (null (find-package :rs-tlm)))
+      (let ((summary (graph-db:materialize-schema
+                      graph-db::*system-directory*)))
+        (is (plusp (getf summary :materialized))))
+      (let* ((sym (intern "READING" :rs-tlm))
+             (class (find-class sym nil)))
+        (is-true class)
+        ;; A method compiles against the materialized class -- the
+        ;; twenty-year problem, pinned.
+        (let ((m (compile nil `(lambda (r)
+                                 (declare (type ,sym r))
+                                 (funcall ',(intern "VALUE" :rs-tlm)
+                                          r)))))
+          (is (= 3.5d0 (funcall m (graph-db:lookup-vertex
+                                   id :graph g)))))))))
+
+(test materialize-skips-source-defined-classes
+  "Source wins: RS-STATIC is defined by def-vertex in this image; its
+manifest row must be skipped, not rebuilt, and the summary says so."
+  (with-rs-store (g)
+    g
+    (let ((summary (graph-db:materialize-schema
+                    graph-db::*system-directory*)))
+      (is (plusp (getf summary :skipped-source)))
+      (is (typep (make-instance 'rs-static) 'rs-static)))))
+
+(test materialize-warns-when-a-skipped-class-diverges
+  "Source wins, but not silently: a manifest row whose slots disagree
+with the live class must reach the user as the #196 divergence warning
+(GH #172, R3)."
+  (with-rs-store (g)
+    g
+    ;; Rewrite RS-STATIC's row with a slot set the live class lacks.
+    (with-open-file (s (graph-db::%schema-manifest-file)
+                       :direction :output :if-exists :append)
+      (let ((*package* (find-package "COMMON-LISP"))
+            (*print-pretty* nil))
+        (format s "~S~%"
+                (list :type 'rs-static :kind :vertex :parents nil
+                      :slots '((not-a-real-slot :accessor
+                                not-a-real-slot :initarg
+                                :not-a-real-slot))
+                      :default-store :rs-store :keep-revisions nil
+                      :provenance :source :time 0))))
+    (let ((warned nil))
+      (handler-bind ((graph-db:divergent-node-type-redefinition
+                       (lambda (c) (setq warned t) (muffle-warning c))))
+        (graph-db:materialize-schema graph-db::*system-directory*))
+      (is-true warned))))
+
+(test materialize-fails-fast-on-an-unresolved-check-function
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:register-schema-function 'rs-plausible-p
+                                       (lambda (v) (< 0 v 100)))
+    (graph-db:create-vertex-type
+     "RS-TLM:CAL" '((value :type double-float :check rs-plausible-p))
+     :default-store :rs-store)
+    (%rs-wipe-runtime-state)
+    ;; Fresh image forgot to register the function:
+    (graph-db::%unregister-schema-function 'rs-plausible-p)
+    (let ((c (handler-case
+                 (progn (graph-db:materialize-schema
+                         graph-db::*system-directory*)
+                        nil)
+               (graph-db:materialize-unresolved-functions (e) e))))
+      (is-true c)
+      (when c
+        (is (member 'rs-plausible-p
+                    (graph-db:unresolved-function-names c))))
+      ;; Fail fast: nothing half-built.
+      (is (null (find-class (and (find-package :rs-tlm)
+                                 (intern "CAL" :rs-tlm))
+                            nil))))))
+
+(test materialize-orders-parents-before-children
+  "A child row that precedes its parent in the manifest still builds:
+the topological pass, not append order, decides (GH #172, R3)."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:BASE" '((a :type string))
+                                 :default-store :rs-store)
+    (graph-db:create-vertex-type "RS-TLM:DERIVED" '((b :type string))
+                                 :parents (list (intern "BASE" :rs-tlm))
+                                 :default-store :rs-store)
+    ;; Re-append BASE's row so it is now LAST: read order would then
+    ;; try DERIVED first.
+    (graph-db:create-vertex-type "RS-TLM:BASE" '((a :type string)
+                                                 (a2 :type string))
+                                 :default-store :rs-store)
+    (%rs-wipe-runtime-state)
+    (graph-db:materialize-schema graph-db::*system-directory*)
+    (let ((derived (find-class (intern "DERIVED" :rs-tlm) nil)))
+      (is-true derived)
+      (is-true (subtypep (intern "DERIVED" :rs-tlm)
+                         (intern "BASE" :rs-tlm))))))
+
+(test materialize-invents-a-package-for-an-orphan-type-row
+  "A hand-trimmed manifest whose type row names a package with no
+namespace record must still materialize -- warn, create the package,
+build the class (GH #172, R3)."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-ORPHAN")
+    (graph-db:create-vertex-type "RS-ORPHAN:THING" '((a :type string))
+                                 :default-store :rs-store)
+    ;; Drop the namespace row, keep the type row.
+    (let* ((file (graph-db::%schema-manifest-file))
+           (lines (with-open-file (s file)
+                    (loop for l = (read-line s nil :eof)
+                          until (eq l :eof) collect l))))
+      (with-open-file (s file :direction :output :if-exists :supersede)
+        (dolist (l lines)
+          (unless (search "RS-ORPHAN\"" l) (write-line l s)))))
+    (let ((pkg (find-package :rs-orphan)))
+      (when pkg
+        (do-symbols (s pkg) (when (find-class s nil)
+                              (setf (find-class s) nil)))
+        (delete-package pkg)))
+    (%rs-drop-orphaned-metas)
+    (handler-bind ((warning #'muffle-warning))
+      (graph-db:materialize-schema graph-db::*system-directory*))
+    (is-true (find-package :rs-orphan))
+    (is-true (find-class (intern "THING" :rs-orphan) nil))))
+
+(test schema-function-registry-round-trips
+  (graph-db:register-schema-function 'rs-registry-probe #'evenp)
+  (is (eq #'evenp (graph-db:find-schema-function 'rs-registry-probe)))
+  (graph-db::%unregister-schema-function 'rs-registry-probe)
+  (is (null (graph-db:find-schema-function 'rs-registry-probe))))
+
+(test create-vertex-type-refuses-an-unregistered-check-function
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db::%unregister-schema-function 'rs-never-registered-p)
+    (signals graph-db:schema-function-unresolved
+      (graph-db:create-vertex-type
+       "RS-TLM:NOFN"
+       '((value :type double-float :check rs-never-registered-p))
+       :default-store :rs-store))))
+
+(test check-constraint-enforces-at-commit
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:register-schema-function 'rs-plausible-p
+                                       (lambda (v) (< 0 v 100)))
+    (graph-db:create-vertex-type
+     "RS-TLM:CAL" '((value :type double-float :check rs-plausible-p))
+     :default-store :rs-store)
+    (with-transaction ((graph-db::transaction-manager g))
+      (funcall (intern "MAKE-CAL" :rs-tlm) :value 50d0))
+    (signals graph-db:value-constraint-violation
+      (with-transaction ((graph-db::transaction-manager g))
+        (funcall (intern "MAKE-CAL" :rs-tlm) :value 5000d0)))))
+
+(test check-constraint-is-null-exempt-and-inherited
+  "NULL is exempt (the :ONE-OF rule), and a :CHECK on a parent slot is
+enforced on a subclass (GH #172, R5)."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:register-schema-function 'rs-plausible-p
+                                       (lambda (v) (< 0 v 100)))
+    (graph-db:create-vertex-type
+     "RS-TLM:CBASE" '((value :type double-float :check rs-plausible-p))
+     :default-store :rs-store)
+    (graph-db:create-vertex-type "RS-TLM:CSUB" '((tag :type string))
+                                 :parents (list (intern "CBASE" :rs-tlm))
+                                 :default-store :rs-store)
+    ;; NIL passes.
+    (with-transaction ((graph-db::transaction-manager g))
+      (funcall (intern "MAKE-CSUB" :rs-tlm) :tag "t"))
+    (signals graph-db:value-constraint-violation
+      (with-transaction ((graph-db::transaction-manager g))
+        (funcall (intern "MAKE-CSUB" :rs-tlm) :tag "t" :value 5000d0)))))
+
+;;; The image provides the behaviour its schema names -- at load time,
+;;; before any manifest row referencing it is materialized (GH #172).
+(graph-db:register-schema-function 'rs-source-plausible-p
+                                   (lambda (v) (< 0 v 100)))
+
+(def-vertex rs-checked () ((value :type double-float
+                                  :check rs-source-plausible-p))
+  :rs-store)
+
+(test def-vertex-accepts-and-enforces-check
+  "Parity: :CHECK is a slot option DEF-VERTEX takes too (GH #172, R5)."
+  (with-rs-store (g)
+    (with-transaction ((graph-db::transaction-manager g))
+      (make-rs-checked :value 10d0))
+    (signals graph-db:value-constraint-violation
+      (with-transaction ((graph-db::transaction-manager g))
+        (make-rs-checked :value 900d0)))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -49,3 +49,80 @@ The full suite is the broad net; this is the focused canary."
       (is-true (fboundp (intern "RS-KNOWS/2" :graph-db/test)))
       (let ((hits (select (:flat nil) (?x ?y) (rs-knows ?x ?y))))
         (is (= 1 (length hits)))))))
+
+(test ensure-namespace-is-cheap-and-idempotent
+  (with-rs-store (g)
+    g
+    (let ((p1 (graph-db:ensure-namespace "RS-TLM" :nicknames '("RST")))
+          (p2 (graph-db:ensure-namespace "RS-TLM")))
+      (is (eq p1 p2))
+      (is (packagep p1))
+      ;; No files, no store: the store registry did not grow.
+      (is (null (graph-db:lookup-graph :rs-tlm))))))
+
+(test create-vertex-type-yields-a-working-class
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (let ((class (graph-db:create-vertex-type
+                  "RS-TLM:READING"
+                  '((sensor-id :type string)
+                    (value :type double-float))
+                  :default-store :rs-store)))
+      (is (typep class 'graph-db::node-class))
+      (with-transaction ((graph-db::transaction-manager g))
+        (funcall (intern "MAKE-READING" :rs-tlm)
+                 :sensor-id "s1" :value 1.5d0))
+      (let* ((sym (intern "READING" :rs-tlm))
+             (hits (graph-db:map-vertices #'identity g :collect-p t
+                                          :vertex-type sym)))
+        (is (= 1 (length hits)))
+        (is (string= "s1"
+                     (funcall (intern "SENSOR-ID" :rs-tlm)
+                              (first hits))))))))
+
+(test create-edge-type-installs-functors-and-places-by-default
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (graph-db:create-edge-type "RS-TLM:FEEDS" '()
+                               :default-store :rs-store)
+    (let (a b)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq a (funcall (intern "MAKE-READING" :rs-tlm) :value 1d0)
+              b (funcall (intern "MAKE-READING" :rs-tlm) :value 2d0))
+        (funcall (intern "MAKE-FEEDS" :rs-tlm)
+                 :from (graph-db:id a) :to (graph-db:id b)))
+      (is-true (gethash (intern "FEEDS/2" :rs-tlm)
+                        graph-db::*prolog-global-functors*)))))
+
+(test manifest-records-both-provenances-and-tolerates-damage
+  (with-rs-store (g)
+    g  ; RS-STATIC/RS-KNOWS registered at load time = :source rows
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (multiple-value-bind (ns types)
+        (graph-db::read-schema-manifest graph-db::*system-directory*)
+      (is (find "RS-TLM" ns :key (lambda (r) (getf r :namespace))
+                :test #'string-equal))
+      (let ((row (find (intern "READING" :rs-tlm) types
+                       :key (lambda (r) (getf r :type)))))
+        (is-true row)
+        (is (eq :runtime (getf row :provenance)))
+        (is (eq :rs-store (getf row :default-store))))
+      (is (eq :source
+              (getf (find 'rs-static types
+                          :key (lambda (r) (getf r :type)))
+                    :provenance))))
+    ;; Torn tail: append garbage, read again, intact rows survive.
+    (with-open-file (s (graph-db::%schema-manifest-file)
+                       :direction :output :if-exists :append)
+      (format s "(:type RS-TORN"))
+    (multiple-value-bind (ns types)
+        (graph-db::read-schema-manifest graph-db::*system-directory*)
+      ns
+      (is (find (intern "READING" :rs-tlm) types
+                :key (lambda (r) (getf r :type)))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -224,3 +224,43 @@ round 1)."
            (graph-db::%find-registered-node-type name :vertex :rs-store)
            g)
           (is (= c1 (row-count))))))))
+
+(test manifest-append-retries-after-a-transient-write-failure
+  "Review round 2: %SCHEMA-MANIFEST-APPEND-IF-CHANGED must not cache a
+row as written before the write's outcome is known.  Swap
+%SCHEMA-MANIFEST-FILE to an unwritable location for one instantiate
+(the append degrades to in-image-only), restore it, and instantiate
+again with the same, already-current, changed slots: the manifest must
+gain the row on this retry -- proving the earlier failure did not
+poison the cache into skipping it for the rest of the session
+(GH #172, review round 2)."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:RETRYROW" '((x :type string))
+                                 :default-store :rs-store)
+    (let ((name (intern "RETRYROW" :rs-tlm))
+          (orig (fdefinition 'graph-db::%schema-manifest-file)))
+      (unwind-protect
+          (progn
+            (setf (fdefinition 'graph-db::%schema-manifest-file)
+                  (lambda ()
+                    (merge-pathnames
+                     "schema-manifest.dat"
+                     #P"/nonexistent-172-review-round-2/")))
+            ;; The class/meta still change here -- only the manifest
+            ;; write itself fails.
+            (graph-db:create-vertex-type "RS-TLM:RETRYROW"
+                                         '((x :type string)
+                                           (y :type string))
+                                         :default-store :rs-store))
+        (setf (fdefinition 'graph-db::%schema-manifest-file) orig))
+      ;; The retry: same current (2-slot) meta, real location restored.
+      (graph-db::instantiate-node-type
+       (graph-db::%find-registered-node-type name :vertex :rs-store)
+       g)
+      (multiple-value-bind (ns types)
+          (graph-db::read-schema-manifest graph-db::*system-directory*)
+        ns
+        (let ((row (find name types :key (lambda (r) (getf r :type)))))
+          (is-true row)
+          (is (= 2 (length (getf row :slots)))))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -703,3 +703,33 @@ docstring's claimed limit."
         (loop for line = (read-line s nil :eof)
               until (eq line :eof)
               do (is (<= (length line) 80)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Task 4, fix round 2 (review): uninterned symbol never signals.
+;;; ---------------------------------------------------------------------
+
+(test export-schema-source-warns-on-uninterned-symbol
+  "Fix round 2: %SCHEMA-QUALIFIED-SYMBOL cannot name a symbol with no
+home package -- an UNINTERNED symbol, unreachable through the ordinary
+CREATE-*-TYPE/DEF-VERTEX APIs, but EXPORT-SCHEMA-SOURCE's read-only,
+never-signal contract must hold regardless.  Constructs the hazard
+directly (%WRITE-SCHEMA-DEF-FORM, not the public API, since no public
+path can produce an uninterned slot symbol) and asserts a WARNING, not
+an ERROR, plus still-bare, still-loadable output text."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (let* ((orphan (make-symbol "ORPHAN"))
+           (entry (list :name (intern "GHOST" :rs-tlm) :kind :vertex
+                       :default-store :rs-store
+                       :slots (list (list orphan :accessor orphan
+                                         :initarg :orphan))
+                       :parents nil :keep-revisions nil))
+          (warned nil))
+      (let ((text
+              (handler-bind
+                  ((warning (lambda (c) (setq warned t) (muffle-warning c))))
+                (with-output-to-string (s)
+                  (graph-db::%write-schema-def-form entry "RS-TLM" s)))))
+        (is-true warned)
+        (is (search "orphan" text))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -270,23 +270,28 @@ poison the cache into skipping it for the rest of the session
 ;;; the :CHECK slot option.
 ;;; ---------------------------------------------------------------------
 
-(defun %rs-wipe-runtime-state (&optional graph)
-  "Simulate a fresh image for the RS-TLM namespace: unintern the
+(defun %rs-wipe-runtime-state (&optional graph (namespace :rs-tlm))
+  "Simulate a fresh image for NAMESPACE (default RS-TLM): unintern the
 classes, delete the package, drop the metas, and empty GRAPH's node
 cache -- a fresh image has no cached instances either, and a cache hit
 would serve the pre-wipe object of the old class.  A real restart is a
 different process; this is the closest single-image ablation and it
-proves materialize rebuilds everything it needs."
+proves materialize rebuilds everything it needs.  NAMESPACE lets a
+test that needs its OWN package (rather than sharing the suite's
+RS-TLM, whose :USE list a prior EXPORT-SCHEMA-SOURCE round trip may
+have already widened to CL/GRAPH-DB) start from a genuinely fresh
+:USE NIL package (GH #172, review round 3, M-2)."
   (when graph (clrhash (graph-db::cache graph)))
-  (let ((pkg (find-package :rs-tlm)))
+  (let ((pkg (find-package namespace)))
     (when pkg
-      ;; DO-SYMBOLS walks INHERITED symbols too -- harmless while RS-TLM
-      ;; is :USE NIL (ENSURE-NAMESPACE's own shape), but EXPORT-SCHEMA-
-      ;; SOURCE's generated DEFPACKAGE legitimately :USEs CL/GRAPH-DB
-      ;; (GH #172, R6), and after that LOAD this loop would otherwise
-      ;; walk COMMON-LISP's own external symbols and try to NIL out a
-      ;; locked class like BUILT-IN-CLASS.  EQ-check the home package so
-      ;; only symbols RS-TLM itself owns are touched (review round 1).
+      ;; DO-SYMBOLS walks INHERITED symbols too -- harmless while the
+      ;; package is :USE NIL (ENSURE-NAMESPACE's own shape), but EXPORT-
+      ;; SCHEMA-SOURCE's generated DEFPACKAGE legitimately :USEs
+      ;; CL/GRAPH-DB (GH #172, R6), and after that LOAD this loop would
+      ;; otherwise walk COMMON-LISP's own external symbols and try to
+      ;; NIL out a locked class like BUILT-IN-CLASS.  EQ-check the home
+      ;; package so only symbols the package itself owns are touched
+      ;; (review round 1).
       (do-symbols (s pkg)
         (when (and (eq (symbol-package s) pkg) (find-class s nil))
           (setf (find-class s) nil)))
@@ -733,3 +738,119 @@ an ERROR, plus still-bare, still-loadable output text."
                   (graph-db::%write-schema-def-form entry "RS-TLM" s)))))
         (is-true warned)
         (is (search "orphan" text))))))
+
+;;; ---------------------------------------------------------------------
+;;; Final whole-branch review, round 3: I-1, M-1, M-2, M-6, M-7.
+;;; ---------------------------------------------------------------------
+
+(test manifest-row-count-does-not-grow-after-cache-wipe
+  "I-1: the dedup cache is per-IMAGE, so a fresh image's first call for
+a name always misses it.  Without seeding the cache from the file on a
+miss, INSTANTIATE-NODE-TYPE would re-append every type row with a
+fresh :TIME on every boot forever, and DESCRIBE-SCHEMA :SINCE would
+list the whole schema after any reopen.  Clearing the cache (not
+restarting SBCL) is the closest single-image simulation of that first
+boot (GH #172, review round 3)."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:WIPEROW" '((c :type string))
+                                 :default-store :rs-store)
+    (let ((name (intern "WIPEROW" :rs-tlm)))
+      (flet ((row-count ()
+               (with-open-file (s (graph-db::%schema-manifest-file))
+                 (loop for line = (read-line s nil :eof)
+                       until (eq line :eof)
+                       count (let ((rec (graph-db::%parse-schema-manifest-line
+                                        line)))
+                               (and rec (eq (getf rec :type) name))))))
+             (row-time ()
+               (getf (find name
+                          (nth-value 1
+                           (graph-db::read-schema-manifest
+                            graph-db::*system-directory*))
+                          :key (lambda (r) (getf r :type)))
+                    :time)))
+        (let ((c1 (row-count)) (time1 (row-time)))
+          (graph-db::%clear-schema-manifest-cache)
+          (graph-db::instantiate-node-type
+           (graph-db::%find-registered-node-type name :vertex :rs-store)
+           g)
+          (is (= c1 (row-count)))
+          (is (= time1 (row-time))))))))
+
+(test create-vertex-type-refuses-locked-package-symbol
+  "M-1: the SYMBOL-argument path (a bare CL-homed symbol, no
+\"PACKAGE:NAME\" string) must hit GRAPH-DB's own refusal BEFORE
+%RETARGET-SLOT-SPECS interns a slot name into that locked package and
+hits SBCL's raw package-lock error instead (GH #172, review round 3)."
+  (with-rs-store (g)
+    g
+    (let ((c (handler-case
+                 (progn (graph-db:create-vertex-type
+                         'cl:type '((probe :type string))
+                         :default-store :rs-store)
+                        nil)
+               (error (e) e))))
+      (is-true c "a CL-homed symbol name should have signaled")
+      (when c
+        (is (search "ENSURE-NAMESPACE" (format nil "~A" c))
+            "should name ENSURE-NAMESPACE: ~A" c)))))
+
+(test export-schema-source-qualifies-a-cl-shadowed-slot-name
+  "M-2: a slot literally named TYPE is homed in the exported namespace,
+but \"type\" is also an external COMMON-LISP symbol the generated
+file's (:use #:cl #:graph-db) pulls in.  Neither printing it bare NOR
+package-qualified (NS::TYPE) is enough on its own: INTERN -- what both
+reduce to -- returns the INHERITED CL:TYPE whenever the name is merely
+accessible via :USE, so the generated DEFPACKAGE must also :SHADOW it;
+without that, the class-defining form hits SBCL's COMMON-LISP package
+lock outright (the file never even loads, let alone silently drifting
+identity).  A dedicated namespace, wiped first: a prior round trip in
+this suite (e.g. EXPORT-SCHEMA-SOURCE-ROUND-TRIPS) may have already
+left RS-TLM itself :USEing CL/GRAPH-DB, which would make ORDINARY
+CREATE-VERTEX-TYPE calls on RS-TLM hit this same collision (GH #172,
+review round 3)."
+  (with-rs-store (g)
+    (%rs-wipe-runtime-state nil :rs-shadow)
+    (graph-db:ensure-namespace "RS-SHADOW")
+    (graph-db:create-vertex-type "RS-SHADOW:SHADOWED" '((type :type string))
+                                 :default-store :rs-store)
+    (let ((path (merge-pathnames
+                 "exported-shadow-schema.lisp"
+                 (uiop:ensure-directory-pathname
+                  graph-db::*system-directory*))))
+      (graph-db:export-schema-source path :namespace :rs-shadow)
+      (%rs-wipe-runtime-state nil :rs-shadow)
+      (load path)
+      (let (node)
+        (with-transaction ((graph-db::transaction-manager g))
+          (setq node (funcall (intern "MAKE-SHADOWED" :rs-shadow)
+                              :type "widget")))
+        (is (string= "widget"
+                     (funcall (intern "TYPE" :rs-shadow) node)))))))
+
+(test schema-since-parses-yyyy-mm-dd-at-utc
+  "M-6: \"YYYY-MM-DD\" must parse at UTC (timezone 0), matching
+%SCHEMA-ISO-DATE's own UTC decode of each row's :TIME -- pinned against
+an explicit-timezone ENCODE-UNIVERSAL-TIME so the assertion holds
+regardless of the host's own local zone (GH #172, review round 3)."
+  (is (= (encode-universal-time 0 0 0 24 8 2026 0)
+         (graph-db::%schema-since-universal-time "2026-08-24"))))
+
+(test ensure-namespace-refuses-locked-package-names
+  "M-7: naming COMMON-LISP or KEYWORD (directly, or via the CL
+nickname) must hit GRAPH-DB's own refusal -- CREATE-VERTEX-TYPE already
+gets this via %REFUSED-SCHEMA-PACKAGE-P/%REFUSE-SCHEMA-PACKAGE; without
+it here, :NICKNAMES on either would reach RENAME-PACKAGE and signal
+SBCL's raw package-lock error instead (GH #172, review round 3)."
+  (with-rs-store (g)
+    g
+    (dolist (bad '("COMMON-LISP" "KEYWORD" "CL"))
+      (let ((c (handler-case
+                   (progn (graph-db:ensure-namespace bad :nicknames '("X"))
+                          nil)
+                 (error (e) e))))
+        (is-true c "~A should have signaled" bad)
+        (when c
+          (is (search "ENSURE-NAMESPACE" (format nil "~A" c))
+              "~A's condition should name ENSURE-NAMESPACE: ~A" bad c))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -286,14 +286,16 @@ proves materialize rebuilds everything it needs."
   (%rs-drop-orphaned-metas))
 
 (defun %rs-drop-orphaned-metas ()
-  "Drop every registered meta whose class symbol lost its home package
--- DELETE-PACKAGE uninterns them, and a later UPDATE-SCHEMA would then
-FIND-CLASS a symbol nothing can name."
+  "Drop every registered meta whose class this ablation removed -- the
+symbol lost its home package (DELETE-PACKAGE uninterns it) or lost its
+class.  A later UPDATE-SCHEMA would otherwise FIND-CLASS something that
+no longer exists."
   (maphash (lambda (store metas)
              (setf (gethash store graph-db::*schema-node-metadata*)
                    (remove-if (lambda (m)
-                                (null (symbol-package
-                                       (graph-db::node-type-name m))))
+                                (let ((n (graph-db::node-type-name m)))
+                                  (or (null (symbol-package n))
+                                      (null (find-class n nil)))))
                               metas)))
            graph-db::*schema-node-metadata*))
 
@@ -334,7 +336,7 @@ manifest row must be skipped, not rebuilt, and the summary says so."
     g
     (let ((summary (graph-db:materialize-schema
                     graph-db::*system-directory*)))
-      (is (plusp (getf summary :skipped-source)))
+      (is (plusp (getf summary :skipped-existing)))
       (is (typep (make-instance 'rs-static) 'rs-static)))))
 
 (test materialize-warns-when-a-skipped-class-diverges
@@ -506,3 +508,88 @@ enforced on a subclass (GH #172, R5)."
     (signals graph-db:value-constraint-violation
       (with-transaction ((graph-db::transaction-manager g))
         (make-rs-checked :value 900d0)))))
+
+;;; ---------------------------------------------------------------------
+;;; Fix round 1 (review of task 3): I-2, M-1.
+;;; ---------------------------------------------------------------------
+
+(test materialize-fails-fast-on-a-parent-outside-the-build-set
+  "I-2: a build set that excludes a parent must abort the whole call --
+ENSURE-CLASS would otherwise leave a FORWARD-REFERENCED-CLASS stub for
+it, which every later materialization would skip as \"already
+defined\", poisoning the image until restart.  So: fail fast, build
+nothing, and let a second call over the whole manifest succeed."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-BASE-NS")
+    (graph-db:ensure-namespace "RS-KID-NS")
+    (graph-db:create-vertex-type "RS-BASE-NS:PARENT" '((a :type string))
+                                 :default-store :rs-store)
+    (graph-db:create-vertex-type
+     "RS-KID-NS:CHILD" '((b :type string))
+     :parents (list (intern "PARENT" :rs-base-ns))
+     :default-store :rs-store)
+    ;; Fresh image for the classes; RS-BASE-NS the PACKAGE survives (a
+    ;; source DEFPACKAGE would have created it), so the CHILD row still
+    ;; READS -- its parent simply has no class and no selected row.
+    (dolist (name '(:rs-kid-ns :rs-base-ns))
+      (let ((pkg (find-package name)))
+        (when pkg
+          (do-symbols (sym pkg) (when (find-class sym nil)
+                                  (setf (find-class sym) nil))))))
+    (let ((pkg (find-package :rs-kid-ns)))
+      (when pkg (delete-package pkg)))
+    (%rs-drop-orphaned-metas)
+    (signals graph-db:materialize-unresolved-parents
+      (graph-db:materialize-schema graph-db::*system-directory*
+                                   :namespaces '("RS-KID-NS")))
+    ;; Nothing built, and no stub left behind for PARENT.
+    (is (null (find-class (intern "CHILD" :rs-kid-ns) nil)))
+    (is (null (find-class (intern "PARENT" :rs-base-ns) nil)))
+    ;; Not poisoned: the call over the whole manifest succeeds.
+    (graph-db:materialize-schema graph-db::*system-directory*)
+    (is-true (find-class (intern "PARENT" :rs-base-ns) nil))
+    (is-true (find-class (intern "CHILD" :rs-kid-ns) nil))
+    (is-true (subtypep (intern "CHILD" :rs-kid-ns)
+                       (intern "PARENT" :rs-base-ns)))))
+
+(test a-forward-referenced-class-does-not-count-as-existing
+  "I-2 pin: the skip test is %MATERIALIZED-CLASS-PRESENT-P, not
+FIND-CLASS -- a stub must be rebuilt, not mistaken for source."
+  ;; Portable way to get one: name an undefined superclass.  The MOP
+  ;; leaves a stub for RS-FWD-ABSENT, and FIND-CLASS answers it.
+  (let ((sym (intern "RS-FWD-ABSENT" :graph-db/test)))
+    (unwind-protect
+         (progn
+           (eval `(defclass ,(intern "RS-FWD-CHILD" :graph-db/test)
+                      (,sym) ()))
+           (is-true (find-class sym nil))
+           (is (null (graph-db::%materialized-class-present-p sym))))
+      (setf (find-class (intern "RS-FWD-CHILD" :graph-db/test)) nil)
+      (setf (find-class sym) nil))))
+
+(test materialize-does-not-grow-the-manifest-per-restart
+  "M-1: the rows materialize installs came OUT of the manifest, so a
+second boot must not append an identical row (with a fresh :TIME) for
+every type it rebuilds."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:BOOTROW" '((x :type string))
+                                 :default-store :rs-store)
+    (let ((name (intern "BOOTROW" :rs-tlm)))
+      (flet ((row-count (sym)
+               (with-open-file (s (graph-db::%schema-manifest-file))
+                 (loop for line = (read-line s nil :eof)
+                       until (eq line :eof)
+                       count (let ((rec
+                                     (graph-db::%parse-schema-manifest-line
+                                      line)))
+                               (and rec (eq (getf rec :type) sym)))))))
+        (let ((before (row-count name)))
+          (is (plusp before))
+          (%rs-wipe-runtime-state g)
+          (graph-db:materialize-schema graph-db::*system-directory*)
+          (is (= before (row-count (intern "BOOTROW" :rs-tlm))))
+          (%rs-wipe-runtime-state g)
+          (graph-db:materialize-schema graph-db::*system-directory*)
+          (is (= before (row-count (intern "BOOTROW" :rs-tlm)))))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -593,3 +593,48 @@ every type it rebuilds."
           (%rs-wipe-runtime-state g)
           (graph-db:materialize-schema graph-db::*system-directory*)
           (is (= before (row-count (intern "BOOTROW" :rs-tlm)))))))))
+
+;;; ---------------------------------------------------------------------
+;;; Task 4 (R6): DESCRIBE-SCHEMA / EXPORT-SCHEMA-SOURCE.
+;;; ---------------------------------------------------------------------
+
+(test describe-schema-shows-provenance-and-slots
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (let ((text (with-output-to-string (s)
+                  (graph-db:describe-schema :stream s))))
+      (is (search "RS-TLM" text))
+      (is (search "READING" text))
+      (is (search "[runtime" text))
+      (is (search "RS-STATIC" text :test #'char-equal))
+      (is (search "[source]" text)))))
+
+(test export-schema-source-round-trips
+  "The promotion path: export the runtime namespace, wipe the image
+state, LOAD the exported file (the ordinary source path -- the ENGINE
+never does this, the developer's build does), and the type is back
+with the SAME registry id."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:READING"
+                                 '((value :type double-float))
+                                 :default-store :rs-store)
+    (let ((id-before (graph-db::node-type-id
+                      (graph-db::%find-registered-node-type
+                       (intern "READING" :rs-tlm) :vertex)))
+          (path (merge-pathnames
+                 "exported-schema.lisp"
+                 (uiop:ensure-directory-pathname
+                  graph-db::*system-directory*))))
+      (graph-db:export-schema-source path :namespace :rs-tlm)
+      (%rs-wipe-runtime-state)
+      (load path)
+      (let ((meta (graph-db::%find-registered-node-type
+                   (intern "READING" :rs-tlm) :vertex)))
+        (is-true meta)
+        (is (= id-before (graph-db::node-type-id meta)))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -126,3 +126,101 @@ The full suite is the broad net; this is the focused canary."
       ns
       (is (find (intern "READING" :rs-tlm) types
                 :key (lambda (r) (getf r :type)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Fix round 1 (review of the first submission): I1, I2, I3.
+;;; ---------------------------------------------------------------------
+
+(test ensure-namespace-manifest-keeps-nicknames-across-calls
+  "I1: a later no-nickname ENSURE-NAMESPACE call must not make the
+manifest's last row for the namespace forget an earlier call's
+nicknames -- the row must record the UNIONED set actually applied to
+the package, not just this call's own :NICKNAMES argument (GH #172,
+review round 1)."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-TLM-I1" :nicknames '("RSTI1"))
+    (graph-db:ensure-namespace "RS-TLM-I1")
+    (multiple-value-bind (ns types)
+        (graph-db::read-schema-manifest graph-db::*system-directory*)
+      types
+      (let ((row (find "RS-TLM-I1" ns :key (lambda (r) (getf r :namespace))
+                       :test #'string-equal)))
+        (is-true row)
+        (is (member "RSTI1" (getf row :nicknames) :test #'string=))))))
+
+(test create-vertex-type-refuses-locked-package-strings
+  "I2: \"COMMON-LISP:X\" and \"KEYWORD:X\" must signal GRAPH-DB's own
+refusal (naming ENSURE-NAMESPACE), not SBCL's raw package-lock error or
+a silent KEYWORD intern followed by a later, unrelated failure
+(GH #172, review round 1)."
+  (with-rs-store (g)
+    g
+    (dolist (bad '("COMMON-LISP:RS-I2-PROBE" "KEYWORD:RS-I2-PROBE"))
+      (let ((c (handler-case
+                   (progn (graph-db:create-vertex-type bad '()
+                                                        :default-store
+                                                        :rs-store)
+                          nil)
+                 (error (e) e))))
+        (is-true c "~A should have signaled" bad)
+        (when c
+          (is (search "ENSURE-NAMESPACE" (format nil "~A" c))
+              "~A's condition should name ENSURE-NAMESPACE: ~A" bad c))))))
+
+(test manifest-uses-the-registered-meta-not-a-divergent-stray
+  "I3a: INSTANTIATE-NODE-TYPE's manifest re-append is sourced from the
+REGISTERED meta for the type's own declared store, not whatever META
+object happens to be passed in -- a stray, never-registered meta (as a
+foreign-store adoption or a stale on-disk read might carry) must never
+overwrite the canonical row with divergent slots (GH #172, review
+round 1)."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:DIVROW" '((a-slot :type string))
+                                 :default-store :rs-store)
+    (let* ((name (intern "DIVROW" :rs-tlm))
+           (canonical (graph-db::node-type-slots
+                       (graph-db::%find-registered-node-type
+                        name :vertex :rs-store)))
+           ;; A hand-built, never-registered, divergent meta for the
+           ;; same class name -- bypasses %INSTALL-NODE-TYPE entirely.
+           (stray (graph-db::make-node-type
+                   :name name :parent-type :vertex
+                   :graph-name :rs-store-b
+                   :slots '((b-slot :type string :accessor b-slot
+                            :initarg :b-slot)))))
+      (handler-bind ((warning #'muffle-warning))
+        (graph-db::instantiate-node-type stray g))
+      (multiple-value-bind (ns types)
+          (graph-db::read-schema-manifest graph-db::*system-directory*)
+        ns
+        (let ((row (find name types :key (lambda (r) (getf r :type)))))
+          (is-true row)
+          (is (equal canonical (getf row :slots))))))))
+
+(test manifest-row-count-does-not-grow-on-reopen
+  "I3b: repeated INSTANTIATE-NODE-TYPE calls (what a reopen does) for an
+unchanged type must not keep growing the manifest -- the cached last-
+written row makes the second and third calls no-ops (GH #172, review
+round 1)."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:create-vertex-type "RS-TLM:COUNTROW" '((c :type string))
+                                 :default-store :rs-store)
+    (let ((name (intern "COUNTROW" :rs-tlm)))
+      (flet ((row-count ()
+               (with-open-file (s (graph-db::%schema-manifest-file))
+                 (loop for line = (read-line s nil :eof)
+                       until (eq line :eof)
+                       count (let ((rec (graph-db::%parse-schema-manifest-line
+                                        line)))
+                               (and rec (eq (getf rec :type) name)))))))
+        (let ((c1 (row-count)))
+          (graph-db::instantiate-node-type
+           (graph-db::%find-registered-node-type name :vertex :rs-store)
+           g)
+          (graph-db::instantiate-node-type
+           (graph-db::%find-registered-node-type name :vertex :rs-store)
+           g)
+          (is (= c1 (row-count))))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -280,8 +280,16 @@ proves materialize rebuilds everything it needs."
   (when graph (clrhash (graph-db::cache graph)))
   (let ((pkg (find-package :rs-tlm)))
     (when pkg
+      ;; DO-SYMBOLS walks INHERITED symbols too -- harmless while RS-TLM
+      ;; is :USE NIL (ENSURE-NAMESPACE's own shape), but EXPORT-SCHEMA-
+      ;; SOURCE's generated DEFPACKAGE legitimately :USEs CL/GRAPH-DB
+      ;; (GH #172, R6), and after that LOAD this loop would otherwise
+      ;; walk COMMON-LISP's own external symbols and try to NIL out a
+      ;; locked class like BUILT-IN-CLASS.  EQ-check the home package so
+      ;; only symbols RS-TLM itself owns are touched (review round 1).
       (do-symbols (s pkg)
-        (when (find-class s nil) (setf (find-class s) nil)))
+        (when (and (eq (symbol-package s) pkg) (find-class s nil))
+          (setf (find-class s) nil)))
       (delete-package pkg)))
   (%rs-drop-orphaned-metas))
 
@@ -638,3 +646,60 @@ with the SAME registry id."
                    (intern "READING" :rs-tlm) :vertex)))
         (is-true meta)
         (is (= id-before (graph-db::node-type-id meta)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Task 4, fix round 1 (review): IMPORTANT + MINOR 1.
+;;; ---------------------------------------------------------------------
+
+(test export-schema-source-qualifies-cross-package-check-names
+  "IMPORTANT, review round 1: a :CHECK name whose home package differs
+from the exported namespace must round-trip identically -- printing it
+BARE would, at load time, intern a NEW symbol under the (re-created)
+namespace package instead of finding the original one, silently
+missing the EQ-keyed *SCHEMA-FUNCTIONS* lookup.  RS-EXPORT-CHECK-P is
+interned in GRAPH-DB/TEST (this file's package) -- a THIRD package,
+neither RS-TLM nor COMMON-LISP/GRAPH-DB -- and survives the wipe
+untouched, exactly like a real image's registered behaviour would."
+  (with-rs-store (g)
+    (graph-db:ensure-namespace "RS-TLM")
+    (graph-db:register-schema-function
+     'rs-export-check-p (lambda (v) (< 0 v 100)))
+    (graph-db:create-vertex-type
+     "RS-TLM:CHK" '((value :type double-float :check rs-export-check-p))
+     :default-store :rs-store)
+    (let ((path (merge-pathnames
+                 "exported-check-schema.lisp"
+                 (uiop:ensure-directory-pathname
+                  graph-db::*system-directory*))))
+      (graph-db:export-schema-source path :namespace :rs-tlm)
+      (%rs-wipe-runtime-state)
+      (load path)
+      (is-true (graph-db:find-schema-function 'rs-export-check-p))
+      (with-transaction ((graph-db::transaction-manager g))
+        (funcall (intern "MAKE-CHK" :rs-tlm) :value 50d0))
+      (signals graph-db:value-constraint-violation
+        (with-transaction ((graph-db::transaction-manager g))
+          (funcall (intern "MAKE-CHK" :rs-tlm) :value 5000d0))))))
+
+(test export-schema-source-wraps-long-lines
+  "MINOR 1, review round 1: with ~10 types in one namespace the
+:EXPORT clause was the known >80-column offender when run together on
+one line -- assert every generated line actually stays within the
+docstring's claimed limit."
+  (with-rs-store (g)
+    g
+    (graph-db:ensure-namespace "RS-WIDE")
+    (dotimes (i 10)
+      (graph-db:create-vertex-type
+       (format nil "RS-WIDE:WIDE-TYPE-NUMBER-~D" i)
+       '((value :type double-float))
+       :default-store :rs-store))
+    (let ((path (merge-pathnames
+                 "exported-wide-schema.lisp"
+                 (uiop:ensure-directory-pathname
+                  graph-db::*system-directory*))))
+      (graph-db:export-schema-source path :namespace :rs-wide)
+      (with-open-file (s path)
+        (loop for line = (read-line s nil :eof)
+              until (eq line :eof)
+              do (is (<= (length line) 80)))))))

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -1,0 +1,51 @@
+;;;; Runtime schema (GH #172).  Spec:
+;;;; docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md
+(in-package #:graph-db/test)
+
+(def-suite runtime-schema-suite :in graph-db-suite
+  :description "Class-from-metadata, manifest, materialize (GH #172).")
+(in-suite runtime-schema-suite)
+
+(def-vertex rs-static () ((label :type string)) :rs-store)
+(def-edge rs-knows () () :rs-store)
+
+(defmacro with-rs-store ((g) &body body)
+  "One open :RS-STORE under a fresh system dir, bound to *GRAPH* too so
+Prolog queries (which read *GRAPH*) work inside BODY."
+  (let ((sys (gensym)) (d (gensym)))
+    `(with-temp-directory (,sys)
+       (with-temp-directory (,d)
+         (let ((graph-db::*system-directory* (namestring ,sys))
+               (graph-db::*type-registry* nil))
+           (let ((,g (make-graph :rs-store (namestring ,d)
+                                 :buffer-pool-size 1000)))
+             (unwind-protect
+                  (let ((graph-db:*graph* ,g))
+                    ,@body)
+               (let ((live (graph-db:lookup-graph :rs-store)))
+                 (when (and live (graph-db::graph-open-p live))
+                   (let ((graph-db:*graph* live))
+                     (ignore-errors
+                      (close-graph live :snapshot-p nil)))))
+               (collect-garbage))))))))
+
+(test source-types-behave-unchanged-through-the-shared-path
+  "R1 equivalence pin: after the refactor a def-vertex/def-edge type
+still constructs, looks up, predicates, and answers its Prolog functor.
+The full suite is the broad net; this is the focused canary."
+  (with-rs-store (g)
+    (let (a b e)
+      (with-transaction ((graph-db::transaction-manager g))
+        (setq a (make-rs-static :label "a")
+              b (make-rs-static :label "b")
+              e (make-rs-knows :from a :to b)))
+      (is (rs-static-p a))
+      (is (typep (lookup-rs-static (graph-db:id a)) 'rs-static))
+      (is (rs-knows-p e))
+      ;; The functor symbol lands in the class symbol's package (the
+      ;; macro's *PACKAGE* at expansion == that package here).
+      (is-true (gethash (intern "RS-KNOWS/2" :graph-db/test)
+                        graph-db::*prolog-global-functors*))
+      (is-true (fboundp (intern "RS-KNOWS/2" :graph-db/test)))
+      (let ((hits (select (:flat nil) (?x ?y) (rs-knows ?x ?y))))
+        (is (= 1 (length hits)))))))

--- a/value-constraint.lisp
+++ b/value-constraint.lisp
@@ -226,6 +226,11 @@ over zero specs is an UNCHECKED graph, not a clean one; a caller that prints
 scan reads live node versions and bypasses MVCC (see MAP-VERTICES), so it is
 for admin passes over a quiescent graph.
 
+⚠ SPEC-COUNT counts DEF-VALUE-CONSTRAINT declarations only.  A :CHECK
+slot option (GH #172) lives on the class, not in this registry, so a
+schema constrained entirely by :CHECK is audited normally and still
+reports SPECS 0 -- do not read that as "unchecked" here.
+
 ⚠ SPEC-COUNT counts declarations registered on GRAPH, not declarations
 that apply to what was scanned -- with a spec on class B only, scanning
 :VERTEX-TYPE 'A returns SPECS > 0 while none of them touched a scanned

--- a/value-constraint.lisp
+++ b/value-constraint.lisp
@@ -21,16 +21,26 @@
    (node-id    :initarg :node-id    :reader vcv-node-id))
   (:report
    (lambda (c s)
-     (if (eq (vcv-reason c) :missing)
-         (format s "Value constraint on ~S.~S violated by node ~A: the ~
-                    slot is required but holds NIL."
-                 (vcv-class-name c) (vcv-slot-name c)
-                 (string-id (vcv-node-id c)))
-         (format s "Value constraint on ~S.~S violated by node ~A: ~
-                    expected one of~{ ~S~}; got ~S."
-                 (vcv-class-name c) (vcv-slot-name c)
-                 (string-id (vcv-node-id c))
-                 (vcv-expected c) (vcv-value c))))))
+     (case (vcv-reason c)
+       (:missing
+        (format s "Value constraint on ~S.~S violated by node ~A: the ~
+                   slot is required but holds NIL."
+                (vcv-class-name c) (vcv-slot-name c)
+                (string-id (vcv-node-id c))))
+       ;; The :CHECK slot option (GH #172, R5): EXPECTED is the name of
+       ;; the schema function that rejected the value.
+       (:check-failed
+        (format s "Value constraint on ~S.~S violated by node ~A: ~S ~
+                   rejected ~S."
+                (vcv-class-name c) (vcv-slot-name c)
+                (string-id (vcv-node-id c))
+                (vcv-expected c) (vcv-value c)))
+       (t
+        (format s "Value constraint on ~S.~S violated by node ~A: ~
+                   expected one of~{ ~S~}; got ~S."
+                (vcv-class-name c) (vcv-slot-name c)
+                (string-id (vcv-node-id c))
+                (vcv-expected c) (vcv-value c)))))))
 
 (defvar *schema-value-constraint-metadata* (make-hash-table)
   "graph-name (symbol) -> list of VALUE-CONSTRAINT-SPECs (newest first).")
@@ -103,6 +113,23 @@ CLASS-UNIQUE-TUPLE-SPECS (unique-constraint.lisp)."
 (defstruct (vc-violation (:constructor %make-vc-violation))
   spec node-id class-name slot actual expected reason)
 
+(defun %check-slot-violations (node class)
+  "Every :CHECK slot of CLASS whose registered function rejects NODE's
+value, as VC-VIOLATION records.  NULL is exempt, exactly as it is for
+:ONE-OF -- \"if present, it must satisfy this\".  The name is resolved
+here, at check time, so a re-registration takes effect immediately;
+presence was verified at definition and at materialize time
+(GH #172, R5)."
+  (loop for (slot . fn-name) in (node-check-slots class)
+        for val = (slot-value node slot)
+        unless (or (null val)
+                   (funcall (%resolve-schema-function fn-name) val))
+        collect (%make-vc-violation
+                 :spec nil :node-id (id node)
+                 :class-name (class-name class) :slot slot
+                 :actual val :expected fn-name
+                 :reason :check-failed)))
+
 (defun %value-constraint-violations (node graph)
   "Every value constraint NODE violates, as VC-VIOLATION records.  The one
 evaluator behind both consumers: the write path signals on the first, the
@@ -128,7 +155,12 @@ EQUAL, not EQL, so a non-keyword enumeration works."
                     :class-name (class-name class) :slot slot
                     :actual val :expected one-of
                     :reason :not-in-vocabulary)))
-            (t nil)))))
+            (t nil))
+          into declared
+          finally
+             (return (nconc declared
+                            (when *schema-check-slots-present-p*
+                              (%check-slot-violations node class)))))))
 
 (defmacro def-value-constraint (owner-class slot graph-name
                                 &key one-of required name)
@@ -165,7 +197,10 @@ name is itself a keyword."
 value constraint.  Called in %COMMIT's manager-locked region, after VALIDATE
 and before durability, so a violation aborts before anything is journaled
 (GH #149)."
-  (when (%registered-value-constraint-specs graph)
+  (when (or (%registered-value-constraint-specs graph)
+            ;; The :CHECK slot option needs no registry entry -- it
+            ;; lives on the class (GH #172, R5).
+            *schema-check-slots-present-p*)
     (dolist (write (writes tx))
       (let ((node (node write)))
         (unless (deleted-p node)      ; a delete claims nothing


### PR DESCRIPTION
Implements runtime schema from persisted metadata — the final build unit of the namespaces epic (#110). Closes #172.

Spec: docs/superpowers/specs/2026-08-24-runtime-schema-172-design.md (R1–R7 + Built note), arguing from the Kevin-approved design artifact docs/runtime-schema-example.lisp (kept in-repo, reconciled to shipped signatures). Plan: docs/superpowers/plans/2026-08-24-runtime-schema-172.md.

## What ships
- **One installation path (R1):** `def-node-type`'s expansion keeps only the literal `defclass`; helpers, edge Prolog functors, registration and instantiation run in the shared `%install-node-type` — so a class built from metadata gets the identical installation. Equivalence pinned against the OLD macro before the refactor; helpers/functors now intern in the class symbol's own package (identical for every ordinary use).
- **Runtime definition (R4):** `ensure-namespace` (a package — no files, no store) and `create-vertex-type`/`create-edge-type` (data in, finalized class out; `:default-store nil` legal; CL/KEYWORD refused before any intern; redefinition = ordinary CLOS + the #196 warning).
- **The system manifest (R2):** `schema-manifest.dat` beside the type registry, appended by both paths, fail-safe like the #167 sidecar; last-row-wins; dedup cache seeded from the file so reopens/boots never grow it or forge timestamps.
- **`materialize-schema` (R3) — the twenty-year load-order answer:** a macro carrying its own `eval-when`, placed before method files; rebuilds packages and classes from plists via the MOP — **restart never evaluates data**. Idempotent, source wins; fails fast before building anything, one condition naming every offender: `materialize-unresolved-functions` and `materialize-unresolved-parents` (an out-of-set parent would otherwise leave a `forward-referenced-class` stub that poisons later attempts).
- **The behaviour boundary (R5):** `register-schema-function`/`find-schema-function` + the `:check FN-NAME` slot option (accepted by `def-vertex` too), enforced with the existing value constraints, NULL-exempt, presence verified at create AND materialize, resolved at each check; documented pure under OCC retry.
- **Visibility (R6):** `describe-schema` (provenance-tagged text dump; `:since` is an honest change log, UTC both sides) and `export-schema-source` (metadata → def-vertex source — the promotion path; cross-package symbols qualified, CL/GRAPH-DB-shadowed names get a `:shadow` clause so the generated file loads back to the same symbols; idempotent, same registry ids).

Follow-ups filed, not blocking: sidecar printer/reader-control parity, and absent-package manifest rows being silently dropped by the tolerant reader.

## Verification (SBCL; ECL demoted per standing policy)
- Fresh-image `(asdf:test-system :graph-db)` on final HEAD: **4627 checks / 4617 pass / 10 skips (GEOS, pre-existing) / 0 fail** (branch-start baseline 4483). Interim full gates also green at Task 1, Task 3, and 6bd5156.
- Focused: runtime-schema-suite 144/144 (incl. the create→wipe→materialize→compile-a-method acceptance test), package-namespace 30/30, keyword-alias 9/9, node-class 55/55, global-type-id 23/23.
- Process: 5 tasks, per-task review + 7 fix rounds, whole-branch review, final fix wave — all findings addressed.

**With this merge, every build unit of the namespaces epic (#110) is Done** (§11 table updated); remaining work is the filed follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95