### PR TITLE
Open-path hygiene: normalize LOCATION; tear down aborted opens (#222, #224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ between releases; cutting a release renames it to the new version and dates it.
   PATHNAME`, before any use -- the same fix `%REOPEN-AND-RESUME`
   (`shadow-store.lisp`, #171) already applied locally, generalized to the
   entry points themselves so every caller gets it for free.
+
+  ⚠ **Upgrade note.** A store originally *created* through a slashless
+  `LOCATION` has `transaction-id.dat`, `lamport.dat` (peer graphs) and
+  `pull-cursor.dat` (peer devices) -- among others -- sitting in its
+  PARENT directory, not inside the store. After this fix, `OPEN-GRAPH`
+  looks for them inside the store and will not find them: the
+  transaction-id watermark and, on a peer graph, the durable Lamport
+  clock and pull cursor all silently reset to their zero/absent
+  defaults on the next open. Before upgrading a store you know was
+  ever created or reopened with a trailing-slash-free `LOCATION`,
+  manually move any of those files sitting beside the store directory
+  (check the PARENT of `LOCATION` for `.dirty`, `heap.dat`,
+  `schema.dat`, `transaction-id.dat`, `lamport.dat`, `pull-cursor.dat`,
+  `policy.dat`) into the store directory itself first. A store that
+  was always opened with a trailing slash is unaffected.
 - **An aborted `MAKE-GRAPH`/`OPEN-GRAPH` leaked every fd it had already
   opened** (#224). Neither function had any teardown on a non-local exit
   partway through -- a `STORE-ID-COLLISION-ERROR` or any other failure left
@@ -57,8 +72,20 @@ between releases; cutting a release renames it to the new version and dates it.
   effort closes (`IGNORE-ERRORS` per component, tolerating slots still
   unbound) everything the partial open acquired, and deregisters the graph
   from `*GRAPHS*`/the open-store vector if that ran before the failure. The
-  signalled condition always propagates unchanged.
-
+  signalled condition always propagates unchanged. The teardown also
+  stops replication before closing anything else (a master's accept
+  thread and listening socket must not outlive the mmaps they
+  reference) and closes every vector segment `RESTORE-VECTOR-SEGMENTS`
+  had already opened (each is marked dirty-on-disk the moment it
+  opens, so leaving one open forces a full rebuild-from-nodes on the
+  next open). One rule needs stating explicitly: the abort deletes a
+  `.dirty` marker only when nothing that can mutate an EXISTING
+  store's heap has run yet (`OPEN-GRAPH`'s recovery/rebuild steps,
+  `MAKE-GRAPH`'s WAL replay for a slave). Once one of those has run,
+  `.dirty` is deliberately left in place -- the store now genuinely
+  needs recovery, and deleting the sentinel would let a later open
+  adopt stale index roots against the now-mutated heap with no
+  recovery pass to catch the mismatch.
 - **`%POSIX-OPEN` created files with an arbitrary permission mode on Apple
   arm64** (#218). `open(2)` is `int open(const char *, int, ...)`, and the
   `mode` argument was passed through a plain `CFFI:FOREIGN-FUNCALL` — as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,34 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **`MAKE-GRAPH`/`OPEN-GRAPH` accepted a slashless `LOCATION` and scattered
+  its sidecar files into the parent directory** (#222). Every sidecar built
+  with `(MAKE-PATHNAME :defaults (LOCATION GRAPH))` -- `.dirty`, `heap.dat`,
+  `schema.dat`, and the rest -- depends on `LOCATION` being a *directory*
+  pathname; a trimmed namestring kept it as a *file* pathname instead, so
+  those sidecars landed next to the store rather than inside it. Both
+  functions now normalize `LOCATION` once, via `UIOP:ENSURE-DIRECTORY-
+  PATHNAME`, before any use -- the same fix `%REOPEN-AND-RESUME`
+  (`shadow-store.lisp`, #171) already applied locally, generalized to the
+  entry points themselves so every caller gets it for free.
+- **An aborted `MAKE-GRAPH`/`OPEN-GRAPH` leaked every fd it had already
+  opened** (#224). Neither function had any teardown on a non-local exit
+  partway through -- a `STORE-ID-COLLISION-ERROR` or any other failure left
+  the heap, indexes, vertex/edge tables and ve/vev indexes already opened
+  memory-mapped and open, and could leave the graph half-registered in
+  `*GRAPHS*`. `MAKE-INSTANCE` evaluates its initarg value-forms before it
+  runs, so a failure partway through that argument list left the
+  already-opened ones reachable from nothing but a local variable; the
+  open-sequence in both functions now binds each resource to a name and
+  tracks it in a small mutable list *before* handing it to `MAKE-INSTANCE`,
+  so the list has every fd-bearing resource open at the moment of failure
+  regardless of where in the sequence it happens. Both functions now run
+  their body under `UNWIND-PROTECT`, and a new `%ABORT-GRAPH-OPEN` best-
+  effort closes (`IGNORE-ERRORS` per component, tolerating slots still
+  unbound) everything the partial open acquired, and deregisters the graph
+  from `*GRAPHS*`/the open-store vector if that ran before the failure. The
+  signalled condition always propagates unchanged.
+
 - **`%POSIX-OPEN` created files with an arbitrary permission mode on Apple
   arm64** (#218). `open(2)` is `int open(const char *, int, ...)`, and the
   `mode` argument was passed through a plain `CFFI:FOREIGN-FUNCALL` — as a

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -561,7 +561,8 @@ cl-temporal-extent."
                (:file "index-prolog-tests")        ; GH #102
                (:file "value-constraint-tests")     ; GH #149
                (:file "peer-unique-tests")
-               (:file "peer-index-tests"))
+               (:file "peer-index-tests")
+               (:file "open-hygiene-tests"))   ; GH #222, #224
   :perform (test-op (op c)
                     (unless (uiop:symbol-call :graph-db/test :run-tests)
                       (error "graph-db test suite failed."))))

--- a/graph.lisp
+++ b/graph.lisp
@@ -290,56 +290,110 @@ debugging an unexpectedly empty result, check the declaration before the data."
     (when segment
       (segment-scan segment query-vector k))))
 
+(defstruct (%graph-open-state (:conc-name %gos-))
+  "Mutable state MAKE-GRAPH/OPEN-GRAPH thread through their private
+%MAKE-GRAPH-1/%OPEN-GRAPH-1 body so an abort mid-open can find what to
+tear down (GH #224).  RAW is every fd-bearing resource opened before
+GRAPH itself existed; GRAPH is the constructed instance once
+MAKE-INSTANCE succeeds (RAW is cleared then -- GRAPH's own slots take
+over).  MUTATED is set just before the first step that can write real
+data against an EXISTING store's heap (recovery/rebuild on OPEN-GRAPH,
+WAL replay on MAKE-GRAPH) -- see %ABORT-GRAPH-OPEN, GH #224 review C1."
+  raw graph mutated)
+
 (defun %close-open-resource (r)
   "Best-effort close of one fd-bearing resource R of unknown runtime
 type (GH #224) -- the exact set MAKE-GRAPH/OPEN-GRAPH ever hand to a
-fresh GRAPH's slots.  Never signals; NIL is silently a no-op."
-  (ignore-errors
-    (cond ((type-index-p r) (close-type-index r))
-          ((vev-index-p r) (close-vev-index r))
-          ((ve-index-p r) (close-ve-index r))
-          ((lhash-p r) (close-lhash r))
-          ((memory-p r) (close-memory r)))))
+fresh GRAPH's slots.  Catches SERIOUS-CONDITION, not just ERROR (the
+CLOSE-GRAPH snapshot precedent, GH #119/#120): a STORAGE-CONDITION mid-
+teardown must not replace the caller's original condition either.
+Never signals; NIL is silently a no-op."
+  (handler-case
+      (cond ((type-index-p r) (close-type-index r))
+            ((vev-index-p r) (close-vev-index r))
+            ((ve-index-p r) (close-ve-index r))
+            ((lhash-p r) (close-lhash r))
+            ((memory-p r) (close-memory r)))
+    (serious-condition () nil)))
 
-(defun %abort-graph-open (raw graph)
+(defun %abort-graph-open (state)
   "Best-effort teardown for a GRAPH construction aborted partway
-through MAKE-GRAPH/OPEN-GRAPH (GH #224).  RAW is every fd-bearing
-resource opened before GRAPH itself existed -- MAKE-INSTANCE evaluates
-its initarg value-forms before it runs, so an error partway through
-that argument list (the original bug report's case) leaves each
-already-opened one reachable from nothing but a local variable, unless
-%MAKE-GRAPH-1/%OPEN-GRAPH-1 push it here as it goes.  GRAPH is the
-constructed instance, or NIL if MAKE-INSTANCE itself never returned.
-Once GRAPH exists it owns everything in RAW via its own slots and the
-caller clears RAW right then, so the two branches below never name the
-same object.  Also deregisters GRAPH from *GRAPHS*/the open-store
-vector if that ran before the failure, and removes a .dirty marker
-this open wrote.  Never signals -- the caller's UNWIND-PROTECT
-re-raises the original condition unchanged."
-  (dolist (r raw) (%close-open-resource r))
-  (when graph
-    (ignore-errors
-      (when (eq graph (gethash (graph-name graph) *graphs*))
-        (remhash (graph-name graph) *graphs*)))
-    (ignore-errors (%unregister-open-store graph))
-    (ignore-errors (%close-open-resource (vertex-index graph)))
-    (ignore-errors (%close-open-resource (edge-index graph)))
-    (ignore-errors (%close-open-resource (vev-index graph)))
-    (ignore-errors (%close-open-resource (ve-index-in graph)))
-    (ignore-errors (%close-open-resource (ve-index-out graph)))
-    (ignore-errors (%close-open-resource (vertex-table graph)))
-    (ignore-errors (%close-open-resource (edge-table graph)))
-    (ignore-errors (%close-open-resource (indexes graph)))
-    (ignore-errors (%close-open-resource (heap graph)))
-    (ignore-errors (close-replication-log graph))
-    (ignore-errors
-      (when (and (slot-exists-p graph 'applied-op-ids)
-                 (slot-boundp graph 'applied-op-ids)
-                 (lhash-p (applied-op-ids graph)))
-        (close-lhash (applied-op-ids graph))))
-    (ignore-errors
-      (let ((dirty-file (format nil "~A/.dirty" (location graph))))
-        (when (probe-file dirty-file) (delete-file dirty-file)))))
+through MAKE-GRAPH/OPEN-GRAPH (GH #224), using STATE
+(%GRAPH-OPEN-STATE) as %MAKE-GRAPH-1/%OPEN-GRAPH-1 left it.
+%GOS-RAW is every fd-bearing resource opened before GRAPH itself
+existed -- MAKE-INSTANCE evaluates its initarg value-forms before it
+runs, so an error partway through that argument list (the original bug
+report's case) leaves each already-opened one reachable from nothing
+but a local variable, unless the caller pushed it onto %GOS-RAW as it
+went.  %GOS-GRAPH is the constructed instance, or NIL if MAKE-INSTANCE
+itself never returned; once it exists it owns everything in %GOS-RAW
+via its own slots and the caller clears %GOS-RAW right then, so the
+two branches below never name the same object twice.
+
+Also: stops replication FIRST (mirrors CLOSE-GRAPH's own ordering) --
+a master's accept-loop thread and listening socket must not survive
+referencing a graph whose mmaps this function is about to close, or a
+retried open on the same port fails EADDRINUSE (GH #224 review I2b);
+closes every open vector segment, the same fd-bearing-and-dirty-flagged
+resource CLOSE-GRAPH's own MAPHASH over VECTOR-SEGMENTS closes (GH #224
+review I2) -- RESTORE-VECTOR-SEGMENTS opens one mmap per (owner . slot)
+and marks each dirty on open, so a failure anywhere after it (the
+STORE-ID-COLLISION-ERROR case #224 was filed for included) leaked
+these and forced a rebuild on the next open; deregisters GRAPH from
+*GRAPHS*/the open-store vector if that ran before the failure.
+
+Finally, removes a .dirty marker this open wrote -- but ONLY when
+%GOS-MUTATED is NIL.  OPEN-GRAPH's recovery/rebuild steps
+(GC-HEAP, RECOVER-TRANSACTIONS, REBUILD-SPATIAL/UNIQUE-INDEXES,
+INSTALL-SECONDARY-INDEXES) and MAKE-GRAPH's WAL replay run AFTER the
+.dirty write and BEFORE CLOSE-GRAPH would ever get to save fresh index
+roots; deleting the sentinel here would let a subsequent OPEN-GRAPH
+adopt the OLD roots against this now-mutated heap with no recovery
+pass to catch the mismatch (CLOSE-GRAPH's own comment on
+SAVE-UNIQUE-INDEX-ROOTS/SAVE-SECONDARY-INDEX-ROOTS names this exact
+hazard).  Leaving .dirty in place when MUTATED is T is correct: the
+store now genuinely requires recovery.  When nothing mutating ran,
+whatever is durable is exactly what a fresh MAKE-GRAPH/an unmodified
+reopen wrote, and .dirty existing at all here means (by each function's
+own upfront invariant) THIS open is the one that wrote it, so deleting
+it is safe (GH #224 review C1).
+
+Never signals -- the caller's UNWIND-PROTECT re-raises the original
+condition unchanged."
+  (let ((raw (%gos-raw state))
+        (graph (%gos-graph state))
+        (mutated (%gos-mutated state)))
+    (dolist (r raw) (%close-open-resource r))
+    (when graph
+      (ignore-errors (stop-replication graph))
+      (ignore-errors
+        (maphash (lambda (k seg)
+                   (declare (ignore k))
+                   (ignore-errors (close-vector-segment seg)))
+                 (vector-segments graph)))
+      (ignore-errors
+        (when (eq graph (gethash (graph-name graph) *graphs*))
+          (remhash (graph-name graph) *graphs*)))
+      (ignore-errors (%unregister-open-store graph))
+      (ignore-errors (%close-open-resource (vertex-index graph)))
+      (ignore-errors (%close-open-resource (edge-index graph)))
+      (ignore-errors (%close-open-resource (vev-index graph)))
+      (ignore-errors (%close-open-resource (ve-index-in graph)))
+      (ignore-errors (%close-open-resource (ve-index-out graph)))
+      (ignore-errors (%close-open-resource (vertex-table graph)))
+      (ignore-errors (%close-open-resource (edge-table graph)))
+      (ignore-errors (%close-open-resource (indexes graph)))
+      (ignore-errors (%close-open-resource (heap graph)))
+      (ignore-errors (close-replication-log graph))
+      (ignore-errors
+        (when (and (slot-exists-p graph 'applied-op-ids)
+                   (slot-boundp graph 'applied-op-ids)
+                   (lhash-p (applied-op-ids graph)))
+          (close-lhash (applied-op-ids graph))))
+      (ignore-errors
+        (unless mutated
+          (let ((dirty-file (format nil "~A/.dirty" (location graph))))
+            (when (probe-file dirty-file) (delete-file dirty-file)))))))
   nil)
 
 (defun %make-graph-1
@@ -380,27 +434,27 @@ re-raises the original condition unchanged."
       ;; is bound, so %ABORT-GRAPH-OPEN can still find and close it.
       (setq heap (create-memory (format nil "~A/heap.dat" path)
                                 heap-size))
-      (push heap (car state))
+      (push heap (%gos-raw state))
       (setq vertex-table (make-vertex-table
                           (format nil "~A/vertex/" path)
                           :base-buckets vertex-buckets))
-      (push vertex-table (car state))
+      (push vertex-table (%gos-raw state))
       (setq edge-table (make-edge-table
                         (format nil "~A/edge/" path)
                         :base-buckets edge-buckets))
-      (push edge-table (car state))
+      (push edge-table (%gos-raw state))
       (setq indexes (create-memory
                      (format nil "~A/indexes.dat" path)
                      index-size))
-      (push indexes (car state))
+      (push indexes (%gos-raw state))
       (setq ve-index-in (make-ve-index
                          (format nil "~A/ve-index-in/" path)))
-      (push ve-index-in (car state))
+      (push ve-index-in (%gos-raw state))
       (setq ve-index-out (make-ve-index
                           (format nil "~A/ve-index-out/" path)))
-      (push ve-index-out (car state))
+      (push ve-index-out (%gos-raw state))
       (setq vev-index (make-vev-index (format nil "~A/vev-index/" path)))
-      (push vev-index (car state))
+      (push vev-index (%gos-raw state))
       (setq graph
             (make-instance
              (cond (slave-p 'slave-graph)
@@ -429,8 +483,13 @@ re-raises the original condition unchanged."
              :ve-index-out ve-index-out
              :vev-index vev-index))
       ;; GRAPH now owns every resource above via its own slots -- hand
-      ;; cleanup off to the GRAPH-based path in %ABORT-GRAPH-OPEN.
-      (setf (car state) nil (cdr state) graph)
+      ;; cleanup off to the GRAPH-based path in %ABORT-GRAPH-OPEN.  Set
+      ;; %GOS-GRAPH BEFORE clearing %GOS-RAW (GH #224 review M2): if an
+      ;; async interrupt lands between the two SETFs, RAW staying non-
+      ;; NIL a moment longer only costs a redundant (IGNORE-ERRORS-
+      ;; wrapped) close, where the other order would drop every
+      ;; resource from STATE entirely.
+      (setf (%gos-graph state) graph (%gos-raw state) nil)
       (setf (vertex-index graph)
             (make-type-index
              (format nil "~A/vertex-index.dat" path) heap))
@@ -462,6 +521,11 @@ re-raises the original condition unchanged."
         (when replication-filter
           (setf (replication-filter graph) replication-filter))
         (when replay-txn-dir
+          ;; GH #224 review C1: REPLAY writes real transaction data
+          ;; into this fresh graph's heap; %ABORT-GRAPH-OPEN must not
+          ;; delete .dirty past this point (see %OPEN-GRAPH-1's mirror
+          ;; of this flag for the reopen case).
+          (setf (%gos-mutated state) t)
           (let ((*graph* graph))
             (replay graph replay-txn-dir package))))
       (when peer-role
@@ -625,10 +689,10 @@ to disk and remove it."
   ;; id.dat above all -- lands in the store's PARENT directory instead
   ;; of inside it.  Normalize once, before any use (GH #222).
   (setq location (namestring (uiop:ensure-directory-pathname location)))
-  ;; GH #224: STATE is a (RAW . GRAPH) cons %MAKE-GRAPH-1 updates as
-  ;; it goes; DONE distinguishes a clean return from a non-local exit.
-  ;; The original condition always propagates unchanged.
-  (let ((state (cons nil nil)) (done nil))
+  ;; GH #224: STATE (%GRAPH-OPEN-STATE) is what %MAKE-GRAPH-1 updates
+  ;; as it goes; DONE distinguishes a clean return from a non-local
+  ;; exit.  The original condition always propagates unchanged.
+  (let ((state (make-%graph-open-state)) (done nil))
     (unwind-protect
         (prog1
             (%make-graph-1 name location state
@@ -661,7 +725,7 @@ to disk and remove it."
                            :system-clock system-clock
                            :recovery-policy recovery-policy)
           (setf done t))
-      (unless done (%abort-graph-open (car state) (cdr state))))))
+      (unless done (%abort-graph-open state)))))
 
 (define-condition recovery-policy-mismatch-warning (warning)
   ;; A named class rather than a bare STRING WARN, so a caller (or a test)
@@ -716,22 +780,22 @@ policy.dat's ~S; the file wins."
       ;; opened resource as soon as it is bound.
       (setq heap (open-memory (format nil "~A/heap.dat" path)
                               :accept-versions accept-versions))
-      (push heap (car state))
+      (push heap (%gos-raw state))
       (setq vertex-table (open-lhash (format nil "~A/vertex/" path)))
-      (push vertex-table (car state))
+      (push vertex-table (%gos-raw state))
       (setq edge-table (open-lhash (format nil "~A/edge/" path)))
-      (push edge-table (car state))
+      (push edge-table (%gos-raw state))
       (setq indexes (open-memory (format nil "~A/indexes.dat" path)
                                  :accept-versions accept-versions))
-      (push indexes (car state))
+      (push indexes (%gos-raw state))
       (setq ve-index-in (open-ve-index
                          (format nil "~A/ve-index-in/" path)))
-      (push ve-index-in (car state))
+      (push ve-index-in (%gos-raw state))
       (setq ve-index-out (open-ve-index
                           (format nil "~A/ve-index-out/" path)))
-      (push ve-index-out (car state))
+      (push ve-index-out (%gos-raw state))
       (setq vev-index (open-vev-index (format nil "~A/vev-index/" path)))
-      (push vev-index (car state))
+      (push vev-index (%gos-raw state))
       (setq graph
             (make-instance
              (cond (slave-p 'slave-graph)
@@ -760,8 +824,13 @@ policy.dat's ~S; the file wins."
              :ve-index-out ve-index-out
              :vev-index vev-index))
       ;; GRAPH now owns every resource above via its own slots -- hand
-      ;; cleanup off to the GRAPH-based path in %ABORT-GRAPH-OPEN.
-      (setf (car state) nil (cdr state) graph)
+      ;; cleanup off to the GRAPH-based path in %ABORT-GRAPH-OPEN.  Set
+      ;; %GOS-GRAPH BEFORE clearing %GOS-RAW (GH #224 review M2): if an
+      ;; async interrupt lands between the two SETFs, RAW staying non-
+      ;; NIL a moment longer only costs a redundant (IGNORE-ERRORS-
+      ;; wrapped) close, where the other order would drop every
+      ;; resource from STATE entirely.
+      (setf (%gos-graph state) graph (%gos-raw state) nil)
       (let ((*graph* graph))
         (setf (vertex-index graph)
               (open-type-index (format nil "~A/vertex-index.dat" path) heap))
@@ -870,6 +939,10 @@ policy.dat's ~S; the file wins."
             (progn
               (setf (gethash name *graphs*) graph)
               (%register-open-store graph)))
+        ;; GH #224 review C1: from here on, recovery/rebuild can write
+        ;; real data against this (possibly pre-existing) store's heap;
+        ;; %ABORT-GRAPH-OPEN must not delete .dirty past this point.
+        (setf (%gos-mutated state) t)
         (when gc-heap-p
           (gc-heap graph))
         ;; A non-empty WAL tail means this open is a CRASH RECOVERY: the .txn files
@@ -1062,10 +1135,10 @@ accepting, as before)."
   ;; id.dat above all -- lands in the store's PARENT directory instead
   ;; of inside it.  Normalize once, before any use (GH #222).
   (setq location (namestring (uiop:ensure-directory-pathname location)))
-  ;; GH #224: STATE is a (RAW . GRAPH) cons %OPEN-GRAPH-1 updates as
-  ;; it goes; DONE distinguishes a clean return from a non-local exit.
-  ;; The original condition always propagates unchanged.
-  (let ((state (cons nil nil)) (done nil))
+  ;; GH #224: STATE (%GRAPH-OPEN-STATE) is what %OPEN-GRAPH-1 updates
+  ;; as it goes; DONE distinguishes a clean return from a non-local
+  ;; exit.  The original condition always propagates unchanged.
+  (let ((state (make-%graph-open-state)) (done nil))
     (unwind-protect
         (prog1
             (%open-graph-1 name location state
@@ -1097,7 +1170,7 @@ accepting, as before)."
                           :recovery-policy recovery-policy
                           :initial-accepting-state initial-accepting-state)
           (setf done t))
-      (unless done (%abort-graph-open (car state) (cdr state))))))
+      (unless done (%abort-graph-open state)))))
 
 (defmethod close-graph ((graph graph) &key (snapshot-p t))
   "Cleanly close GRAPH: stop replication, flush and unmap all on-disk

--- a/graph.lisp
+++ b/graph.lisp
@@ -290,6 +290,229 @@ debugging an unexpectedly empty result, check the declaration before the data."
     (when segment
       (segment-scan segment query-vector k))))
 
+(defun %close-open-resource (r)
+  "Best-effort close of one fd-bearing resource R of unknown runtime
+type (GH #224) -- the exact set MAKE-GRAPH/OPEN-GRAPH ever hand to a
+fresh GRAPH's slots.  Never signals; NIL is silently a no-op."
+  (ignore-errors
+    (cond ((type-index-p r) (close-type-index r))
+          ((vev-index-p r) (close-vev-index r))
+          ((ve-index-p r) (close-ve-index r))
+          ((lhash-p r) (close-lhash r))
+          ((memory-p r) (close-memory r)))))
+
+(defun %abort-graph-open (raw graph)
+  "Best-effort teardown for a GRAPH construction aborted partway
+through MAKE-GRAPH/OPEN-GRAPH (GH #224).  RAW is every fd-bearing
+resource opened before GRAPH itself existed -- MAKE-INSTANCE evaluates
+its initarg value-forms before it runs, so an error partway through
+that argument list (the original bug report's case) leaves each
+already-opened one reachable from nothing but a local variable, unless
+%MAKE-GRAPH-1/%OPEN-GRAPH-1 push it here as it goes.  GRAPH is the
+constructed instance, or NIL if MAKE-INSTANCE itself never returned.
+Once GRAPH exists it owns everything in RAW via its own slots and the
+caller clears RAW right then, so the two branches below never name the
+same object.  Also deregisters GRAPH from *GRAPHS*/the open-store
+vector if that ran before the failure, and removes a .dirty marker
+this open wrote.  Never signals -- the caller's UNWIND-PROTECT
+re-raises the original condition unchanged."
+  (dolist (r raw) (%close-open-resource r))
+  (when graph
+    (ignore-errors
+      (when (eq graph (gethash (graph-name graph) *graphs*))
+        (remhash (graph-name graph) *graphs*)))
+    (ignore-errors (%unregister-open-store graph))
+    (ignore-errors (%close-open-resource (vertex-index graph)))
+    (ignore-errors (%close-open-resource (edge-index graph)))
+    (ignore-errors (%close-open-resource (vev-index graph)))
+    (ignore-errors (%close-open-resource (ve-index-in graph)))
+    (ignore-errors (%close-open-resource (ve-index-out graph)))
+    (ignore-errors (%close-open-resource (vertex-table graph)))
+    (ignore-errors (%close-open-resource (edge-table graph)))
+    (ignore-errors (%close-open-resource (indexes graph)))
+    (ignore-errors (%close-open-resource (heap graph)))
+    (ignore-errors (close-replication-log graph))
+    (ignore-errors
+      (when (and (slot-exists-p graph 'applied-op-ids)
+                 (slot-boundp graph 'applied-op-ids)
+                 (lhash-p (applied-op-ids graph)))
+        (close-lhash (applied-op-ids graph))))
+    (ignore-errors
+      (let ((dirty-file (format nil "~A/.dirty" (location graph))))
+        (when (probe-file dirty-file) (delete-file dirty-file)))))
+  nil)
+
+(defun %make-graph-1
+    (name location state &key master-p slave-p master-host
+                              replication-port replication-key package
+                              replay-txn-dir buffer-pool-p buffer-pool-size
+                              vertex-buckets edge-buckets heap-size
+                              index-size keep-revisions spatial-precision
+                              spatial-max-cells replication-filter
+                              peer-role origin-id peer-host export-predicate
+                              device-registry merge-policy reference-classes
+                              peer-schema-version index-backend
+                              spatial-index-backend system-clock
+                              recovery-policy)
+  ;; Private body of MAKE-GRAPH (GH #224): everything that opens an fd
+  ;; or registers the graph lives here, wrapped by MAKE-GRAPH's
+  ;; UNWIND-PROTECT.  STATE is a (RAW . GRAPH) cons this function
+  ;; updates as it goes, so an abort mid-way still knows what to tear
+  ;; down -- see %ABORT-GRAPH-OPEN.
+  (ensure-directories-exist location)
+  (let* ((path (pathname location))
+         (dirty-file (format nil "~A/.dirty" location)))
+    (unless (probe-file path)
+      (error "Unable to open graph location ~A" path))
+    ;; GH #170 Task 4: persisted once, at create, before anything else
+    ;; touches LOCATION -- SET-STORE-RECOVERY-POLICY validates the value.
+    (when recovery-policy
+      (set-store-recovery-policy path recovery-policy))
+    (when buffer-pool-p
+      (ensure-buffer-pool buffer-pool-size))
+    (let (heap vertex-table edge-table indexes ve-index-in ve-index-out
+          vev-index graph)
+      ;; GH #224: MAKE-INSTANCE evaluates its initarg value-forms before
+      ;; it runs, so an error partway through that argument list -- the
+      ;; original bug report's steady-state case -- would otherwise
+      ;; leave every already-opened resource here unreachable from any
+      ;; variable.  Push each one onto STATE's raw list as soon as it
+      ;; is bound, so %ABORT-GRAPH-OPEN can still find and close it.
+      (setq heap (create-memory (format nil "~A/heap.dat" path)
+                                heap-size))
+      (push heap (car state))
+      (setq vertex-table (make-vertex-table
+                          (format nil "~A/vertex/" path)
+                          :base-buckets vertex-buckets))
+      (push vertex-table (car state))
+      (setq edge-table (make-edge-table
+                        (format nil "~A/edge/" path)
+                        :base-buckets edge-buckets))
+      (push edge-table (car state))
+      (setq indexes (create-memory
+                     (format nil "~A/indexes.dat" path)
+                     index-size))
+      (push indexes (car state))
+      (setq ve-index-in (make-ve-index
+                         (format nil "~A/ve-index-in/" path)))
+      (push ve-index-in (car state))
+      (setq ve-index-out (make-ve-index
+                          (format nil "~A/ve-index-out/" path)))
+      (push ve-index-out (car state))
+      (setq vev-index (make-vev-index (format nil "~A/vev-index/" path)))
+      (push vev-index (car state))
+      (setq graph
+            (make-instance
+             (cond (slave-p 'slave-graph)
+                   (master-p 'master-graph)
+                   (peer-role 'peer-graph)
+                   (t 'graph))
+             :graph-name name
+             :location path
+             :index-backend index-backend
+             :spatial-index-backend spatial-index-backend
+             :views
+             #+sbcl (make-hash-table :synchronized t)
+             #+ccl (make-hash-table :shared t)
+             #+lispworks (make-hash-table :single-thread nil)
+             #+ecl (make-hash-table #+graph-db-ecl-sync-hash :synchronized
+                                     #+graph-db-ecl-sync-hash t)
+             :cache
+             (make-id-table :synchronized t :weakness :value)
+             :replication-key replication-key
+             :replication-port replication-port
+             :vertex-table vertex-table
+             :edge-table edge-table
+             :heap heap
+             :indexes indexes
+             :ve-index-in ve-index-in
+             :ve-index-out ve-index-out
+             :vev-index vev-index))
+      ;; GRAPH now owns every resource above via its own slots -- hand
+      ;; cleanup off to the GRAPH-based path in %ABORT-GRAPH-OPEN.
+      (setf (car state) nil (cdr state) graph)
+      (setf (vertex-index graph)
+            (make-type-index
+             (format nil "~A/vertex-index.dat" path) heap))
+      (setf (edge-index graph)
+            (make-type-index
+             (format nil "~A/edge-index.dat" path) heap))
+      ;; (MVCC: the lhash value-finalizer that copied node bytes under the bucket
+      ;; lock is gone; read paths now materialize bytes under a read pin instead.)
+      (let ((*graph* graph))
+        (init-schema graph)
+        ;; MVCC: graph-wide default retained-version count (per-type overrides via
+        ;; def-vertex/def-edge :keep-revisions).  Set before update-schema persists.
+        (setf (schema-keep-revisions (schema graph)) keep-revisions)
+        (update-schema graph)
+        (setf (graph-default-spatial-precision graph) (or spatial-precision 7))
+        (setf (graph-default-spatial-max-cells graph) (or spatial-max-cells +spatial-insert-max-cells+))
+        ;; REBUILD-SPATIAL-INDEXES persists the (empty, on a fresh graph) sidecar
+        ;; itself once it finishes; a trailing save here would just be a redundant
+        ;; duplicate of the exact same state.
+        (rebuild-spatial-indexes graph)
+        (with-open-file (out dirty-file :direction :output)
+          (format out "~S" (get-universal-time)))
+        (setf (gethash name *graphs*) graph)
+        (%register-open-store graph))
+      (when slave-p
+        (setf (master-host graph) master-host)
+        ;; Set the subset filter before replay/replication so the slave applies
+        ;; only its subset from the very first transaction.
+        (when replication-filter
+          (setf (replication-filter graph) replication-filter))
+        (when replay-txn-dir
+          (let ((*graph* graph))
+            (replay graph replay-txn-dir package))))
+      (when peer-role
+        (setf (peer-role graph) peer-role
+              (origin-id graph) origin-id
+              (peer-host graph) peer-host
+              (export-predicate graph) export-predicate
+              (merge-policy graph) merge-policy
+              (device-registry graph) device-registry
+              (reference-classes graph) reference-classes
+              (peer-schema-version graph) peer-schema-version
+              ;; B1/PT-8: reload the durable Lamport clock so it never resets on
+              ;; restart (0 for a fresh graph, the persisted value on reopen).
+              (lamport-counter graph) (load-lamport-counter graph)
+              ;; B2b: recover per-field Lamport stamps (v1 in-memory snapshot).
+              (field-stamps graph) (load-field-stamps graph)
+              ;; #6: recover the :ORIGIN-scope per-node origin partitions.
+              (node-origins graph) (load-node-origins graph)
+              ;; B3: recover the durable conflict records for the review surface.
+              (peer-conflicts graph) (load-peer-conflicts graph)
+              ;; WP-3: durable applied-op-id dedup index -- op-id (16-byte uuid key)
+              ;; -> lamport (uint64 value), the make-lhash defaults.
+              (applied-op-ids graph)
+              (make-lhash :location (format nil "~A/applied-ops/" path)
+                          :buckets 8)))
+      ;; Unlike OPEN-GRAPH, this TM does not need :OPENING (review round
+      ;; 3): MAKE-GRAPH's *GRAPHS* registration above already runs before
+      ;; this construction, same as before I4, and there is no RECOVER-
+      ;; TRANSACTIONS/rebuild step here for a racing writer to collide
+      ;; with -- a write against the still-unbound TRANSACTION-MANAGER
+      ;; slot in that window signals a loud unbound-slot error, the same
+      ;; acceptable pre-#170 behaviour (GH #170).
+      (setf (transaction-manager graph)
+            (make-instance 'transaction-manager
+                           :graph graph))
+      (when system-clock
+        (attach-to-system-clock graph system-clock))
+      (ensure-directories-exist (persistent-transaction-directory graph))
+      (init-replication-log graph)
+      (start-replication graph :package package)
+      (setf (graph-open-p graph) t)
+      ;; Build the DEF-UNIQUE constraints registered for this graph, as
+      ;; OPEN-GRAPH does.  A fresh graph has no nodes, so this registers empty
+      ;; indexes rather than scanning -- but registration is what lets an
+      ;; ABSENT index mean "not built yet" instead of "brand new", which the
+      ;; consult-only commit path now relies on (GH #129).  After the slave
+      ;; replay above, so a subset replay is covered.
+      (let ((*graph* graph))
+        (install-unique-tuple-constraints graph))
+      graph)))
+
 (defun make-graph (name location &key master-p slave-p master-host
                                    replication-port replication-key package
                                    replay-txn-dir (buffer-pool-p t)
@@ -397,137 +620,48 @@ to disk and remove it."
     (error ":PEER-ROLE must be :HUB or :DEVICE, got ~S" peer-role))
   (when (and (eq peer-role :device) (null origin-id))
     (error "a :DEVICE peer-graph requires a hub-minted :ORIGIN-ID"))
-  (ensure-directories-exist location)
-  (let* ((path (pathname location))
-         (dirty-file (format nil "~A/.dirty" location)))
-    (unless (probe-file path)
-      (error "Unable to open graph location ~A" path))
-    ;; GH #170 Task 4: persisted once, at create, before anything else
-    ;; touches LOCATION -- SET-STORE-RECOVERY-POLICY validates the value.
-    (when recovery-policy
-      (set-store-recovery-policy path recovery-policy))
-    (when buffer-pool-p
-      (ensure-buffer-pool buffer-pool-size))
-    (let* ((heap (create-memory
-                  (format nil "~A/heap.dat" path)
-                  heap-size))
-           (graph
-            (make-instance
-             (cond (slave-p 'slave-graph)
-                   (master-p 'master-graph)
-                   (peer-role 'peer-graph)
-                   (t 'graph))
-             :graph-name name
-             :location path
-             :index-backend index-backend
-             :spatial-index-backend spatial-index-backend
-             :views
-             #+sbcl (make-hash-table :synchronized t)
-             #+ccl (make-hash-table :shared t)
-             #+lispworks (make-hash-table :single-thread nil)
-             #+ecl (make-hash-table #+graph-db-ecl-sync-hash :synchronized
-                                     #+graph-db-ecl-sync-hash t)
-             :cache
-             (make-id-table :synchronized t :weakness :value)
-             :replication-key replication-key
-             :replication-port replication-port
-             :vertex-table (make-vertex-table
-                            (format nil "~A/vertex/" path)
-                            :base-buckets vertex-buckets)
-             :edge-table (make-edge-table
-                          (format nil "~A/edge/" path)
-                          :base-buckets edge-buckets)
-             :heap heap
-             :indexes (create-memory
-                       (format nil "~A/indexes.dat" path)
-                       index-size)
-             :ve-index-in (make-ve-index
-                           (format nil "~A/ve-index-in/" path))
-             :ve-index-out (make-ve-index
-                            (format nil "~A/ve-index-out/" path))
-             :vev-index (make-vev-index
-                         (format nil "~A/vev-index/" path)))))
-      (setf (vertex-index graph)
-            (make-type-index
-             (format nil "~A/vertex-index.dat" path) heap))
-      (setf (edge-index graph)
-            (make-type-index
-             (format nil "~A/edge-index.dat" path) heap))
-      ;; (MVCC: the lhash value-finalizer that copied node bytes under the bucket
-      ;; lock is gone; read paths now materialize bytes under a read pin instead.)
-      (let ((*graph* graph))
-        (init-schema graph)
-        ;; MVCC: graph-wide default retained-version count (per-type overrides via
-        ;; def-vertex/def-edge :keep-revisions).  Set before update-schema persists.
-        (setf (schema-keep-revisions (schema graph)) keep-revisions)
-        (update-schema graph)
-        (setf (graph-default-spatial-precision graph) (or spatial-precision 7))
-        (setf (graph-default-spatial-max-cells graph) (or spatial-max-cells +spatial-insert-max-cells+))
-        ;; REBUILD-SPATIAL-INDEXES persists the (empty, on a fresh graph) sidecar
-        ;; itself once it finishes; a trailing save here would just be a redundant
-        ;; duplicate of the exact same state.
-        (rebuild-spatial-indexes graph)
-        (with-open-file (out dirty-file :direction :output)
-          (format out "~S" (get-universal-time)))
-        (setf (gethash name *graphs*) graph)
-        (%register-open-store graph))
-      (when slave-p
-        (setf (master-host graph) master-host)
-        ;; Set the subset filter before replay/replication so the slave applies
-        ;; only its subset from the very first transaction.
-        (when replication-filter
-          (setf (replication-filter graph) replication-filter))
-        (when replay-txn-dir
-          (let ((*graph* graph))
-            (replay graph replay-txn-dir package))))
-      (when peer-role
-        (setf (peer-role graph) peer-role
-              (origin-id graph) origin-id
-              (peer-host graph) peer-host
-              (export-predicate graph) export-predicate
-              (merge-policy graph) merge-policy
-              (device-registry graph) device-registry
-              (reference-classes graph) reference-classes
-              (peer-schema-version graph) peer-schema-version
-              ;; B1/PT-8: reload the durable Lamport clock so it never resets on
-              ;; restart (0 for a fresh graph, the persisted value on reopen).
-              (lamport-counter graph) (load-lamport-counter graph)
-              ;; B2b: recover per-field Lamport stamps (v1 in-memory snapshot).
-              (field-stamps graph) (load-field-stamps graph)
-              ;; #6: recover the :ORIGIN-scope per-node origin partitions.
-              (node-origins graph) (load-node-origins graph)
-              ;; B3: recover the durable conflict records for the review surface.
-              (peer-conflicts graph) (load-peer-conflicts graph)
-              ;; WP-3: durable applied-op-id dedup index -- op-id (16-byte uuid key)
-              ;; -> lamport (uint64 value), the make-lhash defaults.
-              (applied-op-ids graph)
-              (make-lhash :location (format nil "~A/applied-ops/" path)
-                          :buckets 8)))
-      ;; Unlike OPEN-GRAPH, this TM does not need :OPENING (review round
-      ;; 3): MAKE-GRAPH's *GRAPHS* registration above already runs before
-      ;; this construction, same as before I4, and there is no RECOVER-
-      ;; TRANSACTIONS/rebuild step here for a racing writer to collide
-      ;; with -- a write against the still-unbound TRANSACTION-MANAGER
-      ;; slot in that window signals a loud unbound-slot error, the same
-      ;; acceptable pre-#170 behaviour (GH #170).
-      (setf (transaction-manager graph)
-            (make-instance 'transaction-manager
-                           :graph graph))
-      (when system-clock
-        (attach-to-system-clock graph system-clock))
-      (ensure-directories-exist (persistent-transaction-directory graph))
-      (init-replication-log graph)
-      (start-replication graph :package package)
-      (setf (graph-open-p graph) t)
-      ;; Build the DEF-UNIQUE constraints registered for this graph, as
-      ;; OPEN-GRAPH does.  A fresh graph has no nodes, so this registers empty
-      ;; indexes rather than scanning -- but registration is what lets an
-      ;; ABSENT index mean "not built yet" instead of "brand new", which the
-      ;; consult-only commit path now relies on (GH #129).  After the slave
-      ;; replay above, so a subset replay is covered.
-      (let ((*graph* graph))
-        (install-unique-tuple-constraints graph))
-      graph)))
+  ;; A slashless namestring keeps LOCATION as a FILE pathname, so every
+  ;; (make-pathname :defaults (location graph)) sidecar -- transaction-
+  ;; id.dat above all -- lands in the store's PARENT directory instead
+  ;; of inside it.  Normalize once, before any use (GH #222).
+  (setq location (namestring (uiop:ensure-directory-pathname location)))
+  ;; GH #224: STATE is a (RAW . GRAPH) cons %MAKE-GRAPH-1 updates as
+  ;; it goes; DONE distinguishes a clean return from a non-local exit.
+  ;; The original condition always propagates unchanged.
+  (let ((state (cons nil nil)) (done nil))
+    (unwind-protect
+        (prog1
+            (%make-graph-1 name location state
+                           :master-p master-p :slave-p slave-p
+                           :master-host master-host
+                           :replication-port replication-port
+                           :replication-key replication-key
+                           :package package
+                           :replay-txn-dir replay-txn-dir
+                           :buffer-pool-p buffer-pool-p
+                           :buffer-pool-size buffer-pool-size
+                           :vertex-buckets vertex-buckets
+                           :edge-buckets edge-buckets
+                           :heap-size heap-size
+                           :index-size index-size
+                           :keep-revisions keep-revisions
+                           :spatial-precision spatial-precision
+                           :spatial-max-cells spatial-max-cells
+                           :replication-filter replication-filter
+                           :peer-role peer-role
+                           :origin-id origin-id
+                           :peer-host peer-host
+                           :export-predicate export-predicate
+                           :device-registry device-registry
+                           :merge-policy merge-policy
+                           :reference-classes reference-classes
+                           :peer-schema-version peer-schema-version
+                           :index-backend index-backend
+                           :spatial-index-backend spatial-index-backend
+                           :system-clock system-clock
+                           :recovery-policy recovery-policy)
+          (setf done t))
+      (unless done (%abort-graph-open (car state) (cdr state))))))
 
 (define-condition recovery-policy-mismatch-warning (warning)
   ;; A named class rather than a bare STRING WARN, so a caller (or a test)
@@ -546,81 +680,23 @@ policy.dat's ~S; the file wins."
                      (recovery-policy-mismatch-warning-requested c)
                      (recovery-policy-mismatch-warning-on-disk c)))))
 
-(defun open-graph (name location &key master-p slave-p master-host replication-port
-                   replication-key package (buffer-pool-p t) (gc-heap-p t)
-                   (buffer-pool-size 100000)
-                   (accept-versions (list +storage-version+))
-                   keep-revisions regenerate-views
-                   peer-role origin-id peer-host
-                   export-predicate device-registry merge-policy
-                   reference-classes (peer-schema-version '(1 0))
-                   (index-backend *index-backend*)
-                   spatial-index-backend
-                   ;; Default geohash precision for spatial indexes CREATED on this
-                   ;; graph (MAKE-GRAPH takes the same keyword).  Existing indexes
-                   ;; reopen at their own persisted precision from the v3 sidecar,
-                   ;; so this governs only indexes created after the open -- and,
-                   ;; for a pre-v3 graph, the ones its migration re-derives.
-                   (spatial-precision 7)
-                   (spatial-max-cells +spatial-insert-max-cells+)
-                   (system-clock *system-clock*)
-                   shadow-p recovery-policy
-                   (initial-accepting-state t))
-  "Open the existing graph named NAME whose files live under directory
-LOCATION, register it, and return it.  Use this to reopen a graph created
-earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's, including
-:SYSTEM-CLOCK -- attaching raises the clock above this store's persisted
-highest id (the spec §6 watermark).
-
-Signals an error if LOCATION holds a .dirty marker, which means the graph was
-not closed cleanly and must be recovered first (see RECOVER-TRANSACTIONS and
-the backup/recovery chapter).  By default the heap is garbage-collected
-(:GC-HEAP-P) and outstanding transactions are recovered on open.  Views are
-reconciled against their declarative definitions and kept as-is unless changed
-(see DEF-VIEW); pass :REGENERATE-VIEWS T to force-rebuild every view on open.
-Always CLOSE-GRAPH when finished.
-
-*SYSTEM-DIRECTORY* must be set: reopening replays the schema and may assign
-ids to types added since (GH #186).
-
-:SHADOW-P T opens an unregistered shadow generation (GH #170,
-OPEN-SHADOW-GRAPH): the graph is never placed in *GRAPHS*, never
-published to the open-store vector (%REGISTER-OPEN-STORE is skipped;
-STORE-ID is still interned from the registry, directly, so v8 ids
-minted here carry the live store's tag), and replication is never
-started.
-
-:RECOVERY-POLICY (GH #170) is only a HINT here, unlike MAKE-GRAPH: if
-LOCATION already carries a policy.dat, that file is authoritative --
-this keyword is ignored (a value that disagrees with the file signals
-RECOVERY-POLICY-MISMATCH-WARNING, a WARNING, but the file still wins)
-rather than silently rewritten out from under whatever wrote it.  It
-is persisted only when LOCATION is being
-created-on-open (no schema.dat yet, the same condition INIT-SCHEMA
-below branches on) -- a genuine reopen of an existing graph with no
-policy.dat leaves it absent (STORE-RECOVERY-POLICY's :AUTHORED
-default), it does not retroactively opt that graph in.
-
-:INITIAL-ACCEPTING-STATE (GH #170, review finding I4) is the state this
-call leaves the graph in once it returns -- e.g. SHADOW-STORE's reopen
-passes :READ-ONLY so the returned graph never briefly comes up fully
-writable.  The fresh TRANSACTION-MANAGER itself always starts at
-:OPENING (review round 3), not this value directly: :OPENING is what is
-in force, before the graph is registered in *GRAPHS*, for every
-rebuild/recovery step this call runs internally, refusing a racing
-external writer with STORE-NOT-ACCEPTING-ERROR reason :OPENING while
-still admitting the read pins those internal steps themselves take.
-Only once GRAPH-OPEN-P is T, at the very end, does ACCEPTING-P flip to
-INITIAL-ACCEPTING-STATE.  Defaults to T (ordinary opens end up fully
-accepting, as before)."
-  (unless *system-directory*
-    (error 'system-directory-required :operation 'open-graph))
-  (when (and peer-role (or master-p slave-p))
-    (error ":PEER-ROLE is mutually exclusive with :MASTER-P / :SLAVE-P"))
-  (when (and peer-role (not (member peer-role '(:hub :device))))
-    (error ":PEER-ROLE must be :HUB or :DEVICE, got ~S" peer-role))
-  (when (and (eq peer-role :device) (null origin-id))
-    (error "a :DEVICE peer-graph requires a hub-minted :ORIGIN-ID"))
+(defun %open-graph-1
+    (name location state &key master-p slave-p master-host
+                              replication-port replication-key package
+                              buffer-pool-p gc-heap-p buffer-pool-size
+                              accept-versions keep-revisions
+                              regenerate-views peer-role origin-id
+                              peer-host export-predicate device-registry
+                              merge-policy reference-classes
+                              peer-schema-version index-backend
+                              spatial-index-backend spatial-precision
+                              spatial-max-cells system-clock shadow-p
+                              recovery-policy initial-accepting-state)
+  ;; Private body of OPEN-GRAPH (GH #224): everything that opens an fd
+  ;; or registers the graph lives here, wrapped by OPEN-GRAPH's
+  ;; UNWIND-PROTECT.  STATE is a (RAW . GRAPH) cons this function
+  ;; updates as it goes, so an abort mid-way still knows what to tear
+  ;; down -- see %ABORT-GRAPH-OPEN.
   (ensure-directories-exist location)
   (let ((path (pathname location))
         (dirty-file (format nil "~A/.dirty" location))
@@ -633,9 +709,30 @@ accepting, as before)."
     (when buffer-pool-p
       (log:info "Initializing buffer pool.")
       (ensure-buffer-pool buffer-pool-size))
-    (let* ((heap (open-memory (format nil "~A/heap.dat" path)
+    (let (heap vertex-table edge-table indexes ve-index-in ve-index-out
+          vev-index graph)
+      ;; GH #224: same STATE-tracking as MAKE-GRAPH -- MAKE-INSTANCE
+      ;; evaluates its initarg value-forms before it runs, so push each
+      ;; opened resource as soon as it is bound.
+      (setq heap (open-memory (format nil "~A/heap.dat" path)
                               :accept-versions accept-versions))
-           (graph
+      (push heap (car state))
+      (setq vertex-table (open-lhash (format nil "~A/vertex/" path)))
+      (push vertex-table (car state))
+      (setq edge-table (open-lhash (format nil "~A/edge/" path)))
+      (push edge-table (car state))
+      (setq indexes (open-memory (format nil "~A/indexes.dat" path)
+                                 :accept-versions accept-versions))
+      (push indexes (car state))
+      (setq ve-index-in (open-ve-index
+                         (format nil "~A/ve-index-in/" path)))
+      (push ve-index-in (car state))
+      (setq ve-index-out (open-ve-index
+                          (format nil "~A/ve-index-out/" path)))
+      (push ve-index-out (car state))
+      (setq vev-index (open-vev-index (format nil "~A/vev-index/" path)))
+      (push vev-index (car state))
+      (setq graph
             (make-instance
              (cond (slave-p 'slave-graph)
                    (master-p 'master-graph)
@@ -655,20 +752,16 @@ accepting, as before)."
              (make-id-table :synchronized t :weakness :value)
              :replication-key replication-key
              :replication-port replication-port
-             :vertex-table (open-lhash
-                            (format nil "~A/vertex/" path))
-             :edge-table (open-lhash
-                          (format nil "~A/edge/" path))
+             :vertex-table vertex-table
+             :edge-table edge-table
              :heap heap
-             :indexes (open-memory
-                       (format nil "~A/indexes.dat" path)
-                       :accept-versions accept-versions)
-             :ve-index-in (open-ve-index
-                           (format nil "~A/ve-index-in/" path))
-             :ve-index-out (open-ve-index
-                            (format nil "~A/ve-index-out/" path))
-             :vev-index (open-vev-index
-                         (format nil "~A/vev-index/" path)))))
+             :indexes indexes
+             :ve-index-in ve-index-in
+             :ve-index-out ve-index-out
+             :vev-index vev-index))
+      ;; GRAPH now owns every resource above via its own slots -- hand
+      ;; cleanup off to the GRAPH-based path in %ABORT-GRAPH-OPEN.
+      (setf (car state) nil (cdr state) graph)
       (let ((*graph* graph))
         (setf (vertex-index graph)
               (open-type-index (format nil "~A/vertex-index.dat" path) heap))
@@ -888,6 +981,123 @@ accepting, as before)."
       ;; (GH #170, review round 3).
       (%set-accepting-p (transaction-manager graph) initial-accepting-state)
       graph)))
+
+(defun open-graph (name location &key master-p slave-p master-host replication-port
+                   replication-key package (buffer-pool-p t) (gc-heap-p t)
+                   (buffer-pool-size 100000)
+                   (accept-versions (list +storage-version+))
+                   keep-revisions regenerate-views
+                   peer-role origin-id peer-host
+                   export-predicate device-registry merge-policy
+                   reference-classes (peer-schema-version '(1 0))
+                   (index-backend *index-backend*)
+                   spatial-index-backend
+                   ;; Default geohash precision for spatial indexes CREATED on this
+                   ;; graph (MAKE-GRAPH takes the same keyword).  Existing indexes
+                   ;; reopen at their own persisted precision from the v3 sidecar,
+                   ;; so this governs only indexes created after the open -- and,
+                   ;; for a pre-v3 graph, the ones its migration re-derives.
+                   (spatial-precision 7)
+                   (spatial-max-cells +spatial-insert-max-cells+)
+                   (system-clock *system-clock*)
+                   shadow-p recovery-policy
+                   (initial-accepting-state t))
+  "Open the existing graph named NAME whose files live under directory
+LOCATION, register it, and return it.  Use this to reopen a graph created
+earlier with MAKE-GRAPH; the keyword arguments mirror MAKE-GRAPH's, including
+:SYSTEM-CLOCK -- attaching raises the clock above this store's persisted
+highest id (the spec §6 watermark).
+
+Signals an error if LOCATION holds a .dirty marker, which means the graph was
+not closed cleanly and must be recovered first (see RECOVER-TRANSACTIONS and
+the backup/recovery chapter).  By default the heap is garbage-collected
+(:GC-HEAP-P) and outstanding transactions are recovered on open.  Views are
+reconciled against their declarative definitions and kept as-is unless changed
+(see DEF-VIEW); pass :REGENERATE-VIEWS T to force-rebuild every view on open.
+Always CLOSE-GRAPH when finished.
+
+*SYSTEM-DIRECTORY* must be set: reopening replays the schema and may assign
+ids to types added since (GH #186).
+
+:SHADOW-P T opens an unregistered shadow generation (GH #170,
+OPEN-SHADOW-GRAPH): the graph is never placed in *GRAPHS*, never
+published to the open-store vector (%REGISTER-OPEN-STORE is skipped;
+STORE-ID is still interned from the registry, directly, so v8 ids
+minted here carry the live store's tag), and replication is never
+started.
+
+:RECOVERY-POLICY (GH #170) is only a HINT here, unlike MAKE-GRAPH: if
+LOCATION already carries a policy.dat, that file is authoritative --
+this keyword is ignored (a value that disagrees with the file signals
+RECOVERY-POLICY-MISMATCH-WARNING, a WARNING, but the file still wins)
+rather than silently rewritten out from under whatever wrote it.  It
+is persisted only when LOCATION is being
+created-on-open (no schema.dat yet, the same condition INIT-SCHEMA
+below branches on) -- a genuine reopen of an existing graph with no
+policy.dat leaves it absent (STORE-RECOVERY-POLICY's :AUTHORED
+default), it does not retroactively opt that graph in.
+
+:INITIAL-ACCEPTING-STATE (GH #170, review finding I4) is the state this
+call leaves the graph in once it returns -- e.g. SHADOW-STORE's reopen
+passes :READ-ONLY so the returned graph never briefly comes up fully
+writable.  The fresh TRANSACTION-MANAGER itself always starts at
+:OPENING (review round 3), not this value directly: :OPENING is what is
+in force, before the graph is registered in *GRAPHS*, for every
+rebuild/recovery step this call runs internally, refusing a racing
+external writer with STORE-NOT-ACCEPTING-ERROR reason :OPENING while
+still admitting the read pins those internal steps themselves take.
+Only once GRAPH-OPEN-P is T, at the very end, does ACCEPTING-P flip to
+INITIAL-ACCEPTING-STATE.  Defaults to T (ordinary opens end up fully
+accepting, as before)."
+  (unless *system-directory*
+    (error 'system-directory-required :operation 'open-graph))
+  (when (and peer-role (or master-p slave-p))
+    (error ":PEER-ROLE is mutually exclusive with :MASTER-P / :SLAVE-P"))
+  (when (and peer-role (not (member peer-role '(:hub :device))))
+    (error ":PEER-ROLE must be :HUB or :DEVICE, got ~S" peer-role))
+  (when (and (eq peer-role :device) (null origin-id))
+    (error "a :DEVICE peer-graph requires a hub-minted :ORIGIN-ID"))
+  ;; A slashless namestring keeps LOCATION as a FILE pathname, so every
+  ;; (make-pathname :defaults (location graph)) sidecar -- transaction-
+  ;; id.dat above all -- lands in the store's PARENT directory instead
+  ;; of inside it.  Normalize once, before any use (GH #222).
+  (setq location (namestring (uiop:ensure-directory-pathname location)))
+  ;; GH #224: STATE is a (RAW . GRAPH) cons %OPEN-GRAPH-1 updates as
+  ;; it goes; DONE distinguishes a clean return from a non-local exit.
+  ;; The original condition always propagates unchanged.
+  (let ((state (cons nil nil)) (done nil))
+    (unwind-protect
+        (prog1
+            (%open-graph-1 name location state
+                          :master-p master-p :slave-p slave-p
+                          :master-host master-host
+                          :replication-port replication-port
+                          :replication-key replication-key
+                          :package package
+                          :buffer-pool-p buffer-pool-p
+                          :gc-heap-p gc-heap-p
+                          :buffer-pool-size buffer-pool-size
+                          :accept-versions accept-versions
+                          :keep-revisions keep-revisions
+                          :regenerate-views regenerate-views
+                          :peer-role peer-role
+                          :origin-id origin-id
+                          :peer-host peer-host
+                          :export-predicate export-predicate
+                          :device-registry device-registry
+                          :merge-policy merge-policy
+                          :reference-classes reference-classes
+                          :peer-schema-version peer-schema-version
+                          :index-backend index-backend
+                          :spatial-index-backend spatial-index-backend
+                          :spatial-precision spatial-precision
+                          :spatial-max-cells spatial-max-cells
+                          :system-clock system-clock
+                          :shadow-p shadow-p
+                          :recovery-policy recovery-policy
+                          :initial-accepting-state initial-accepting-state)
+          (setf done t))
+      (unless done (%abort-graph-open (car state) (cdr state))))))
 
 (defmethod close-graph ((graph graph) &key (snapshot-p t))
   "Cleanly close GRAPH: stop replication, flush and unmap all on-disk

--- a/tests/open-hygiene-tests.lisp
+++ b/tests/open-hygiene-tests.lisp
@@ -5,11 +5,14 @@
 ;;;;    (MAKE-PATHNAME :defaults (LOCATION GRAPH)) landed in the store's
 ;;;;    PARENT directory instead of inside it.
 ;;;;  - GH #224: a MAKE-GRAPH/OPEN-GRAPH call that fails partway through used
-;;;;    to leak every fd it had already opened, and could leave the graph
-;;;;    half-registered in *GRAPHS*.
+;;;;    to leak every fd it had already opened, leaked open vector segments
+;;;;    and a replication listener/thread, could leave the graph half-
+;;;;    registered in *GRAPHS*, and could delete a .dirty marker even after
+;;;;    recovery/rebuild had already mutated the store (review round 1: C1,
+;;;;    I2, I2b, I3).
 ;;;;
-;;;; Both fixes live in graph.lisp; see %ABORT-GRAPH-OPEN and the
-;;;; MAKE-GRAPH/OPEN-GRAPH LOCATION-normalization comments there.
+;;;; Both fixes live in graph.lisp; see %ABORT-GRAPH-OPEN, %GRAPH-OPEN-STATE
+;;;; and the MAKE-GRAPH/OPEN-GRAPH LOCATION-normalization comments there.
 
 (in-package #:graph-db/test)
 
@@ -22,16 +25,36 @@
 ;; A tiny schema of our own, so these tests don't share
 ;; *INTEGRATION-GRAPH-NAME*'s graph identity with the rest of the suite.
 (def-vertex oh-thing () ((label :type string)) :oh-graph)
+;; A :VECTOR-INDEX owner, for the vector-segment leak coverage (GH #224
+;; review I2) -- same graph, so it shares OH-THING's schema/directory story.
+(def-vertex oh-vec () ((embedding :vector-index t)) :oh-graph)
+
+(defun %oh-embedding (dim base)
+  (let ((v (make-array dim :element-type 'single-float)))
+    (dotimes (i dim v) (setf (aref v i) (coerce (+ base (* 0.01 i))
+                                                'single-float)))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; fd-count helper
 ;;; ---------------------------------------------------------------------------
 
 (defun %oh-fd-count ()
-  "Open fd count for this process.  SBCL's DIRECTORY walks /proc/self/fd
-directly and is internally consistent across calls (a fixed small offset
-from the readdir fd itself), which is all a before/after delta needs."
+  "Open fd count for this process, via SBCL's DIRECTORY over
+/proc/self/fd -- internally consistent across calls (a fixed small
+offset from the readdir fd itself), which is all a before/after delta
+needs.  Linux-only (see the #-LINUX SKIP in every caller).  CAVEAT (GH
+#224 review M1): DIRECTORY resolves each /proc/self/fd/N entry as a
+pathname, and a socket or pipe fd's target (e.g. \"socket:[12345]\") is
+not a filesystem path -- SBCL silently drops those rather than
+counting them.  A leaked listening socket (the I2b hazard) therefore
+does NOT move this number; the I2b coverage below asserts call
+ORDERING instead of relying on this counter to see a socket leak."
   (length (directory "/proc/self/fd/*")))
+
+(defmacro %oh-skip-unless-linux (&body body)
+  `(progn
+     #-linux (skip "fd counting here is Linux-only (/proc/self/fd)")
+     #+linux (progn ,@body)))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Aborted-open injection: force one internal opener to signal, so
@@ -39,7 +62,10 @@ from the readdir fd itself), which is all a before/after delta needs."
 ;;; open.  MAKE-VEV-INDEX/OPEN-VEV-INDEX are the LAST resource MAKE-INSTANCE
 ;;; opens in both functions (vertex-table, edge-table, heap, indexes,
 ;;; ve-index-in and ve-index-out all precede it), so injecting there proves
-;;; the abort path runs with real partial state already open.
+;;; the abort path runs with real partial state already open.  Later tests
+;;; inject at %REGISTER-OPEN-STORE and INSTALL-SECONDARY-INDEXES instead, to
+;;; reach the GRAPH-branch of %ABORT-GRAPH-OPEN the early injection never
+;;; exercises (GH #224 review I3).
 ;;; ---------------------------------------------------------------------------
 
 (defmacro %oh-with-injected-failure (fn-name &body body)
@@ -58,6 +84,9 @@ original definition -- even if BODY itself signals."
               ,@body)
          (setf (fdefinition ,fn) ,orig)))))
 
+(defun %oh-dirty-file (path)
+  (merge-pathnames ".dirty" (uiop:ensure-directory-pathname path)))
+
 ;;; ---------------------------------------------------------------------------
 ;;; GH #222
 ;;; ---------------------------------------------------------------------------
@@ -71,9 +100,7 @@ read that way must reopen and read back correctly (GH #222)."
            (slashless (string-right-trim "/" (namestring dir)))
            id)
       (let ((g (make-graph :oh-graph slashless :buffer-pool-size 1000)))
-        (is (probe-file (merge-pathnames
-                          ".dirty" (uiop:ensure-directory-pathname
-                                    slashless)))
+        (is (probe-file (%oh-dirty-file slashless))
             "~A/.dirty must exist while the graph is open" slashless)
         (is (not (probe-file (merge-pathnames ".dirty" parent)))
             "no .dirty must leak into the parent directory")
@@ -99,59 +126,279 @@ read that way must reopen and read back correctly (GH #222)."
     (collect-garbage)))
 
 ;;; ---------------------------------------------------------------------------
-;;; GH #224
+;;; GH #224 -- early injection (before MAKE-INSTANCE returns; GRAPH is NIL
+;;; throughout the abort, so these only exercise %ABORT-GRAPH-OPEN's RAW-list
+;;; branch, not its GRAPH-slot branch).
 ;;; ---------------------------------------------------------------------------
 
 (test aborted-make-graph-does-not-leak-fds
   "Ten aborted MAKE-GRAPH calls, each failing after most of its resources
 are already open, must not leak fds and must not half-register the graph
 (GH #224)."
-  (with-temp-directory (dir)
-    (let* ((path (namestring dir))
-           (before (%oh-fd-count)))
-      (%oh-with-injected-failure 'graph-db::make-vev-index
-        (dotimes (i 10)
-          (signals error
-            (make-graph :oh-graph
-                        (format nil "~A/g~D/" path i)
-                        :buffer-pool-size 1000))))
-      (let ((after (%oh-fd-count)))
-        (is (<= after (+ before 3))
-            "fd count grew from ~D to ~D across 10 aborted make-graph calls"
-            before after))
-      (is (null (graph-db:lookup-graph :oh-graph))
-          "an aborted make-graph must not leave a half-registered graph"))
-    (collect-garbage)))
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir))
+             (before (%oh-fd-count)))
+        (is (plusp before) "fd counting looks broken (0 fds reported)")
+        (%oh-with-injected-failure 'graph-db::make-vev-index
+          (dotimes (i 10)
+            (signals error
+              (make-graph :oh-graph
+                          (format nil "~A/g~D/" path i)
+                          :buffer-pool-size 1000))))
+        (let ((after (%oh-fd-count)))
+          (is (<= after (+ before 3))
+              "fd count grew from ~D to ~D across 10 aborted make-graph ~
+               calls"
+              before after))
+        (is (null (graph-db:lookup-graph :oh-graph))
+            "an aborted make-graph must not leave a half-registered graph"))
+      (collect-garbage))))
 
 (test aborted-open-graph-does-not-leak-fds
   "Ten aborted OPEN-GRAPH calls against a valid, cleanly-closed store must
 not leak fds, must not half-register the graph, and must not corrupt the
 store -- a subsequent un-injected OPEN-GRAPH still succeeds and reads the
 data back (GH #224)."
-  (with-temp-directory (dir)
-    (let* ((path (namestring dir)) id)
-      (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
-        (let ((*graph* g))
-          (with-transaction ()
-            (setq id (id (make-oh-thing :label "survives")))))
-        (close-graph g :snapshot-p nil))
-      (let ((before (%oh-fd-count)))
-        (%oh-with-injected-failure 'graph-db::open-vev-index
-          (dotimes (i 10)
-            (signals error
-              (open-graph :oh-graph path :buffer-pool-size 1000))))
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir)) id)
+        (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((*graph* g))
+            (with-transaction ()
+              (setq id (id (make-oh-thing :label "survives")))))
+          (close-graph g :snapshot-p nil))
+        (let ((before (%oh-fd-count)))
+          (is (plusp before) "fd counting looks broken (0 fds reported)")
+          (%oh-with-injected-failure 'graph-db::open-vev-index
+            (dotimes (i 10)
+              (signals error
+                (open-graph :oh-graph path :buffer-pool-size 1000))))
+          (let ((after (%oh-fd-count)))
+            (is (<= after (+ before 3))
+                "fd count grew from ~D to ~D across 10 aborted open-graph ~
+                 calls"
+                before after)))
+        (is (null (graph-db:lookup-graph :oh-graph))
+            "an aborted open-graph must not leave a half-registered graph")
+        (let ((g2 (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (unwind-protect
+               (let ((*graph* g2))
+                 (is (string= "survives" (slot-value (lookup-vertex id)
+                                                      'label))
+                     "a subsequent un-injected open-graph must still read ~
+                      back data written before the aborted opens"))
+            (close-graph g2 :snapshot-p nil))))
+      (collect-garbage))))
+
+;;; ---------------------------------------------------------------------------
+;;; GH #224 -- late injection: GRAPH is fully constructed, registered, and
+;;; (for the OPEN-GRAPH case) past the point recovery/rebuild can mutate the
+;;; store, before the injected failure fires.  These are what the early
+;;; tests above cannot reach: %ABORT-GRAPH-OPEN's GRAPH-slot branch, the
+;;; .dirty MUTATED-gated deletion rule (review C1), and the vector-segment /
+;;; replication-ordering cleanup (review I2 / I2b).
+;;; ---------------------------------------------------------------------------
+
+(test aborted-make-graph-late-registration-cleans-up
+  "A MAKE-GRAPH aborted at %REGISTER-OPEN-STORE -- GRAPH fully built, every
+fd open, but nothing that writes against a PRE-EXISTING store's heap has
+run (a fresh MAKE-GRAPH has no prior state to leave stale) -- must close
+every resource, deregister, and delete the .dirty marker THIS open wrote,
+so a subsequent OPEN-GRAPH succeeds directly with no recovery step (GH
+#224 review C1, I3)."
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir))
+             (before (%oh-fd-count)))
+        (%oh-with-injected-failure 'graph-db::%register-open-store
+          (signals error
+            (make-graph :oh-graph path :buffer-pool-size 1000)))
         (let ((after (%oh-fd-count)))
           (is (<= after (+ before 3))
-              "fd count grew from ~D to ~D across 10 aborted open-graph ~
-               calls"
-              before after)))
-      (is (null (graph-db:lookup-graph :oh-graph))
-          "an aborted open-graph must not leave a half-registered graph")
-      (let ((g2 (open-graph :oh-graph path :buffer-pool-size 1000)))
+              "fd count grew from ~D to ~D across one late-aborted ~
+               make-graph"
+              before after))
+        (is (null (graph-db:lookup-graph :oh-graph))
+            "an aborted make-graph must not leave a half-registered graph")
+        (is (not (probe-file (%oh-dirty-file path)))
+            "nothing mutating ran, so .dirty (this open's own) must be ~
+             gone -- otherwise a later open would wrongly demand recovery")
+        (let ((g (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (is (graph-db::graph-open-p g)
+              "the recovered store must open cleanly")
+          (close-graph g :snapshot-p nil)))
+      (collect-garbage))))
+
+(test aborted-open-graph-early-registration-deletes-dirty
+  "An OPEN-GRAPH aborted at %REGISTER-OPEN-STORE -- before recovery/rebuild
+(GC-HEAP, RECOVER-TRANSACTIONS, etc.) has run, so nothing mutated the
+store past what the previous CLOSE-GRAPH already made durable -- must
+delete the .dirty marker THIS open wrote, and a subsequent OPEN-GRAPH must
+succeed with no separate recovery step (GH #224 review C1, I3)."
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir)) id)
+        (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((*graph* g))
+            (with-transaction ()
+              (setq id (id (make-oh-thing :label "early")))))
+          (close-graph g :snapshot-p nil))
+        (let ((before (%oh-fd-count)))
+          (%oh-with-injected-failure 'graph-db::%register-open-store
+            (signals error
+              (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((after (%oh-fd-count)))
+            (is (<= after (+ before 3))
+                "fd count grew from ~D to ~D across one late-aborted ~
+                 open-graph"
+                before after)))
+        (is (null (graph-db:lookup-graph :oh-graph))
+            "an aborted open-graph must not leave a half-registered graph")
+        (is (not (probe-file (%oh-dirty-file path)))
+            "nothing mutating ran, so .dirty (this open's own) must be ~
+             gone")
+        (let ((g2 (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (unwind-protect
+               (let ((*graph* g2))
+                 (is (string= "early" (slot-value (lookup-vertex id)
+                                                   'label))
+                     "the un-injected reopen must still read back the ~
+                      data, with no manual recovery step needed"))
+            (close-graph g2 :snapshot-p nil))))
+      (collect-garbage))))
+
+(test aborted-open-graph-late-injection-retains-dirty-when-mutated
+  "An OPEN-GRAPH aborted at INSTALL-SECONDARY-INDEXES -- well past
+GC-HEAP/RECOVER-TRANSACTIONS/REBUILD-SPATIAL-INDEXES/REBUILD-UNIQUE-
+INDEXES, all of which can write against the store's heap -- must NOT
+delete .dirty: the store now genuinely needs recovery, and a later open
+adopting the OLD index roots against this now-mutated heap (with no
+recovery pass to catch the mismatch) would be silently wrong (GH #224
+review C1).  Once a recovery step clears .dirty (simulated here by
+deleting it directly, mirroring what a real operator's recovery run
+would leave behind), a following OPEN-GRAPH succeeds and the data
+survives."
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir)) id)
+        (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((*graph* g))
+            (with-transaction ()
+              (setq id (id (make-oh-thing :label "recovered")))))
+          (close-graph g :snapshot-p nil))
+        (let ((before (%oh-fd-count)))
+          (%oh-with-injected-failure 'graph-db::install-secondary-indexes
+            (signals error
+              (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((after (%oh-fd-count)))
+            (is (<= after (+ before 3))
+                "fd count grew from ~D to ~D across one late-aborted ~
+                 open-graph"
+                before after)))
+        (is (null (graph-db:lookup-graph :oh-graph))
+            "an aborted open-graph must not leave a half-registered graph")
+        (is (probe-file (%oh-dirty-file path))
+            "mutating steps ran -- .dirty must remain so a later open ~
+             demands recovery rather than silently reopening")
+        (signals error
+          (open-graph :oh-graph path :buffer-pool-size 1000))
+        ;; The operator's recovery step: clear the sentinel.
+        (delete-file (%oh-dirty-file path))
+        (let ((g2 (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (unwind-protect
+               (let ((*graph* g2))
+                 (is (string= "recovered" (slot-value (lookup-vertex id)
+                                                       'label))
+                     "after recovery, a following open-graph must still ~
+                      read back data written before the aborted opens"))
+            (close-graph g2 :snapshot-p nil))))
+      (collect-garbage))))
+
+(test aborted-open-graph-closes-vector-segments
+  "An OPEN-GRAPH aborted after RESTORE-VECTOR-SEGMENTS has opened a
+segment -- which marks the on-disk clean flag DIRTY the moment it opens,
+regardless of whether it will rebuild -- must close that segment during
+the abort (setting the flag back to clean) exactly like CLOSE-GRAPH's own
+MAPHASH over VECTOR-SEGMENTS does.  Otherwise the segment leaks its fd
+and, worse, the NEXT open finds the flag still dirty and pays a full
+rebuild-from-nodes it never needed (GH #224 review I2)."
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir)) id)
+        (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((*graph* g))
+            (with-transaction ()
+              (setq id (id (make-oh-vec :embedding (%oh-embedding 8 1.0))))))
+          (close-graph g :snapshot-p nil))
+        (let ((before (%oh-fd-count)))
+          (%oh-with-injected-failure 'graph-db::install-secondary-indexes
+            (signals error
+              (open-graph :oh-graph path :buffer-pool-size 1000)))
+          (let ((after (%oh-fd-count)))
+            (is (<= after (+ before 3))
+                "fd count grew from ~D to ~D across one late-aborted ~
+                 open-graph (vector segment left open?)"
+                before after)))
+        (delete-file (%oh-dirty-file path))
+        (let ((rebuild-warned nil))
+          (handler-bind
+              ((warning (lambda (c)
+                          (when (search "not closed cleanly"
+                                        (princ-to-string c))
+                            (setq rebuild-warned t))
+                          (muffle-warning c))))
+            (let ((g2 (open-graph :oh-graph path :buffer-pool-size 1000)))
+              (unwind-protect
+                   (let ((*graph* g2))
+                     (is (not rebuild-warned)
+                         "the vector segment must have been closed cleanly ~
+                          by the abort -- a dirty-segment rebuild warning ~
+                          means it leaked open")
+                     (is (equalp (%oh-embedding 8 1.0)
+                                 (slot-value (lookup-vertex id) 'embedding))
+                         "the embedding must survive the aborted-then- ~
+                          recovered reopen"))
+                (close-graph g2 :snapshot-p nil))))))
+      (collect-garbage))))
+
+(test aborted-open-graph-stops-replication-before-other-teardown
+  "%ABORT-GRAPH-OPEN must call STOP-REPLICATION before any other teardown
+step -- specifically before CLOSE-REPLICATION-LOG -- so a master's
+accept-loop thread and listening socket are torn down before anything
+referencing the graph's mmaps is closed; otherwise a retried open on the
+same port fails EADDRINUSE (GH #224 review I2b).  STOP-REPLICATION and
+CLOSE-REPLICATION-LOG are both temporarily wrapped with call-order spies
+rather than exercised through a real master listener, to keep this
+regression fast and independent of networking."
+  (with-temp-directory (dir)
+    (let* ((path (namestring dir)) (order nil))
+      (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
+        (close-graph g :snapshot-p nil))
+      (let ((orig-stop (fdefinition 'graph-db::stop-replication))
+            (orig-log (fdefinition 'graph-db::close-replication-log)))
         (unwind-protect
-             (let ((*graph* g2))
-               (is (string= "survives" (slot-value (lookup-vertex id) 'label))
-                   "a subsequent un-injected open-graph must still read ~
-                    back data written before the aborted opens"))
-          (close-graph g2 :snapshot-p nil))))
+             (progn
+               (setf (fdefinition 'graph-db::stop-replication)
+                     (lambda (g)
+                       (push :stop-replication order)
+                       (funcall orig-stop g)))
+               (setf (fdefinition 'graph-db::close-replication-log)
+                     (lambda (g)
+                       (push :close-replication-log order)
+                       (funcall orig-log g)))
+               (%oh-with-injected-failure 'graph-db::install-secondary-indexes
+                 (signals error
+                   (open-graph :oh-graph path :buffer-pool-size 1000))))
+          (setf (fdefinition 'graph-db::stop-replication) orig-stop)
+          (setf (fdefinition 'graph-db::close-replication-log) orig-log)
+          (ignore-errors (delete-file (%oh-dirty-file path)))))
+      (setf order (nreverse order))
+      (is (member :stop-replication order)
+          "stop-replication must run during the abort")
+      (is (member :close-replication-log order)
+          "close-replication-log must run during the abort")
+      (is (< (position :stop-replication order)
+             (position :close-replication-log order))
+          "stop-replication must run BEFORE close-replication-log"))
     (collect-garbage)))

--- a/tests/open-hygiene-tests.lisp
+++ b/tests/open-hygiene-tests.lisp
@@ -1,0 +1,157 @@
+;;;; Coverage for two open-path hygiene fixes:
+;;;;
+;;;;  - GH #222: a slashless LOCATION namestring used to keep LOCATION as a
+;;;;    FILE pathname, so every sidecar built with
+;;;;    (MAKE-PATHNAME :defaults (LOCATION GRAPH)) landed in the store's
+;;;;    PARENT directory instead of inside it.
+;;;;  - GH #224: a MAKE-GRAPH/OPEN-GRAPH call that fails partway through used
+;;;;    to leak every fd it had already opened, and could leave the graph
+;;;;    half-registered in *GRAPHS*.
+;;;;
+;;;; Both fixes live in graph.lisp; see %ABORT-GRAPH-OPEN and the
+;;;; MAKE-GRAPH/OPEN-GRAPH LOCATION-normalization comments there.
+
+(in-package #:graph-db/test)
+
+(def-suite open-hygiene-suite
+  :description "LOCATION normalization and aborted-open fd hygiene."
+  :in graph-db-suite)
+
+(in-suite open-hygiene-suite)
+
+;; A tiny schema of our own, so these tests don't share
+;; *INTEGRATION-GRAPH-NAME*'s graph identity with the rest of the suite.
+(def-vertex oh-thing () ((label :type string)) :oh-graph)
+
+;;; ---------------------------------------------------------------------------
+;;; fd-count helper
+;;; ---------------------------------------------------------------------------
+
+(defun %oh-fd-count ()
+  "Open fd count for this process.  SBCL's DIRECTORY walks /proc/self/fd
+directly and is internally consistent across calls (a fixed small offset
+from the readdir fd itself), which is all a before/after delta needs."
+  (length (directory "/proc/self/fd/*")))
+
+;;; ---------------------------------------------------------------------------
+;;; Aborted-open injection: force one internal opener to signal, so
+;;; MAKE-GRAPH/OPEN-GRAPH fail after several other components are already
+;;; open.  MAKE-VEV-INDEX/OPEN-VEV-INDEX are the LAST resource MAKE-INSTANCE
+;;; opens in both functions (vertex-table, edge-table, heap, indexes,
+;;; ve-index-in and ve-index-out all precede it), so injecting there proves
+;;; the abort path runs with real partial state already open.
+;;; ---------------------------------------------------------------------------
+
+(defmacro %oh-with-injected-failure (fn-name &body body)
+  "Redefine the internal GRAPH-DB function named by FN-NAME (a symbol) to
+unconditionally signal an error, run BODY, then always restore the
+original definition -- even if BODY itself signals."
+  (let ((orig (gensym "ORIG")) (fn (gensym "FN")))
+    `(let* ((,fn ,fn-name)
+            (,orig (fdefinition ,fn)))
+       (unwind-protect
+            (progn
+              (setf (fdefinition ,fn)
+                    (lambda (&rest args)
+                      (declare (ignore args))
+                      (error "GH #224 test: injected open failure")))
+              ,@body)
+         (setf (fdefinition ,fn) ,orig)))))
+
+;;; ---------------------------------------------------------------------------
+;;; GH #222
+;;; ---------------------------------------------------------------------------
+
+(test slashless-location-keeps-sidecars-inside-the-store
+  "A slashless LOCATION namestring must not scatter .dirty/heap.dat/
+schema.dat into the store's parent directory, and a graph created and
+read that way must reopen and read back correctly (GH #222)."
+  (with-temp-directory (dir)
+    (let* ((parent (uiop:temporary-directory))
+           (slashless (string-right-trim "/" (namestring dir)))
+           id)
+      (let ((g (make-graph :oh-graph slashless :buffer-pool-size 1000)))
+        (is (probe-file (merge-pathnames
+                          ".dirty" (uiop:ensure-directory-pathname
+                                    slashless)))
+            "~A/.dirty must exist while the graph is open" slashless)
+        (is (not (probe-file (merge-pathnames ".dirty" parent)))
+            "no .dirty must leak into the parent directory")
+        (let ((*graph* g))
+          (with-transaction ()
+            (setq id (id (make-oh-thing :label "inside")))))
+        (close-graph g :snapshot-p nil))
+      (is (probe-file (merge-pathnames
+                        "heap.dat"
+                        (uiop:ensure-directory-pathname slashless)))
+          "heap.dat must exist inside the store directory")
+      (is (not (probe-file (merge-pathnames "heap.dat" parent)))
+          "heap.dat must not leak into the parent directory")
+      (is (not (probe-file (merge-pathnames "schema.dat" parent)))
+          "schema.dat must not leak into the parent directory")
+      (let ((g2 (open-graph :oh-graph slashless :buffer-pool-size 1000)))
+        (unwind-protect
+             (let ((*graph* g2))
+               (is (string= "inside" (slot-value (lookup-vertex id) 'label))
+                   "data written under the slashless location must survive ~
+                    a reopen through the same slashless string"))
+          (close-graph g2 :snapshot-p nil))))
+    (collect-garbage)))
+
+;;; ---------------------------------------------------------------------------
+;;; GH #224
+;;; ---------------------------------------------------------------------------
+
+(test aborted-make-graph-does-not-leak-fds
+  "Ten aborted MAKE-GRAPH calls, each failing after most of its resources
+are already open, must not leak fds and must not half-register the graph
+(GH #224)."
+  (with-temp-directory (dir)
+    (let* ((path (namestring dir))
+           (before (%oh-fd-count)))
+      (%oh-with-injected-failure 'graph-db::make-vev-index
+        (dotimes (i 10)
+          (signals error
+            (make-graph :oh-graph
+                        (format nil "~A/g~D/" path i)
+                        :buffer-pool-size 1000))))
+      (let ((after (%oh-fd-count)))
+        (is (<= after (+ before 3))
+            "fd count grew from ~D to ~D across 10 aborted make-graph calls"
+            before after))
+      (is (null (graph-db:lookup-graph :oh-graph))
+          "an aborted make-graph must not leave a half-registered graph"))
+    (collect-garbage)))
+
+(test aborted-open-graph-does-not-leak-fds
+  "Ten aborted OPEN-GRAPH calls against a valid, cleanly-closed store must
+not leak fds, must not half-register the graph, and must not corrupt the
+store -- a subsequent un-injected OPEN-GRAPH still succeeds and reads the
+data back (GH #224)."
+  (with-temp-directory (dir)
+    (let* ((path (namestring dir)) id)
+      (let ((g (make-graph :oh-graph path :buffer-pool-size 1000)))
+        (let ((*graph* g))
+          (with-transaction ()
+            (setq id (id (make-oh-thing :label "survives")))))
+        (close-graph g :snapshot-p nil))
+      (let ((before (%oh-fd-count)))
+        (%oh-with-injected-failure 'graph-db::open-vev-index
+          (dotimes (i 10)
+            (signals error
+              (open-graph :oh-graph path :buffer-pool-size 1000))))
+        (let ((after (%oh-fd-count)))
+          (is (<= after (+ before 3))
+              "fd count grew from ~D to ~D across 10 aborted open-graph ~
+               calls"
+              before after)))
+      (is (null (graph-db:lookup-graph :oh-graph))
+          "an aborted open-graph must not leave a half-registered graph")
+      (let ((g2 (open-graph :oh-graph path :buffer-pool-size 1000)))
+        (unwind-protect
+             (let ((*graph* g2))
+               (is (string= "survives" (slot-value (lookup-vertex id) 'label))
+                   "a subsequent un-injected open-graph must still read ~
+                    back data written before the aborted opens"))
+          (close-graph g2 :snapshot-p nil))))
+    (collect-garbage)))


### PR DESCRIPTION
Closes #222 and #224.

- **#222**: `make-graph`/`open-graph` normalize `LOCATION` once, at the top, via `uiop:ensure-directory-pathname` — a slashless namestring no longer scatters sidecars (`transaction-id.dat`, `.dirty`, `schema.dat`, …) into the store's PARENT directory. Generalizes the #171 `%reopen-and-resume` local fix to the entry points. **⚠ CHANGELOG carries an upgrade note**: a store ever *created* through a slashless location has those sidecars in its parent dir, and after this fix they are no longer found — move them into the store directory before upgrading such a store.
- **#224**: an aborted open tears down everything it acquired. Both functions bind each fd-bearing resource and track it in a `%graph-open-state` BEFORE `make-instance` (whose initarg evaluation was the leak window), run under `unwind-protect`, and a new `%abort-graph-open` best-effort closes every component, stops replication first, closes every vector segment (`restore-vector-segments` marks each dirty on open — leaking one forced a rebuild), and deregisters a half-registered graph. The original condition always propagates unchanged. One rule made explicit (review round 1, C1): the abort deletes `.dirty` **only** when this open wrote it and no mutating recovery/rebuild/replay step ran — otherwise the sentinel deliberately stays, because deleting it would let a later open adopt stale index roots against a mutated heap with no recovery pass.

Review process: independent review found the `.dirty` regression (C1), the vector-segment and replication teardown gaps (I2/I2b), and that the initial tests never reached the graph branch (I3) — all fixed; re-review verified initarg-by-initarg equivalence of the restructured open sequences and ADDRESSED on all findings.

Tests: new `open-hygiene-suite` (8 tests / 57 checks): slashless round-trip; early + late fault-injected aborts for both functions (fd flatness over 10 aborts, `.dirty` per-rule both ways, no half-registration, clean subsequent opens); vector-segment closure; replication-ordering spy. Full `(asdf:test-system :graph-db)`: **4684 checks / 4674 pass / 10 skips (GEOS, pre-existing) / 0 fail** (SBCL; ECL demoted per standing policy).

Deferred with notes: pre-existing double-open `*graphs*` overwrite; `&key`-default drop in the private bodies. Filed separately: the memory-graph twin exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95