### PR TITLE
Registry diagnostics, cross-file clobber warning, GC enumeration test (#194, #198, #195, #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,51 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **`type-registry-package-missing-error`** (#195). A type-registry
+  record naming a package absent from the image used to re-signal as a
+  generic "malformed type registry record" wrapping a reader error, so
+  `make-graph`/`def-vertex` in an image that had not loaded every
+  contributing package failed without naming the actual constraint.
+  `%registry-load` now signals this named condition instead, carrying
+  the missing package name and the registry file, with the remedy in
+  its report (load the system that defines the package first).
+  Torn-final-record tolerance is unchanged — a tail cut mid-symbol is
+  still dropped with a log, whatever error it raises — and genuinely
+  malformed records still signal the malformed-record error. The
+  operational requirement itself is now documented in the manual's
+  type-registry chapter. (Option 2 — lazy per-record interning — is
+  deferred pending a format decision.)
+
+- **`schema-graph-name-cross-file-style-warning`** (#198). Test files
+  isolate reloads by clearing their graph name's entry in
+  `*schema-node-metadata*` at load time; two files claiming one graph
+  name therefore silently erase each other, with the failures landing
+  in the innocent file. Registration now records which loaded file
+  registered which types per graph name, and warns — naming BOTH
+  files — when a registration finds that another file's types under
+  the name have all vanished. Same-file reloads, REPL/runtime
+  definitions, and a second file merely *adding* types stay silent on
+  clean sequential loads; a warm-image reload of the owning file may
+  warn transiently — its own clear discards the adder's types — until
+  the later files reload too.
+
+- **GC mark-phase enumeration regression test** (#194).
+  `map-type-index-list-addresses` has been wrong twice (#166, #186),
+  both times caught only by incidental tests. A new test pins the
+  invariant by name against a store whose type-ids are sparse and
+  non-contiguous (placed via `%registry-adopt`, the registry-assigned
+  shape): every node of every type must survive `gc-heap`, verified
+  down to the allocation table. Dropping any one id from the
+  enumeration fails it.
+
+- **#202 documented as policy.** The manual's renumbering section now
+  states that reconcile-at-open's tolerance of an orphaned occupied id
+  at/below the registry mark is a policy choice, not a reachability
+  proof — a later `%registry-adopt` can bind another symbol to that
+  id, after which registry-derived views (e.g. peer type tables)
+  misread that store at that id; the remedy is the documented
+  renumbering migration.
+
 - **`compact-edges` `:policy` keyword** (#208, #209). The default
   `:conservative` compacts exactly what it always did (soft-deleted
   edges, provably-missing endpoints); `:policy :trust-tags` additionally

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -3449,6 +3449,19 @@ read the registry concurrently, and ~type-registry-busy~ is signalled if
 another image holds the append lock. Reads of an already-assigned id take no
 lock at all.
 
+*An image that creates graphs or adds types must have loaded every package
+that contributed a type name anywhere in the system.* Registry records are
+fully package-qualified symbols — that qualification is what makes a type-id
+mean the same thing everywhere — and opening the registry reads the *whole*
+file, so a record naming a package absent from the image cannot be read. In
+that case ~make-graph~ / ~def-vertex~ / ~create-vertex-type~ signal
+~graph-db:type-registry-package-missing-error~, whose report names the
+missing package and this remedy: load the system that defines it before
+creating graphs or adding types in that image (readers:
+~type-registry-package-missing-name~, ~type-registry-package-missing-file~;
+GH #195). A plain reopen of an existing store that defines no new types
+never opens the registry and is unaffected.
+
 Two consequences worth knowing. A store's type-ids are *sparse*: it holds the
 ids of the types it defines, wherever those landed in the system's numbering,
 not a dense run from 1. And ids are never reused or renumbered — the registry
@@ -3557,6 +3570,19 @@ must unify whichever store wins, so such a store is always in the migration
 set even if nothing else contests it. Seeding reports it in
 ~seeding-report-duplicates~, and the renumbering migration reports the
 unification in its second return value rather than picking one id silently.
+
+One tolerance in reconcile-at-open deserves honesty. A store may *occupy* an
+id — written into node heads on disk — that no type it currently answers to
+by name uses (orphaned metadata from its own history). When that id is at or
+below the registry's high-water mark, opening the store is *tolerated with a
+log warning*, and that is a policy choice about already-orphaned metadata,
+not a proof the id is unreachable: ~%registry-assign~ never re-mints it, but
+~%registry-adopt~ (which reconciliation itself uses) can later bind a
+*different* symbol to that id. From then on registry-derived views — the
+peer type table, anything that maps ids through the registry — misread that
+store's on-disk nodes at that id, while the store's own reads stay correct.
+The remedy is the renumbering procedure described here
+(~migrate-graph :renumber-p t~), which such a store owes anyway (GH #202).
 
 Plan the run: each renumbering is a ~migrate-graph~, so the transient disk
 and the deployment gate described in Chapter 12 apply to every store in the

--- a/package.lisp
+++ b/package.lisp
@@ -117,6 +117,9 @@
            #:close-type-registry
            #:type-registry-busy
            #:type-registry-busy-location
+           #:type-registry-package-missing-error
+           #:type-registry-package-missing-name
+           #:type-registry-package-missing-file
            #:registry-id-for
            #:registry-intern
            #:registry-entries
@@ -295,6 +298,10 @@
            #:divergent-type-name
            #:divergent-type-graph-name
            #:divergent-type-other-graphs
+           #:schema-graph-name-cross-file-style-warning
+           #:cross-file-graph-name
+           #:cross-file-registering-file
+           #:cross-file-previous-file
 
            ;; packages as namespaces (GH #167)
            #:default-store-not-open-error

--- a/schema.lisp
+++ b/schema.lisp
@@ -539,6 +539,64 @@ locked (GH #172)." name (package-name pkg))
                   (%make-constructor-closure name graph-name kind))))
     name))
 
+(defvar *schema-graph-name-registrants* (make-hash-table :test 'equal)
+  "GRAPH-NAME -> alist of (TRUENAME . TYPE-NAMES): which loaded file
+registered which types under each graph name.  Survives the load-time
+(SETF (GETHASH name *SCHEMA-NODE-METADATA*) NIL) clear idiom, which is
+exactly what lets %WARN-IF-CROSS-FILE-CLOBBER see that another file's
+registrations were discarded (GH #198).")
+
+(define-condition schema-graph-name-cross-file-style-warning
+    (style-warning)
+  ((graph-name :initarg :graph-name :reader cross-file-graph-name)
+   (registering-file :initarg :registering-file
+                     :reader cross-file-registering-file)
+   (previous-file :initarg :previous-file
+                  :reader cross-file-previous-file))
+  (:report
+   (lambda (c s)
+     (format s "Graph name ~S is being claimed by ~A, and the types ~A ~
+registered under it earlier are gone -- a load-time clear of the name ~
+discarded them.  Two files claiming one graph name erase each other, ~
+and the failures surface in the OTHER file, the one that did nothing ~
+wrong.  Give each file its own graph name (GH #198)."
+             (cross-file-graph-name c)
+             (cross-file-registering-file c)
+             (cross-file-previous-file c)))))
+
+(defun %warn-if-cross-file-clobber (graph-name type-name)
+  "STYLE-WARNING when the file now registering TYPE-NAME under GRAPH-NAME
+finds that some OTHER file's registrations there have all vanished --
+the two-files-one-graph-name clobber (GH #198).  Silent for same-file
+reloads, REPL/runtime definitions (no load truename), and a second file
+merely ADDING types while the first file's are still present.  Records
+this registration's source file either way.  Accepted false negative:
+the check hangs off registration, so a file that only CLEARS and
+registers nothing never triggers it."
+  (let ((here (or *compile-file-truename* *load-truename*)))
+    (when here
+      (let ((regs (gethash graph-name *schema-graph-name-registrants*))
+            (metas (gethash graph-name *schema-node-metadata*)))
+        (dolist (entry regs)
+          (destructuring-bind (file . names) entry
+            (when (and (not (equal file here))
+                       names
+                       (notany (lambda (n)
+                                 (find n metas :key #'node-type-name))
+                               names))
+              (warn 'schema-graph-name-cross-file-style-warning
+                    :graph-name graph-name
+                    :registering-file here :previous-file file)
+              ;; Warn once per discarded file, not once per type the
+              ;; clobbering file goes on to register.
+              (setf regs (remove entry regs)))))
+        (let ((mine (assoc here regs :test #'equal)))
+          (if mine
+              (pushnew type-name (cdr mine))
+              (push (cons here (list type-name)) regs)))
+        (setf (gethash graph-name *schema-graph-name-registrants*)
+              regs)))))
+
 (defun %register-node-type-meta (meta)
   "Put META in *SCHEMA-NODE-METADATA* under its own store, replacing any
 entry for the same class IN PLACE.  A class may be registered under more
@@ -548,6 +606,7 @@ still governs UPDATE-SCHEMA's instantiation order (GH #53, #167)."
          (metas (gethash graph-name *schema-node-metadata*))
          (pos (position (node-type-name meta) metas
                         :key #'node-type-name)))
+    (%warn-if-cross-file-clobber graph-name (node-type-name meta))
     (if pos
         (setf (nth pos metas) meta)
         (setf (gethash graph-name *schema-node-metadata*)

--- a/tests/runtime-schema-tests.lisp
+++ b/tests/runtime-schema-tests.lisp
@@ -854,3 +854,94 @@ SBCL's raw package-lock error instead (GH #172, review round 3)."
         (when c
           (is (search "ENSURE-NAMESPACE" (format nil "~A" c))
               "~A's condition should name ENSURE-NAMESPACE: ~A" bad c))))))
+
+;;; ---------------------------------------------------------------------------
+;;; Cross-file graph-name clobber warning (GH #198)
+;;;
+;;; Exercised on %REGISTER-NODE-TYPE-META directly, with fabricated load
+;;; truenames and both tables rebound -- actually loading two colliding
+;;; files would need scratch files compiled mid-test for no extra proof.
+;;; ---------------------------------------------------------------------------
+
+(defun %xf-meta (name)
+  (graph-db::make-node-type :name name :parent-type :vertex
+                            :graph-name :xf-gh198-test :slots nil))
+
+(defmacro with-xf-tables (&body body)
+  "Fresh metadata + registrant tables, so these tests neither see nor
+pollute the suite's real registrations (GH #198)."
+  `(let ((graph-db::*schema-node-metadata*
+           (make-hash-table :test 'equal))
+         (graph-db::*schema-graph-name-registrants*
+           (make-hash-table :test 'equal)))
+     ,@body))
+
+(defun %xf-register (truename meta)
+  "Register META as if loaded from TRUENAME, returning the cross-file
+warning it signaled, or NIL."
+  (let ((caught nil)
+        (*load-truename* truename)
+        (*compile-file-truename* nil))
+    (handler-bind
+        ((graph-db:schema-graph-name-cross-file-style-warning
+           (lambda (w) (setf caught w) (muffle-warning w))))
+      (graph-db::%register-node-type-meta meta))
+    caught))
+
+(test cross-file-clobber-signals-a-style-warning-naming-both-files
+  "GH #198: file B's load-time clear of a graph name file A populated,
+followed by B's own registration, warns naming BOTH files -- because the
+failures land in file A, which did nothing wrong.  Fires once per
+discarded file, not once per type B registers."
+  (with-xf-tables
+    (is-false (%xf-register #P"/tmp/gh198-file-a.lisp"
+                            (%xf-meta 'xf-a1)))
+    ;; File B isolates itself with the standard load-time clear...
+    (setf (gethash :xf-gh198-test graph-db::*schema-node-metadata*) nil)
+    ;; ...silently discarding file A's registrations.
+    (let ((w (%xf-register #P"/tmp/gh198-file-b.lisp"
+                           (%xf-meta 'xf-b1))))
+      (is-true w "the clobbering registration must warn")
+      (when w
+        (is (eq :xf-gh198-test (graph-db:cross-file-graph-name w)))
+        (is (equal #P"/tmp/gh198-file-b.lisp"
+                   (graph-db:cross-file-registering-file w)))
+        (is (equal #P"/tmp/gh198-file-a.lisp"
+                   (graph-db:cross-file-previous-file w)))))
+    (is-false (%xf-register #P"/tmp/gh198-file-b.lisp"
+                            (%xf-meta 'xf-b2))
+              "warn once per discarded file, not per type")))
+
+(test same-file-reload-clear-stays-silent
+  "The clear idiom exists FOR same-file reloads; those must not warn."
+  (with-xf-tables
+    (is-false (%xf-register #P"/tmp/gh198-file-a.lisp"
+                            (%xf-meta 'xf-a1)))
+    (setf (gethash :xf-gh198-test graph-db::*schema-node-metadata*) nil)
+    (is-false (%xf-register #P"/tmp/gh198-file-a.lisp"
+                            (%xf-meta 'xf-a1))
+              "a file reloading itself is the sanctioned case")))
+
+(test repl-registration-stays-silent
+  "No load truename -- REPL or runtime schema work -- never warns, even
+right after another file's registrations were cleared."
+  (with-xf-tables
+    (is-false (%xf-register #P"/tmp/gh198-file-a.lisp"
+                            (%xf-meta 'xf-a1)))
+    (setf (gethash :xf-gh198-test graph-db::*schema-node-metadata*) nil)
+    (is-false (%xf-register nil (%xf-meta 'xf-b1)))))
+
+(test additive-second-file-stays-silent
+  "A second file ADDING types while the first file's registrations are
+still present is the sanctioned multi-file shape (graph-tests +
+segment-integration-tests share *INTEGRATION-GRAPH-NAME* this way); only
+evidence of a DISCARD warns.  Caveat: a WARM-IMAGE reload of the owning
+file's clear DOES discard the adder's types, so its first
+re-registration warns transiently -- accurately -- until the later file
+reloads too (GH #198)."
+  (with-xf-tables
+    (is-false (%xf-register #P"/tmp/gh198-file-a.lisp"
+                            (%xf-meta 'xf-a1)))
+    (is-false (%xf-register #P"/tmp/gh198-file-b.lisp"
+                            (%xf-meta 'xf-b1))
+              "no clear happened, so no warning")))

--- a/tests/type-id-width-tests.lisp
+++ b/tests/type-id-width-tests.lisp
@@ -684,3 +684,134 @@ edge intact after migration"))))))))
         (is (null (set-exclusive-or (append ids-a ids-b) listed
                                     :test #'equalp))
             "the pushed ids and the surviving ids must be the same set")))))
+
+;;; ---------------------------------------------------------------------------
+;;; GC mark-phase type-id enumeration under registry-sparse ids (GH #194)
+;;; ---------------------------------------------------------------------------
+
+;; Its own graph name, same reload discipline as TI-GC-REOPEN-TEST above.
+;; THREE vertex types plus one edge type: dropping any single id from the
+;; enumeration must lose exactly one type's nodes.
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :ti-gc-sparse-test *schema-node-metadata*) nil))
+(def-vertex ti-sparse-a () ((label :type string)) :ti-gc-sparse-test)
+(def-vertex ti-sparse-b () ((label :type string)) :ti-gc-sparse-test)
+(def-vertex ti-sparse-c () ((label :type string)) :ti-gc-sparse-test)
+(def-edge ti-sparse-link () () :ti-gc-sparse-test)
+
+;; The ids this test pins.  Non-contiguous BY CONSTRUCTION -- the shape a
+;; store in a many-store system actually has -- and placed by %REGISTRY-
+;; ADOPT, the same sanctioned write RECONCILE-SCHEMA-WITH-REGISTRY uses to
+;; record a store's pre-existing ids (GH #186, spec 10.1).
+(defparameter *ti-sparse-ids*
+  '((ti-sparse-a    :vertex 4001)
+    (ti-sparse-b    :vertex 4013)
+    (ti-sparse-c    :vertex 4057)
+    (ti-sparse-link :edge   4007)))
+
+(defun %adopt-sparse-test-ids ()
+  "Place *TI-SPARSE-IDS* in the run's registry, idempotently.  Fails loudly
+if some other type already holds one of the ids (would invalidate the
+fixture, and %REGISTRY-ADOPT refuses it by contract)."
+  (let ((r (graph-db::ensure-type-registry)))
+    (graph-db::with-registry-append-lock (r)
+      (loop for (sym parent id) in *ti-sparse-ids*
+            do (let ((known (graph-db::registry-id-for r sym parent))
+                     (holder (gethash id (graph-db::registry-ids-table
+                                          r parent))))
+                 (cond ((eql known id))   ; already placed (re-run)
+                       (known
+                        (error "~S already has id ~D, not ~D" sym known id))
+                       ((and holder (not (eq holder sym)))
+                        (error "id ~D is already held by ~S" id holder))
+                       (t (graph-db::%registry-adopt r sym parent id))))))))
+
+(test gc-mark-enumerates-every-sparse-type-id
+  "GC-HEAP's mark phase must enumerate EVERY assigned type-id; a type-id
+MAP-TYPE-INDEX-LIST-ADDRESSES misses has its nodes swept -- silent, total
+loss of one type.  Broken twice: #166 (enumerated the lazily-populated
+cache, empty on a fresh open) and #186 (DOTIMES against the schema
+counter, missing registry-sparse ids).  Both were caught only by
+incidental tests; this one holds the invariant by name, against a store
+whose ids are sparse and non-contiguous (GH #194).  Trap: the sparse ids
+are adopted into the RUN's shared registry, so they must stay clear of
+ids other tests mint."
+  (%adopt-sparse-test-ids)
+  (with-temp-directory (dir)
+    (let ((node-ids (make-hash-table :test 'eq)))
+      (let ((g (make-graph :ti-gc-sparse-test (namestring dir)
+                           :buffer-pool-size 1000)))
+        ;; The fixture's premise: the store's ids really are the sparse
+        ;; ones, not a dense mint.
+        (loop for (sym parent id) in *ti-sparse-ids*
+              do (is (eql id (graph-db::node-type-id
+                              (graph-db::lookup-node-type-by-name
+                               sym parent :graph g)))
+                     "~S must hold sparse id ~D" sym id))
+        (let ((*graph* g))
+          (with-transaction ()
+            (let ((va (make-ti-sparse-a :label "A-LIVES"))
+                  (vb (make-ti-sparse-b :label "B-LIVES"))
+                  (vc (make-ti-sparse-c :label "C-LIVES")))
+              (setf (gethash 'ti-sparse-a node-ids) (id va)
+                    (gethash 'ti-sparse-b node-ids) (id vb)
+                    (gethash 'ti-sparse-c node-ids) (id vc)
+                    (gethash 'ti-sparse-link node-ids)
+                    (id (make-ti-sparse-link :from va :to vc))))))
+        (close-graph g :snapshot-p nil))
+      ;; Reopen fresh (lazy, unpopulated type-index cache -- the #166
+      ;; shape; :GC-HEAP-P T is the default) and then GC again explicitly.
+      (let ((g (open-graph :ti-gc-sparse-test (namestring dir))))
+        (unwind-protect
+             (let ((*graph* g))
+               (graph-db::gc-heap g)
+               ;; Every node's data block must still be ALLOCATED --
+               ;; checked before touching data, since FREE threads its
+               ;; free-list through the block.
+               (let ((blocks (make-hash-table)))
+                 (graph-db::map-memory
+                  (lambda (addr size free-p)
+                    (declare (ignore size))
+                    (setf (gethash addr blocks) free-p))
+                  (graph-db::heap g) :include-free-p t)
+                 (flet ((alive-p (sym lookup)
+                          (let* ((node (funcall lookup
+                                                (gethash sym node-ids)))
+                                 (dp (and node
+                                          (graph-db::data-pointer node))))
+                            (is-true node "~S: node must still look up"
+                                     sym)
+                            ;; a slotless node (the edge) has no data
+                            ;; block at all -- data-pointer 0
+                            (when (and dp (plusp dp))
+                              (multiple-value-bind (free-p found-p)
+                                  (gethash dp blocks)
+                                (is-true found-p
+                                         "~S: data block ~D must exist"
+                                         sym dp)
+                                (is-false free-p
+                                          "~S: data block ~D was swept"
+                                          sym dp))))))
+                   (alive-p 'ti-sparse-a #'lookup-vertex)
+                   (alive-p 'ti-sparse-b #'lookup-vertex)
+                   (alive-p 'ti-sparse-c #'lookup-vertex)
+                   (alive-p 'ti-sparse-link #'lookup-edge)))
+               ;; And every node of every type is still reachable through
+               ;; its type index, data intact.
+               (flet ((labels-of (type)
+                        (let (seen)
+                          (map-vertices
+                           (lambda (v)
+                             (push (slot-value v 'label) seen))
+                           g :vertex-type type)
+                          seen)))
+                 (is (equal '("A-LIVES") (labels-of 'ti-sparse-a)))
+                 (is (equal '("B-LIVES") (labels-of 'ti-sparse-b)))
+                 (is (equal '("C-LIVES") (labels-of 'ti-sparse-c))))
+               (let (links)
+                 (map-edges (lambda (e) (push (id e) links))
+                            g :edge-type 'ti-sparse-link)
+                 (is (= 1 (length links))
+                     "the edge must survive both GC passes")))
+          (close-graph g :snapshot-p nil)
+          (collect-garbage))))))

--- a/tests/type-registry-tests.lisp
+++ b/tests/type-registry-tests.lisp
@@ -141,3 +141,78 @@ idea of \"next id\" cached at open time."
 not reuse the first's id"))
         (graph-db::close-type-registry r1)
         (graph-db::close-type-registry r2)))))
+
+(test registry-names-the-missing-package-not-a-reader-error
+  "GH #195: a record naming a package this image has not loaded used to
+re-signal as \"malformed type registry record\" -- a reader error naming
+a package instead of a diagnostic naming the constraint.  It must signal
+TYPE-REGISTRY-PACKAGE-MISSING-ERROR carrying the package name and the
+registry file.  The record is written as text: its symbol cannot be
+interned from here, which is the point."
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (graph-db::registry-intern r 'reg-pm-keep :vertex)
+      (graph-db::close-type-registry r))
+    (let ((f (merge-pathnames "type-registry.log" dir)))
+      (with-open-file (s f :direction :output :if-exists :append)
+        (format s "(:SYMBOL GH195-NO-SUCH-PKG::WIDGET ~
+:PARENT :VERTEX :ID 90)~%"))
+      (let ((caught nil))
+        (handler-case (graph-db::close-type-registry
+                       (graph-db::open-type-registry (namestring dir)))
+          (graph-db:type-registry-package-missing-error (e)
+            (setf caught e)))
+        (is-true caught "must signal the named condition, not malformed")
+        (when caught
+          (is (string= "GH195-NO-SUCH-PKG"
+                       (string
+                        (graph-db:type-registry-package-missing-name
+                         caught))))
+          (is (equal (namestring (truename f))
+                     (namestring
+                      (truename
+                       (graph-db:type-registry-package-missing-file
+                        caught))))
+              "the report must say WHICH registry file")
+          (is (search "GH195-NO-SUCH-PKG"
+                      (format nil "~A" caught))
+              "the report text names the package"))))))
+
+(test registry-tolerates-a-torn-final-record-naming-a-missing-package
+  "GH #195 must not narrow #191's torn-tail tolerance: a FINAL record cut
+mid-symbol can raise the package error too (the truncation can fall
+inside the package prefix), and it is still dropped with a log, not
+signaled."
+  (with-temp-directory (dir)
+    (let ((r (graph-db::open-type-registry (namestring dir))))
+      (graph-db::registry-intern r 'reg-pm-torn-keep :vertex)
+      (graph-db::close-type-registry r))
+    (let ((f (merge-pathnames "type-registry.log" dir)))
+      (with-open-file (s f :direction :output :if-exists :append)
+        ;; truncated, no newline: a torn tail whose symbol names an
+        ;; absent package
+        (format s "(:SYMBOL GH195-NO-SUCH-PKG::WID"))
+      (let ((r2 (graph-db::open-type-registry (namestring dir))))
+        (unwind-protect
+             (is (= 1 (length (graph-db::registry-entries r2)))
+                 "the intact record survives; the torn tail is dropped")
+          (graph-db::close-type-registry r2))))))
+
+(test registry-still-signals-malformed-for-a-non-package-defect
+  "GH #195 narrows only the missing-package case; a genuinely malformed
+earlier record still signals the malformed-record error, never the
+package-missing condition."
+  (with-temp-directory (dir)
+    (let ((f (merge-pathnames "type-registry.log" dir)))
+      (with-open-file (s f :direction :output :if-does-not-exist :create)
+        (format s "(:SYMBOL 42 :PARENT :VERTEX :ID 7)~%")
+        (format s "(:SYMBOL REG-PM-AFTER :PARENT :VERTEX :ID 8)~%"))
+      (handler-case
+          (progn (graph-db::close-type-registry
+                  (graph-db::open-type-registry (namestring dir)))
+                 (fail "a malformed non-final record must signal"))
+        (graph-db:type-registry-package-missing-error (e)
+          (fail "wrongly classified as package-missing: ~A" e))
+        (error (e)
+          (is (search "malformed type registry record"
+                      (format nil "~A" e))))))))

--- a/type-registry.lisp
+++ b/type-registry.lisp
@@ -30,6 +30,54 @@
 REGISTRY-INTERN.  Retry once the holder's assignment completes (GH #186)."
              (type-registry-busy-location c)))))
 
+(define-condition type-registry-package-missing-error (error)
+  ((package-name :initarg :package-name
+                 :reader type-registry-package-missing-name)
+   (file :initarg :file :reader type-registry-package-missing-file))
+  (:report
+   (lambda (c s)
+     (let ((pkg (type-registry-package-missing-name c)))
+       (format s "The type registry at ~A names a type in package ~S, ~
+which is not loaded in this image.  Registry records are fully ~
+package-qualified type names, so creating a graph or adding a type ~
+needs every package that contributed one.  Load the system that ~
+defines ~S before creating graphs or adding types in this image ~
+(GH #195)."
+               (type-registry-package-missing-file c) pkg pkg)))))
+
+(defun %missing-package-in-line (line)
+  "The first package prefix in LINE naming no package in this image, or
+NIL.  Text fallback for implementations whose reader signals something
+other than a PACKAGE-ERROR on an unknown package (GH #195)."
+  (let ((start 0))
+    (loop
+      (let ((colon (position #\: line :start start)))
+        (unless colon (return nil))
+        (let* ((tok-start
+                 (1+ (or (position-if
+                          (lambda (ch) (member ch '(#\Space #\( #\))))
+                          line :end colon :from-end t)
+                         -1)))
+               (prefix (subseq line tok-start colon)))
+          (when (and (plusp (length prefix))
+                     (not (find-package prefix)))
+            (return prefix))
+          (setf start (1+ colon))
+          (when (and (< start (length line))
+                     (char= #\: (char line start)))
+            (incf start)))))))
+
+(defun %missing-package-name (condition line)
+  "The name of the package CONDITION says is absent, or NIL when
+CONDITION is not about a missing package.  SBCL's reader signals a
+PACKAGE-ERROR whose PACKAGE-ERROR-PACKAGE is the missing NAME (a
+designator, never a package object); elsewhere fall back to scanning
+LINE for a prefix FIND-PACKAGE cannot resolve (GH #195)."
+  (or (and (typep condition 'package-error)
+           (let ((p (package-error-package condition)))
+             (and (not (packagep p)) (string p))))
+      (%missing-package-in-line line)))
+
 (defun %registry-file (location)
   (make-pathname :name "type-registry" :type "log" :defaults location))
 
@@ -97,13 +145,23 @@ both are empty and every symbol reads back a spurious NIL."
                 (let ((parsed
                         (handler-case (%parse-registry-record line)
                           (error (e)
-                            (if missing-newline-p
-                                (progn
-                                  (log:warn "type registry: dropping torn ~
+                            ;; Torn-final tolerance first, for ANY error:
+                            ;; a tail cut mid-symbol can raise the package
+                            ;; error too (GH #191, #195).
+                            (let ((pkg (unless missing-newline-p
+                                         (%missing-package-name e line))))
+                              (cond
+                                (missing-newline-p
+                                 (log:warn "type registry: dropping torn ~
 final record in ~A: ~A" file e)
-                                  (return))
-                                (error "malformed type registry record in ~
-~A: ~A" file e))))))
+                                 (return))
+                                (pkg
+                                 (error
+                                  'type-registry-package-missing-error
+                                  :package-name pkg :file file))
+                                (t
+                                 (error "malformed type registry record ~
+in ~A: ~A" file e))))))))
                   (destructuring-bind (symbol parent id) parsed
                     (setf (gethash symbol (table-for parent)) id)
                     (push (list symbol parent id) entries)


### PR DESCRIPTION
The build half of the #202/#200/#199/#198/#195/#194 design-flavored group. Per the decisions recorded on the issues: #195 gets option 1 only (option 2 deferred), #202 gets option 3 (accept and document), and #200+#199 are parked as a future wire-generation-3 contract batch (comments on both — nothing here touches them).

## What changed

- **#195 (option 1):** a type-registry record naming a package absent from the image now signals **`type-registry-package-missing-error`** — carrying the missing package name, the registry file, and the remedy in its report — instead of the generic "malformed type registry record" wrapping a raw reader error. Detection is portable without reader-conditionals: CLHS makes a string designator legal in `package-error-package` (SBCL's reader puts the missing *name* there, verified), with a text-scan fallback for other implementations. Torn-final tolerance (#191) is checked first for *any* error type and re-pinned by test; genuinely malformed records still take the malformed path. The manual's type-registry chapter now states the operational requirement plainly.
- **#198:** **`schema-graph-name-cross-file-style-warning`** in `%register-node-type-meta` (the #172 functional core). A parallel registrant table survives the load-time clear idiom, which is exactly what makes the discard visible: the warning fires when a different file registers and an earlier file's types under the name have *all vanished*, naming both files (the failures surface in the innocent one). Silent for same-file reloads, REPL/runtime definitions, and the suite's sanctioned additive share on clean sequential loads (a warm-image reload of the owning file may warn transiently — documented). Four tests pin fire and all three no-fire guarantees.
- **#194:** the missing GC mark-phase enumeration regression test. Sparse, non-contiguous type-ids (4001/4013/4057 + edge 4007) placed via `%registry-adopt` — the registry-assigned shape no fixture guaranteed before. Every node of every type must survive reopen (+ default gc) and an explicit `gc-heap`, asserted down to the allocation table (load-bearing: node heads live in the lhash, so lookup succeeds even after a bad sweep frees the data block). Ablation evidence, run by hand: dropping one id from the enumeration fails exactly this test; the #186 dead-counter `dotimes` shape fails it hard. Docstring names the invariant and both historical breakages.
- **#202 (option 3, doc-only):** the manual's renumbering section now states honestly that reconcile-at-open's orphaned-id tolerance is a policy choice, not a reachability proof — `%registry-adopt` can later bind another symbol to the id, after which registry-derived views misread that store there; remedy is `migrate-graph :renumber-p t`.

## Method & verification

Implementer → independent adversarial review (APPROVE-WITH-NITS; all 8 new tests verified passing, the ablation verified failing cleanly, the #194 discrimination question resolved — the #186 shape uses the schema's dead counters and fails hard) → nit round (warm-reload honesty caveat, clear-only false-negative note, double-eval fix).

**Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (source-registry pinned): 4896 checks, Pass 4886, Skip 10 (pre-existing GEOS environmental), Fail 0.** ECL skipped per the standing demotion directive.

Fixes #194. Fixes #198. Fixes #195. Fixes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp