### PR TITLE
Test scratch space is self-cleaning: per-run parent + stale sweep (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Changed
 
+- **Test scratch space is now self-cleaning** (#214). All FiveAM suites
+  route their scratch (per-test directories, loose files, each runner's
+  system directory) through a new shared `GRAPH-DB/TEST-SCRATCH` system:
+  everything lives under one lazily created per-run parent,
+  `$TMPDIR/graph-db-test-run-<tag>/`, which each runner deletes whole in
+  its unwind — a killed or crashed run leaks exactly one tree instead of
+  hundreds of flat `graph-db-test-*` entries. Creating the parent also
+  sweeps the temp root once per run parent for stale scratch (an exact
+  whitelist of `graph-db-*`/`gda-*`/`vgseg-*`/`vgquery-*` name prefixes;
+  symlinks are skipped, never followed) older than 24 hours
+  (`SWEEP-STALE-SCRATCH`), so leaked trees from aborted runs no longer
+  accumulate (1.2 TB was observed once). The age guard keeps concurrent
+  runs on a shared host safe. Manual cleanup:
+  `rm -rf ${TMPDIR:-/tmp}/graph-db-* ${TMPDIR:-/tmp}/gda-*` (plus
+  `vgseg-*`/`vgquery-*` loose files).
+
 - **`DEF-NODE-TYPE` now installs through a shared functional core**
   (#172). The macro's expansion keeps only the literal `DEFCLASS`; the
   generated helpers (`MAKE-<N>`, `LOOKUP-<N>`, `<N>-P`), the `<N>/2` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,21 @@ To run one, e.g.:
 (test-alloc)
 ```
 
-Tests write scratch databases under `/var/tmp/`; clean those up between runs if state seems stale.
+Scratch locations differ between the two generations of tests:
+
+- **FiveAM suites** put all scratch under one per-run parent,
+  `$TMPDIR/graph-db-test-run-<tag>/` (shared `graph-db/test-scratch` system,
+  GH #214). Each runner deletes its parent on exit, and suite start sweeps the
+  temp root for scratch older than 24 hours (a whitelist of `graph-db-*`,
+  `gda-*`, `vgseg-*`, `vgquery-*` name prefixes; symlinks skipped) — so stale
+  trees from killed runs clean themselves up. Manual cleanup if ever needed —
+  note these globs are broader than the sweep's exact whitelist, so check
+  nothing else of yours matches first:
+  `rm -rf ${TMPDIR:-/tmp}/graph-db-* ${TMPDIR:-/tmp}/gda-*
+  ${TMPDIR:-/tmp}/vgseg-* ${TMPDIR:-/tmp}/vgquery-*`.
+- **The ad-hoc REPL exercises above** write scratch databases under
+  `/var/tmp/` (e.g. `/var/tmp/graph/`); clean those up between runs if state
+  seems stale — nothing sweeps them.
 
 ## Architecture (bottom-up)
 

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -197,10 +197,16 @@
   :components ((:file "rest"))
   :in-order-to ((test-op (test-op :graph-db/test))))
 
+(defsystem graph-db/test-scratch
+  :name "VivaceGraph shared test scratch-space manager"
+  :description "Per-run scratch parent + stale sweep for all suites (GH #214)."
+  :pathname "tests/"
+  :components ((:file "scratch")))
+
 (defsystem graph-db/concurrency-test
   :name "VivaceGraph concurrency test suite"
   :description "FiveAM thread-safety and concurrency tests for graph-db."
-  :depends-on (:graph-db :fiveam :bordeaux-threads)
+  :depends-on (:graph-db :graph-db/test-scratch :fiveam :bordeaux-threads)
   :pathname "tests/concurrency/"
   :serial t
   :components ((:file "package")
@@ -221,7 +227,7 @@
 
 (defsystem graph-db/acid-test
   :name "VivaceGraph ACID compliance tests"
-  :depends-on (:graph-db :fiveam :bordeaux-threads)
+  :depends-on (:graph-db :graph-db/test-scratch :fiveam :bordeaux-threads)
   :pathname "tests/acid/"
   :serial t
   :components ((:file "package")
@@ -236,7 +242,7 @@
 (defsystem graph-db/stress-test
   :name "VivaceGraph stress test suite"
   :description "Single-threaded scale and correctness stress tests for graph-db."
-  :depends-on (:graph-db :fiveam)
+  :depends-on (:graph-db :graph-db/test-scratch :fiveam)
   :pathname "tests/stress/"
   :serial t
   :components ((:file "package")
@@ -254,7 +260,8 @@
 (defsystem graph-db/concurrent-stress-test
   :name "VivaceGraph concurrent stress test suite"
   :description "Multi-threaded scale and stability tests for graph-db."
-  :depends-on (:graph-db :fiveam :bordeaux-threads)
+  :depends-on (:graph-db :graph-db/test-scratch :fiveam
+               :bordeaux-threads)
   :pathname "tests/concurrent-stress/"
   :serial t
   :components ((:file "package")
@@ -275,7 +282,7 @@
 (defsystem graph-db/perf-test
   :name "VivaceGraph performance benchmark suite"
   :description "SBCL-focused performance benchmarks for graph-db (measurement, not pass/fail)."
-  :depends-on (:graph-db :bordeaux-threads)
+  :depends-on (:graph-db :graph-db/test-scratch :bordeaux-threads)
   :pathname "tests/perf/"
   :serial t
   :components ((:file "package")
@@ -356,7 +363,8 @@
 (defsystem graph-db/algorithms-test
   :name "VivaceGraph graph-algorithms test suite"
   :description "FiveAM tests for graph-db/algorithms."
-  :depends-on (:graph-db/algorithms :graph-db/algorithms-io :fiveam)
+  :depends-on (:graph-db/algorithms :graph-db/algorithms-io
+               :graph-db/test-scratch :fiveam)
   :pathname "tests/algorithms/"
   :serial t
   :components ((:file "package")
@@ -395,7 +403,8 @@
 (defsystem graph-db/geos-test
   :name "VivaceGraph GEOS test suite"
   :description "FiveAM tests for the optional GEOS integration."
-  :depends-on (:graph-db/geos :fiveam :bordeaux-threads)
+  :depends-on (:graph-db/geos :graph-db/test-scratch :fiveam
+               :bordeaux-threads)
   :pathname "tests/geos/"
   :serial t
   :components ((:file "package")
@@ -444,7 +453,8 @@ cl-temporal-extent."
   ;; without the add-on REGISTER-GEOMETRY correctly refuses to answer at
   ;; all (#138, design §6).  The GEOS-dependent test skips when libgeos_c
   ;; is absent, as tests/geos/ does.
-  :depends-on (:graph-db/spacetime :graph-db/core :graph-db/geos :fiveam)
+  :depends-on (:graph-db/spacetime :graph-db/core :graph-db/geos
+               :graph-db/test-scratch :fiveam)
   :pathname "tests/spacetime/"
   :serial t
   :components ((:file "package")
@@ -469,7 +479,7 @@ cl-temporal-extent."
 (defsystem graph-db/test
   :name "VivaceGraph test suite"
   :description "FiveAM unit tests for graph-db."
-  :depends-on (:graph-db :fiveam :drakma)
+  :depends-on (:graph-db :graph-db/test-scratch :fiveam :drakma)
   :pathname "tests/"
   :serial t
   :components ((:file "package")
@@ -569,7 +579,8 @@ cl-temporal-extent."
                (:file "value-constraint-tests")     ; GH #149
                (:file "peer-unique-tests")
                (:file "peer-index-tests")
-               (:file "open-hygiene-tests"))   ; GH #222, #224
+               (:file "open-hygiene-tests")    ; GH #222, #224
+               (:file "scratch-cleanup-tests")) ; GH #214
   :perform (test-op (op c)
                     (unless (uiop:symbol-call :graph-db/test :run-tests)
                       (error "graph-db test suite failed."))))

--- a/tests/acid/suite.lisp
+++ b/tests/acid/suite.lisp
@@ -23,34 +23,17 @@ Called by (asdf:test-system :graph-db/acid-test)."
          (let ((results (run 'acid-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Temp-directory helpers
 ;;; ---------------------------------------------------------------------------
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "graph-db-acid-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-acid"))
 
 (defmacro with-temp-directory ((var) &body body)
   `(let ((,var (make-temp-directory)))

--- a/tests/algorithms/fixtures.lisp
+++ b/tests/algorithms/fixtures.lisp
@@ -23,27 +23,9 @@
 
 ;;; ---- scratch graph lifecycle -------------------------------------
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "gda-test-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "gda-test"))
 
 (defmacro with-temp-directory ((var) &body body)
   `(let ((,var (make-temp-directory)))

--- a/tests/algorithms/io-tests.lisp
+++ b/tests/algorithms/io-tests.lisp
@@ -9,10 +9,8 @@
 (in-suite io-suite)
 
 (defun write-temp-file (content ext)
-  ;; SCRATCH-TAG, not a bare (RANDOM ...): SBCL's default *RANDOM-STATE* is
-  ;; constant, so concurrent runs would pick the same name.
-  (let ((path (merge-pathnames (format nil "gda-io-~A.~A" (scratch-tag) ext)
-                               (uiop:temporary-directory))))
+  (let ((path (graph-db-test-scratch:make-scratch-file-name
+               "gda-io" ext)))
     (with-open-file (out path :direction :output :if-exists :supersede
                               :if-does-not-exist :create)
       (write-string content out))

--- a/tests/algorithms/suite.lisp
+++ b/tests/algorithms/suite.lisp
@@ -13,19 +13,14 @@ Invoked by (asdf:test-system :graph-db/algorithms-test)."
   ;; Type-ids come from the system-wide registry, so every store this suite
   ;; opens needs a system directory (GH #186).  One for the whole run, which
   ;; is the shape a real system has: many stores, one registry.
-  ;; Built inline rather than via FIXTURES.LISP's MAKE-TEMP-DIRECTORY: that
-  ;; file loads after this one, and a forward reference would compile with a
-  ;; style warning.
-  (let* ((system-dir (ensure-directories-exist
-                      (merge-pathnames
-                       (format nil "graph-db-algo-sysdir-~36R/"
-                               (random (expt 36 12) (make-random-state t)))
-                       (uiop:temporary-directory))))
+  (let* ((system-dir (graph-db-test-scratch:make-scratch-directory
+                      "graph-db-algo-sysdir"))
          (graph-db::*system-directory* (namestring system-dir))
          (graph-db::*type-registry* nil))
     (unwind-protect
          (let ((results (run 'graph-db-algorithms-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))

--- a/tests/concurrency/suite.lisp
+++ b/tests/concurrency/suite.lisp
@@ -27,34 +27,17 @@ Called by (asdf:test-system :graph-db/concurrency-test)."
          (let ((results (run 'concurrency-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Temp-directory and GC helpers (mirrored from graph-db/test)
 ;;; ---------------------------------------------------------------------------
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "graph-db-conc-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-conc"))
 
 (defmacro with-temp-directory ((var) &body body)
   `(let ((,var (make-temp-directory)))

--- a/tests/concurrent-stress/suite.lisp
+++ b/tests/concurrent-stress/suite.lisp
@@ -23,8 +23,9 @@
          (let ((results (run 'concurrent-stress-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Thread-count parameter
@@ -91,27 +92,9 @@ slower machines or bumped for deeper stress.  Must be ≥ 4.")
 ;;; Temp-directory and GC helpers
 ;;; ---------------------------------------------------------------------------
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "graph-db-cstress-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-cstress"))
 
 (defmacro with-temp-directory ((var) &body body)
   `(let ((,var (make-temp-directory)))

--- a/tests/geos/suite.lisp
+++ b/tests/geos/suite.lisp
@@ -20,8 +20,9 @@ Invoked by (asdf:test-system :graph-db/geos)."
          (let ((results (run 'geos-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 ;;; A handful of tests need to run with GEOS forced unavailable to prove the
 ;;; fallback path.  This binds the flag off for the dynamic extent of BODY.
@@ -44,27 +45,9 @@ Invoked by (asdf:test-system :graph-db/geos)."
   ((geom :type graph-db::geometry :index t))
   :graph-db-geos-test)
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "graph-db-geos-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-geos"))
 
 (defmacro with-geos-graph ((g) &body body)
   "Bind G + *graph* to a fresh on-disk graph; tear it down afterwards."

--- a/tests/open-hygiene-tests.lisp
+++ b/tests/open-hygiene-tests.lisp
@@ -96,7 +96,9 @@ original definition -- even if BODY itself signals."
 schema.dat into the store's parent directory, and a graph created and
 read that way must reopen and read back correctly (GH #222)."
   (with-temp-directory (dir)
-    (let* ((parent (uiop:temporary-directory))
+    ;; The store's actual parent (the #214 run parent), NOT the temp
+    ;; root -- that is where a slashless location would scatter files.
+    (let* ((parent (uiop:pathname-parent-directory-pathname dir))
            (slashless (string-right-trim "/" (namestring dir)))
            id)
       (let ((g (make-graph :oh-graph slashless :buffer-pool-size 1000)))

--- a/tests/perf/benchmarks.lisp
+++ b/tests/perf/benchmarks.lisp
@@ -249,19 +249,22 @@ Measurement-only; always returns T."
     (reset-perf-report)
     (format t "~&=== graph-db perf (~A, scale ~A) ===~%" *lisp-impl* scale)
     (finish-output)
-    (bench-crud)
-    (bench-edges)
-    (bench-view)
-    (bench-unique)
-    (bench-index)
-    (bench-prolog)
-    (bench-commit-overhead)
-    (bench-concurrent-rw)
-    (bench-disk-growth)
-    (bench-snapshot-restore-reopen)
-    (write-perf-report output :tag tag)
-    (uiop:delete-directory-tree system-dir :validate t
-                                           :if-does-not-exist :ignore))
+    (unwind-protect
+         (progn
+           (bench-crud)
+           (bench-edges)
+           (bench-view)
+           (bench-unique)
+           (bench-index)
+           (bench-prolog)
+           (bench-commit-overhead)
+           (bench-concurrent-rw)
+           (bench-disk-growth)
+           (bench-snapshot-restore-reopen)
+           (write-perf-report output :tag tag))
+      ;; system-dir and all bench scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run)))
   t)
 
 ;; Alias so the headless driver can call (graph-db/perf-test:perf-suite).

--- a/tests/perf/bplus-bench.lisp
+++ b/tests/perf/bplus-bench.lisp
@@ -141,16 +141,15 @@ skip list uses ~52 MB and the B+ tree ~23 MB, so 256 MB is ample.)"
   (format t "~&~%############  B+ TREE  vs  SKIP-LIST  (~A, page ~A B)  ############~%"
           (lisp-implementation-type) page-size)
   (dolist (n sizes)
-    ;; Scratch names must be unique per PROCESS, not just per N: two benchmark
-    ;; runs on a shared host would otherwise map the same heap file.  The default
-    ;; *RANDOM-STATE* is a fixed constant on SBCL, so seed from entropy.
-    (let* ((tag (random (expt 36 12) (make-random-state t)))
-           (sl-path (namestring
-                     (merge-pathnames (format nil "bench-sl-~36R-~A.dat" tag n)
-                                      (uiop:temporary-directory))))
+    ;; Scratch names must be unique per PROCESS, not just per N; the shared
+    ;; scratch manager's tag guarantees that, and its per-run parent keeps
+    ;; the heap files out of the bare temp root (GH #214).
+    (let* ((sl-path (namestring
+                     (graph-db-test-scratch:make-scratch-file-name
+                      (format nil "bench-sl-~A" n) "dat")))
            (bp-path (namestring
-                     (merge-pathnames (format nil "bench-bp-~36R-~A.dat" tag n)
-                                      (uiop:temporary-directory))))
+                     (graph-db-test-scratch:make-scratch-file-name
+                      (format nil "bench-bp-~A" n) "dat")))
            ;; CREATE-MEMORY does NOT truncate an existing file -- it maps it at its
            ;; current size.  A stale file left by a prior crashed/oversized run
            ;; (e.g. a 1 GB file from :heap-mb 1024) is then reused with a

--- a/tests/perf/suite.lisp
+++ b/tests/perf/suite.lisp
@@ -70,27 +70,9 @@
 ;;; Temp dirs / gc (same pattern as the stress suite)
 ;;; ---------------------------------------------------------------------------
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "graph-db-perf-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-perf"))
 
 (defmacro with-temp-directory ((var) &body body)
   `(let ((,var (make-temp-directory)))

--- a/tests/scratch-cleanup-tests.lisp
+++ b/tests/scratch-cleanup-tests.lisp
@@ -1,0 +1,105 @@
+;;;; Scratch-space manager tests (GH #214).
+;;;;
+;;;; The sweep tests operate ONLY on fabricated roots the test owns --
+;;;; never on the real temp root, whose live entries belong to concurrent
+;;;; runs on this shared host.
+
+(in-package #:graph-db/test)
+
+(def-suite scratch-cleanup-suite
+  :description "Per-run scratch parent + stale sweep (GH #214)."
+  :in graph-db-suite)
+
+(in-suite scratch-cleanup-suite)
+
+(test scratch-lives-under-run-parent
+  "Fixture scratch (dirs and file names) lands under the per-run parent."
+  (let ((parent (namestring (graph-db-test-scratch:scratch-run-directory)))
+        (dir (make-temp-directory))
+        (file (make-temp-file-name "sc214" "dat")))
+    (unwind-protect
+         (progn
+           (is (uiop:string-prefix-p parent (namestring dir)))
+           (is (uiop:string-prefix-p parent (namestring file))))
+      (uiop:delete-directory-tree dir :validate t
+                                      :if-does-not-exist :ignore))))
+
+(defun make-fake-scratch-entry (root name)
+  "Create directory or plain-file NAME under ROOT; returns its pathname.
+NAME ending in / makes a directory."
+  (let ((path (merge-pathnames name root)))
+    (if (uiop:directory-pathname-p path)
+        (ensure-directories-exist path)
+        (with-open-file (s path :direction :output
+                                :if-does-not-exist :create)
+          (declare (ignorable s))))
+    path))
+
+;; MOST-NEGATIVE-FIXNUM (not 0) so any age qualifies even when a
+;; filesystem timestamp runs ahead of GET-UNIVERSAL-TIME.
+(test sweep-deletes-stale-matching-entries
+  "With every age qualifying, the sweep removes every matching entry in
+a fabricated root -- legacy flat dirs, old run parents, loose files --
+and never touches non-matching names."
+  (with-temp-directory (root)
+    (let ((stale-dir (make-fake-scratch-entry root "graph-db-test-old1/"))
+          (stale-run (make-fake-scratch-entry root "graph-db-test-run-old2/"))
+          (stale-file (make-fake-scratch-entry root "graph-db-test-old3.dat"))
+          (other-dir (make-fake-scratch-entry root "keepme-dir/"))
+          (other-file (make-fake-scratch-entry root "keepme.dat"))
+          ;; Near-miss: shares "graph-db-test" but not the "-" boundary.
+          (near-miss (make-fake-scratch-entry root "graph-db-testx/")))
+      (is (= 3 (graph-db-test-scratch:sweep-stale-scratch
+                :root root :max-age-seconds most-negative-fixnum)))
+      (is (null (uiop:directory-exists-p stale-dir)))
+      (is (null (uiop:directory-exists-p stale-run)))
+      (is (null (probe-file stale-file)))
+      (is (not (null (uiop:directory-exists-p other-dir))))
+      (is (not (null (probe-file other-file))))
+      (is (not (null (uiop:directory-exists-p near-miss)))))))
+
+(defun make-symlink (target link)
+  "POSIX symlink LINK -> TARGET via ln(1); NIL where that isn't possible."
+  (ignore-errors
+    (uiop:run-program
+     (list "ln" "-s"
+           (string-right-trim "/" (namestring target))
+           (string-right-trim "/" (namestring link))))
+    t))
+
+(test sweep-skips-symlinks
+  "Symlinks with matching names are SKIPPED, never followed: deleting
+through a dir link would empty its target (GH #214).  Pinned behavior:
+the link itself survives too."
+  (with-temp-directory (root)
+    (let* ((victim (merge-pathnames "victim-dir/" root))
+           (victim-file (merge-pathnames "victim.dat" victim))
+           (dir-link (merge-pathnames "graph-db-test-evil/" root))
+           (file-link (merge-pathnames "graph-db-test-evil.dat" root)))
+      (ensure-directories-exist victim)
+      (with-open-file (s victim-file :direction :output
+                                     :if-does-not-exist :create)
+        (write-string "keep" s))
+      (if (not (and (make-symlink victim dir-link)
+                    (make-symlink victim-file file-link)))
+          (skip "no symlink support on this host")
+          (progn
+            (is (= 0 (graph-db-test-scratch:sweep-stale-scratch
+                      :root root
+                      :max-age-seconds most-negative-fixnum)))
+            (is (not (null (uiop:directory-exists-p victim))))
+            (is (not (null (probe-file victim-file))))
+            ;; The links resolve to intact targets, so they still exist.
+            (is (not (null (uiop:directory-exists-p dir-link))))
+            (is (not (null (probe-file file-link)))))))))
+
+(test sweep-keeps-fresh-matching-entries
+  "Entries younger than the age threshold survive the sweep, matching
+name or not -- the guard that makes the sweep safe beside live runs."
+  (with-temp-directory (root)
+    (let ((fresh-dir (make-fake-scratch-entry root "graph-db-test-fresh/"))
+          (fresh-file (make-fake-scratch-entry root "graph-db-conc-f.dat")))
+      (is (= 0 (graph-db-test-scratch:sweep-stale-scratch
+                :root root :max-age-seconds most-positive-fixnum)))
+      (is (not (null (uiop:directory-exists-p fresh-dir))))
+      (is (not (null (probe-file fresh-file)))))))

--- a/tests/scratch.lisp
+++ b/tests/scratch.lisp
@@ -1,0 +1,150 @@
+;;;; Shared scratch-space manager for every graph-db test suite (GH #214).
+;;;;
+;;;; All test scratch (per-test directories, loose files, each runner's
+;;;; system directory) lives under ONE lazily created per-run parent in
+;;;; the temp root, so a killed or crashed run leaks exactly one tree.
+;;;; Creating that parent also sweeps stale scratch left by earlier
+;;;; aborted runs.  Loaded by the GRAPH-DB/TEST-SCRATCH system, which all
+;;;; test systems depend on.
+
+(defpackage #:graph-db-test-scratch
+  (:use #:cl)
+  (:export #:scratch-tag
+           #:scratch-run-directory
+           #:make-scratch-directory
+           #:make-scratch-file-name
+           #:cleanup-scratch-run
+           #:sweep-stale-scratch
+           #:*scratch-prefixes*))
+
+(in-package #:graph-db-test-scratch)
+
+;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded
+;; (RANDOM ...) yields the SAME name sequence in every image: concurrent
+;; runs on a shared host would collide.  Seed from entropy, lazily so a
+;; dumped image reseeds per process; the counter keeps one image from
+;; ever repeating a name.
+(defvar *scratch-random-state* nil)
+(defvar *scratch-counter* 0)
+
+(defun scratch-tag ()
+  "A name fragment unique across concurrent processes and across calls."
+  (unless *scratch-random-state*
+    (setf *scratch-random-state* (make-random-state t)))
+  (format nil "~36R-~36R"
+          (random (expt 36 12) *scratch-random-state*)
+          (incf *scratch-counter*)))
+
+(defvar *scratch-run-directory* nil
+  "The current run's scratch parent pathname, or NIL before first
+use (and again after CLEANUP-SCRATCH-RUN).")
+
+;; Temp-root entry names the stale sweep may delete: the per-run parents
+;; plus every legacy flat prefix the suites ever used.  NOTHING outside
+;; this list is ever touched (GH #214).
+(defparameter *scratch-prefixes*
+  '("graph-db-test-"       ; main suite dirs + graph-db-test-run-* parents
+    "graph-db-conc-" "graph-db-acid-" "graph-db-stress-"
+    "graph-db-cstress-" "graph-db-perf-" "graph-db-geos-"
+    "graph-db-spacetime-" "graph-db-algo-"
+    "gda-test-" "gda-io-"  ; legacy algorithms scratch
+    "vgseg-" "vgquery-")   ; legacy segment-test loose files
+  "Name prefixes SWEEP-STALE-SCRATCH may delete in its root.")
+
+(defun scratch-name-matches-p (name)
+  "True when NAME starts with one of *SCRATCH-PREFIXES*."
+  (some (lambda (prefix)
+          (let ((len (length prefix)))
+            (and (>= (length name) len)
+                 (string= prefix name :end2 len))))
+        *scratch-prefixes*))
+
+(defun sweep-stale-scratch (&key (root (uiop:temporary-directory))
+                              (max-age-seconds (* 24 60 60)))
+  "Delete ROOT entries whose names match *SCRATCH-PREFIXES* and whose
+FILE-WRITE-DATE is at least MAX-AGE-SECONDS old.  Returns the count
+deleted.  Each deletion is guarded, so one EPERM or race skips that
+entry instead of aborting the sweep.  The age guard is what makes this
+safe on a shared host: a live run's scratch is always younger than the
+24h default, so never lower the threshold against the real temp root."
+  ;; Accepted residual risk: an image wedged idle for over 24h can have
+  ;; its live parent swept by another image -- normal activity keeps the
+  ;; parent's mtime fresh via direct-child churn (GH #214).
+  (let ((true-root (uiop:truename* root))
+        (live (and *scratch-run-directory*
+                   (uiop:truename* *scratch-run-directory*)))
+        (now (get-universal-time))
+        (deleted 0))
+    (unless true-root
+      (return-from sweep-stale-scratch 0))
+    (flet ((stale-p (path)
+             (let ((write-date (ignore-errors (file-write-date path))))
+               (and write-date (>= (- now write-date) max-age-seconds))))
+           ;; Skip symlinks: TRUENAME resolves them, so a link's truename
+           ;; differs from its listed path under TRUE-ROOT.  Deleting
+           ;; through one would empty its target (GH #214).
+           (not-a-symlink-p (path)
+             (equal (uiop:truename* path) path)))
+      (dolist (dir (ignore-errors (uiop:subdirectories true-root)))
+        (let ((name (first (last (pathname-directory dir)))))
+          (when (and (stringp name)
+                     (scratch-name-matches-p name)
+                     (not (equal dir *scratch-run-directory*))
+                     (not (equal dir live))
+                     (not-a-symlink-p dir)
+                     (stale-p dir))
+            (handler-case
+                (progn
+                  (uiop:delete-directory-tree
+                   dir :validate t :if-does-not-exist :ignore)
+                  (incf deleted))
+              (error () nil)))))
+      (dolist (file (ignore-errors (uiop:directory-files true-root)))
+        (let ((name (file-namestring file)))
+          (when (and (stringp name)
+                     (scratch-name-matches-p name)
+                     (not-a-symlink-p file)
+                     (stale-p file))
+            (handler-case
+                (progn (delete-file file) (incf deleted))
+              (error () nil))))))
+    deleted))
+
+(defun scratch-run-directory ()
+  "The current run's scratch parent, created on first call.  Creation
+also sweeps the temp root for stale scratch (once per run parent --
+CLEANUP-SCRATCH-RUN resets, so the next run in the same image sweeps
+again).  Returns a directory pathname."
+  (or *scratch-run-directory*
+      (let ((dir (merge-pathnames
+                  (format nil "graph-db-test-run-~A/" (scratch-tag))
+                  (uiop:temporary-directory))))
+        (ensure-directories-exist dir)
+        (setf *scratch-run-directory* dir)
+        (ignore-errors (sweep-stale-scratch))
+        dir)))
+
+(defun make-scratch-directory (&optional (prefix "graph-db-test"))
+  "Create and return a fresh scratch directory PREFIX-<tag>/ under the
+per-run parent.  Callers still delete it promptly; the parent catches
+whatever an aborted run leaves behind."
+  (let ((dir (merge-pathnames (format nil "~A-~A/" prefix (scratch-tag))
+                              (scratch-run-directory))))
+    (ensure-directories-exist dir)
+    dir))
+
+(defun make-scratch-file-name (prefix type)
+  "A unique, not-yet-created scratch file pathname under the per-run
+parent (PREFIX-<tag>.TYPE)."
+  (merge-pathnames (format nil "~A-~A.~A" prefix (scratch-tag) type)
+                   (scratch-run-directory)))
+
+(defun cleanup-scratch-run ()
+  "Delete this image's scratch parent (if any) and forget it, so a later
+run in the same image gets a fresh one.  Safe to call when none exists.
+Trap: everything under the parent dies -- close mmaps first."
+  (let ((dir *scratch-run-directory*))
+    (setf *scratch-run-directory* nil)
+    (when dir
+      (uiop:delete-directory-tree dir :validate t
+                                      :if-does-not-exist :ignore))))

--- a/tests/spacetime/suite.lisp
+++ b/tests/spacetime/suite.lisp
@@ -19,8 +19,9 @@ Invoked by (asdf:test-system :graph-db/spacetime)."
          (let ((results (run 'spacetime-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 (defun exact-interval (s e)
   "An interval extent with exact endpoints.  Three lines, duplicated from
@@ -42,24 +43,9 @@ can accidentally depend on the host timezone (design §3.5)."
 ;;; the same call GRAPH-DB/GEOS-TEST makes (tests/geos/suite.lisp).
 ;;; ---------------------------------------------------------------------------
 
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  "Create and return a fresh, unique scratch directory pathname."
-  (let ((dir (merge-pathnames
-              (format nil "graph-db-spacetime-~A/" (scratch-tag))
-              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-spacetime"))
 
 (defmacro with-temp-directory ((var) &body body)
   "Bind VAR to a fresh scratch directory, run BODY, then delete the tree."

--- a/tests/stress/suite.lisp
+++ b/tests/stress/suite.lisp
@@ -23,8 +23,9 @@ Called by (asdf:test-system :graph-db/stress-test)."
          (let ((results (run 'stress-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; system-dir and all test scratch live under the shared per-run
+      ;; parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Scale control
@@ -90,27 +91,9 @@ Prints a summary line and pushes structured data into *TIMING-REPORT*."
 ;;; Temp-directory helpers (same pattern as concurrency suite)
 ;;; ---------------------------------------------------------------------------
 
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
-
 (defun make-temp-directory ()
-  (let ((dir (merge-pathnames (format nil "graph-db-stress-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  "A fresh scratch dir under the shared per-run parent (GH #214)."
+  (graph-db-test-scratch:make-scratch-directory "graph-db-stress"))
 
 (defmacro with-temp-directory ((var) &body body)
   `(let ((,var (make-temp-directory)))

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -28,43 +28,26 @@ Invoked by (asdf:test-system :graph-db)."
          (let ((results (run 'graph-db-suite)))
            (explain! results)
            (results-status results))
-      (uiop:delete-directory-tree system-dir :validate t
-                                             :if-does-not-exist :ignore))))
+      ;; Everything this run scratched -- system-dir included -- lives
+      ;; under the shared per-run parent; drop it whole (GH #214).
+      (graph-db-test-scratch:cleanup-scratch-run))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Temp-file fixtures
 ;;;
 ;;; The storage layers all live in mmap'd files, so each test needs a
 ;;; private scratch directory that is reliably torn down afterwards.
+;;; All scratch lives under GRAPH-DB-TEST-SCRATCH's per-run parent, which
+;;; also sweeps stale trees from killed runs (GH #214).
 ;;; ---------------------------------------------------------------------------
-
-;; SBCL's initial *RANDOM-STATE* is a fixed constant, so an unseeded (RANDOM ...)
-;; produces the SAME name sequence in every image: two concurrent suite runs on a
-;; shared host would share -- and delete -- each other's scratch dirs.  Seed from
-;; entropy, lazily so a dumped image reseeds in each new process, and add a
-;; counter so one image can never repeat a name either.
-(defvar *scratch-random-state* nil)
-(defvar *scratch-counter* 0)
-
-(defun scratch-tag ()
-  "A name fragment unique across concurrent processes and across calls."
-  (unless *scratch-random-state*
-    (setf *scratch-random-state* (make-random-state t)))
-  (format nil "~36R-~36R"
-          (random (expt 36 12) *scratch-random-state*)
-          (incf *scratch-counter*)))
 
 (defun make-temp-directory ()
   "Create and return a fresh, unique scratch directory pathname."
-  (let ((dir (merge-pathnames (format nil "graph-db-test-~A/" (scratch-tag))
-                              (uiop:temporary-directory))))
-    (ensure-directories-exist dir)
-    dir))
+  (graph-db-test-scratch:make-scratch-directory "graph-db-test"))
 
 (defun make-temp-file-name (prefix type)
   "A unique, not-yet-created scratch file pathname (PREFIX-<tag>.TYPE)."
-  (merge-pathnames (format nil "~A-~A.~A" prefix (scratch-tag) type)
-                   (uiop:temporary-directory)))
+  (graph-db-test-scratch:make-scratch-file-name prefix type))
 
 (defmacro with-temp-directory ((var) &body body)
   "Bind VAR to a fresh scratch directory, run BODY, then delete the tree."


### PR DESCRIPTION
Fixes #214 — test suites leave scratch directories behind on abnormal exit (1.2 TB / 132 dirs accumulated once; ~1,700 stale flat dirs sat on the dev host when this work started).

## What changed

All nine FiveAM test systems previously carried mirrored private copies of the scratch fixtures, each writing flat `graph-db-*` dirs straight into the temp root, cleaned only by per-test unwinds. They now delegate to a new shared **`graph-db/test-scratch`** system (`tests/scratch.lisp`), combining both candidates from the issue:

- **Per-run parent**: all scratch — per-test directories, loose files, each runner's system directory — lives under one lazily created `$TMPDIR/graph-db-test-run-<tag>/`, which each runner deletes whole in its unwind (`cleanup-scratch-run`). A killed or crashed run leaks exactly one tree.
- **Stale sweep** (`sweep-stale-scratch`, runs once per run parent at creation): deletes temp-root entries matching an **exact prefix whitelist** (the nine suites' historical prefixes plus legacy loose-file prefixes) whose mtime is at least 24 h old. **Symlinks are skipped, never followed** — an lstat-equivalent truename guard on both directory and file entries (review destructively proved pre-fix `uiop:delete-directory-tree` recurses through a `graph-db-test-evil -> victim` link; the fix is pinned by a hostile-symlink test). Each deletion is individually error-guarded; the age guard keeps concurrent runs on a shared host safe (a live run's parent mtime stays fresh via direct-child churn).
- The `:root`/`:max-age-seconds` parameters exist so tests exercise the sweep only against fabricated roots — never the real temp root.

Also fixed in passing: the #222 regression test now probes the store's *actual* parent (the run parent) instead of the temp root, restoring its teeth; `run-perf`'s cleanup is in an `unwind-protect`; `bplus-bench` heap files moved under the parent.

Docs: CLAUDE.md's test section now distinguishes the self-sweeping FiveAM scratch from the un-swept ad-hoc `/var/tmp` exercises, with a manual-cleanup one-liner; CHANGELOG entry added.

## Method & verification

Implementer → independent adversarial review (NEEDS-FIXES: the symlink-traversal blocker, verified destructively against a fabricated root, plus the weakened #222 test) → fix round → scoped re-review (APPROVE; guard verified against five hostile symlink shapes including dangling and self-loop links).

**Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (`--dynamic-space-size 16384`, source-registry pinned): 4819 checks (17 new), Pass 4809, Skip 10 (pre-existing GEOS environmental), Fail 0.** ECL skipped per the standing demotion directive.

Operational effect observed during verification: /tmp went from ~1,700 stale entries to 593, all younger than 24 h (correctly preserved; they age out on the next day's first run).

Note: `graph-db/algorithms-test` cannot fully load on this host (`dso-lex` missing from Quicklisp — pre-existing, unrelated, tracked separately); its three touched files were compile-checked against their systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp