### PR TITLE
Hand-roll the GML lexer: dso-lex left Quicklisp (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Removed
+
+- **`dso-lex` dependency** (#240). It was dropped from Quicklisp between
+  the 2025-06-22 and 2026-01-01 dists, which made `graph-db/algorithms-io`
+  (and with it `graph-db/algorithms-test`) unloadable on a current dist —
+  the "Known issues" entry under 3.0.0 below. Its only use, the GML
+  tokenizer `SCAN-GML`, is now a plain hand-rolled function with the same
+  `(values class image remainder)` contract, including the silent-NIL
+  result for an unterminated quoted string. `cl-yacc` (still in the dist)
+  remains the GML parser. New lexer unit tests pin the token stream.
+
 ### Fixed
 
 - **Clock/journal hygiene batch** (#184, #178, #177, #183, #179, #180,

--- a/algorithms/io.lisp
+++ b/algorithms/io.lisp
@@ -1,7 +1,7 @@
 ;;;; graph-db/algorithms-io -- graph import (GML, Pajek) and Graphviz export.
 ;;;;
 ;;;; The OPTIONAL io add-on for graph-db/algorithms.  It pulls in the parsing
-;;;; dependencies (cl-ppcre, yacc, dso-lex, parse-number) that the core algorithm
+;;;; dependencies (cl-ppcre, yacc, parse-number) that the core algorithm
 ;;;; add-on deliberately avoids, so importers stay out of the embeddable core.
 ;;;;
 ;;;; The file parsers are vendored from graph-utils: they build an in-memory
@@ -15,7 +15,7 @@
 ;;; ==================================================================
 
 (defpackage :graph-db-algorithms-io
-  (:use :cl :cl-ppcre :yacc :dso-lex)
+  (:use :cl :cl-ppcre :yacc)
   (:nicknames :graph-db-aio)
   (:export #:parse-gml #:parse-pajek))
 
@@ -26,12 +26,53 @@
 (defun un-dquote (s) (regex-replace-all "\"\"" (snip s) "\""))
 (defun strip-whitespace (s) (regex-replace-all "(^\\s+|\\s+$)" s ""))
 
-(deflexer scan-gml ()
-  ("\\s+" whitespace strip-whitespace)
-  ("[^\"'\\[\\]\\s]+" val strip-whitespace)
-  ("(\\[|\\])" bracket)
-  ("'(?:[^']|'')*'" val un-squote)
-  ("\"(?:[^\"]|\"\")*\"" val un-dquote))
+;; Hand-rolled replacement for the dso-lex DEFLEXER, which was dropped
+;; from Quicklisp (GH #240).  Same (values class image remainder)
+;; contract; rules are disjoint on the first character.
+(defun scan-gml (input &optional (start 0))
+  "Scan one GML token in INPUT at START.
+Returns (values class image next-start).  An unterminated quoted
+string returns class NIL (LEX-GML then yields NIL), not an error."
+  (flet ((ws-p (ch)
+           (member ch '(#\Space #\Tab #\Newline #\Return #\Page)))
+         (quoted-end (qch)
+           ;; Index just past the closing QCH, honoring doubled
+           ;; QCH-QCH escapes; NIL when unterminated.
+           (loop with i = (1+ start) with len = (length input)
+                 while (< i len)
+                 do (cond ((char/= (char input i) qch) (incf i))
+                          ((and (< (1+ i) len)
+                                (char= (char input (1+ i)) qch))
+                           (incf i 2))
+                          (t (return (1+ i)))))))
+    (when (>= start (length input))          ; exhausted input, no match
+      (return-from scan-gml (values nil nil start)))
+    (let ((len (length input))
+          (ch (char input start)))
+      (cond ((ws-p ch)
+             (values 'whitespace ""
+                     (or (position-if-not #'ws-p input :start start)
+                         len)))
+            ((or (char= ch #\[) (char= ch #\]))
+             (values 'bracket (string ch) (1+ start)))
+            ((char= ch #\')
+             (let ((end (quoted-end #\')))
+               (if end
+                   (values 'val (un-squote (subseq input start end)) end)
+                   (values nil nil start))))
+            ((char= ch #\")
+             (let ((end (quoted-end #\")))
+               (if end
+                   (values 'val (un-dquote (subseq input start end)) end)
+                   (values nil nil start))))
+            (t
+             (let ((end (or (position-if
+                             (lambda (c)
+                               (or (ws-p c) (find c "\"'[]")))
+                             input :start start)
+                            len)))
+               (values 'val (strip-whitespace (subseq input start end))
+                       end)))))))
 
 (defun lex-gml (lexer input)
   (labels ((my-scan (start tokens)

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2575,7 +2575,7 @@ The generators persist a random topology into a real graph in one transaction. T
 
 *** Importing and visualizing (~graph-db/algorithms-io~)
 
-Import from standard graph file formats and export to Graphviz live in a *separate* optional system, ~graph-db/algorithms-io~, so its parsing dependencies (~yacc~, ~dso-lex~, ~parse-number~) stay out of the core add-on:
+Import from standard graph file formats and export to Graphviz live in a *separate* optional system, ~graph-db/algorithms-io~, so its parsing dependencies (~yacc~, ~parse-number~) stay out of the core add-on (the GML lexer itself is hand-rolled — no lexer-generator dependency):
 
 #+BEGIN_SRC lisp
   (ql:quickload :graph-db/algorithms-io)

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -349,12 +349,13 @@
                (:file "prolog")))
 
 ;; OPTIONAL io add-on: GML/Pajek import + Graphviz export.  Kept separate so the
-;; parsing deps (yacc, dso-lex, parse-number) stay out of the core algorithm
-;; add-on and the embeddable core.
+;; parsing deps (yacc, parse-number) stay out of the core algorithm
+;; add-on and the embeddable core.  The GML lexer is hand-rolled here
+;; since dso-lex left Quicklisp (GH #240).
 (defsystem graph-db/algorithms-io
   :name "VivaceGraph graph-algorithms IO"
   :description "Optional GML/Pajek import + Graphviz export for graph-db/algorithms."
-  :depends-on (:graph-db/algorithms :cl-ppcre :yacc :dso-lex :parse-number
+  :depends-on (:graph-db/algorithms :cl-ppcre :yacc :parse-number
                :trivial-shell)
   :pathname "algorithms/"
   :serial t

--- a/tests/algorithms/io-tests.lisp
+++ b/tests/algorithms/io-tests.lisp
@@ -19,6 +19,47 @@
 (defun io-vc () (lambda (i label) (declare (ignore i)) (make-an :name label)))
 (defun io-ec () (lambda (a b w) (make-ae :from a :to b :weight (coerce w 'float))))
 
+(test gml-lexer-token-stream
+  "Hand-rolled SCAN-GML (GH #240) yields the dso-lex-era token stream."
+  (let ((line
+         (concatenate
+          'string
+          "  node [ id 1 label \"say \"\"hi\"\"\" tag 'it''s' ]  ")))
+    (is (equal
+         (list (list 'graph-db-aio::val "node")
+               (list 'graph-db-aio::bracket "[")
+               (list 'graph-db-aio::val "id")
+               (list 'graph-db-aio::val "1")
+               (list 'graph-db-aio::val "label")
+               (list 'graph-db-aio::val "say \"hi\"")
+               (list 'graph-db-aio::val "tag")
+               (list 'graph-db-aio::val "it's")
+               (list 'graph-db-aio::bracket "]"))
+         (graph-db-aio::lex-gml 'graph-db-aio::scan-gml line)))))
+
+(test gml-lexer-single-token-classes
+  "Each rule in isolation: bare val, brackets, quoted vals."
+  (flet ((one (s)
+           (first (graph-db-aio::lex-gml 'graph-db-aio::scan-gml s))))
+    (is (equal (list 'graph-db-aio::val "42.5") (one "42.5")))
+    (is (equal (list 'graph-db-aio::bracket "[") (one "[")))
+    (is (equal (list 'graph-db-aio::bracket "]") (one "]")))
+    (is (equal (list 'graph-db-aio::val "a b") (one "'a b'")))
+    (is (equal (list 'graph-db-aio::val "a b") (one "\"a b\"")))
+    ;; LEX-GML drops empty images, so "" lexes to no token at all --
+    ;; exactly as under dso-lex.
+    (is (null (one "\"\"")))
+    ;; Doubled escape flush against the closing quote at end of input.
+    (is (equal (list 'graph-db-aio::val "a\"") (one "\"a\"\"\"")))))
+
+(test gml-lexer-unterminated-string-yields-nil
+  "An unterminated quoted string makes LEX-GML return NIL, as the
+dso-lex lexer did (no rule matched => silent NIL)."
+  (is (null (graph-db-aio::lex-gml 'graph-db-aio::scan-gml
+                                   "label \"oops")))
+  (is (null (graph-db-aio::lex-gml 'graph-db-aio::scan-gml
+                                   "label 'oops"))))
+
 (defparameter +pajek-text+
   "*Vertices 3
 1 \"A\" 0.0 0.0


### PR DESCRIPTION
Fixes #240 — `dso-lex` was dropped from Quicklisp between the 2025-06-22 and 2026-01-01 dists, which made `graph-db/algorithms-io` (and with it `graph-db/algorithms-test`) unloadable on a current dist.

## What changed

Option 1 from the issue: the single `deflexer scan-gml` form is replaced by a plain hand-rolled `scan-gml` function with the identical `(values class image remainder)` contract, dispatching on the first character (whitespace / brackets / single- and double-quoted strings with doubled-quote escapes / bare values). The pre-existing behaviors are preserved exactly — empty images are dropped (so `""` labels silently vanish, as before) and an unterminated quoted string yields class NIL, making `lex-gml` return NIL for the line rather than erroring. `lex-gml` and the cl-yacc `*gml-parser*` are untouched; `cl-yacc` (still in the dist) remains the parser. `:dso-lex` is removed from the `.asd` and the package `:use`; docs and CHANGELOG updated.

## Verification

- Independent adversarial review proved semantic fidelity with a **20,000-case random differential test** over an adversarial alphabet, comparing the new lexer against an anchored cl-ppcre emulation of the five old dso-lex rules — zero mismatches — plus directed probes of the quoted-string edge cases (doubled escape flush against the closing quote at EOF, unterminated quotes, empty strings). Verdict APPROVE-WITH-NITS; both nits applied (bounds guard for direct `scan-gml` calls past end of input; one extra edge-case assertion).
- **Gate: fresh-image `(asdf:test-system :graph-db/algorithms-test)` on SBCL (source-registry pinned): 151 checks, 151 pass, 0 fail** — the algorithms test system loads and runs again on this dist for the first time (141 pre-existing checks incl. the GML import round-trip, + 10 new lexer checks pinning the token stream).
- Main `:graph-db` system untouched beyond the `graph-db/algorithms-io` dependency lines. ECL skipped per the standing demotion directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp