### PR TITLE
call-with-read-snapshot: no acquisition escapes its cleanup (#181, #211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,24 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **`CALL-WITH-READ-SNAPSHOT` could leak a registered transaction or a held
+  read-epoch pin, wedging the reaper forever** (#181, #211). It acquired its
+  transaction (`CREATE-TRANSACTION`, which registers the tx) and its read
+  pin (`PIN-READ-EPOCH`) as two separate `LET` bindings *before* entering
+  the `UNWIND-PROTECT` that releases them. A signal from either call left
+  whatever the prior call had already acquired stranded: the tx stayed
+  `:active` in the manager's table forever, so `MINIMUM-START-TRANSACTION-ID`
+  never returned NIL again and the reaper's floor never advanced. #211's
+  concrete trigger is a `%QUIESCE-TRANSACTION-MANAGER` flip (#170) landing
+  in the window between the two calls, making `PIN-READ-EPOCH` signal
+  `STORE-NOT-ACCEPTING-ERROR` after the tx was already registered. Fixed by
+  acquiring progressively inside nested `UNWIND-PROTECT`s, each covering its
+  resource from the instant it succeeds, so a later cleanup signal (e.g. from
+  `REMOVE-TRANSACTION`) cannot skip an earlier one (`UNPIN-READ-EPOCH` no
+  longer depends on `REMOVE-TRANSACTION`'s outcome at all). New suite
+  `read-snapshot-leak-suite` reproduces both leak arms via `FDEFINITION`
+  swaps and asserts the pre-fix failure mode is impossible.
+
 - **`%POSIX-OPEN` created files with an arbitrary permission mode on Apple
   arm64** (#218). `open(2)` is `int open(const char *, int, ...)`, and the
   `mode` argument was passed through a plain `CFFI:FOREIGN-FUNCALL` — as a

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -547,6 +547,7 @@ cl-temporal-extent."
                (:file "store-registry-tests")     ; GH #169
                (:file "store-resolver-tests")     ; GH #169
                (:file "detach-tests")             ; GH #170
+               (:file "read-snapshot-leak-tests") ; GH #181, #211
                (:file "system-restore-tests")     ; GH #171
                (:file "package-namespace-tests")  ; GH #167
                (:file "runtime-schema-tests")     ; GH #172

--- a/tests/read-snapshot-leak-tests.lisp
+++ b/tests/read-snapshot-leak-tests.lisp
@@ -1,0 +1,143 @@
+;;;; CALL-WITH-READ-SNAPSHOT leak regression (GH #181, #211).
+;;;;
+;;;; Before the fix, CREATE-TRANSACTION and PIN-READ-EPOCH ran as two
+;;;; separate LET bindings BEFORE the UNWIND-PROTECT that releases them.
+;;;; A signal from either one leaked whatever the prior binding had
+;;;; already acquired: the tx stayed registered forever, pinning the
+;;;; reaper's floor (GH #181's general shape; GH #211's concrete
+;;;; trigger is a %QUIESCE-TRANSACTION-MANAGER flip landing between the
+;;;; two calls).
+(in-package #:graph-db/test)
+
+(def-suite read-snapshot-leak-suite
+  :description "CALL-WITH-READ-SNAPSHOT leaks nothing when an acquisition
+signals (GH #181, #211)."
+  :in graph-db-suite)
+
+(in-suite read-snapshot-leak-suite)
+
+(defmacro with-failing-function ((name error-call) &body body)
+  "Run BODY with the function NAME replaced by one that runs ERROR-CALL
+\(a form that signals, e.g. `(error 'some-condition ...)`) exactly once,
+then falls through to the original definition, and finally restores it
+(GH #181, #211) -- adapted from GRAPH-TESTS.LISP's WITH-FAILING-SNAPSHOT."
+  (let ((orig (gensym "ORIG")) (fired (gensym "FIRED")))
+    `(let ((,orig (fdefinition ',name))
+           (,fired nil))
+       (unwind-protect
+            (progn
+              (setf (fdefinition ',name)
+                    (lambda (&rest args)
+                      (if ,fired
+                          (apply ,orig args)
+                          (progn (setf ,fired t) ,error-call))))
+              ,@body)
+         (setf (fdefinition ',name) ,orig)))))
+
+;; A dedicated pair of graph names for the cross-graph composition test
+;; below -- distinct from every other suite's names so it never collides
+;; on GH #169's one-store-id-per-name-per-image rule.
+(def-vertex rsl-node-a () ((label :type string)) :rsl-graph-a)
+(def-vertex rsl-node-b () ((label :type string)) :rsl-graph-b)
+
+(defmacro with-two-graphs ((ga gb) &body body)
+  "Bind GA/GB to freshly created graphs :RSL-GRAPH-A / :RSL-GRAPH-B, each in
+its own scratch directory; close and clean up both regardless of how BODY
+exits.  Mirrors MULTI-GRAPH-TESTS.LISP's WITH-THREE-GRAPHS."
+  (let ((dir-a (gensym "DIR-A")) (dir-b (gensym "DIR-B")))
+    `(with-temp-directory (,dir-a)
+       (with-temp-directory (,dir-b)
+         (let ((,ga (make-graph :rsl-graph-a (namestring ,dir-a)
+                                :buffer-pool-size 1000))
+               (,gb (make-graph :rsl-graph-b (namestring ,dir-b)
+                                :buffer-pool-size 1000)))
+           (unwind-protect
+                (progn ,@body)
+             (ignore-errors (close-graph ,ga :snapshot-p nil))
+             (ignore-errors (close-graph ,gb :snapshot-p nil))
+             (collect-garbage)))))))
+
+(defun tx-table-count (tm)
+  (hash-table-count (graph-db::transactions tm)))
+
+(defun pin-table-count (tm)
+  (hash-table-count (graph-db::read-pins tm)))
+
+(test pin-read-epoch-signal-does-not-leak-the-tx-entry
+  "GH #211's exact race: PIN-READ-EPOCH signals STORE-NOT-ACCEPTING-ERROR
+after CREATE-TRANSACTION already registered the tx.  The signal must
+propagate, but the manager's transactions table must have no leftover
+entry -- the pre-fix failure mode (MINIMUM-START-TRANSACTION-ID wedged
+forever) must be impossible."
+  (with-test-graph (g)
+    (let* ((tm (graph-db::transaction-manager g))
+           (before (tx-table-count tm)))
+      (with-failing-function
+          (graph-db::pin-read-epoch
+           (error 'graph-db::store-not-accepting-error
+                  :name (graph-db:graph-name g) :reason :detaching))
+        (signals graph-db::store-not-accepting-error
+          (graph-db:with-read-snapshot (g) (error "thunk must not run"))))
+      (is (= before (tx-table-count tm))
+          "no leftover transactions-table entry after the leak window")
+      (is (null (graph-db::minimum-start-transaction-id tm))
+          "the reaper's floor is not wedged by a leaked entry")
+      (is (= 0 (pin-table-count tm)) "no pin left held either"))))
+
+(test create-transaction-signal-registers-and-pins-nothing
+  "GH #181's other arm: CREATE-TRANSACTION itself signals, before
+PIN-READ-EPOCH ever runs.  Nothing is registered and no pin is held."
+  (with-test-graph (g)
+    (let* ((tm (graph-db::transaction-manager g))
+           (tx-before (tx-table-count tm))
+           (pin-before (pin-table-count tm)))
+      (with-failing-function
+          (graph-db::create-transaction
+           (error 'graph-db::store-not-accepting-error
+                  :name (graph-db:graph-name g) :reason :detaching))
+        (signals graph-db::store-not-accepting-error
+          (graph-db:with-read-snapshot (g) (error "thunk must not run"))))
+      (is (= tx-before (tx-table-count tm)) "no tx registered")
+      (is (= pin-before (pin-table-count tm)) "no pin acquired"))))
+
+(test remove-transaction-signal-still-releases-the-pin
+  "Cleanup robustness: REMOVE-TRANSACTION signals once during teardown.
+UNPIN-READ-EPOCH runs from a nested UNWIND-PROTECT around the pin
+acquisition (GH #181) so it does not depend on REMOVE-TRANSACTION's
+outcome at all -- the pin is released, and the cleanup signal from
+REMOVE-TRANSACTION is what ultimately propagates."
+  (with-test-graph (g)
+    (let* ((tm (graph-db::transaction-manager g))
+           (pin-before (pin-table-count tm)))
+      (with-failing-function
+          (graph-db::remove-transaction
+           (error "simulated remove-transaction failure"))
+        (signals error
+          (graph-db:with-read-snapshot (g) nil)))
+      (is (= pin-before (pin-table-count tm))
+          "the read pin is still released despite the cleanup signal"))))
+
+(test read-snapshot-happy-path-still-composes-across-graphs
+  "Two graphs' snapshots still compose (GH #53), and the floor clears on
+each graph's manager once WITH-READ-SNAPSHOT exits -- the restructure
+(GH #181, #211) changes only the failure paths."
+  (with-two-graphs (g1 g2)
+    (let ((tm1 (graph-db::transaction-manager g1))
+          (tm2 (graph-db::transaction-manager g2))
+          id1 id2)
+      (let ((*graph* g1))
+        (with-transaction () (setq id1 (id (make-rsl-node-a :label "A")))))
+      (let ((*graph* g2))
+        (with-transaction () (setq id2 (id (make-rsl-node-b :label "B")))))
+      (graph-db:with-read-snapshot (g1)
+        (graph-db:with-read-snapshot (g2)
+          (is (not (null (graph-db::minimum-start-transaction-id tm1))))
+          (is (not (null (graph-db::minimum-start-transaction-id tm2))))
+          (let ((*graph* g1))
+            (is (equalp id1 (id (lookup-vertex id1)))))
+          (let ((*graph* g2))
+            (is (equalp id2 (id (lookup-vertex id2)))))))
+      (is (null (graph-db::minimum-start-transaction-id tm1))
+          "g1's floor clears after the nested snapshots exit")
+      (is (null (graph-db::minimum-start-transaction-id tm2))
+          "g2's floor clears after the nested snapshots exit"))))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -3267,18 +3267,31 @@ store it touched."
       ;; already snapshotted this graph -> inherit
       ((and *read-snapshots* (gethash graph *read-snapshots*)) (funcall thunk))
       (t
-       (let ((txn (create-transaction tm :allow-read-only t))
-             (table (or *read-snapshots* (make-hash-table :test 'eq)))
-             (pin (pin-read-epoch tm)))
+       (let ((txn nil)
+             (pin nil)
+             (table (or *read-snapshots* (make-hash-table :test 'eq))))
+         ;; Each acquisition is covered by cleanup from the instant it
+         ;; succeeds -- a signal from PIN-READ-EPOCH after CREATE-
+         ;; TRANSACTION already registered TXN must not leak the tx
+         ;; entry (GH #181, #211).  Nested UNWIND-PROTECTs release in
+         ;; reverse acquisition order and isolate each cleanup step, so
+         ;; UNPIN runs regardless of what REMOVE-TRANSACTION later does.
          (unwind-protect
-              (let ((*read-snapshots* table))
-                (setf (gethash graph table) txn)
-                (funcall thunk))
-           ;; the entry must not outlive the extent: a stale snapshot pins the
-           ;; reaper's floor and retains versions forever (GH #53)
-           (remhash graph table)
-           (remove-transaction txn tm)
-           (unpin-read-epoch tm pin)))))))
+              (progn
+                (setq txn (create-transaction tm :allow-read-only t))
+                (unwind-protect
+                     (progn
+                       (setq pin (pin-read-epoch tm))
+                       (let ((*read-snapshots* table))
+                         (setf (gethash graph table) txn)
+                         (funcall thunk)))
+                  (when pin (unpin-read-epoch tm pin))))
+           ;; The entry must not outlive the extent: a stale snapshot
+           ;; pins the reaper's floor and retains versions forever (GH
+           ;; #53).  REMHASH is nested so REMOVE-TRANSACTION still runs
+           ;; even if REMHASH itself signals (GH #181).
+           (unwind-protect (remhash graph table)
+             (when txn (remove-transaction txn tm)))))))))
 
 (defmacro with-read-snapshot ((&optional (graph '*graph*)) &body body)
   "Evaluate BODY with reads of GRAPH pinned to a single consistent MVCC snapshot.


### PR DESCRIPTION
Closes #181 and #211.

`call-with-read-snapshot` acquired its registered transaction (`create-transaction`) and read-epoch pin (`pin-read-epoch`) as two separate `let` bindings BEFORE the `unwind-protect` releasing them. A signal from either left the earlier acquisition stranded — concretely (#211), a `%quiesce-transaction-manager` flip landing between the two calls makes `pin-read-epoch` signal `store-not-accepting-error` after the tx is already registered, and the leaked `:active` entry pins `minimum-start-transaction-id` forever: the MVCC reaper's floor never advances and a later detach drain times out. #181 is the general shape.

Fix: progressive acquisition inside nested `unwind-protect`s, each covering its resource from the instant it succeeds, cleanup steps isolated so a signal from one cannot skip another (`unpin-read-epoch` no longer depends on `remove-transaction`'s outcome; `remhash` nested around `remove-transaction`). Cleanup calls stay bare — failures surface as before. Review verified the changed release order is invisible to `reap-safe-floor` (a tx's start-id always dominates its own later pin).

Tests (`read-snapshot-leak-suite`, 4 tests / 15 checks): #211's exact race via a swapped `pin-read-epoch` signalling a genuine `store-not-accepting-error` (empty tx table, empty pin table, floor NIL afterward); the create-transaction arm; cleanup robustness; the two-graph composition + floor-clears happy path. **Pre-fix failure proven**: with the fix stashed, tests 1 and 3 fail exactly as predicted.

Verification: mvcc-suite 51/51, detach-suite 150/150, full `(asdf:test-system :graph-db)` **4642 checks / 4632 pass / 10 skips (GEOS, pre-existing) / 0 fail** (SBCL; ECL demoted per standing policy). Independent review: approved, zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165cF945XK8wjtgvSuj4U95