### PR TITLE
Clock/journal hygiene batch (#184, #178, #177, #183, #179, #180, #176, #212, #234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,52 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Clock/journal hygiene batch** (#184, #178, #177, #183, #179, #180,
+  #176, #212, #234):
+  - `JOURNAL-APPEND` reads the epoch *inside* the clock lock, and
+    attach (watermark raise + `:ATTACH` record) and detach (lease +
+    `:DETACH` record) each hold the clock lock across both steps, so
+    journal records always land in `:EPOCH` order (#184). Lock
+    ordering is manager → clock, never the reverse.
+  - `JOURNAL-APPEND` normalizes its `:STORE` property to a keyword,
+    and the restore scans normalize both journal-read `:STORE` values
+    (tolerating pre-fix records) and live graph names when comparing —
+    a graph named by a user-package symbol now round-trips through the
+    journal and is found by `RETIRED-GENERATIONS`/`RESTORE-SYSTEM`
+    (#178).
+  - `PERSIST-HIGHEST-TRANSACTION-ID` is monotonic: it locks around the
+    whole read-compare-write and never rewinds `transaction-id.dat`;
+    the raw overwrite survives as the internal
+    `%WRITE-HIGHEST-TRANSACTION-ID` for crash-fabricating tests
+    (#177).
+  - `GRAPH-SYSTEM-CLOCK` is now a reader-only export (writer internal:
+    `%GRAPH-SYSTEM-CLOCK`), so `ATTACH-TO-SYSTEM-CLOCK`'s watermark
+    and journal record cannot be bypassed by `SETF` (#183); the
+    `TM-NEXT-EPOCH`/`TM-CURRENT-EPOCH`/`TM-PEEK-EPOCH` helpers are
+    unexported (#179).
+  - `MAKE-GRAPH :SLAVE-P T :REPLAY-TXN-DIR` under a system clock
+    (explicit or via `*SYSTEM-CLOCK*`) is refused before any side
+    effect — replay would mint ids from the local counter before the
+    clock attaches (#180).
+  - `MAKE-MEMORY-GRAPH`/`OPEN-MEMORY-GRAPH` take `:SYSTEM-CLOCK`
+    (default `*SYSTEM-CLOCK*`) and attach like the disk constructors,
+    so memory graphs no longer silently opt out of the image clock; a
+    failed attach unwinds through the normal `CLOSE-GRAPH` instead of
+    leaving a half-registered graph (#176).
+  - A failed `ATTACH-TO-SYSTEM-CLOCK` after a successful reopen inside
+    `SWAP-IN-SHADOW`/`%REOPEN-AND-RESUME` closes the just-opened graph
+    before propagating, so the recovery path no longer dies on the
+    stranded `.dirty` marker (#212). The other #212 shape — a missing
+    `:SWAP` record after a post-rename journal failure — remains
+    tolerated as warnings on both the write and read sides.
+  - shadow-store's `policy.dat`/`lease.dat` and system-restore's
+    manifest now use the shared `WITH-SIDECAR-OUTPUT`/`-INPUT`
+    discipline instead of partial `*PRINT-READABLY*`/`*READ-EVAL*`
+    bindings, surviving hostile ambient printer/reader bindings
+    (#234).
+
 ### Changed
 
 - **`DEF-NODE-TYPE` now installs through a shared functional core**

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2640,6 +2640,8 @@ The ~location~ directory is still required, but it now holds only the *durable* 
 
 An in-memory graph is a distinct graph *class*, chosen at construction; the on-disk engine is left entirely untouched. It has no memory-mapped heap (~(heap g)~ is ~nil~), no buffer pool, and no persistent free list, so you pass neither ~:buffer-pool-size~ nor any heap-tuning option.
 
+Both constructors take ~:system-clock~ (default ~*system-clock*~), exactly as ~make-graph~/~open-graph~ do, so a memory graph joins the image-level epoch clock (Chapter 17) instead of silently keeping its own counter — a memory store and a disk store on one clock draw from one epoch space (GH #176).
+
 *** What changes under the hood
 
 The graph model, transaction machinery, and query surface are all shared; the in-memory backend simply overrides the small set of storage primitives they call:
@@ -3614,6 +3616,14 @@ the store's transaction-manager lock and refuses (signalling
 transaction, since attaching mid-transaction would poison that
 transaction's overlap window.
 
+~graph-system-clock~ reads a graph's attached clock (or ~nil~); it is a
+*reader only* — the writer is internal, so ~attach-to-system-clock~ is
+the only way to attach, and its watermark and ~:attach~ journal record
+cannot be bypassed by a bare ~setf~ (GH #183). The transaction-manager
+epoch helpers (~tm-next-epoch~ and friends) are likewise internal —
+~tm-next-epoch~ *burns* an epoch per call and was never consumer API
+(GH #179).
+
 **One limitation**: the watermark only ever raises the clock forward. It
 cannot place the clock *below* a store's history, so a store cannot be
 attached to reconstruct what its epoch numbering would have been had the
@@ -3622,12 +3632,13 @@ the pre-migration past across stores. A store's own history before attach
 remains ordered correctly by its own counter; only new activity after
 attach shares the image-wide sequence.
 
-This guarantee does not extend to ~make-graph :replay-txn-dir D
-:system-clock C~: replay runs before the transaction manager and the
-attach exist, so it mints local ids from zero and the later attach's
-watermark observation is then a no-op, leaving the restored store
-holding epochs the clock already issued to other stores. See
-vivace-graph#180.
+~make-graph :slave-p t :replay-txn-dir D~ under a clock (explicitly, or
+implicitly via a bound ~*system-clock*~) is *refused* with an error
+before any directory is created: replay would run before the
+transaction manager and the attach exist, minting local ids from zero
+and leaving the restored store holding epochs the clock already issued
+to other stores. Create the clocked graph first, then replay into it
+once it is open (GH #180).
 
 *** Cross-process exclusion
 
@@ -3694,6 +3705,15 @@ oldest first. ~attach-to-system-clock~ already appends an ~:attach~
 record on every attach; **built (#170):** ~detach-store~ appends
 ~:detach~ and ~swap-in-shadow~ appends ~:swap~; ~:retire~ is left for
 #171's restore work.
+
+Records land in the file in ~:epoch~ order — the epoch is read and the
+record written under one clock-lock hold, and compound events (attach's
+watermark raise + record, detach's lease + record) hold the lock across
+both steps (GH #184). A record's ~:store~ field is always the
+*keyword* form of the graph's name: journal I/O reads under ~*package*~
+~common-lisp~, so a user-package symbol would read back as a different
+symbol; the restore scans normalize live graph names the same way when
+comparing, so a graph named by any symbol is found (GH #178).
 
 **The journal is read with ~*read-eval*~ bound to ~nil~: it is data, and
 is never evaluated.** This is load-bearing, not a stylistic default —
@@ -3874,8 +3894,16 @@ original error, mirroring ~shadow-store~'s own recovery. A crash
 the live data sits at the retired path and the live location may be
 missing or half-replaced, needing manual recovery; that window, and
 the possibility of a missing ~:swap~ journal record after a completed
-swap, are tracked as GH #171 and #212. Either recovery reopen itself
-failing signals ~shadow-recovery-failed~, same as ~shadow-store~.
+swap, are tracked as GH #171 and #212 (the missing-record shape is
+tolerated on read: ~retired-generations~ warns
+~swap-record-missing-warning~ and takes the epoch from the directory
+name). One #212 hazard is fixed outright: an ~attach-to-system-clock~
+failure *after* the post-swap reopen succeeded now closes the
+just-opened graph before propagating — it used to stay open
+(registered, ~.dirty~ on disk), which made the recovery reopen
+deterministically fail on the ~.dirty~ marker. Either recovery reopen
+itself failing signals ~shadow-recovery-failed~, same as
+~shadow-store~.
 ~swap-in-shadow~ returns ~(values new-graph retired-path)~; the retired
 directory is kept, not deleted, on success.
 
@@ -4085,6 +4113,13 @@ persists the id it actually used, and a fresh transaction manager's
 ~initialize-instance :after~ already re-adds the missing one itself, via
 ~(1+ (max ...))~. Restored ids are unchanged; only the trailing watermark
 is one lower than before, closing a gap that was always wasted.
+
+The persisted watermark itself is now *monotonic* (GH #177):
+~persist-highest-transaction-id~ takes its lock around the whole
+read-compare-write and writes only when the new id is *greater* than
+what ~transaction-id.dat~ already holds, returning whatever is on disk
+after the call — two racing committers can no longer let the lower id
+land last and silently rewind the file.
 
 *** Cross-store snapshots pin every store they touch
 
@@ -4959,10 +4994,10 @@ This chapter provides a categorized reference for the most important exported sy
   Opens an existing graph database from ~location~. Fails if the database was not closed cleanly (i.e., if the ~.dirty~ file exists). ~:index-backend~ governs only *new* indexes created after open; each existing index reopens on the backend it was written with (its persisted tag). ~:initial-accepting-state~ (default ~t~, GH #170) is the state the graph is left in once this call returns — used by ~shadow-store~'s reopen to come back ~:read-only~. The transaction manager itself always starts at ~:opening~ (review round 3), before the graph is registered anywhere, for the duration of ~open-graph~'s own internal rebuild/recovery steps; it flips to ~:initial-accepting-state~ only at the very end, once the graph is fully open. Returns a `graph` object.
 
 - ~make-memory-graph (name location &key lazy peer-role origin-id peer-host ... )~ ::
-  Like ~make-graph~, but constructs an *in-memory* graph (Chapter 15): the graph lives as live Lisp objects in RAM, with the same schema/transaction/query API. ~location~ still holds the durable journal, checkpoint image, schema and peer state. Pass ~:lazy t~ for fault-on-access materialization (near-instant open); accepts the same peer arguments as ~make-graph~ for an in-memory peer device.
+  Like ~make-graph~, but constructs an *in-memory* graph (Chapter 15): the graph lives as live Lisp objects in RAM, with the same schema/transaction/query API. ~location~ still holds the durable journal, checkpoint image, schema and peer state. Pass ~:lazy t~ for fault-on-access materialization (near-instant open); accepts the same peer arguments as ~make-graph~ for an in-memory peer device, and ~:system-clock~ (default ~*system-clock*~) to join the image-level epoch clock (GH #176).
 
 - ~open-memory-graph (name location &key lazy peer-role ... )~ ::
-  Reopens an in-memory graph, restoring it from its checkpoint image and replaying the retained journal tail. Tolerates a ~.dirty~ marker (it always rebuilds from the durable journal + image). Pass ~:lazy t~ to restore nodes as deferred blobs.
+  Reopens an in-memory graph, restoring it from its checkpoint image and replaying the retained journal tail. Tolerates a ~.dirty~ marker (it always rebuilds from the durable journal + image). Pass ~:lazy t~ to restore nodes as deferred blobs, and ~:system-clock~ (default ~*system-clock*~) to rejoin the image-level epoch clock (GH #176).
 
 - ~checkpoint-memory-graph (graph)~ ::
   Forces an in-memory graph to write its checkpoint image and clear the journal *now*, without closing. Call after a ~peer-sync~ on a device so pulled (un-journaled) state survives a restart.

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -221,9 +221,12 @@ received an UNRESOLVED-NODE marker instead (GH #169, D8)."
                                        #+graph-db-ecl-sync-hash t)
                #+sbcl (make-hash-table :test 'eq :synchronized t))
    ;; The image-level epoch clock (GH #168), or NIL for this store's own
-   ;; counter.  NIL is the pre-#168 behaviour and the default.
-   (system-clock :accessor graph-system-clock :initarg :system-clock
-                 :initform nil)
+   ;; counter.  NIL is the pre-#168 behaviour and the default.  Reader
+   ;; public, writer internal: ATTACH-TO-SYSTEM-CLOCK is the only entry
+   ;; point -- a bare SETF would skip its watermark/journal (GH #183).
+   (system-clock :reader graph-system-clock
+                 :accessor %graph-system-clock
+                 :initarg :system-clock :initform nil)
    ;; Shadow generations (GH #170).  SHADOW-P: T on a graph opened via
    ;; OPEN-SHADOW-GRAPH -- never registered in *GRAPHS*/open-store vector,
    ;; never starts replication.  EPOCH-LEASE: an EPOCH-LEASE struct

--- a/graph.lisp
+++ b/graph.lisp
@@ -673,6 +673,15 @@ to disk and remove it."
     (error 'system-directory-required :operation 'make-graph))
   (when (and replay-txn-dir (not slave-p))
     (error ":REPLAY-TXN-DIR is only for slave graphs"))
+  ;; Replay runs BEFORE the clock attaches, so replayed nodes would get
+  ;; ids from the local counter -- the very audit-class bug #168 exists
+  ;; to prevent.  Refuse before any side effect (GH #180).
+  (when (and slave-p replay-txn-dir system-clock)
+    (error "MAKE-GRAPH: :REPLAY-TXN-DIR cannot be combined with a ~
+:SYSTEM-CLOCK (yours may come implicitly from *SYSTEM-CLOCK*): replay ~
+would mint ids from the store's local counter before the clock ~
+attaches.  Create the clocked graph first, then replay into it once it ~
+is open (GH #180)."))
   (when (and (or slave-p master-p) (not replication-port))
     (error ":REPLICATION-PORT is required for master and slave graphs"))
   (when (and slave-p (not master-host))

--- a/memory-graph.lisp
+++ b/memory-graph.lisp
@@ -240,13 +240,16 @@ applied-op-id dedup lhash (opened when MODE is :OPEN and it already exists)."
                           &key package replication-port replication-key
                             peer-role origin-id peer-host lazy
                             export-predicate device-registry merge-policy
-                            reference-classes (peer-schema-version '(1 0)))
+                            reference-classes (peer-schema-version '(1 0))
+                            (system-clock *system-clock*))
   "Create a brand-new in-memory graph named NAME.  LOCATION is used for the
 durable journal, cl-store image and schema (the RAM structures are rebuilt from
 them on OPEN-MEMORY-GRAPH).  With :PEER-ROLE (:HUB or :DEVICE, a :DEVICE also
 needs a hub-minted :ORIGIN-ID) a MEMORY-PEER-GRAPH is built and the peer
 replication path is wired.  With :LAZY, the graph uses the VG-native image format
 and materializes nodes on first touch (fault-on-access) for a near-instant open.
+:SYSTEM-CLOCK (default *SYSTEM-CLOCK*) attaches the graph to the image-level
+epoch clock, exactly as MAKE-GRAPH does (GH #176).
 Registers the graph and returns it."
   (%validate-peer-role peer-role origin-id)
   (ensure-directories-exist location)
@@ -278,6 +281,18 @@ Registers the graph and returns it."
     ;; rather than "brand new" (GH #129).  No nodes yet, so no scan.
     (let ((*graph* graph))
       (install-unique-tuple-constraints graph))
+    ;; Join the image-level clock, as MAKE-GRAPH does (GH #176).  Last,
+    ;; once GRAPH-OPEN-P is set, so a failed attach unwinds through the
+    ;; NORMAL close path (deregister, delete .dirty) instead of leaving
+    ;; a half-registered graph behind (same shape as GH #212).
+    (when system-clock
+      (let ((attached nil))
+        (unwind-protect
+            (progn (attach-to-system-clock graph system-clock)
+                   (setf attached t))
+          (unless attached
+            (let ((*graph* graph))
+              (ignore-errors (close-graph graph :snapshot-p nil)))))))
     graph))
 
 ;;; ---------------------------------------------------------------------------
@@ -962,13 +977,16 @@ and the app re-cold-syncs.  Cheap: ~0.06 s / 0.2 MB for ~800 nodes."
                           &key package replication-port replication-key
                             peer-role origin-id peer-host lazy regenerate-views
                             export-predicate device-registry merge-policy
-                            reference-classes (peer-schema-version '(1 0)))
+                            reference-classes (peer-schema-version '(1 0))
+                            (system-clock *system-clock*))
   "Reopen the in-memory graph NAME from LOCATION: restore the schema, restore the
 image checkpoint (if any), then replay the retained .txn journal tail.  Tolerates a
 .dirty marker (a memory-graph always rebuilds from its durable journal + image, so
 an unclean shutdown is recovered, not an error).  :PEER-ROLE and the peer keys
 mirror MAKE-MEMORY-GRAPH, reopening a MEMORY-PEER-GRAPH.  With :LAZY, nodes restore
-as deferred blobs and materialize on first touch (needs a VG-native image)."
+as deferred blobs and materialize on first touch (needs a VG-native image).
+:SYSTEM-CLOCK (default *SYSTEM-CLOCK*) attaches to the image-level epoch clock,
+as OPEN-GRAPH does (GH #176)."
   (%validate-peer-role peer-role origin-id)
   (ensure-directories-exist location)
   (let* ((path (pathname location))
@@ -1059,6 +1077,16 @@ as deferred blobs and materialize on first touch (needs a VG-native image)."
     (init-replication-log graph)
     (start-replication graph :package package)
     (setf (graph-open-p graph) t)
+    ;; Join the image-level clock, as OPEN-GRAPH does (GH #176).  Last,
+    ;; once GRAPH-OPEN-P is set -- see MAKE-MEMORY-GRAPH's comment.
+    (when system-clock
+      (let ((attached nil))
+        (unwind-protect
+            (progn (attach-to-system-clock graph system-clock)
+                   (setf attached t))
+          (unless attached
+            (let ((*graph* graph))
+              (ignore-errors (close-graph graph :snapshot-p nil)))))))
     graph))
 
 ;; Clean-close checkpoint: write the image, then clear the (now-superseded)

--- a/package.lisp
+++ b/package.lisp
@@ -176,9 +176,9 @@
            #:frozen-graph-cannot-replicate-location
            ;; Open a store the registry disagrees with, to read it.
            #:with-schema-frozen
-           #:tm-next-epoch
-           #:tm-current-epoch
-           #:tm-peek-epoch
+           ;; tm-next-epoch/tm-current-epoch/tm-peek-epoch are internal:
+           ;; TRANSACTION-MANAGER itself is unexported, and TM-NEXT-EPOCH
+           ;; burns epochs -- not consumer API (GH #179).
            #:make-graph
            #:*default-heap-size*
            #:*default-index-size*

--- a/shadow-store.lisp
+++ b/shadow-store.lisp
@@ -128,12 +128,13 @@ gate input (GH #170)."
   (let ((file (%policy-file location)))
     (if (probe-file file)
         (with-open-file (in file)
-          (let* ((*read-eval* nil)
-                 (value (read in nil nil)))
-            (unless (member value '(:derivable :authored))
-              (error "~A does not hold a valid recovery policy (expected ~
+          ;; Full reader-control set, not just *READ-EVAL* (GH #234).
+          (with-sidecar-input ()
+            (let ((value (read in nil nil)))
+              (unless (member value '(:derivable :authored))
+                (error "~A does not hold a valid recovery policy (expected ~
 :DERIVABLE or :AUTHORED, read ~S)." file value))
-            value))
+              value)))
         :authored)))
 
 (defun set-store-recovery-policy (location policy)
@@ -147,7 +148,8 @@ silently authorize the WAL-free path (GH #170)."
   (with-open-file (out (%policy-file location)
                        :direction :output :if-exists :supersede
                        :if-does-not-exist :create)
-    (let ((*print-readably* nil) (*print-pretty* nil))
+    ;; Full printer-control set (GH #234).
+    (with-sidecar-output ()
       (prin1 policy out)))
   policy)
 
@@ -202,9 +204,19 @@ above all -- land in the store's PARENT directory (GH #171)."
                                     (uiop:ensure-directory-pathname
                                      location))
                               :system-clock nil
-                              :initial-accepting-state reason)))
-    (attach-to-system-clock reopened clock)
-    reopened))
+                              :initial-accepting-state reason))
+        (attached nil))
+    ;; An attach failure must close the just-opened graph before
+    ;; propagating: leaving it open (registered, .dirty on disk) makes
+    ;; the NEXT open-graph here fail on the .dirty marker (GH #212).
+    (unwind-protect
+        (progn
+          (attach-to-system-clock reopened clock)
+          (setf attached t)
+          reopened)
+      (unless attached
+        (let ((*graph* reopened))
+          (ignore-errors (close-graph reopened :snapshot-p nil)))))))
 
 (defun shadow-store (graph &key (timeout 60))
   "Take a consistent shadow copy of GRAPH's store: quiesce (reason
@@ -293,7 +305,8 @@ path (GH #170, fix round 1)."
   (with-open-file (out (%lease-file shadow-location)
                        :direction :output :if-exists :supersede
                        :if-does-not-exist :create)
-    (let ((*print-readably* nil) (*print-pretty* nil))
+    ;; Full printer-control set (GH #234).
+    (with-sidecar-output ()
       (prin1 (list :lease-start start :lease-end end) out))))
 
 (defun %read-lease (shadow-location)
@@ -302,7 +315,8 @@ may have been copied from anywhere and is untrusted input (GH #170)."
   (let ((file (%lease-file shadow-location)))
     (when (probe-file file)
       (with-open-file (in file)
-        (let ((*read-eval* nil))
+        ;; Full reader-control set, not just *READ-EVAL* (GH #234).
+        (with-sidecar-input ()
           (read in nil nil))))))
 
 (defun open-shadow-graph (shadow-location graph-name
@@ -503,8 +517,17 @@ NEW store).  Split out so that HANDLER-CASE reads cleanly."
      (delete-file (merge-pathnames "lease.dat"
                                    (uiop:ensure-directory-pathname live))))
     (journal-append clock :swap :store name :retired retired-path)
-    (let ((new-graph (open-graph name live :system-clock nil)))
-      (attach-to-system-clock new-graph clock)
+    (let ((new-graph (open-graph name live :system-clock nil))
+          (attached nil))
+      ;; Attach failure closes NEW-GRAPH before propagating, or the
+      ;; recovery reopen deterministically dies on .dirty (GH #212).
+      (unwind-protect
+          (progn
+            (attach-to-system-clock new-graph clock)
+            (setf attached t))
+        (unless attached
+          (let ((*graph* new-graph))
+            (ignore-errors (close-graph new-graph :snapshot-p nil)))))
       (values new-graph retired-path))))
 
 (defun swap-in-shadow (graph shadow-location &key (timeout 60))

--- a/system-clock.lisp
+++ b/system-clock.lisp
@@ -116,11 +116,29 @@ later open in this image, for the life of the process (GH #182)."
         (setf (system-clock-lock-fd clock) nil))))
   clock)
 
+(defun %store-name-key (name)
+  "NAME normalized for journal storage/lookup: a symbol becomes the
+same-named keyword, anything else passes through.  Journal I/O reads
+under *PACKAGE* COMMON-LISP, so a user-package symbol would read back
+as a different symbol; keywords are package-independent (GH #178)."
+  (if (symbolp name)
+      (intern (symbol-name name) :keyword)
+      name))
+
 (defun journal-append (clock kind &rest plist)
   "Append one lifecycle record.  KIND is :CREATE :DETACH :SWAP :ATTACH
-:RETIRE :RETIRE-LIVE :RESTORE or :SWAP-ABORTED (the last four: GH #171)."
-  (let ((record (list* :kind kind :epoch (clock-current-epoch clock) plist)))
-    (with-recursive-lock-held ((system-clock-lock clock))
+:RETIRE :RETIRE-LIVE :RESTORE or :SWAP-ABORTED (the last four: GH #171).
+A :STORE property is normalized to a keyword via %STORE-NAME-KEY, so
+the written record always reads back package-independently (GH #178)."
+  ;; Epoch is read INSIDE the lock: outside it, a concurrent allocator
+  ;; could slot between the read and the append, so records could hit
+  ;; the file out of :EPOCH order (GH #184).
+  (with-recursive-lock-held ((system-clock-lock clock))
+    (let ((record (list* :kind kind :epoch (clock-current-epoch clock)
+                         (loop for (k v) on plist by #'cddr
+                               append (list k (if (eq k :store)
+                                                  (%store-name-key v)
+                                                  v))))))
       (unless (system-clock-journal clock)
         (setf (system-clock-journal clock)
               (open (%clock-journal-file (system-clock-location clock))
@@ -134,8 +152,8 @@ later open in this image, for the life of the process (GH #182)."
         ;; produce a line JOURNAL-RECORDS then can't read back.
         (with-sidecar-output ()
           (format s "~S~%" record))
-        (finish-output s)))
-    record))
+        (finish-output s))
+      record)))
 
 (define-condition system-journal-corrupt (error)
   ((file :initarg :file :reader journal-corrupt-file)

--- a/system-restore.lisp
+++ b/system-restore.lisp
@@ -88,9 +88,11 @@ is fresh, so it inherits nothing (GH #171)."
   (let ((by-store (make-hash-table :test 'equal)))
     (dolist (r (journal-records clock))
       (when (and (eq (getf r :kind) :restore) (getf r :from))
+        ;; %STORE-NAME-KEY: a PRE-#178 journal may hold a user-package
+        ;; symbol; normalize so it shares a bucket with new records.
         (push (cons (getf r :epoch)
                     (%trimmed-namestring (getf r :from)))
-              (gethash (getf r :store) by-store))))
+              (gethash (%store-name-key (getf r :store)) by-store))))
     (maphash (lambda (store prs)
                (setf (gethash store by-store) (sort prs #'< :key #'car)))
              by-store)
@@ -134,12 +136,15 @@ inherited its content (see %ASSIGN-GENERATION-ERAS)."
         (pruned (%pruned-retired-paths clock)))
     ;; Journal first: records name the live locations to scan.
     (dolist (r (%retired-directory-records clock))
-      (let ((retired (%trimmed-namestring (getf r :retired))))
+      ;; %STORE-NAME-KEY on the record side too: a PRE-#178 journal may
+      ;; hold a user-package symbol (GH #178).
+      (let ((retired (%trimmed-namestring (getf r :retired)))
+            (store (%store-name-key (getf r :store))))
         (setf (gethash (%live-location-of-retired retired) locations)
-              (getf r :store))
+              store)
         (setf (gethash retired by-retired)
               (%make-generation
-               :store (getf r :store)
+               :store store
                :location (%live-location-of-retired retired)
                :retired retired
                :swap-epoch (getf r :epoch)
@@ -160,9 +165,11 @@ inherited its content (see %ASSIGN-GENERATION-ERAS)."
                                      (graph-system-clock graph)))
                                    (%trimmed-namestring
                                     (system-clock-location clock))))
+                 ;; Normalized so it compares against journal :STORE
+                 ;; values, which are always keywords (GH #178).
                  (setf (gethash (%trimmed-namestring (location graph))
                                 locations)
-                       name)))
+                       (%store-name-key name))))
              *graphs*)
     (maphash
      (lambda (location store)
@@ -312,11 +319,25 @@ last live window (GH #171, fix rounds 2 and 3)."
                    (or (null best-from) (> (car era) best-from)))
           (setq best g best-from (car era)))))))
 
+(defun %lookup-store-by-key (name)
+  "LOOKUP-GRAPH tolerant of journal-normalized names: tries NAME
+directly, then scans *GRAPHS* for a key whose %STORE-NAME-KEY matches
+NAME's -- a journal :STORE keyword must find a graph registered under a
+user-package symbol (GH #178)."
+  (or (lookup-graph name)
+      (let ((key (%store-name-key name)))
+        (block scan
+          (maphash (lambda (k graph)
+                     (when (equal (%store-name-key k) key)
+                       (return-from scan graph)))
+                   *graphs*)))))
+
 (defun %open-store-for-clock (name clock)
   "The graph registered as NAME if it is attached to CLOCK -- matched by
 SYSTEM-CLOCK-LOCATION string, the comparison every scan in this file
-uses -- else NIL (GH #171)."
-  (let ((graph (lookup-graph name)))
+uses -- else NIL (GH #171).  NAME may be a journal-normalized keyword
+for a graph registered under another symbol (GH #178)."
+  (let ((graph (%lookup-store-by-key name)))
     (when (and graph (typep graph 'graph) (graph-system-clock graph)
                (string= (%trimmed-namestring
                          (system-clock-location (graph-system-clock graph)))
@@ -343,16 +364,19 @@ reversed to its live location (older journals predating :ATTACH's
 :LOCATION field); and any graph *GRAPHS* still holds open under this
 clock right now."
   (let ((acc (make-hash-table :test 'equal)))
+    ;; %STORE-NAME-KEY on record-side stores: a PRE-#178 journal may
+    ;; hold user-package symbols (GH #178).
     (dolist (r (journal-records clock))
       (when (eq (getf r :kind) :attach)
         (let ((loc (getf r :location)))
           (when loc
-            (setf (gethash (%trimmed-namestring loc) acc) (getf r :store))))))
+            (setf (gethash (%trimmed-namestring loc) acc)
+                  (%store-name-key (getf r :store)))))))
     (dolist (r (%retired-directory-records clock))
       (setf (gethash (%live-location-of-retired
                       (%trimmed-namestring (getf r :retired)))
                      acc)
-            (getf r :store)))
+            (%store-name-key (getf r :store))))
     (maphash (lambda (name graph)
                (when (and (typep graph 'graph)
                           (graph-system-clock graph)
@@ -361,8 +385,9 @@ clock right now."
                                      (graph-system-clock graph)))
                                    (%trimmed-namestring
                                     (system-clock-location clock))))
+                 ;; Normalized, as journal :STORE values are (GH #178).
                  (setf (gethash (%trimmed-namestring (location graph)) acc)
-                       name)))
+                       (%store-name-key name))))
              *graphs*)
     acc))
 
@@ -480,12 +505,15 @@ lands in the same RESTORE-REFUSED-ERROR as every other refusal."
     ;; same way a rewind would (GH #171).
     (maphash (lambda (name graph)
                (declare (ignore graph))
-               (let ((open-graph (%open-store-for-clock name clock)))
+               ;; Hash keys normalized to match journal-derived stores
+               ;; (GH #178).
+               (let ((key (%store-name-key name))
+                     (open-graph (%open-store-for-clock name clock)))
                  (when open-graph
-                   (unless (nth-value 1 (gethash name by-store))
-                     (setf (gethash name by-store) nil))
+                   (unless (nth-value 1 (gethash key by-store))
+                     (setf (gethash key by-store) nil))
                    (unless (%supported-for-restore-p open-graph)
-                     (setf (gethash name unsupported) t)))))
+                     (setf (gethash key unsupported) t)))))
              *graphs*)
     (maphash
      (lambda (store gens)
@@ -583,16 +611,17 @@ R1/R2)."
     ;; colon only when *package* is NOT the keyword package itself, and
     ;; a bare T/NIL in an entry stays unqualified since CL is its home
     ;; package; *PRINT-READABLY* stays NIL, as the journal's own
-    ;; records already do (GH #171).
-    (let ((*print-readably* nil) (*print-pretty* nil)
-          (*package* (find-package :common-lisp)))
+    ;; records already do (GH #171).  Full printer set via the shared
+    ;; macro, whose defaults match both choices (GH #234).
+    (with-sidecar-output ()
       (prin1 manifest out)))
   manifest)
 
 (defun read-restore-manifest (path)
   "PATH's manifest plist.  *READ-EVAL* NIL: data, never code (GH #171)."
   (with-open-file (in path)
-    (let ((*read-eval* nil) (*package* (find-package :common-lisp)))
+    ;; Full reader-control set, not just *READ-EVAL* (GH #234).
+    (with-sidecar-input ()
       (read in))))
 
 (defun %entry-with (entry &rest kvs)
@@ -656,7 +685,10 @@ live generation moved to RETIRED, which it no longer has.  Once the
 rename-back itself succeeds, a :RETIRE-LIVE-ABORTED record cancels it
 (RETIRED-GENERATIONS' journal-join excludes any path a
 :RETIRE-LIVE-ABORTED names)."
-  (let* ((graph (lookup-graph name))
+  (let* ((graph (%lookup-store-by-key name))
+         ;; The live graph's own name, not the journal keyword: reopens
+         ;; must re-register under the caller's key (GH #178).
+         (name (graph-name graph))
          (live (%trimmed-namestring (location graph)))
          (from (getf entry :from))
          (retired (%retired-path-for clock live))
@@ -709,7 +741,10 @@ possibly half-populated generation is left live, its predecessor
 retired at :RETIRED-LIVE -- a :RESTORE :MODE :REBUILT :FAILED T journal
 record names both before the original error is resignalled, so the
 journal says what actually happened (GH #171)."
-  (let* ((graph (lookup-graph name))
+  (let* ((graph (%lookup-store-by-key name))
+         ;; As in %RESTORE-ONE-STORE: rebuild under the live graph's own
+         ;; name, not the journal keyword (GH #178).
+         (name (graph-name graph))
          (live (%trimmed-namestring (location graph)))
          (policy (store-recovery-policy live))
          (retired (%retired-path-for clock live)))
@@ -748,6 +783,8 @@ nothing, rather than every legacy v5 id (GH #171)."
     (when store-id
       (maphash
        (lambda (name graph)
+         ;; EXCLUDE and the result hold journal-normalized keys (GH #178).
+         (setq name (%store-name-key name))
          (when (and (not (member name exclude))
                     (%open-store-for-clock name clock))
            (let ((n 0))
@@ -802,14 +839,19 @@ Returns the manifest (GH #171, spec S3-S4)."
     (let ((queue (copy-list rebuilt)))
       (loop while queue do
         (let* ((source (pop queue))
-               (tag (store-registry-id-for source)))
+               ;; SOURCE is a journal-normalized key; the registry is
+               ;; keyed by the graph's real name (GH #178).
+               (source-graph (%lookup-store-by-key source))
+               (tag (and source-graph
+                         (store-registry-id-for
+                          (graph-name source-graph)))))
           (loop for (name . n) in (%dangling-into clock tag rebuilt) do
             (let ((pos (position name entries
                                  :key (lambda (x) (getf x :store)))))
               (when pos
                 (let ((entry (nth pos entries)))
                   (if (eq (store-recovery-policy
-                           (location (lookup-graph name)))
+                           (location (%lookup-store-by-key name)))
                           :derivable)
                       (let ((extra (%rebuild-one-store
                                     clock name rebuild timeout)))

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1328,12 +1328,12 @@ still open."
           (mock-clock (graph-db::%make-system-clock
                        :location "/nonexistent-dir-for-gh-170-i3/"
                        :counter 1)))
-      (setf (graph-db:graph-system-clock g) mock-clock)
+      (setf (graph-db::%graph-system-clock g) mock-clock)
       (unwind-protect
            (signals error (graph-db:detach-store g))
         ;; Restore the real clock so the fixture's own teardown can close
         ;; G normally regardless of this test's outcome.
-        (setf (graph-db:graph-system-clock g) clock))
+        (setf (graph-db::%graph-system-clock g) clock))
       (is (eq t (graph-db:accepting-p tm)))
       (is (graph-db::graph-open-p g))
       (with-transaction (tm)
@@ -1521,7 +1521,10 @@ assertion fail -- it would still encode ID-A+1."
             (rename-file (first committed-files)
                          (make-pathname :type "txn"
                                         :defaults (first committed-files)))
-            (graph-db::persist-highest-transaction-id id-a g)
+            ;; Raw writer: PERSIST-HIGHEST-TRANSACTION-ID is monotonic
+            ;; now (GH #177), and this fabricates a crashed, rewound
+            ;; watermark on purpose.
+            (graph-db::%write-highest-transaction-id id-a g)
             (is (= id-a (graph-db::load-highest-transaction-id g))
                 "sanity: the watermark file is now stale")
             (with-open-file (out dirty :direction :output
@@ -1599,3 +1602,150 @@ has completed."
              (let ((pin (graph-db:pin-read-epoch tm)))
                (graph-db:unpin-read-epoch tm pin)))
         (graph-db::%set-accepting-p tm t)))))
+
+;;; Clock/journal hygiene batch (GH #177, #212).
+
+(test persist-highest-transaction-id-is-monotonic
+  "GH #177: PERSIST-HIGHEST-TRANSACTION-ID only moves the durable
+watermark FORWARD -- a racing lower id must not clobber a higher one --
+and returns whatever is on disk after the call.  The raw
+%WRITE-HIGHEST-TRANSACTION-ID stays available for tests that fabricate
+crash states (see CRASH-RECOVERY-RESEEDS-THE-TX-ID-WATERMARK)."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :gh-177-monotonic (namestring dir)
+                             :buffer-pool-size 1000)))
+          (unwind-protect
+               (progn
+                 (is (= 100 (graph-db::persist-highest-transaction-id
+                             100 g)))
+                 (is (= 100 (graph-db::persist-highest-transaction-id
+                             50 g))
+                     "a lower id returns the standing watermark")
+                 (is (= 100 (load-highest-transaction-id g))
+                     "and must not have rewound the file")
+                 (is (= 150 (graph-db::persist-highest-transaction-id
+                             150 g)))
+                 (is (= 150 (load-highest-transaction-id g)))
+                 ;; The raw writer is the deliberate escape hatch.
+                 (graph-db::%write-highest-transaction-id 10 g)
+                 (is (= 10 (load-highest-transaction-id g))))
+            (let ((graph-db:*graph* g))
+              (ignore-errors (close-graph g :snapshot-p nil)))))))))
+
+(defun %mock-clock-failing-ceiling (journal-file)
+  "A real SYSTEM-CLOCK struct whose JOURNAL-APPEND works (the journal
+stream is pre-opened onto JOURNAL-FILE) but whose ceiling write fails
+deterministically (LOCATION does not exist) -- so ATTACH-TO-SYSTEM-
+CLOCK's CLOCK-OBSERVE-EPOCH is the first thing to die, AFTER any
+:SWAP journal record and AFTER OPEN-GRAPH (GH #212)."
+  (graph-db::%make-system-clock
+   :location "/nonexistent-dir-for-gh-212-attach/"
+   :counter 0
+   :journal (open journal-file :direction :output
+                               :if-exists :append
+                               :if-does-not-exist :create)))
+
+(test swap-in-shadow-1-attach-failure-leaves-the-store-openable
+  "GH #212: in %SWAP-IN-SHADOW-1, an ATTACH-TO-SYSTEM-CLOCK failure
+AFTER its OPEN-GRAPH succeeded used to leave the new generation open
+(registered, mmapped, .dirty on disk), so the recovery handler's
+%REOPEN-AND-RESUME deterministically died on the .dirty marker.  Now
+the just-opened graph is closed before the error propagates: nothing
+stays registered, no .dirty remains, and the live location reopens
+cleanly."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (with-transaction ((graph-db::transaction-manager g))
+      (graph-db:make-vertex :generic nil :graph g))
+    (let ((name (graph-db:graph-name g))
+          (location (graph-db::location g))
+          (retired nil))
+      (unwind-protect
+           (progn
+             (let ((graph-db:*graph* g))
+               (close-graph g :snapshot-p nil))
+             (with-temp-directory (shadow-dir)
+               (let ((sg (make-graph name (namestring shadow-dir)
+                                     :buffer-pool-size 1000)))
+                 (with-transaction ((graph-db::transaction-manager sg))
+                   (graph-db:make-vertex :generic nil :graph sg))
+                 (let ((graph-db:*graph* sg))
+                   (close-graph sg :snapshot-p nil)))
+               (with-temp-directory (jdir)
+                 (let ((mock (%mock-clock-failing-ceiling
+                              (merge-pathnames "mock-journal.log" jdir)))
+                       (progress (vector nil nil)))
+                   (unwind-protect
+                        (progn
+                          (signals error
+                            (graph-db::%swap-in-shadow-1
+                             name location shadow-dir mock progress))
+                          (is-true (aref progress 0)
+                                   "both renames landed before the attach")
+                          (setq retired (aref progress 1))
+                          (is-false (graph-db:lookup-graph name)
+                                    "the failed generation must not stay ~
+registered")
+                          (is-false
+                           (probe-file
+                            (merge-pathnames
+                             ".dirty"
+                             (uiop:ensure-directory-pathname location)))
+                           "no .dirty may survive the attach failure")
+                          ;; The whole point: the live dir opens again.
+                          (let ((g2 (open-graph
+                                     name
+                                     (namestring
+                                      (uiop:ensure-directory-pathname
+                                       location))
+                                     :buffer-pool-size 1000
+                                     :system-clock nil)))
+                            (let ((graph-db:*graph* g2))
+                              (close-graph g2 :snapshot-p nil))))
+                     ;; No handle leak: the mock's pre-opened journal
+                     ;; stream must not outlive the temp dir.
+                     (ignore-errors
+                      (close (graph-db::system-clock-journal mock))))))))
+        (when (and retired (probe-file retired))
+          (ignore-errors
+           (uiop:delete-directory-tree
+            (uiop:ensure-directory-pathname retired)
+            :validate t :if-does-not-exist :ignore)))))))
+
+(test reopen-and-resume-attach-failure-closes-the-reopened-graph
+  "GH #212, the recovery helper itself: %REOPEN-AND-RESUME's attach
+failing after its OPEN-GRAPH succeeded must close the reopened graph
+before propagating, so the caller's next recovery attempt (or a manual
+OPEN-GRAPH) is not refused on .dirty."
+  (with-clocked-store (g clock sys)
+    clock sys
+    (let ((name (graph-db:graph-name g))
+          (location (graph-db::location g)))
+      (let ((graph-db:*graph* g))
+        (close-graph g :snapshot-p nil))
+      (with-temp-directory (jdir)
+        (let ((mock (%mock-clock-failing-ceiling
+                     (merge-pathnames "mock-journal.log" jdir))))
+          (unwind-protect
+               (progn
+                 (signals error
+                   (graph-db::%reopen-and-resume name location mock t))
+                 (is-false (graph-db:lookup-graph name))
+                 (is-false (probe-file
+                            (merge-pathnames
+                             ".dirty"
+                             (uiop:ensure-directory-pathname location))))
+                 (let ((g2 (open-graph
+                            name
+                            (namestring (uiop:ensure-directory-pathname
+                                         location))
+                            :buffer-pool-size 1000
+                            :system-clock nil)))
+                   (let ((graph-db:*graph* g2))
+                     (close-graph g2 :snapshot-p nil))))
+            ;; No handle leak (see the swap test above).
+            (ignore-errors
+             (close (graph-db::system-clock-journal mock)))))))))

--- a/tests/sidecar-io-tests.lisp
+++ b/tests/sidecar-io-tests.lisp
@@ -217,3 +217,69 @@ store-id registry's own reopen path (%STORE-REGISTRY-LOAD ->
         (setq graph-db::*store-registry* nil)
         (with-hostile-read-env
           (is (eql target-id (store-registry-id-for 'sr-hostile-target))))))))
+
+;;; GH #234: shadow-store's policy.dat / lease.dat and system-restore's
+;;; restore manifest now go through WITH-SIDECAR-OUTPUT/-INPUT instead
+;;; of partial *PRINT-READABLY*/*READ-EVAL* bindings.
+
+(defmacro with-hostile-print-env (&body body)
+  "Every ambient binding a sidecar WRITER must survive: hex *PRINT-BASE*
+(with *PRINT-RADIX* noise), truncating *PRINT-LENGTH*/*PRINT-LEVEL*,
+and -- the #234-specific hazard for the previously package-blind
+shadow-store writers -- *PACKAGE* bound to KEYWORD, under which an
+unfixed PRIN1 drops every keyword's leading colon."
+  `(let ((*print-base* 16) (*print-radix* t)
+         (*print-length* 1) (*print-level* 1)
+         (*print-case* :downcase)
+         (*package* (find-package :keyword)))
+     ,@body))
+
+(test shadow-policy-survives-a-hostile-dynamic-environment
+  "GH #234: SET-STORE-RECOVERY-POLICY under hostile printer bindings
+still writes a line STORE-RECOVERY-POLICY (itself under hostile reader
+bindings) reads back as the same keyword -- pre-fix, *PACKAGE* KEYWORD
+made the policy print colon-less and fail the strict member check."
+  (with-temp-directory (dir)
+    (with-hostile-print-env
+      (graph-db::set-store-recovery-policy dir :derivable))
+    (with-hostile-read-env
+      (is (eq :derivable (graph-db::store-recovery-policy dir))))))
+
+(test shadow-lease-survives-a-hostile-dynamic-environment
+  "GH #234: %PERSIST-LEASE/%READ-LEASE round-trip decimal integers and
+keywords under hostile bindings on both sides -- pre-fix, *PRINT-BASE*
+16 wrote the lease bounds in hex and *PRINT-LENGTH* 1 truncated the
+plist to (:LEASE-START ...)."
+  (with-temp-directory (dir)
+    (with-hostile-print-env
+      (graph-db::%persist-lease dir 100 2000000))
+    (with-hostile-read-env
+      (let ((lease (graph-db::%read-lease dir)))
+        (is (eql 100 (getf lease :lease-start)))
+        (is (eql 2000000 (getf lease :lease-end)))))))
+
+(test restore-manifest-survives-a-hostile-dynamic-environment
+  "GH #234: %WRITE-MANIFEST / READ-RESTORE-MANIFEST under hostile
+bindings on both sides; the decimal :STATE-AT and the keyword actions
+must survive exactly."
+  (with-temp-directory (dir)
+    (let ((clock (graph-db::%make-system-clock
+                  :location (namestring dir)))
+          (manifest (list :restore t :requested 5 :at 100
+                          :clock (namestring dir)
+                          :stores (list (list :store :m234-store
+                                              :action :rewound
+                                              :state-at 100
+                                              :exact t)))))
+      (with-hostile-print-env
+        (graph-db::%write-manifest clock manifest))
+      (with-hostile-read-env
+        (let* ((back (graph-db::read-restore-manifest
+                      (graph-db::%manifest-file clock 100)))
+               (entry (first (getf back :stores))))
+          (is (eql 5 (getf back :requested)))
+          (is (eql 100 (getf back :at)))
+          (is (eq :m234-store (getf entry :store)))
+          (is (eq :rewound (getf entry :action)))
+          (is (eql 100 (getf entry :state-at)))
+          (is (eq t (getf entry :exact))))))))

--- a/tests/system-clock-tests.lisp
+++ b/tests/system-clock-tests.lisp
@@ -928,3 +928,197 @@ break the #170 path."
              (is (> (clock-next-epoch c2) a)
                  "a reopened clock never reissues")
           (close-system-clock c2))))))
+
+;;; Clock/journal hygiene batch (GH #184, #178, #179, #183, #180, #176).
+
+(test journal-records-stay-in-epoch-order-under-contention
+  "GH #184: JOURNAL-APPEND reads the epoch INSIDE the clock lock, so two
+appenders racing an allocator cannot interleave a later epoch's record
+before an earlier one.  Pre-fix, the epoch was read in a LET outside
+WITH-RECURSIVE-LOCK-HELD, so appender A could read epoch E, the
+allocator could advance past E, appender B could read and append E+k
+first, and A's record then lands after it with the smaller epoch."
+  (with-temp-directory (dir)
+    (let ((c (open-system-clock (namestring dir))))
+      (unwind-protect
+           (let* ((stop nil)
+                  (alloc (bt:make-thread
+                          (lambda ()
+                            (loop until stop
+                                  do (clock-next-epoch c)))))
+                  (appenders
+                    (loop for tag in '(:stress-a :stress-b)
+                          collect
+                          (let ((tag tag))
+                            (bt:make-thread
+                             (lambda ()
+                               (dotimes (i 200)
+                                 (journal-append c :attach
+                                                 :store tag))))))))
+             (mapc #'bt:join-thread appenders)
+             (setq stop t)
+             (bt:join-thread alloc)
+             (let ((epochs (mapcar (lambda (r) (getf r :epoch))
+                                   (journal-records c))))
+               (is (= 400 (length epochs)))
+               (is-true (every #'<= epochs (rest epochs))
+                        "journal file order must match :EPOCH order")))
+        (close-system-clock c)))))
+
+(test attach-and-detach-journal-user-package-store-names-as-keywords
+  "GH #178: journal I/O reads under *PACKAGE* COMMON-LISP, so a graph
+named by a user-package symbol must be journaled as the same-named
+KEYWORD or the record's :STORE would read back as a different symbol.
+Covers the :ATTACH and :DETACH write sites plus %LOOKUP-STORE-BY-KEY,
+the read-side normalization the restore scans use."
+  (with-clock-system-dir ()
+    (with-temp-directory (cdir)
+      (with-temp-directory (gdir)
+        (let ((clock (open-system-clock (namestring cdir))))
+          (unwind-protect
+               (let ((g (make-graph 'graph-db/test::sc-userpkg-store
+                                    (namestring gdir)
+                                    :buffer-pool-size 1000
+                                    :system-clock clock)))
+                 (is (eq g (graph-db::%lookup-store-by-key
+                            :sc-userpkg-store))
+                     "a journal keyword must find the live graph")
+                 (let ((attach (find :attach (journal-records clock)
+                                     :key (lambda (r) (getf r :kind)))))
+                   (is (eq :sc-userpkg-store (getf attach :store)))
+                   (is (keywordp (getf attach :store))))
+                 (graph-db:detach-store g)
+                 (let ((detach (find :detach (journal-records clock)
+                                     :key (lambda (r) (getf r :kind)))))
+                   (is (eq :sc-userpkg-store (getf detach :store)))))
+            (close-system-clock clock)))))))
+
+(test store-name-key-normalizes-symbols-only
+  "GH #178: symbols (of any package) become same-named keywords;
+non-symbols pass through untouched."
+  (is (eq :foo (graph-db::%store-name-key :foo)))
+  (is (eq :sc-nk-sym (graph-db::%store-name-key 'graph-db/test::sc-nk-sym)))
+  (is (equal "a string name" (graph-db::%store-name-key "a string name")))
+  (is (eql 42 (graph-db::%store-name-key 42))))
+
+(test tm-epoch-helpers-are-internal
+  "GH #179: TM-NEXT-EPOCH (which BURNS an epoch), TM-CURRENT-EPOCH and
+TM-PEEK-EPOCH are not consumer API -- TRANSACTION-MANAGER itself is
+unexported -- so none of the three may be external in GRAPH-DB."
+  (dolist (name '("TM-NEXT-EPOCH" "TM-CURRENT-EPOCH" "TM-PEEK-EPOCH"))
+    (multiple-value-bind (sym status) (find-symbol name :graph-db)
+      (is-true sym "~A must still exist" name)
+      (is (eq :internal status)
+          "~A must be internal, was ~S" name status))))
+
+(test graph-system-clock-is-a-reader-only-export
+  "GH #183: GRAPH-SYSTEM-CLOCK stays exported as a READER; the writer is
+the internal %GRAPH-SYSTEM-CLOCK, so ATTACH-TO-SYSTEM-CLOCK (watermark +
+journal) is the only public way to attach."
+  (multiple-value-bind (sym status) (find-symbol "GRAPH-SYSTEM-CLOCK"
+                                                 :graph-db)
+    (is (eq :external status))
+    (is-false (fboundp (list 'setf sym))
+              "(SETF GRAPH-SYSTEM-CLOCK) must not be defined"))
+  (is-true (fboundp '(setf graph-db::%graph-system-clock))))
+
+(test make-graph-refuses-replay-under-a-system-clock
+  "GH #180: MAKE-GRAPH :SLAVE-P :REPLAY-TXN-DIR under a clock (explicit
+or via *SYSTEM-CLOCK*) must refuse BEFORE any side effect -- replay
+would mint ids from the local counter before the clock attaches.  The
+same call without a clock proceeds past this check (it then fails on
+the missing :REPLICATION-PORT, a different, non-#180 error)."
+  (with-clock-system-dir ()
+    (with-temp-directory (cdir)
+      (with-temp-directory (gdir)
+        (with-temp-directory (txn-dir)
+          (let ((clock (open-system-clock (namestring cdir)))
+                (loc (namestring (merge-pathnames "never-created/" gdir))))
+            (unwind-protect
+                 (progn
+                   (let ((msg (handler-case
+                                  (progn
+                                    (make-graph :sc-replay-clocked loc
+                                                :slave-p t
+                                                :replay-txn-dir
+                                                (namestring txn-dir)
+                                                :system-clock clock)
+                                    nil)
+                                (error (e) (format nil "~A" e)))))
+                     (is-true (and msg (search "GH #180" msg))
+                              "must signal the #180 refusal, got: ~A" msg)
+                     (is-false (probe-file loc)
+                               "refusal must precede directory creation"))
+                   ;; Implicit path: *SYSTEM-CLOCK* bound is enough.
+                   (let ((*system-clock* clock))
+                     (is-true
+                      (handler-case
+                          (progn (make-graph :sc-replay-clocked-2 loc
+                                             :slave-p t
+                                             :replay-txn-dir
+                                             (namestring txn-dir))
+                                 nil)
+                        (error (e)
+                          (and (search "GH #180" (format nil "~A" e)) t)))))
+                   ;; No clock: sails past #180, fails later on ports.
+                   (let ((*system-clock* nil))
+                     (is-false
+                      (handler-case
+                          (progn (make-graph :sc-replay-unclocked loc
+                                             :slave-p t
+                                             :replay-txn-dir
+                                             (namestring txn-dir))
+                                 nil)
+                        (error (e)
+                          (and (search "GH #180" (format nil "~A" e))
+                               t))))))
+              (close-system-clock clock))))))))
+
+(test memory-graph-joins-the-image-clock
+  "GH #176: MAKE-MEMORY-GRAPH and OPEN-MEMORY-GRAPH take :SYSTEM-CLOCK
+(default *SYSTEM-CLOCK*) and attach exactly as the disk constructors do
+-- so a memory graph and a disk graph on one clock draw from one epoch
+space and never collide.  Also covers the clean close and the reopen
+re-attach."
+  (with-clock-system-dir ()
+    (with-temp-directory (cdir)
+      (with-temp-directory (mdir)
+        (with-temp-directory (ddir)
+          (let ((clock (open-system-clock (namestring cdir))))
+            (unwind-protect
+                 (let ((mg (graph-db::make-memory-graph
+                            :sc-mem-clocked (namestring mdir)
+                            :system-clock clock))
+                       (dg (make-graph :sc-disk-clocked (namestring ddir)
+                                       :buffer-pool-size 1000
+                                       :system-clock clock)))
+                   (unwind-protect
+                        (let ((ids '()))
+                          (is (eq clock (graph-system-clock mg)))
+                          (dotimes (i 3)
+                            (push (transaction-id
+                                   (with-transaction
+                                       ((graph-db::transaction-manager mg))
+                                     graph-db::*transaction*))
+                                  ids)
+                            (push (transaction-id
+                                   (with-transaction
+                                       ((graph-db::transaction-manager dg))
+                                     graph-db::*transaction*))
+                                  ids))
+                          (is (= (length ids)
+                                 (length (remove-duplicates ids)))
+                              "one epoch space: no id collides"))
+                     (let ((graph-db:*graph* dg))
+                       (close-graph dg :snapshot-p nil))
+                     (let ((graph-db:*graph* mg))
+                       (close-graph mg :snapshot-p nil)))
+                   ;; Reopen re-attaches through the same keyword.
+                   (let ((mg2 (graph-db::open-memory-graph
+                               :sc-mem-clocked (namestring mdir)
+                               :system-clock clock)))
+                     (unwind-protect
+                          (is (eq clock (graph-system-clock mg2)))
+                       (let ((graph-db:*graph* mg2))
+                         (close-graph mg2 :snapshot-p nil)))))
+              (close-system-clock clock))))))))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -1011,7 +1011,10 @@ APPLY-TRANSACTION)."
                    :type "dat"
                    :defaults (location graph))))
 
-(defgeneric persist-highest-transaction-id (transaction-id graph)
+(defgeneric %write-highest-transaction-id (transaction-id graph)
+  (:documentation "Unconditional raw overwrite of transaction-id.dat --
+no max, no lock.  For crash-fabricating tests; production writers go
+through PERSIST-HIGHEST-TRANSACTION-ID (GH #177).")
   (:method (transaction-id graph)
     (let ((persist-file (highest-transaction-id-file graph))
           (serialized (make-byte-vector 8)))
@@ -1021,9 +1024,21 @@ APPLY-TRANSACTION)."
                               :element-type '(unsigned-byte 8)
                               :if-does-not-exist :create
                               :if-exists :overwrite)
-        (with-recursive-lock-held (*highest-transaction-id-lock*)
-          (write-sequence serialized stream)))
+        (write-sequence serialized stream))
       transaction-id)))
+
+(defgeneric persist-highest-transaction-id (transaction-id graph)
+  (:documentation "Persist TRANSACTION-ID as GRAPH's durable watermark
+unless a higher one is already on disk -- the file only ever moves
+forward.  Returns the id actually on disk after the call (GH #177).")
+  (:method (transaction-id graph)
+    ;; Lock spans read-compare-write: two racing writers must not let
+    ;; the lower id land last (GH #177).
+    (with-recursive-lock-held (*highest-transaction-id-lock*)
+      (let ((current (load-highest-transaction-id graph)))
+        (if (> transaction-id current)
+            (%write-highest-transaction-id transaction-id graph)
+            current)))))
 
 (defgeneric load-highest-transaction-id (graph)
   (:method (graph)
@@ -3174,10 +3189,15 @@ longer open (GH #171, spec R6)."
                             (if (peer-graph-p graph)
                                 (load-peer-pull-cursor graph)
                                 0))))
-        (clock-observe-epoch clock watermark)
-        (journal-append clock :attach :store (graph-name graph)
-                        :location (namestring (location graph)))
-        (setf (graph-system-clock graph) clock))))
+        ;; One clock-lock hold over raise+record, so no allocator slots
+        ;; between them.  Lock ordering invariant: manager -> clock,
+        ;; never the reverse -- every site that holds both takes the TM
+        ;; lock first (GH #184).
+        (with-recursive-lock-held ((system-clock-lock clock))
+          (clock-observe-epoch clock watermark)
+          (journal-append clock :attach :store (graph-name graph)
+                          :location (namestring (location graph)))
+          (setf (%graph-system-clock graph) clock)))))
   graph)
 
 (defgeneric remove-transaction (transaction transaction-manager)
@@ -3597,9 +3617,14 @@ hand over."))
       (%quiesce-transaction-manager tm :detaching timeout)
       (handler-case
           (multiple-value-bind (start end)
-              (clock-lease-epochs clock lease-epochs)
-            (journal-append clock :detach
-                            :store name :lease-start start :lease-end end)
+              ;; One clock-lock hold over lease+record (GH #184); no TM
+              ;; lock is held here, so the manager->clock order holds.
+              (with-recursive-lock-held ((system-clock-lock clock))
+                (multiple-value-bind (start end)
+                    (clock-lease-epochs clock lease-epochs)
+                  (journal-append clock :detach :store name
+                                  :lease-start start :lease-end end)
+                  (values start end)))
             ;; CLOSE-GRAPH's own snapshot scans the graph via WITH-READ-PIN;
             ;; ACCEPTING-P is already :DETACHING, so it needs the one bypass
             ;; above -- see *QUIESCED-STORE-CLOSING-P*'s docstring.


### PR DESCRIPTION
One coherent batch over the #168-era system-clock/lifecycle-journal surface, per the post-namespaces-epic sweep ordering.

## Fixes

- **#184** — `journal-append` reads the epoch **inside** the clock lock, and the compound events hold one clock-lock across both steps (attach: watermark raise + `:attach` record; detach: lease + `:detach` record), so journal file order always matches `:epoch` order. The manager → clock lock-ordering invariant is now documented at the attach site.
- **#178** — `journal-append` normalizes its `:store` property to a keyword centrally (`%store-name-key`); the restore scans normalize journal-read values (tolerating pre-fix journals holding user-package symbols) and live graph names at every comparison boundary (`%lookup-store-by-key`, `retired-generations`, `%known-locations`, `%restore-plan-entries`, the `restore-system` cascade). `%restore-one-store`/`%rebuild-one-store` re-derive the live graph's real name so reopens re-register under the caller's key.
- **#177** — `persist-highest-transaction-id` is monotonic: the lock spans the whole read-compare-write (previously it sat *inside* the file open), a lower id never rewinds `transaction-id.dat`, and the call returns what is on disk. The raw overwrite survives as internal `%write-highest-transaction-id` for crash-fabricating tests.
- **#183** — `graph-system-clock` is a reader-only export; the writer is the internal `%graph-system-clock`, so `attach-to-system-clock`'s watermark and quiescence guard cannot be bypassed by `setf`.
- **#179** — `tm-next-epoch` / `tm-current-epoch` / `tm-peek-epoch` unexported (`transaction-manager` was never exported, and `tm-next-epoch` burns epochs — not consumer API).
- **#180** — `make-graph :slave-p t :replay-txn-dir` under a clock (explicit or implicit via `*system-clock*`) is refused with a clear error before any side effect.
- **#176** — `make-memory-graph`/`open-memory-graph` take `:system-clock` (default `*system-clock*`) and attach after the graph is fully open; a failed attach unwinds through the normal `close-graph`.
- **#212** — the remaining substantive family member: an `attach-to-system-clock` failure after a successful `open-graph` inside `%swap-in-shadow-1`/`%reopen-and-resume` now closes the just-opened graph before propagating, ending the double-open/`.dirty` deadlock in recovery. The missing-`:swap`-record shape stays tolerated as warnings on both sides (see issue close note).
- **#234** — `policy.dat`, `lease.dat`, and the restore manifest converted to the shared `with-sidecar-output`/`with-sidecar-input` discipline, with hostile-environment round-trip tests.

## Method & verification

Subagent-driven: implementer → independent adversarial review (APPROVE-WITH-NITS; lock-ordering audit clean) → fix round (centralized #178 normalization, pre-fix-journal read-side tolerance, memory-graph attach unwind, test handle leak) → scoped re-review (APPROVE).

**Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (`--dynamic-space-size 16384`, source-registry pinned to the branch tree): 4802 checks, Pass 4792, Skip 10 (pre-existing GEOS environmental), Fail 0.** ECL skipped per the standing demotion directive.

13 new tests across system-clock / detach / sidecar-io suites, including a 3-thread epoch-order contention pin and deterministic attach-failure tests via a mock clock with a failing ceiling write.

Follow-ups filed separately: #177's per-commit read+write cost on the hot apply path (perf watch), and the narrow memory-peer-hub push window between `start-replication` and attach.

Closes #184, #178, #177, #183, #179, #180, #176, #234. #212 to be closed with a landing note on merge (one family member deliberately left as warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp