### PR TITLE
Peer type table: splice unregistered CLOS mixins out of SUPERS (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **Unregistered CLOS mixin superclasses no longer break the peer type
+  table** (#216). `%peer-type-direct-supers` emitted every non-base
+  direct superclass name, so a plain-CLOS mixin that `def-vertex`/
+  `def-edge` never registered appeared in a row's SUPERS with no row of
+  its own, and `%peer-validate-type-table-rows`' closure check refused
+  to encode the table — on the hub's auth-ok path and the device path
+  alike. Unregistered superclasses are now spliced out of SUPERS,
+  replaced by their nearest *registered* ancestors (a node type may
+  inherit through such a mixin from a registered type, and dropping the
+  mixin outright would sever that chain on the wire). The validator
+  itself stays strict: a dangling SUPERS reference is still a refusal.
+
 - **Legacy v5 cross-store edges are no longer filtered as inactive**
   (#208). `active-edge-p` (and so `map-edges`/`edge-exists-p`) now
   falls back to the all-open-stores scan for an untagged v5 endpoint

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -2890,7 +2890,11 @@ wire from a type that really does root at ~vertex~/~edge~. A consumer places
 it at the root and drops it from its parent's closure. This became ordinary
 when the table became image-wide (an image holding store A's schema but not
 store B's still ships B's names); it is tracked as issue #200, with #195 as
-the same absence one level down.
+the same absence one level down. Relatedly, a plain CLOS mixin class that was
+never registered via ~def-vertex~/~def-edge~ carries no wire meaning: since
+GH #216 it is spliced out of ~supers~ and replaced by its nearest
+*registered* ancestors, so inheriting *through* a mixin still reaches the
+registered ancestor on the wire and no ~supers~ entry ever dangles.
 
 The downcased-name collision deserves a note, because pooling every store's
 types into one table *widened* it: two types that never shared a schema now

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -114,27 +114,48 @@ treats #\\: specially either)."
           (package-name (symbol-package symbol))
           (symbol-name symbol)))
 
-(defun %peer-type-direct-supers (name)
-  "Downcased package-qualified names of NAME's direct superclasses.
-LIST of strings, NIL when NAME roots directly at VERTEX/EDGE.
+(defun %peer-type-direct-supers (name registered)
+  "Downcased package-qualified names of NAME's nearest REGISTERED
+superclasses.  LIST of strings, NIL when NAME roots directly at VERTEX/EDGE.
+REGISTERED is an EQ hash-set of the registry's type symbols -- built by the
+caller from the SAME REGISTRY-ENTRIES its rows come from, so SUPERS can never
+name a type with no row (GH #216).
 
-A LIST, not a single name: DEF-NODE-TYPE's docstring claims single inheritance but does
-NOT enforce it -- it splices PARENT-TYPES straight into DEFCLASS -- so
-(DEF-VERTEX M-UAV (M-HAZARD M-ASSET) ...) really does define a type that IS an M-ASSET
-on the hub.  Emitting only the first parent would drop M-UAV from a device's \"all
-m-assets\" closure while the hub kept it: silent, per-peer divergent wrong answers.
+A LIST, not a single name: DEF-NODE-TYPE's docstring claims single
+inheritance but does NOT enforce it -- it splices PARENT-TYPES straight into
+DEFCLASS -- so (DEF-VERTEX M-UAV (M-HAZARD M-ASSET) ...) really does define
+a type that IS an M-ASSET on the hub.  Emitting only the first parent would
+drop M-UAV from a device's \"all m-assets\" closure while the hub kept it:
+silent, per-peer divergent wrong answers.
 
-This CANNOT come from NODE-TYPE-PARENT-TYPE: that slot holds :VERTEX or :EDGE -- the
-KIND, not the superclass (DEF-NODE-TYPE sets it from (LAST1 PARENT-TYPES)).  The
-inheritance graph lives only in CLOS, never in the persisted schema.
-FIND-GRAPH-PARENT-CLASSES is also wrong here: it returns TRANSITIVE ancestors, and we
-want only the direct parents so the consumer can rebuild the closure itself."
-  (let ((class (find-class name nil)))
+An UNREGISTERED direct superclass -- a plain CLOS mixin DEF-VERTEX/DEF-EDGE
+never saw -- carries no wire meaning and is SPLICED OUT, replaced by ITS
+nearest registered ancestors: a node type may inherit THROUGH a mixin from
+a registered type, and dropping the mixin outright would break that chain
+on the wire while %PEER-VALIDATE-TYPE-TABLE-ROWS stays strict (GH #216).
+
+This CANNOT come from NODE-TYPE-PARENT-TYPE: that slot holds :VERTEX or
+:EDGE -- the KIND, not the superclass (DEF-NODE-TYPE sets it from
+(LAST1 PARENT-TYPES)).  The inheritance graph lives only in CLOS, never in
+the persisted schema.  FIND-GRAPH-PARENT-CLASSES is also wrong here: it
+returns TRANSITIVE ancestors, and we want the nearest parents so the
+consumer can rebuild the closure itself."
+  (let ((class (find-class name nil))
+        (out '()))
     (when class
-      (loop for super in (class-direct-superclasses class)
-            unless (member (class-name super)
-                           '(vertex edge primitive-node node standard-object t))
-              collect (%peer-qualified-wire-name (class-name super))))))
+      (labels ((walk (c)
+                 (dolist (super (class-direct-superclasses c))
+                   (let ((sname (class-name super)))
+                     (cond ((member sname '(vertex edge primitive-node node
+                                            standard-object t)))
+                           ((gethash sname registered)
+                            (pushnew (%peer-qualified-wire-name sname) out
+                                     :test #'string=))
+                           ;; Unregistered mixin: splice in its own
+                           ;; registered ancestors (GH #216).
+                           (t (walk super)))))))
+        (walk class))
+      (nreverse out))))
 
 (defun %peer-type-label (type)
   "TYPE printed package-qualified, for an error an operator has to act on.  ~S
@@ -202,19 +223,25 @@ SUPERS comes from CLOS, so a registered symbol whose class this image has not
 loaded emits an EMPTY supers field -- indistinguishable on the wire from a
 type that really does root at VERTEX/EDGE, so the device places it at the root
 and drops it from its parent's closure.  GH #200; GH #195 is the same absence
-one level down."
-  (flet ((rows-for (parent kind-string)
-           ;; LOOP COLLECT, not REMOVE-IF-NOT: the latter may return the
-           ;; registry's own list, which SORT would then destroy.
-           (let ((entries (loop for e in (registry-entries registry)
-                                when (eq parent (second e)) collect e)))
-             (loop for (type nil id) in (sort entries #'< :key #'third)
-                   collect (list kind-string
-                                 id
-                                 (%peer-qualified-wire-name type)
-                                 (%peer-type-direct-supers type)
-                                 type)))))
-    (append (rows-for :vertex "v") (rows-for :edge "e"))))
+one level down.  An UNREGISTERED CLOS mixin in the chain is spliced out of
+SUPERS, its registered ancestors kept (GH #216)."
+  ;; REGISTERED mirrors the rows' own source, so the SUPERS filter in
+  ;; %PEER-TYPE-DIRECT-SUPERS can never disagree with the row set (GH #216).
+  (let ((registered (make-hash-table :test 'eq)))
+    (dolist (e (registry-entries registry))
+      (setf (gethash (first e) registered) t))
+    (flet ((rows-for (parent kind-string)
+             ;; LOOP COLLECT, not REMOVE-IF-NOT: the latter may return the
+             ;; registry's own list, which SORT would then destroy.
+             (let ((entries (loop for e in (registry-entries registry)
+                                  when (eq parent (second e)) collect e)))
+               (loop for (type nil id) in (sort entries #'< :key #'third)
+                     collect (list kind-string
+                                   id
+                                   (%peer-qualified-wire-name type)
+                                   (%peer-type-direct-supers type registered)
+                                   type)))))
+      (append (rows-for :vertex "v") (rows-for :edge "e")))))
 
 (defun %peer-graph-scoped-rows (rows graph)
   "ROWS (%PEER-TYPE-TABLE-ROWS output) filtered to the types actually

--- a/tests/peer-type-table-tests.lisp
+++ b/tests/peer-type-table-tests.lisp
@@ -176,6 +176,51 @@ asserts STRINGP first."
   ()
   :peer-type-table-dupname-test)
 
+;;; --- Unregistered CLOS mixins in the inheritance chain (GH #216). --------
+;;; PTM-MIXIN and PTM-TAGGED are plain DEFCLASS -- never DEF-VERTEXed, so in
+;;; no registry.  PTM-CHILD inherits from registered PTM-BASE THROUGH
+;;; PTM-MIXIN (which needs :METACLASS NODE-CLASS only because it inherits
+;;; FROM a node class -- the default VALIDATE-SUPERCLASS rejects a
+;;; STANDARD-CLASS subclass of a NODE-CLASS; PTM-TAGGED shows plain
+;;; STANDARD-CLASS works fine ABOVE a node type.  DEF-NODE-TYPE checks
+;;; nothing, so both shapes are legal).  PTM-LEAF mixes in PTM-TAGGED, which
+;;; has no registered ancestor at all.  PTM-DIAMOND and PTM-DIRECT-AND-VIA
+;;; pin dedup: two spliced paths to one registered ancestor must emit it
+;;; once.
+
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :peer-type-table-mixin-test *schema-node-metadata*) nil))
+
+(def-vertex ptm-base ()
+  ((label))
+  :peer-type-table-mixin-test)
+
+(defclass ptm-mixin (ptm-base) ()
+  (:metaclass graph-db::node-class))
+
+(defclass ptm-tagged () ())
+
+(def-vertex ptm-child (ptm-mixin)
+  ((extra))
+  :peer-type-table-mixin-test)
+
+(def-vertex ptm-leaf (ptm-tagged)
+  ((leafish))
+  :peer-type-table-mixin-test)
+
+(defclass ptm-mixin-2 (ptm-base) ()
+  (:metaclass graph-db::node-class))
+
+(def-vertex ptm-diamond (ptm-mixin ptm-mixin-2)
+  ()
+  :peer-type-table-mixin-test)
+
+;; PTM-MIXIN precedes PTM-BASE: it is PTM-BASE's subclass, so the other
+;; order is an illegal class precedence list.
+(def-vertex ptm-direct-and-via (ptm-mixin ptm-base)
+  ()
+  :peer-type-table-mixin-test)
+
 ;;; ---------------------------------------------------------------------------
 ;;; Round-trip
 ;;; ---------------------------------------------------------------------------
@@ -330,6 +375,56 @@ the pre-#201 bare-name assertions."
         (is (null (supers-of (%ptt-qname 'm-hazard))))
         (is (null (supers-of (%ptt-qname 'm-asset))))
         (is (null (supers-of (%ptt-qname 'm-find-of-type))))))))
+
+;;; ---------------------------------------------------------------------------
+;;; Unregistered CLOS mixins carry no wire meaning (GH #216)
+;;; ---------------------------------------------------------------------------
+
+(test type-table-splices-out-an-unregistered-mixin
+  "A plain CLOS mixin used as a node type's direct superclass has no row --
+DEF-VERTEX never saw it -- so emitting it into SUPERS made
+%PEER-VALIDATE-TYPE-TABLE-ROWS refuse the whole table (GH #216).  The mixin
+must be filtered out of SUPERS, and a registered ancestor reached THROUGH it
+must be spliced in, or the child would drop out of its ancestor's closure on
+the device while the hub kept it.  The validator itself stays strict (see
+TYPE-TABLE-VALIDATE-ROWS-SIGNALS-ON-DANGLING-SUPER)."
+  (with-ptt-registry-graph (g :peer-type-table-mixin-test r)
+    ;; The hub genuinely believes PTM-CHILD is a PTM-BASE, via the mixin.
+    (is (subtypep 'ptm-child 'ptm-mixin))
+    (is (subtypep 'ptm-child 'ptm-base))
+    (let* ((s (graph-db::peer-type-table-string))
+           (parsed (graph-db::peer-parse-type-table s)))
+      ;; (a) The table encodes at all -- the bug was a refusal here.
+      (is (stringp s))
+      ;; The unregistered mixins appear NOWHERE: no row, no SUPERS entry.
+      (is (not (search "ptm-mixin" s)))
+      (is (not (search "ptm-tagged" s)))
+      (flet ((supers-of (name)
+               (fourth (find name parsed :key #'third :test #'string=))))
+        ;; (b) The registered ancestor reached THROUGH the mixin is spliced
+        ;; into SUPERS in the mixin's place.
+        (is (equal (list (%ptt-qname 'ptm-base))
+                   (supers-of (%ptt-qname 'ptm-child))))
+        ;; A mixin with no registered ancestor simply vanishes.
+        (is (null (supers-of (%ptt-qname 'ptm-leaf))))
+        ;; Dedup pins: two mixins sharing one registered ancestor
+        ;; (diamond), and an ancestor both direct AND via a mixin, each
+        ;; emit it exactly ONCE.  EQUAL against the singleton also pins
+        ;; the order stable.
+        (is (equal (list (%ptt-qname 'ptm-base))
+                   (supers-of (%ptt-qname 'ptm-diamond))))
+        (is (equal (list (%ptt-qname 'ptm-base))
+                   (supers-of (%ptt-qname 'ptm-direct-and-via)))))
+      ;; The hub's auth-ok path scopes to the graph; it must encode too,
+      ;; and the spliced SUPERS keeps its closure resolvable.
+      (let ((scoped (graph-db::peer-parse-type-table
+                     (graph-db::peer-type-table-string r g))))
+        (is (find (%ptt-qname 'ptm-base) scoped
+                  :key #'third :test #'string=))
+        (dolist (row scoped)
+          (dolist (super (fourth row))
+            (is (find super scoped :key #'third :test #'string=)
+                "scoped SUPERS entry ~S must resolve" super)))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Encode-time validation: a loud hub error beats silent device corruption


### PR DESCRIPTION
Fixes #216 — the wire-v2 type-table closure validator refused to encode any schema whose node types use a plain CLOS mixin as a direct superclass: the mixin (never registered via `def-vertex`/`def-edge`) appeared in SUPERS with no row of its own, and the refusal fired on both the hub auth-ok path and the device path through `%peer-registry-conflicts`.

## What changed

Per the issue's prescription — fix in `%peer-type-direct-supers`, never weaken the validator — with one addition the implementation surfaced: nothing enforces `def-node-type`'s single-inheritance claim and `validate-superclass` permits both a standard-class above a node type and a node-class mixin between two registered types, so a mixin can legally sit *inside* the inheritance chain. Simply dropping it would sever the child's wire IS-A link to its registered ancestor — silent per-peer closure divergence. Unregistered superclasses are therefore **spliced**: replaced by their nearest registered ancestors via a recursive walk of `class-direct-superclasses` (base classes terminate; `pushnew` dedup keeps first-occurrence order). The `registered` set is built by `%peer-type-table-rows` from the same `registry-entries` call its rows come from, so the SUPERS filter and the row set structurally cannot disagree. The validator stays strict: a dangling SUPERS reference on the wire is still a refusal.

## Verification

- Independent adversarial review confirmed: the frozen **generation-2 wire is byte-identical** for every mixin-free schema (empirically `string=` on the multiple-inheritance registry); the walk terminates safely (CLOS rejects class cycles at defclass time; `class-direct-superclasses` on a forward-referenced class returns NIL without error); and the new test **fails pre-fix** as the validator's dangling-SUPERS refusal, not vacuously. Verdict APPROVE-WITH-NITS; both nits applied (fixture-comment direction; diamond/dedup pins).
- New test `type-table-splices-out-an-unregistered-mixin` (13 checks): encodes without refusal, mixins appear nowhere on the wire, ancestor-through-mixin spliced in, rootless mixin vanishes, diamond and direct-and-via shapes emit the shared ancestor exactly once in stable order, and the graph-scoped table stays closure-resolvable. Peer-type-table suite standalone: 315/315.
- **Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (source-registry pinned): 4860 checks, Pass 4850, Skip 10 (pre-existing GEOS environmental), Fail 0.** ECL skipped per the standing demotion directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp