### PR TITLE
map-vertices: pin the untyped scan; document the subclass-overlap reporting trap (#219)

### DIFF
--- a/docs/superpowers/notes/2026-08-25-219-map-vertices-not-a-bug.md
+++ b/docs/superpowers/notes/2026-08-25-219-map-vertices-not-a-bug.md
@@ -1,0 +1,88 @@
+# GH #219 — `map-vertices` without `:vertex-type` — debug report
+
+**Verdict: NOT AN ENGINE DEFECT.** The untyped walk is correct and complete.
+The reported "48% loss" is a double-count in the per-type cross-check.
+
+## What actually happens
+
+`map-vertices` with `:vertex-type` defaults to `:include-subclasses-p t`
+(`vertex.lisp:180`), and the typed branch expands the request through
+`resolve-node-type-ids` (`vertex.lisp:230-241`) before walking the type index.
+So a walk of a PARENT type already visits every vertex of every subtype.
+Summing `parent + subtype-a + subtype-b` therefore counts the subtypes twice.
+
+On the reporter's store `IMSMA-EVIDENCE-POINT` and `IMSMA-TURNING-POINT` are
+subclasses of `IMSMA-RECORD`. The real store size is 14512 — which is exactly
+what the untyped scan returned. The "28169" is `14512 + 5004 + 8653`, i.e. the
+14512 plus a second copy of the two subtypes.
+
+The edge line in the issue corroborates this: the two edge types are siblings
+(no inheritance), so no double count, and untyped == the sum exactly (13635).
+
+## Reproduction
+
+`/tmp/.../scratchpad/repro3.lisp` builds the reporter's exact shape — a base
+type with two populated subtypes plus two unrelated empty types, populated with
+855 / 5004 / 8653 vertices and 5002 / 8633 edges — closes and reopens the store,
+and prints:
+
+```
+untyped              = 14512
+R-RECORD (default)   = 14512     <- parent, subclasses included
+R-RECORD (no subs)   =   855
+R-EVIDENCE           =  5004
+R-TURNING            =  8653
+S-FIND               =     0
+S-AREA               =     0
+naive sum            = 28169
+edges untyped        = 13635  e1=5002 e2=8633
+```
+
+Every figure in the issue is reproduced to the digit, including the two zeros
+and the edge total. 855 + 5004 + 8653 = 14512, and 14512 + 5004 + 8653 = 28169.
+
+## Things ruled out along the way
+
+- **Cold open / size.** Neither mattered. Untyped == the disjoint per-type sum
+  on 23-vertex and 6000-vertex stores, hot and after a `close-graph`/`open-graph`
+  round trip, with vertices written interleaved and in per-type blocks, with
+  three and with five types.
+- **`map-lhash` iteration** (`linear-hash.lisp:782-793`) — walks
+  `0..%bucket-count-1`, and `read-bucket` (`linear-hash.lisp:502-518`) follows
+  the overflow chain. The untyped total also matches
+  `(read-lhash-count (vertex-table g))` exactly, which is maintained by the
+  insert path, not by the scan — an independent witness that no pair is dropped.
+- **`deserialize-vertex-head`** (`vertex.lisp:65-87`) — resolves type-id -> class
+  via `*graph*`, and `map-vertices` binds `*graph*` to its GRAPH argument
+  (`vertex.lisp:205`). The `migrate-graph` comment the reporter flagged
+  (`backup.lisp:376`) is that binding being honoured by a caller that maps a
+  graph other than the ambient one, not a divergent code path.
+- **Pooled node buffers** (`buffer-pool.lisp:500-524`) — `get-vertex-buffer`
+  pops a buffer and never returns it, so there is no stale `deleted-p` /
+  `written-p` carried between deserializations.
+
+## Blast radius
+
+None: nothing to fix in the storage or scan path. `map-edges` shares the same
+`:include-subclasses-p t` default and the same untyped `map-lhash` branch, so it
+has the same *reporting* trap; its numbers in the issue happen to be clean only
+because those two edge types are siblings.
+
+## Proposed minimal change (optional, docs-only)
+
+There is no code defect to fix. If anything ships for #219 it should be a
+docstring note on `map-vertices` / `map-edges` (`vertex.lisp:181-198`) saying
+that per-type walks OVERLAP by default and a per-type sum is only comparable to
+the untyped total with `:include-subclasses-p nil` on non-leaf types. Close #219
+as not-a-bug with the arithmetic above.
+
+## Regression test
+
+`tests/map-vertices-untyped-tests.lisp` (registered in `graph-db.asd`), suite
+`map-vertices-untyped-suite`, 12 checks, all passing:
+
+- untyped == the DISJOINT per-type sum == `read-lhash-count` of the vertex
+  table, across a close/reopen;
+- the parent's default walk equals the untyped total and equals
+  bare + subtype-a + subtype-b (pinning the overlap that misled the report);
+- the same equality at 2700 vertices.

--- a/edge.lisp
+++ b/edge.lisp
@@ -365,6 +365,11 @@ or to a specific endpoint pair with :FROM-VERTEX and :TO-VERTEX.  Deleted edges
 are skipped unless :INCLUDE-DELETED-P.  With :COLLECT-P, collect and return FN's
 values; otherwise return NIL.  This drives OUTGOING-EDGES / INCOMING-EDGES.
 
+Per-type walks OVERLAP by default: :INCLUDE-SUBCLASSES-P T expands a parent type
+over its subtypes, so summing parent + subtypes double-counts them.  A per-type
+sum is comparable to the untyped total only with :INCLUDE-SUBCLASSES-P NIL on
+every non-leaf type (GH #219).
+
 NOTE: the fully-untyped, non-adjacency scan (no type and no vertex/endpoint)
 walks the raw edge lhash, which reads LIVE edge versions and so BYPASSES MVCC
 snapshot isolation -- intended for back-end / admin passes run while the graph is

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -537,6 +537,7 @@ cl-temporal-extent."
                (:file "write-path-tests")
                (:file "slot-mutation-tests")
                (:file "reopen-tests")
+               (:file "map-vertices-untyped-tests") ; GH #219
                (:file "backup-tests")
                (:file "mvcc-tests")
                (:file "system-clock-tests")       ; GH #168

--- a/tests/map-vertices-untyped-tests.lisp
+++ b/tests/map-vertices-untyped-tests.lisp
@@ -1,0 +1,103 @@
+;;;; Untyped MAP-VERTICES vs the per-type walks (GH #219).
+;;;;
+;;;; The untyped scan walks the raw vertex lhash; a typed scan walks the type
+;;;; index.  These tests pin the two against each other on a multi-type store
+;;;; across a close/reopen, including the inheritance case that made #219 look
+;;;; like a lost-vertex bug: :VERTEX-TYPE defaults to :INCLUDE-SUBCLASSES-P T,
+;;;; so a parent's walk already contains every subtype and summing parent +
+;;;; subtypes double-counts.
+
+(in-package #:graph-db/test)
+
+(def-suite map-vertices-untyped-suite
+  :description "Untyped MAP-VERTICES agrees with the per-type walks."
+  :in graph-db-suite)
+
+(in-suite map-vertices-untyped-suite)
+
+(def-vertex mv-record ()
+  ((n :type integer))
+  :graph-db-integration-test)
+
+(def-vertex mv-evidence (mv-record)
+  ()
+  :graph-db-integration-test)
+
+(def-vertex mv-turning (mv-record)
+  ()
+  :graph-db-integration-test)
+
+(def-vertex mv-unrelated ()
+  ((n :type integer))
+  :graph-db-integration-test)
+
+(defun mv-count (graph &rest args)
+  "Number of vertices GRAPH's MAP-VERTICES visits under ARGS."
+  (let ((n 0))
+    (apply #'map-vertices (lambda (v) (declare (ignore v)) (incf n)) graph args)
+    n))
+
+(defmacro with-mv-store ((g &key (bare 5) (evidence 7) (turning 11)) &body body)
+  "Populate a fresh store with BARE MV-RECORDs, EVIDENCE MV-EVIDENCEs and
+TURNING MV-TURNINGs (no MV-UNRELATEDs), close it, reopen it from disk and
+bind G to the reopened graph."
+  (let ((dir (gensym "DIR")) (path (gensym "PATH")) (g1 (gensym "G1")))
+    `(with-temp-directory (,dir)
+       (let ((,path (namestring ,dir)))
+         (let ((,g1 (make-graph *integration-graph-name* ,path
+                                :buffer-pool-size 1000)))
+           (let ((*graph* ,g1))
+             (with-transaction ()
+               (dotimes (i ,bare) (make-mv-record :n i))
+               (dotimes (i ,evidence) (make-mv-evidence :n i))
+               (dotimes (i ,turning) (make-mv-turning :n i))))
+           (close-graph ,g1 :snapshot-p nil))
+         (let ((,g (open-graph *integration-graph-name* ,path)))
+           (unwind-protect (let ((*graph* ,g)) ,@body)
+             (ignore-errors (close-graph ,g :snapshot-p nil))
+             (collect-garbage)))))))
+
+(test untyped-map-vertices-equals-disjoint-per-type-sum
+  "GH #219: after a reopen the untyped walk sees every vertex -- it equals the
+sum over a DISJOINT type partition (the parent without subclasses, plus each
+subtype), and equals the raw vertex-table count."
+  (with-mv-store (g :bare 5 :evidence 7 :turning 11)
+    (let ((untyped (mv-count g))
+          (bare (mv-count g :vertex-type 'mv-record :include-subclasses-p nil))
+          (evidence (mv-count g :vertex-type 'mv-evidence))
+          (turning (mv-count g :vertex-type 'mv-turning))
+          (unrelated (mv-count g :vertex-type 'mv-unrelated)))
+      (is (= 5 bare))
+      (is (= 7 evidence))
+      (is (= 11 turning))
+      (is (= 0 unrelated))
+      (is (= 23 untyped))
+      (is (= untyped (+ bare evidence turning unrelated)))
+      (is (= untyped (graph-db::read-lhash-count
+                      (graph-db::vertex-table g)))))))
+
+(test typed-parent-walk-includes-subclasses-by-default
+  "The shape that made GH #219 look like a defect: MV-RECORD's default walk
+already contains both subtypes, so parent + subtypes over-counts the store.
+:INCLUDE-SUBCLASSES-P NIL is what makes a per-type sum comparable."
+  (with-mv-store (g :bare 5 :evidence 7 :turning 11)
+    (let ((untyped (mv-count g))
+          (parent (mv-count g :vertex-type 'mv-record))
+          (bare (mv-count g :vertex-type 'mv-record :include-subclasses-p nil))
+          (evidence (mv-count g :vertex-type 'mv-evidence))
+          (turning (mv-count g :vertex-type 'mv-turning)))
+      (is (= parent untyped))
+      (is (= parent (+ bare evidence turning)))
+      ;; the naive sum a caller reaches for is strictly larger
+      (is (> (+ parent evidence turning) untyped)))))
+
+(test untyped-map-vertices-scales-past-one-bucket-load
+  "The same equality at a size with real lhash bucket collisions, so a
+truncated bucket read or a missed overflow chain would show up."
+  (with-mv-store (g :bare 300 :evidence 900 :turning 1500)
+    (let ((untyped (mv-count g)))
+      (is (= 2700 untyped))
+      (is (= untyped
+             (+ (mv-count g :vertex-type 'mv-record :include-subclasses-p nil)
+                (mv-count g :vertex-type 'mv-evidence)
+                (mv-count g :vertex-type 'mv-turning)))))))

--- a/vertex.lisp
+++ b/vertex.lisp
@@ -192,6 +192,11 @@ also matches its subtypes (see RESOLVE-NODE-TYPE-IDS).  Deleted vertices are
 skipped unless :INCLUDE-DELETED-P.  With :COLLECT-P, collect and return FN's
 values as a list; otherwise return NIL.
 
+Per-type walks OVERLAP by default: :INCLUDE-SUBCLASSES-P T expands a parent type
+over its subtypes, so summing parent + subtypes double-counts them.  A per-type
+sum is comparable to the untyped total only with :INCLUDE-SUBCLASSES-P NIL on
+every non-leaf type (GH #219).
+
 NOTE: the fully-untyped scan (no :VERTEX-TYPE and no :INCLUDE-VERTEX-TYPES) walks
 the raw vertex lhash, which reads LIVE node versions and so BYPASSES MVCC
 snapshot isolation.  It is intended for back-end / admin passes (backup, GC,


### PR DESCRIPTION
Closes #219 — root-caused as **not a defect**.

The untyped `map-vertices` count is the true store size: a neutral reproduction matched every figure in the issue to the digit, and the untyped walk independently equals the vertex lhash's own insert-maintained counter. The apparent 48% shortfall was double-counting on the reporting side: `:vertex-type` defaults to `:include-subclasses-p t`, so a parent type's walk already visits every subtype — on the reporting store the two "missing" types are subclasses of the first (855 bare + 5004 + 8653 = 14512, exactly the untyped total). The edge counts only agreed because those types are siblings. `map-lhash` iteration, `deserialize-vertex-head`'s `*graph*` resolution, and buffer reuse were each independently ruled out.

Ships:
- A 4-line trap note in both `map-vertices` and `map-edges` docstrings: a per-type sum is only comparable to the untyped total with `:include-subclasses-p nil` on non-leaf types.
- `tests/map-vertices-untyped-tests.lisp` (12 checks, all green): untyped == disjoint-partition sum == raw lhash count, across a close/reopen and past lhash bucket-split sizes, plus the exact overlap shape that made this look like a lost-vertex bug.
- The full analysis at `docs/superpowers/notes/2026-08-25-219-map-vertices-not-a-bug.md`.

Verification: fresh recompile byte-identical warning count; the new suite 12/12 (SBCL; ECL demoted per standing policy). Docstring/test/docs-only — no engine behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95