### PR TITLE
Resolver trust boundaries: v5 cross-store scan, five-way endpoint status, compact-edges :policy (#208, #209, #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Added
+
+- **`compact-edges` `:policy` keyword** (#208, #209). The default
+  `:conservative` compacts exactly what it always did (soft-deleted
+  edges, provably-missing endpoints); `:policy :trust-tags` additionally
+  compacts endpoints whose v8 tag the registry never assigned
+  (`:unknown`) or whose tag resolves to an open store that lacks the
+  vertex (`:absent-in-store`) — treating this system's tag space as
+  authoritative. It is refused with `compact-trust-tags-on-peer-error`
+  on a peer graph, whose tables hold device-minted foreign tags, and a
+  `:detached` endpoint (registered store, not open) is never compacted
+  under either policy; `:trust-tags` is likewise refused
+  (`compact-trust-tags-no-registry-error`) when no store registry is
+  loaded, since `:detached` is then indistinguishable from `:unknown`.
+  `%active-endpoint-status` now returns the full five-way
+  classification instead of collapsing everything non-provable into
+  one `:unknown` bucket; `active-edge-p`'s visible behavior is
+  unchanged. `compact-edges` (and `map-edges`' emit filters) now
+  resolve endpoint liveness against the explicit graph argument
+  rather than the dynamic `*graph*` — the wrong-graph audit's defect
+  shape, latent here.
+
 ### Removed
 
 - **`dso-lex` dependency** (#240). It was dropped from Quicklisp between
@@ -23,6 +45,24 @@ between releases; cutting a release renames it to the new version and dates it.
   remains the GML parser. New lexer unit tests pin the token stream.
 
 ### Fixed
+
+- **Legacy v5 cross-store edges are no longer filtered as inactive**
+  (#208). `active-edge-p` (and so `map-edges`/`edge-exists-p`) now
+  falls back to the all-open-stores scan for an untagged v5 endpoint
+  that misses the local table — but only when another store is
+  actually open, keeping the single-store hot path's short-circuit
+  (the scan measures ~3.5 µs per open store). `resolve-node-graph`'s
+  docstring and `dangling-edge-warning`'s report now state the
+  resolver trust boundary: a store tag indexes THIS system's registry,
+  so a foreign-minted id resolves unsoundly (#209).
+
+- **`remove-from-index-list` looped forever on a lazily-deleted cell**
+  (#242, found on #208). Deleted pcons cells stay in the chain (removal
+  only flags
+  them), but the walk never advanced past one, so any removal that met
+  an earlier removal's cell spun forever. Latent since the beginning —
+  reachable only through `compact-edges`, which had zero test coverage;
+  exposed by its first tests on this unit.
 
 - **Clock/journal hygiene batch** (#184, #178, #177, #183, #179, #180,
   #176, #212, #234):

--- a/backup.lisp
+++ b/backup.lisp
@@ -161,10 +161,11 @@ RECREATE-GRAPH's :PACKAGE-NAME."
    (store-id :initarg :store-id :reader dangling-edge-store-id))
   (:report
    (lambda (c s)
-     (format s "Backup includes edge ~A whose endpoint ~A lives in ~
-store ~A, which is not open -- the edge is written, connectivity is ~
-preserved, and restoring it before that store is attached leaves it ~
-dangling (GH #169, spec sec.7)."
+     (format s "Backup includes edge ~A whose endpoint ~A is absent ~
+here; its tag resolves to store ~A in THIS system's registry -- a ~
+foreign-minted id may name that store unsoundly (GH #209).  The edge ~
+is written, connectivity is preserved, and restoring it before the ~
+endpoint's store is attached leaves it dangling (GH #169, spec sec.7)."
              (dangling-edge-id c) (dangling-edge-endpoint-id c)
              (dangling-edge-store-id c)))))
 
@@ -173,7 +174,9 @@ dangling (GH #169, spec sec.7)."
 GRAPH's own table and either detached (registered, not open) or
 resolved to a DIFFERENT open graph -- both cases leave it absent from
 this backup file (GH #169, spec sec.7).  EDGE is still written either
-way; this only reports the gap."
+way; this only reports the gap.  The named store is per THIS system's
+registry -- a foreign-tagged id resolves unsoundly, so the report
+hedges rather than asserts it (GH #209)."
   (unless (lookup-vertex endpoint-id :graph graph)
     (multiple-value-bind (endpoint-graph status store-id)
         (resolve-node-graph endpoint-id)

--- a/docs/superpowers/specs/2026-08-20-namespaces-design.md
+++ b/docs/superpowers/specs/2026-08-20-namespaces-design.md
@@ -397,6 +397,21 @@ result but is not walked past — full cross-store continuation is
 with two scoped gaps tracked as #208 (no v5 cross-store scan; an
 unregistered tag counts as live).
 
+**Built (#208/#209):** both #208 gaps closed. A v5 miss now runs the
+all-open-stores scan whenever another store is open (single-store
+short-circuit kept; a completed scan is disproof — no tag to
+mistrust — though only over open stores: a v5 vertex in a detached
+store stays invisible, and its edge compacts even conservatively).
+The endpoint classification is five-way (`:found`
+`:missing` `:absent-in-store` `:detached` `:unknown`); `active-edge-p`
+still treats the last three as live, and the compaction decision is an
+explicit `compact-edges :policy :trust-tags` knob — refused on a
+peer-graph (`compact-trust-tags-on-peer-error`), since hub tables hold
+device-minted tags foreign to this registry (#209.3); `:detached` is
+never compacted. `resolve-node-graph` and the dangling-edge warning
+now state the trust boundary (#209.2) rather than asserting a foreign
+tag's resolution as ground truth.
+
 ## 8. Bulk load and detach
 
 **Detach is a quiescence protocol over the existing pin machinery:** refuse new pins and

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -4199,10 +4199,48 @@ object, or the ~unresolved-node~ marker), but the walk does not
 continue past it into the other store's own adjacency -- following a
 cross-store edge across the boundary is left to a later unit. Likewise
 ~active-edge-p~ resolves a cross-store endpoint to decide whether an
-edge is still live, with two narrow, accepted gaps documented at the
-call site and tracked as GH #208: an untagged v5 endpoint gets no
-cross-store scan on this hot path, and an unregistered tag is treated
-as live rather than proven dead, since it cannot be disproved.
+edge is still live, from a five-way endpoint classification (GH #208):
+a vertex found in any open store is live, and a same-store miss is
+proven dead. An untagged v5 miss now falls back to the all-open-stores
+scan -- but only when another store is actually open, so the
+single-store hot path keeps its cheap short-circuit (the scan measures
+a few microseconds per open store), and a completed scan counts as
+disproof, since a v5 id has no tag to mistrust. One hedge: the scan
+covers /open/ stores only -- a v5 vertex sitting in a detached store
+is invisible (a tagless id cannot name its store), so its edge is
+treated as dead, and compacts, even under the conservative policy.
+The remaining three
+cases -- a detached store, a tag the registry never assigned
+(~:unknown~), and a tag that resolves to an open store whose table
+misses (~:absent-in-store~) -- all count as live, because disproving
+them requires trusting the tag.
+
+~compact-edges~ turns that classification into reclaimed space: it
+soft-deletes and de-indexes edges whose endpoints are disproved. Its
+~:policy~ keyword defaults to ~:conservative~, which compacts only
+tag-free disproof (a deleted edge, a ~:missing~ or found-but-deleted
+endpoint) -- exactly what it always compacted. ~:policy :trust-tags~
+additionally compacts ~:unknown~ and ~:absent-in-store~ endpoints,
+treating this system's tag space as authoritative; it is refused with
+~compact-trust-tags-on-peer-error~ on a peer graph, whose tables hold
+ids minted by /other/ systems' registries (device-minted v8 ids land
+verbatim on a hub), and with ~compact-trust-tags-no-registry-error~
+when no store registry is loaded (~*system-directory*~ unbound), since
+without one a detached tag cannot be told from an unassigned one. A
+~:detached~ endpoint is never compacted under either policy -- its
+store may reattach.
+
+*Resolver trust boundary* (GH #209): a v8 id's 12-bit store tag is an
+index into /one/ system directory's registry, but ids travel across
+systems -- peer replication preserves device-minted UUIDs on the hub,
+and backups move ids between systems. A foreign tag that happens to
+coincide with a local store-id resolves to the wrong store and still
+reports ~:resolved~. The engine's discipline around this: lookups are
+local-table-first, so a local hit never consults the tag; a backup's
+~dangling-edge-warning~ names the resolved store only as this system's
+registry reading, not as ground truth; and anything that would treat
+a tag as /disproof/ of liveness is either conservative by default or
+an explicit opt-in (~:trust-tags~).
 
 ** Chapter 18: Temporal Extents — graph-db/spacetime (optional)
 

--- a/edge.lisp
+++ b/edge.lisp
@@ -291,41 +291,72 @@ regenerates the id on a duplicate-key collision."
            :node edge))
   (delete-node edge graph))
 
-(defun %active-endpoint-status (id graph)
-  "(values VERTEX-OR-NIL STATUS) for edge endpoint ID against GRAPH, for
-ACTIVE-EDGE-P.  :FOUND when GRAPH's own table (or, for a definitely
-cross-store v8 id, LOOKUP-VERTEX-ANYWHERE) resolves a live vertex;
-:MISSING for a same-store/untagged miss -- unchanged pre-#169 semantics,
-an edge with a genuinely absent endpoint is inactive; :UNKNOWN for a
-cross-store id whose store is detached or unregistered -- can't disprove
-liveness, so it must not silently kill the edge (D8; GH #169).
-LOOKUP-VERTEX-ANYWHERE is defined in interface.lisp, loaded after this
-file; resolved at runtime like PIN-READ-EPOCH in graph-class.lisp.
+(defun %another-store-open-p (graph)
+  "True when any open graph other than GRAPH is registered in *GRAPHS*.
+Gates the v5 cross-store scan in %ACTIVE-ENDPOINT-STATUS (GH #208)."
+  (maphash (lambda (name g)
+             (declare (ignore name))
+             (when (and (not (eq g graph)) (graph-open-p g))
+               (return-from %another-store-open-p t)))
+           *graphs*)
+  nil)
 
-Two accepted scoped gaps here, not full parity with the resolver
-(GH #208): (1) an untagged v5 id gets NO cross-store scan -- a same-
-store miss is :MISSING/inactive even if the vertex lives in another
-open store, unlike LOOKUP-VERTEX-ANYWHERE's own v5 fallback; a
-deliberate hot-path tradeoff, this runs on every MAP-EDGES emit.
-(2) an unregistered v8 tag (:UNKNOWN) counts as active -- we cannot
-disprove liveness -- so a compacting/GC pass over edges will never
-collect such an edge, where pre-#169 it eventually would have; a
-conservative choice, not a bug."
+(defun %active-endpoint-status (id graph)
+  "(values VERTEX-OR-NIL STATUS) for edge endpoint ID against GRAPH,
+for ACTIVE-EDGE-P and COMPACT-EDGES.  STATUS is one of:
+  :FOUND    -- a live table holds the vertex (GRAPH's own, or another
+     open store's -- including a v5 id found by the all-open-stores
+     scan, which runs on a miss whenever another store is open;
+     measured ~3.5us per open store, affordable here (GH #208)).
+  :MISSING  -- disproved without trusting a tag: a same-store v8
+     miss, or a v5 miss after (or with no stores to) scan -- a
+     completed v5 scan IS disproof, there is no tag to mistrust,
+     though it covers OPEN stores only: a v5 vertex in a detached
+     store is invisible (a tagless id cannot name it) and its edge
+     compacts even under :CONSERVATIVE.
+  :ABSENT-IN-STORE -- the tag resolves to an open store whose own
+     table misses.
+  :DETACHED -- the registry knows the tag; its store is not open.
+  :UNKNOWN  -- this system's registry never assigned the tag.
+Trap (GH #208, #209): a tag indexes THIS system's registry, but ids
+travel -- peer hubs hold device-minted v8 ids verbatim, restores cross
+systems -- so :ABSENT-IN-STORE and :UNKNOWN are disproof only where
+the tag is trusted.  ACTIVE-EDGE-P counts both (and :DETACHED) as
+live; only COMPACT-EDGES' explicit :TRUST-TAGS policy collects them.
+RESOLVE-NODE-GRAPH / LOOKUP-VERTEX-ANYWHERE live in interface.lisp,
+loaded after this file; resolved at runtime like PIN-READ-EPOCH in
+graph-class.lisp."
   (let ((v (lookup-vertex id :graph graph)))
-    (cond
-      (v (values v :found))
-      (t (let ((tag (id-store-tag id)))
-           (if (and tag (not (eql tag (store-id graph))))
-               (let ((r (lookup-vertex-anywhere id)))
-                 (if (vertex-p r) (values r :found) (values nil :unknown)))
-               (values nil :missing)))))))
+    (if v
+        (values v :found)
+        (let ((tag (id-store-tag id)))
+          (cond
+            ((and tag (not (eql tag (store-id graph))))
+             (multiple-value-bind (other status) (resolve-node-graph id)
+               (ecase status
+                 (:resolved
+                  (let ((r (lookup-vertex id :graph other)))
+                    (if r
+                        (values r :found)
+                        (values nil :absent-in-store))))
+                 (:detached (values nil :detached))
+                 (:unknown (values nil :unknown)))))
+            ((and (null tag) (%another-store-open-p graph))
+             (let ((r (lookup-vertex-anywhere id)))
+               (if (vertex-p r)
+                   (values r :found)
+                   (values nil :missing))))
+            (t (values nil :missing)))))))
 
 (defmethod active-edge-p ((edge edge) &key (graph *graph*))
   (flet ((endpoint-active-p (id)
            (multiple-value-bind (v status) (%active-endpoint-status id graph)
              (ecase status
                (:found (not (deleted-p v)))
-               (:unknown t)
+               ;; Not disprovable without trusting the tag -> live
+               ;; (GH #208, #209); COMPACT-EDGES :TRUST-TAGS is the
+               ;; explicit opt-in.
+               ((:detached :unknown :absent-in-store) t)
                (:missing nil)))))
     (and (not (deleted-p edge))
          (endpoint-active-p (from edge))
@@ -405,7 +436,10 @@ typed/adjacency scans skip the 0 sentinel, as they always have.)"
     (with-read-pin (graph) ; retain whatever versions this scan observes
       (flet ((emit (edge)
                (when (and edge (written-p edge)
-                          (or include-deleted-p (active-edge-p edge)))
+                          ;; Explicit :GRAPH, not dynamic *GRAPH* --
+                          ;; the wrong-graph pattern (GH #208 unit).
+                          (or include-deleted-p
+                              (active-edge-p edge :graph graph)))
                  (if collect-p (push (funcall fn edge) result) (funcall fn edge))))
              (keep-type (tid) (and (plusp tid) (not (member tid excluded)))))
         (cond
@@ -447,7 +481,9 @@ typed/adjacency scans skip the 0 sentinel, as they always have.)"
             #'(lambda (pair)
                 (let ((edge (cdr pair)))
                   (when (and edge (written-p edge)
-                             (or include-deleted-p (active-edge-p edge))
+                             ;; Explicit :GRAPH -- see EMIT above.
+                             (or include-deleted-p
+                                 (active-edge-p edge :graph graph))
                              (not (member (type-id edge) excluded)))
                     (setf (id edge) (car pair))
                     ;; The deserializer builds these; a side-effect scan never
@@ -485,13 +521,65 @@ subtypes.  :INCLUDE-DELETED-P includes soft-deleted edges (excluded by default).
              :include-subclasses-p include-subclasses-p :direction :in
              :collect-p t :include-deleted-p include-deleted-p))
 
-(defmethod compact-edges ((graph graph))
-  (map-edges (lambda (edge)
-               (unless (active-edge-p edge)
-                 (unless (deleted-p edge)
-                   (delete-edge edge :graph graph))
-                 (remove-from-type-index edge graph)
-                 (remove-from-ve-index edge graph)
-                 (remove-from-vev-index edge graph)))
-             graph
-             :include-deleted-p t))
+(define-condition compact-trust-tags-on-peer-error (error)
+  ((graph :initarg :graph :reader compact-trust-tags-peer-graph))
+  (:report
+   (lambda (c s)
+     (format s "COMPACT-EDGES :POLICY :TRUST-TAGS refused on peer ~
+graph ~S: peer tables hold foreign-minted v8 ids whose tags index ~
+ANOTHER system's registry, so an unrecognized tag is not disproof of ~
+liveness there (GH #209)."
+             (compact-trust-tags-peer-graph c)))))
+
+(define-condition compact-trust-tags-no-registry-error (error)
+  ((graph :initarg :graph :reader compact-trust-tags-registry-graph))
+  (:report
+   (lambda (c s)
+     (format s "COMPACT-EDGES :POLICY :TRUST-TAGS refused on ~S: no ~
+store registry is loaded (*SYSTEM-DIRECTORY* is NIL), so a ~
+registered-but-detached tag cannot be told apart from an unassigned ~
+one -- :TRUST-TAGS would delete edges to reattachable stores ~
+(GH #208, #209)."
+             (compact-trust-tags-registry-graph c)))))
+
+(defmethod compact-edges ((graph graph) &key (policy :conservative))
+  "Delete and de-index GRAPH's edges whose endpoints are disproved.
+:POLICY :CONSERVATIVE (default) compacts only tag-free disproof --
+a soft-deleted edge's indexes, a :MISSING endpoint, or a :FOUND
+endpoint that is itself deleted.  :POLICY :TRUST-TAGS additionally
+compacts :UNKNOWN and :ABSENT-IN-STORE endpoints, treating this
+system's tag space as authoritative -- refused on a PEER-GRAPH
+(COMPACT-TRUST-TAGS-ON-PEER-ERROR), whose tables hold foreign-tagged
+ids, and with no store registry loaded (*SYSTEM-DIRECTORY* NIL,
+COMPACT-TRUST-TAGS-NO-REGISTRY-ERROR), where :DETACHED cannot be told
+from :UNKNOWN (GH #208, #209).  A :DETACHED endpoint is never
+compacted under either policy: its store may reattach.  Returns NIL.
+Trap: runs the untyped live-lhash scan -- use on a quiescent graph
+only."
+  (ecase policy ((:conservative :trust-tags)))
+  (when (eq policy :trust-tags)
+    (when (typep graph 'peer-graph)
+      (error 'compact-trust-tags-on-peer-error :graph graph))
+    ;; No registry -> :detached is unreachable (RESOLVE-NODE-GRAPH
+    ;; needs *SYSTEM-DIRECTORY* to confirm a tag), so every detached
+    ;; tag would classify :UNKNOWN and be collected (GH #208, #209).
+    (unless *system-directory*
+      (error 'compact-trust-tags-no-registry-error :graph graph)))
+  (flet ((endpoint-dead-p (id)
+           (multiple-value-bind (v status) (%active-endpoint-status id graph)
+             (ecase status
+               (:found (deleted-p v))
+               (:missing t)
+               (:detached nil)
+               ((:unknown :absent-in-store) (eq policy :trust-tags))))))
+    (map-edges (lambda (edge)
+                 (when (or (deleted-p edge)
+                           (endpoint-dead-p (from edge))
+                           (endpoint-dead-p (to edge)))
+                   (unless (deleted-p edge)
+                     (delete-edge edge :graph graph))
+                   (remove-from-type-index edge graph)
+                   (remove-from-ve-index edge graph)
+                   (remove-from-vev-index edge graph)))
+               graph
+               :include-deleted-p t)))

--- a/index-list.lisp
+++ b/index-list.lisp
@@ -190,23 +190,28 @@
   (setf (index-list-head il) 0)
   nil)
 
-(defmethod remove-from-index-list ((uuid array) (il index-list) &key remove-all-p)
-  (let ((address (index-list-head il)) (prev nil)
+(defmethod remove-from-index-list ((uuid array) (il index-list)
+                                   &key remove-all-p)
+  (let ((address (index-list-head il))
         (pcons-buffer (get-pcons-buffer)))
     (loop until (eq address 0) do
          (let ((pcons (deserialize-pcons il address pcons-buffer)))
-           (unless (%pcons-deleted-p pcons)
-             (let ((id (%pcons-car pcons))
-                   (next (%pcons-cdr pcons)))
-               (if (uuid-array-equal id uuid)
-                   (progn ;; remove it!
-                     (mark-pcons-deleted pcons (index-list-heap il) address)
-                     (setf (index-list-dirty-p il) t)
-                     (setq address next)
-                     (unless remove-all-p
-                       ;; Only remove the first one!
-                       (return)))
-                   ;; otherwise, just advance
-                   (setq prev address
-                         address next))))))
+           ;; A deleted cell stays in the chain (MARK-PCONS-DELETED only
+           ;; flags it) -- it MUST still advance, or any walk that meets
+           ;; one spins forever.  First hit by COMPACT-EDGES' second
+           ;; removal pass (GH #242, found on #208).
+           (if (%pcons-deleted-p pcons)
+               (setq address (%pcons-cdr pcons))
+               (let ((id (%pcons-car pcons))
+                     (next (%pcons-cdr pcons)))
+                 (if (uuid-array-equal id uuid)
+                     (progn ;; remove it!
+                       (mark-pcons-deleted pcons (index-list-heap il) address)
+                       (setf (index-list-dirty-p il) t)
+                       (setq address next)
+                       (unless remove-all-p
+                         ;; Only remove the first one!
+                         (return)))
+                     ;; otherwise, just advance
+                     (setq address next))))))
     il))

--- a/interface.lisp
+++ b/interface.lisp
@@ -14,7 +14,10 @@ holding store's id (or NIL when untagged/unknown).  ID may be a
 32-hex-digit string, coerced like LOOKUP-VERTEX (GH #209).  A tag whose
 store the registry once knew but *SYSTEM-DIRECTORY* is unbound at
 query time also reports :UNKNOWN, not :DETACHED -- :DETACHED requires
-a live registry to confirm the tag (GH #169, #209)."
+a live registry to confirm the tag (GH #169, #209).  Trap: a tag is an
+index into THIS system's registry only; a foreign-minted v8 id (peer
+hub, cross-system restore) whose tag coincides with a local store-id
+resolves to the WRONG graph yet reports :RESOLVED (GH #209)."
   (when (stringp id)
     (setq id (read-id-array-from-string id)))
   (let ((tag (id-store-tag id)))

--- a/tests/index-list-tests.lisp
+++ b/tests/index-list-tests.lisp
@@ -98,3 +98,19 @@
       (let ((live (index-list-keys il)))
         (is (= 4 (length live)))
         (is-false (member (third keys) live :test #'equalp))))))
+
+(test remove-advances-past-deleted-cells
+  "Removal must ADVANCE over a lazily-deleted cell, not spin on it:
+remove the head key, then remove a key that lies BEYOND the deleted
+cell.  Pre-fix, REMOVE-FROM-INDEX-LIST never advanced past a deleted
+pcons and looped forever -- first exposed by COMPACT-EDGES' second
+removal pass (GH #242, found on #208)."
+  (with-temp-memory (heap)
+    (let* ((keys (loop repeat 3 collect (gen-id)))
+           (il (apply #'make-index-list heap (mapcar #'copy-seq keys))))
+      ;; head-to-tail walk order == KEYS order
+      (remove-from-index-list (first keys) il)  ; deleted cell at head
+      (remove-from-index-list (third keys) il)  ; must walk past it
+      (let ((live (index-list-keys il)))
+        (is (= 1 (length live)))
+        (is (equalp (second keys) (first live)))))))

--- a/tests/store-resolver-tests.lisp
+++ b/tests/store-resolver-tests.lisp
@@ -375,3 +375,165 @@ backup."
                          "a clean single-store backup must never warn")))
               (ignore-errors (close-graph g :snapshot-p nil))
               (collect-garbage))))))))
+
+;;; --- Resolver trust boundaries (GH #208, #209) ------------------------
+
+(test endpoint-status-decision-table
+  "%ACTIVE-ENDPOINT-STATUS's five-way classification (GH #208, #209).
+The v5-in-another-open-store row is the #208.1 fix and FAILS pre-fix
+(it was :MISSING with no scan); :ABSENT-IN-STORE / :DETACHED /
+:UNKNOWN were all one :UNKNOWN bucket pre-#208.  Nearest wrong
+implementation: trust the tag and call :UNKNOWN or :ABSENT-IN-STORE
+disproof -- they are disproof only inside the system that minted the
+tag."
+  (with-two-stores (g1 g2 sys)
+    (let ((v5id (graph-db::gen-vertex-id))   ; untagged
+          v1 v2)
+      (with-transaction ((graph-db::transaction-manager g1))
+        (setq v1 (graph-db:make-vertex :generic nil :graph g1)))
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v2 (graph-db:make-vertex :generic nil :graph g2))
+        (graph-db:make-vertex :generic nil :id v5id :graph g2))
+      (flet ((status (id) (nth-value
+                           1 (graph-db::%active-endpoint-status id g1))))
+        (is (eq :found (status (id v1)))
+            "same-store hit")
+        (is (eq :found (status v5id))
+            "v5 miss here, live in the OTHER open store (#208.1)")
+        (is (eq :found (status (id v2)))
+            "v8 cross-store resolved hit")
+        (is (eq :missing (status (graph-db::gen-vertex-id)))
+            "v5 absent everywhere: a completed scan IS disproof")
+        (is (eq :unknown (status (graph-db::gen-v8-uuid 4000)))
+            "tag this registry never assigned")
+        (is (eq :absent-in-store
+                (status (graph-db::gen-vertex-id
+                         (graph-db::store-id g2))))
+            "tag resolves to open G2, G2's table misses")
+        (close-graph g2 :snapshot-p nil)
+        (is (eq :detached (status (id v2)))
+            "registered tag, store not open")))))
+
+(test v5-miss-with-no-other-store-is-missing
+  "A v5 miss with only this store open stays :MISSING via the cheap
+short-circuit -- no scan to run, same answer as a completed scan
+(GH #208)."
+  (with-temp-directory (sys)
+    (with-temp-directory (d)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :rsv-store-1 (namestring d)
+                             :buffer-pool-size 1000)))
+          (unwind-protect
+               (is (eq :missing
+                       (nth-value 1 (graph-db::%active-endpoint-status
+                                     (graph-db::gen-vertex-id) g))))
+            (ignore-errors (close-graph g :snapshot-p nil))
+            (collect-garbage)))))))
+
+(test v5-cross-store-edge-is-visible
+  "GH #208.1 end to end: an edge whose far endpoint is a v5 id living
+in ANOTHER open store is live -- EDGE-EXISTS-P finds it and the
+adjacency scan emits it.  Pre-fix, ACTIVE-EDGE-P classified the
+endpoint :MISSING without scanning and filtered the edge as inactive."
+  (with-two-stores (g1 g2 sys)
+    (let ((v5id (graph-db::gen-vertex-id))
+          v1 v2)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v2 (graph-db:make-vertex :generic nil :id v5id :graph g2)))
+      (with-transaction ((graph-db::transaction-manager g1))
+        (setq v1 (graph-db:make-vertex :generic nil :graph g1))
+        (make-rsv-edge :from v1 :to v2 :graph g1))
+      (is-true (graph-db:edge-exists-p 'rsv-edge v1 v2 :graph g1))
+      (is (= 1 (length (graph-db:outgoing-edges
+                        v1 :graph g1 :edge-type 'rsv-edge)))))))
+
+(test compact-edges-policies
+  "First COMPACT-EDGES coverage (GH #208, #209).  :CONSERVATIVE
+compacts only tag-free disproof (soft-deleted edge, :MISSING
+endpoint) and keeps :UNKNOWN / :ABSENT-IN-STORE / :DETACHED;
+:TRUST-TAGS additionally compacts :UNKNOWN and :ABSENT-IN-STORE but
+NEVER :DETACHED (the store may reattach).  Nearest wrong
+implementation: treat every non-:FOUND endpoint as dead (the
+pre-#169 same-store rule applied to travelled ids)."
+  (with-two-stores (g1 g2 sys)
+    (let ((detached-tag (graph-db::store-registry-intern "rsv-offline"))
+          v1 vx v2 e-live e-del e-missing e-unknown e-absent e-detached)
+      (with-transaction ((graph-db::transaction-manager g2))
+        (setq v2 (graph-db:make-vertex :generic nil :graph g2)))
+      (with-transaction ((graph-db::transaction-manager g1))
+        (setq v1 (graph-db:make-vertex :generic nil :graph g1))
+        (setq vx (graph-db:make-vertex :generic nil :graph g1))
+        (flet ((edge-to (to)
+                 (graph-db:make-edge :generic (id v1) to 1.0 nil
+                                     :graph g1)))
+          (setq e-live (edge-to (id vx))
+                e-del (edge-to (id vx))
+                e-missing (edge-to (graph-db::gen-vertex-id))
+                e-unknown (edge-to (graph-db::gen-v8-uuid 4000))
+                e-absent (edge-to (graph-db::gen-vertex-id
+                                   (graph-db::store-id g2)))
+                e-detached (edge-to (graph-db::gen-vertex-id
+                                     detached-tag)))))
+      (with-transaction ((graph-db::transaction-manager g1))
+        (mark-deleted (graph-db:lookup-edge (id e-del) :graph g1)))
+      (graph-db::compact-edges g1)       ; default :conservative
+      (flet ((dead-p (e)
+               (graph-db:deleted-p
+                (graph-db:lookup-edge (id e) :graph g1))))
+        (is-false (dead-p e-live) "live edge survives :conservative")
+        (is-true (dead-p e-del) ":found+deleted-edge case compacted")
+        (is-true (dead-p e-missing) ":missing compacted (as pre-#208)")
+        (is-false (dead-p e-unknown) ":unknown kept by :conservative")
+        (is-false (dead-p e-absent)
+                  ":absent-in-store kept by :conservative")
+        (is-false (dead-p e-detached) ":detached kept by :conservative")
+        (graph-db::compact-edges g1 :policy :trust-tags)
+        (is-false (dead-p e-live) "live edge survives :trust-tags")
+        (is-true (dead-p e-unknown) ":unknown compacted by :trust-tags")
+        (is-true (dead-p e-absent)
+                 ":absent-in-store compacted by :trust-tags")
+        (is-false (dead-p e-detached)
+                  ":detached survives BOTH policies")))))
+
+(test compact-edges-policy-validation
+  ":TRUST-TAGS on a peer graph signals COMPACT-TRUST-TAGS-ON-PEER-ERROR
+-- a hub's tables hold device-minted v8 ids whose tags index the
+DEVICE's registry (GH #209.3) -- while :CONSERVATIVE stays allowed;
+and a mistyped policy signals instead of silently running
+:conservative.  The refusal fires BEFORE any storage access, so a
+hand-built PEER-GRAPH instance suffices (a full MAKE-GRAPH hub starts
+the peer accept-loop thread -- see the collision tests' precedent for
+hand-built instances)."
+  (with-temp-directory (dummy)
+    ;; Refusal precedes storage access: hand-built instance, no store.
+    (let ((pg (make-instance 'graph-db::peer-graph
+                             :graph-name :rsv-peer
+                             :location dummy
+                             :peer-role :hub)))
+      (signals graph-db::compact-trust-tags-on-peer-error
+        (graph-db::compact-edges pg :policy :trust-tags))
+      (signals error
+        (graph-db::compact-edges pg :policy :trust-tgas))))
+  (with-temp-directory (sys)
+    (with-temp-directory (d)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :rsv-store-1 (namestring d)
+                             :buffer-pool-size 1000)))
+          (unwind-protect
+               (progn
+                 ;; :conservative runs on anything, :trust-tags on a
+                 ;; NON-peer graph too.
+                 (finishes (graph-db::compact-edges g))
+                 (finishes (graph-db::compact-edges
+                            g :policy :trust-tags))
+                 ;; No registry loaded -> :detached is unreachable, so
+                 ;; :trust-tags must refuse; :conservative still runs.
+                 (let ((graph-db::*system-directory* nil))
+                   (signals
+                       graph-db::compact-trust-tags-no-registry-error
+                     (graph-db::compact-edges g :policy :trust-tags))
+                   (finishes (graph-db::compact-edges g))))
+            (ignore-errors (close-graph g :snapshot-p nil))
+            (collect-garbage)))))))


### PR DESCRIPTION
Closes both #208 gaps, hardens the #209 trust boundary, and fixes #242 — a latent infinite loop exposed by this unit's first-ever `compact-edges` tests.

## What changed

- **#208.1 — v5 cross-store scan.** `%active-endpoint-status` now falls back to the all-open-stores scan on an untagged v5 miss whenever another store is open, so legacy v5 cross-store edges are visible to `map-edges`/`edge-exists-p` again. The single-store short-circuit is kept; the pre-design survey measured the scan at ~3.5 µs per open store, making the conditional scan affordable without a miss-rate gate at realistic store counts. A completed v5 scan is sound disproof (no tag to mistrust), covering open stores only — hedged in the docs.
- **#208.2 + #209.3 — five-way status + explicit compaction policy.** The endpoint classification is now `:found` / `:missing` / `:absent-in-store` / `:detached` / `:unknown` instead of collapsing everything non-provable into one bucket. `active-edge-p`'s visible behavior is unchanged. `compact-edges` gains `:policy`: `:conservative` (default) compacts exactly the old set (traced bit-identical in review); `:trust-tags` opts in to collecting `:unknown` and `:absent-in-store` endpoints and is refused on peer graphs (`compact-trust-tags-on-peer-error` — hub tables hold device-minted foreign tags verbatim) and when no store registry is loaded (`compact-trust-tags-no-registry-error` — review caught that `:detached` is then indistinguishable from `:unknown`, and reattachable stores' edges would have been deleted). `:detached` is never compacted under either policy.
- **#209.2 hardening.** `resolve-node-graph`'s docstring and the backup `dangling-edge-warning` now state the trust boundary — a tag indexes THIS system's registry, so a foreign-minted id resolves unsoundly — instead of asserting a foreign tag's resolution as ground truth. The full fix (id provenance) stays tracked on #209, which remains open. Also fixed in passing: `compact-edges` and `map-edges`' emit filters resolve endpoint liveness against the explicit graph argument rather than dynamic `*graph*` (the wrong-graph audit's defect shape, latent here).
- **#242.** `remove-from-index-list` never advanced past a lazily-deleted pcons cell — a guaranteed infinite loop whenever a removal walked over an earlier removal's cell, reachable only through `compact-edges` (zero test coverage before this unit). Fixed, with a regression test.

## Method & verification

Design was surveyed and measured first (approved before building), then implementer → independent adversarial review (NEEDS-FIXES: the no-registry hole; the `:conservative` compaction set traced bit-identical across both endpoints; the #242 fix semantics verified) → fix round → scoped re-review (APPROVE, including empirically re-running the new tests).

**Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (`--dynamic-space-size 16384`, source-registry pinned): 4847 checks, Pass 4837, Skip 10 (standing platform skips), Fail 0.** New coverage: the five-way decision-table test, v5 cross-store visibility end-to-end, the first `compact-edges` tests (both policies, both refusals), and the #242 regression pin. ECL skipped per the standing demotion directive.

Fixes #208. Fixes #242. Refs #209 (stays open for the id-provenance design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp