### PR TITLE
Memory-graph constructor hygiene: normalization, abort guard, attach before replication (#230, #238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,33 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **The memory constructors mirror the disk side's open hygiene**
+  (#230). `make-memory-graph`/`open-memory-graph` now normalize a
+  slashless `location` namestring at the boundary (the #222 shape:
+  a file pathname used to scatter the `tx/` journal and `applied-ops/`
+  sidecars into the store's *parent* directory), and both run under an
+  abort guard (the #224 shape, `%abort-memory-graph-open`): a
+  construction that fails partway closes the replication-log stream, a
+  peer's applied-op-ids table and any restored vector segments,
+  deregisters the graph, and removes the `.dirty` marker — but only
+  when *this* call wrote it; a pre-existing marker (an earlier crash's
+  record) is left in place. Once `graph-open-p` is set the guard
+  unwinds through the normal `close-graph` path instead — which
+  removes the marker regardless of provenance, harmless on a memory
+  graph since opens never gate on it — and subsumes the constructors'
+  previous attach-only unwind.
+
+- **Memory peer-hub: the clock attach now precedes
+  `start-replication`** (#238). Both memory constructors used to start
+  replication before attaching to the system clock, leaving a
+  microseconds-wide window in which a peer hub's live listener could
+  re-home an inbound push with ids minted from the pre-attach local
+  counter (the #180 bug class). The attach now runs between
+  `(setf (graph-open-p ...) t)` and `start-replication`, so the window
+  is gone — and a failed attach never has replication threads to tear
+  down. The disk constructors already attached first and are
+  unchanged.
+
 - **`make-graph` refuses a `.dirty`-carrying location upfront** (#246).
   It used to create `heap.dat`, both linear-hash tables, `indexes.dat`
   and the three adjacency-index directories before dying on a raw

--- a/memory-graph.lisp
+++ b/memory-graph.lisp
@@ -205,6 +205,52 @@ MEMORY-PEER-GRAPH.  With LAZY, the node tables materialize on first touch."
                                                      :if-exists :supersede)
     (format out "~S" (get-universal-time))))
 
+(defun %abort-memory-graph-open (graph dirty-preexisted)
+  "Best-effort teardown for a MAKE-MEMORY-GRAPH/OPEN-MEMORY-GRAPH
+aborted partway (GH #230) -- the memory analogue of %ABORT-GRAPH-OPEN.
+Once GRAPH-OPEN-P is set the graph is fully wired, so the normal
+CLOSE-GRAPH path (checkpoint skipped) does the whole job; before that,
+close what a partial open can hold: the replication-log stream, a
+peer's applied-op-ids lhash, restored vector segments, and the
+*GRAPHS*/open-store registrations.  No open step mutates the durable
+record (the journal is replayed into RAM, never rewritten), so the disk
+side's MUTATED gate reduces to marker ownership: delete .dirty only
+when THIS call wrote it fresh (DIRTY-PREEXISTED nil) -- a pre-existing
+marker records an earlier crash this abort must not erase.  That rule
+governs only the pre-OPEN-P branch: past OPEN-P, CLOSE-GRAPH removes
+the marker regardless of provenance, which is harmless here -- a
+memory open never gates on it and always replays the journal.  Returns
+NIL; never signals."
+  (handler-case
+      (if (graph-open-p graph)
+          (let ((*graph* graph))
+            (close-graph graph :snapshot-p nil))
+          (progn
+            (ignore-errors (stop-replication graph))
+            (ignore-errors
+              (maphash (lambda (k seg)
+                         (declare (ignore k))
+                         (ignore-errors (close-vector-segment seg)))
+                       (vector-segments graph)))
+            (ignore-errors
+              (when (eq graph (gethash (graph-name graph) *graphs*))
+                (remhash (graph-name graph) *graphs*)))
+            (ignore-errors (%unregister-open-store graph))
+            (ignore-errors
+              (when (slot-boundp graph 'transaction-manager)
+                (close-replication-log graph)))
+            (ignore-errors
+              (when (and (slot-exists-p graph 'applied-op-ids)
+                         (slot-boundp graph 'applied-op-ids)
+                         (lhash-p (applied-op-ids graph)))
+                (close-lhash (applied-op-ids graph))))
+            (ignore-errors
+              (unless dirty-preexisted
+                (let ((f (format nil "~A/.dirty" (location graph))))
+                  (when (probe-file f) (delete-file f)))))))
+    (serious-condition () nil))
+  nil)
+
 (defun %validate-peer-role (peer-role origin-id)
   (when (and peer-role (not (member peer-role '(:hub :device))))
     (error ":PEER-ROLE must be :HUB or :DEVICE, got ~S" peer-role))
@@ -252,48 +298,61 @@ and materializes nodes on first touch (fault-on-access) for a near-instant open.
 epoch clock, exactly as MAKE-GRAPH does (GH #176).
 Registers the graph and returns it."
   (%validate-peer-role peer-role origin-id)
+  ;; A slashless namestring keeps LOCATION a FILE pathname, so every
+  ;; MERGE-PATHNAMES sidecar (tx/, applied-ops/, ...) lands in the
+  ;; store's PARENT directory.  Normalize once, before any use
+  ;; (GH #222/#230).
+  (setq location (namestring (uiop:ensure-directory-pathname location)))
   (ensure-directories-exist location)
   (let* ((path (pathname location))
+         (dirty-preexisted (probe-file (format nil "~A.dirty" location)))
          (graph (%make-empty-memory-graph
                  name path
                  :class (if peer-role 'memory-peer-graph 'memory-graph)
                  :lazy lazy
                  :replication-key replication-key
-                 :replication-port replication-port)))
-    (let ((*graph* graph))
-      (init-schema graph)
-      (update-schema graph)
-      (%write-dirty-marker path)
-      (setf (gethash name *graphs*) graph)
-      (%register-open-store graph))
-    (when peer-role
-      (%init-memory-peer-slots graph :make path peer-role origin-id peer-host
-                               export-predicate device-registry merge-policy
-                               reference-classes peer-schema-version))
-    (setf (transaction-manager graph)
-          (make-instance 'transaction-manager :graph graph))
-    (ensure-directories-exist (persistent-transaction-directory graph))
-    (init-replication-log graph)
-    (start-replication graph :package package)
-    (setf (graph-open-p graph) t)
-    ;; As MAKE-GRAPH and OPEN-MEMORY-GRAPH do: register this graph's
-    ;; DEF-UNIQUE constraints so an ABSENT index means "not built yet"
-    ;; rather than "brand new" (GH #129).  No nodes yet, so no scan.
-    (let ((*graph* graph))
-      (install-unique-tuple-constraints graph))
-    ;; Join the image-level clock, as MAKE-GRAPH does (GH #176).  Last,
-    ;; once GRAPH-OPEN-P is set, so a failed attach unwinds through the
-    ;; NORMAL close path (deregister, delete .dirty) instead of leaving
-    ;; a half-registered graph behind (same shape as GH #212).
-    (when system-clock
-      (let ((attached nil))
-        (unwind-protect
-            (progn (attach-to-system-clock graph system-clock)
-                   (setf attached t))
-          (unless attached
-            (let ((*graph* graph))
-              (ignore-errors (close-graph graph :snapshot-p nil)))))))
-    graph))
+                 :replication-port replication-port))
+         (done nil))
+    ;; GH #230: MAKE-GRAPH's abort-guard shape -- a failure below must
+    ;; not leak streams or leave a half-registered graph behind.
+    (unwind-protect
+        (progn
+          (let ((*graph* graph))
+            (init-schema graph)
+            (update-schema graph)
+            (%write-dirty-marker path)
+            (setf (gethash name *graphs*) graph)
+            (%register-open-store graph))
+          (when peer-role
+            (%init-memory-peer-slots graph :make path peer-role origin-id
+                                     peer-host export-predicate
+                                     device-registry merge-policy
+                                     reference-classes peer-schema-version))
+          (setf (transaction-manager graph)
+                (make-instance 'transaction-manager :graph graph))
+          (ensure-directories-exist
+           (persistent-transaction-directory graph))
+          (init-replication-log graph)
+          (setf (graph-open-p graph) t)
+          ;; As MAKE-GRAPH and OPEN-MEMORY-GRAPH do: register this
+          ;; graph's DEF-UNIQUE constraints so an ABSENT index means
+          ;; "not built yet" rather than "brand new" (GH #129).  No
+          ;; nodes yet, so no scan.
+          (let ((*graph* graph))
+            (install-unique-tuple-constraints graph))
+          ;; Join the image-level clock (GH #176) BEFORE replication
+          ;; starts (GH #238): an inbound push must never mint ids from
+          ;; the pre-attach counter, and a failed attach then has no
+          ;; replication threads to tear down.  GRAPH-OPEN-P is already
+          ;; set, so the abort guard unwinds a failure from here on
+          ;; through the NORMAL close path (same intent as GH #212).
+          (when system-clock
+            (attach-to-system-clock graph system-clock))
+          (start-replication graph :package package)
+          (setf done t)
+          graph)
+      (unless done
+        (%abort-memory-graph-open graph dirty-preexisted)))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Durability (design §7).  Three tiers, all reusing the existing journal:
@@ -973,6 +1032,106 @@ and the app re-cold-syncs.  Cheap: ~0.06 s / 0.2 MB for ~800 nodes."
   (clear-memory-journal graph)
   graph)
 
+(defun %open-memory-graph-1 (graph name path schema-file
+                             &key package peer-role origin-id peer-host
+                               regenerate-views export-predicate
+                               device-registry merge-policy reference-classes
+                               peer-schema-version system-clock)
+  "Private body of OPEN-MEMORY-GRAPH (GH #230): every step that opens a
+stream, registers GRAPH, or starts a thread runs here, inside the
+caller's abort guard.  Returns GRAPH."
+  (let ((*graph* graph) (*memory-image-view-dump* :none)
+        (*memory-image-unique-loaded* nil))
+    (if (probe-file schema-file)
+        (progn
+          (setf (schema graph) (cl-store:restore schema-file))
+          (restore-schema-locks (schema graph)))
+        (init-schema graph))
+    (setf (schema-lock (schema graph)) (make-recursive-lock))
+    (update-schema graph)
+    (%write-dirty-marker path)
+    (setf (gethash name *graphs*) graph)
+    (%register-open-store graph)
+    ;; Restore the checkpoint, then replay the journal tail committed after it.
+    ;; Recovery runs BEFORE the transaction-manager is installed (the reaper
+    ;; tolerates the unbound slot); the retain hook keeps the journal.
+    (let ((image-restore-result (restore-memory-image graph)))
+      ;; Vector segments (GH #58): reopen-or-rebuild BEFORE any journal
+      ;; replay, mirroring OPEN-GRAPH.  RECOVER-TRANSACTIONS replays through
+      ;; the shared APPLY-TRANSACTION, which maintains segments via
+      ;; %ENSURE-SEGMENT -- and an unregistered (owner . slot) there
+      ;; unconditionally CREATE-VECTOR-SEGMENTs over any same-named file
+      ;; already on disk, destroying it.  RESTORE-MEMORY-IMAGE above has
+      ;; already populated the type index (structurally, or via the v1
+      ;; rebuild-from-nodes fallback) for either branch below, so a rebuild
+      ;; here sweeps the right checkpoint-time corpus; replay then updates
+      ;; the segment(s) incrementally, same story as the spatial index.
+      ;; Skipped on a LAZY graph, same reason RESTORE-SECONDARY-INDEXES is
+      ;; skipped below: a rebuild sweep would materialize every LZNODE blob.
+      (unless (lazy-p graph)
+        (restore-vector-segments graph))
+      (if (eq image-restore-result :structural)
+          ;; v2 image: views/indexes/spatial were restored structurally.
+          ;; Create + populate the views from the image dump, THEN replay the
+          ;; journal tail so its authored ops update the already-restored
+          ;; derived structures incrementally (fast open -- no map/reduce
+          ;; regen; #50).
+          (progn (restore-views graph)
+                 (recover-transactions graph))
+          ;; v1 / no image: load the journal tail into the tables first, then
+          ;; rebuild views in-RAM from ALL restored nodes (rebuild-on-open
+          ;; fallback).
+          (progn (recover-transactions graph)
+                 (restore-views graph))))
+    ;; Reconcile the declarative view registry (issue #49) after views are
+    ;; restored AND the journal tail is replayed, so any regenerate sees all
+    ;; nodes.
+    (install-views graph)
+    (when regenerate-views
+      (regenerate-all-views graph))
+    ;; Unique constraints (issue #6): the image restore (structural or
+    ;; cl-store) loads the unique indexes -- so scan-rebuild only when it did
+    ;; NOT (a fresh graph, or a pre-#6 v3 image / crash fallback).  This is
+    ;; the durable path on the memory backend: no open-time scan, no
+    ;; lazy-node materialization.
+    (unless *memory-image-unique-loaded*
+      (rebuild-unique-indexes graph))
+    ;; DEF-UNIQUE constraints the image did not carry (one declared while the
+    ;; graph was closed).  Deliberately NOT lazy-guarded, unlike the ordered
+    ;; indexes below: a missing constraint silently stops ENFORCING, so the
+    ;; scan is worth the materialization -- the same trade REBUILD-UNIQUE-
+    ;; INDEXES above already makes.  A normal reopen restores every constraint
+    ;; from the image, so this is a no-op there.  Scans per owner type, so an
+    ;; unrelated class's blobs stay unmaterialized either way (GH #107).
+    (install-unique-tuple-constraints graph)
+    ;; General ordered indexes: rebuild-on-open on the memory backend (image
+    ;; persistence is a follow-up, mirroring unique's v1).  REBUILD covers the
+    ;; MOP :INDEX slots; INSTALL covers DEF-INDEX declarations.  NOT on a LAZY
+    ;; graph: rebuilding scans every node and would thus MATERIALIZE the
+    ;; LZNODE blobs, defeating fault-on-access (a geometry :INDEX slot alone
+    ;; would trip it).  A lazy graph maintains its indexes in-session via
+    ;; APPLY; persisting them in the checkpoint image (so a lazy reopen needs
+    ;; no scan) is the deferred follow-up.
+    (unless (lazy-p graph)
+      (rebuild-secondary-indexes graph)
+      (install-secondary-indexes graph)))
+  (when peer-role
+    (%init-memory-peer-slots graph :open path peer-role origin-id peer-host
+                             export-predicate device-registry merge-policy
+                             reference-classes peer-schema-version))
+  (setf (transaction-manager graph)
+        (make-instance 'transaction-manager :graph graph))
+  (ensure-directories-exist (persistent-transaction-directory graph))
+  (init-replication-log graph)
+  (setf (graph-open-p graph) t)
+  ;; Join the image-level clock (GH #176) BEFORE replication starts
+  ;; (GH #238), with GRAPH-OPEN-P already set -- see MAKE-MEMORY-GRAPH's
+  ;; comment.
+  (when system-clock
+    (attach-to-system-clock graph system-clock))
+  (start-replication graph :package package)
+  graph)
+
 (defun open-memory-graph (name location
                           &key package replication-port replication-key
                             peer-role origin-id peer-host lazy regenerate-views
@@ -988,106 +1147,38 @@ as deferred blobs and materialize on first touch (needs a VG-native image).
 :SYSTEM-CLOCK (default *SYSTEM-CLOCK*) attaches to the image-level epoch clock,
 as OPEN-GRAPH does (GH #176)."
   (%validate-peer-role peer-role origin-id)
+  ;; Normalize a slashless LOCATION before any use, as MAKE-MEMORY-GRAPH
+  ;; does (GH #222/#230).
+  (setq location (namestring (uiop:ensure-directory-pathname location)))
   (ensure-directories-exist location)
   (let* ((path (pathname location))
          (schema-file (format nil "~A/schema.dat" location))
+         (dirty-preexisted (probe-file (format nil "~A.dirty" location)))
          (graph (%make-empty-memory-graph
                  name path
                  :class (if peer-role 'memory-peer-graph 'memory-graph)
                  :lazy lazy
                  :replication-key replication-key
-                 :replication-port replication-port)))
-    (let ((*graph* graph) (*memory-image-view-dump* :none)
-          (*memory-image-unique-loaded* nil))
-      (if (probe-file schema-file)
-          (progn
-            (setf (schema graph) (cl-store:restore schema-file))
-            (restore-schema-locks (schema graph)))
-          (init-schema graph))
-      (setf (schema-lock (schema graph)) (make-recursive-lock))
-      (update-schema graph)
-      (%write-dirty-marker path)
-      (setf (gethash name *graphs*) graph)
-      (%register-open-store graph)
-      ;; Restore the checkpoint, then replay the journal tail committed after it.
-      ;; Recovery runs BEFORE the transaction-manager is installed (the reaper
-      ;; tolerates the unbound slot); the retain hook keeps the journal.
-      (let ((image-restore-result (restore-memory-image graph)))
-        ;; Vector segments (GH #58): reopen-or-rebuild BEFORE any journal
-        ;; replay, mirroring OPEN-GRAPH.  RECOVER-TRANSACTIONS replays through
-        ;; the shared APPLY-TRANSACTION, which maintains segments via
-        ;; %ENSURE-SEGMENT -- and an unregistered (owner . slot) there
-        ;; unconditionally CREATE-VECTOR-SEGMENTs over any same-named file
-        ;; already on disk, destroying it.  RESTORE-MEMORY-IMAGE above has
-        ;; already populated the type index (structurally, or via the v1
-        ;; rebuild-from-nodes fallback) for either branch below, so a rebuild
-        ;; here sweeps the right checkpoint-time corpus; replay then updates
-        ;; the segment(s) incrementally, same story as the spatial index.
-        ;; Skipped on a LAZY graph, same reason RESTORE-SECONDARY-INDEXES is
-        ;; skipped below: a rebuild sweep would materialize every LZNODE blob.
-        (unless (lazy-p graph)
-          (restore-vector-segments graph))
-        (if (eq image-restore-result :structural)
-            ;; v2 image: views/indexes/spatial were restored structurally.  Create +
-            ;; populate the views from the image dump, THEN replay the journal tail so
-            ;; its authored ops update the already-restored derived structures
-            ;; incrementally (fast open -- no map/reduce regen; #50).
-            (progn (restore-views graph)
-                   (recover-transactions graph))
-            ;; v1 / no image: load the journal tail into the tables first, then
-            ;; rebuild views in-RAM from ALL restored nodes (rebuild-on-open fallback).
-            (progn (recover-transactions graph)
-                   (restore-views graph))))
-      ;; Reconcile the declarative view registry (issue #49) after views are
-      ;; restored AND the journal tail is replayed, so any regenerate sees all nodes.
-      (install-views graph)
-      (when regenerate-views
-        (regenerate-all-views graph))
-      ;; Unique constraints (issue #6): the image restore (structural or cl-store)
-      ;; loads the unique indexes -- so scan-rebuild only when it did NOT (a fresh
-      ;; graph, or a pre-#6 v3 image / crash fallback).  This is the durable path on
-      ;; the memory backend: no open-time scan, no lazy-node materialization.
-      (unless *memory-image-unique-loaded*
-        (rebuild-unique-indexes graph))
-      ;; DEF-UNIQUE constraints the image did not carry (one declared while the
-      ;; graph was closed).  Deliberately NOT lazy-guarded, unlike the ordered
-      ;; indexes below: a missing constraint silently stops ENFORCING, so the
-      ;; scan is worth the materialization -- the same trade REBUILD-UNIQUE-
-      ;; INDEXES above already makes.  A normal reopen restores every constraint
-      ;; from the image, so this is a no-op there.  Scans per owner type, so an
-      ;; unrelated class's blobs stay unmaterialized either way (GH #107).
-      (install-unique-tuple-constraints graph)
-      ;; General ordered indexes: rebuild-on-open on the memory backend (image
-      ;; persistence is a follow-up, mirroring unique's v1).  REBUILD covers the MOP
-      ;; :INDEX slots; INSTALL covers DEF-INDEX declarations.  NOT on a LAZY graph:
-      ;; rebuilding scans every node and would thus MATERIALIZE the LZNODE blobs,
-      ;; defeating fault-on-access (a geometry :INDEX slot alone would trip it).  A
-      ;; lazy graph maintains its indexes in-session via APPLY; persisting them in the
-      ;; checkpoint image (so a lazy reopen needs no scan) is the deferred follow-up.
-      (unless (lazy-p graph)
-        (rebuild-secondary-indexes graph)
-        (install-secondary-indexes graph)))
-    (when peer-role
-      (%init-memory-peer-slots graph :open path peer-role origin-id peer-host
-                               export-predicate device-registry merge-policy
-                               reference-classes peer-schema-version))
-    (setf (transaction-manager graph)
-          (make-instance 'transaction-manager :graph graph))
-    (ensure-directories-exist (persistent-transaction-directory graph))
-    (init-replication-log graph)
-    (start-replication graph :package package)
-    (setf (graph-open-p graph) t)
-    ;; Join the image-level clock, as OPEN-GRAPH does (GH #176).  Last,
-    ;; once GRAPH-OPEN-P is set -- see MAKE-MEMORY-GRAPH's comment.
-    (when system-clock
-      (let ((attached nil))
-        (unwind-protect
-            (progn (attach-to-system-clock graph system-clock)
-                   (setf attached t))
-          (unless attached
-            (let ((*graph* graph))
-              (ignore-errors (close-graph graph :snapshot-p nil)))))))
-    graph))
+                 :replication-port replication-port))
+         (done nil))
+    ;; GH #230: abort guard, as in MAKE-MEMORY-GRAPH.
+    (unwind-protect
+        (prog1
+            (%open-memory-graph-1 graph name path schema-file
+                                  :package package
+                                  :peer-role peer-role
+                                  :origin-id origin-id
+                                  :peer-host peer-host
+                                  :regenerate-views regenerate-views
+                                  :export-predicate export-predicate
+                                  :device-registry device-registry
+                                  :merge-policy merge-policy
+                                  :reference-classes reference-classes
+                                  :peer-schema-version peer-schema-version
+                                  :system-clock system-clock)
+          (setf done t))
+      (unless done
+        (%abort-memory-graph-open graph dirty-preexisted)))))
 
 ;; Clean-close checkpoint: write the image, then clear the (now-superseded)
 ;; journal.  Runs BEFORE the base CLOSE-GRAPH removes .dirty and nils the tables.

--- a/tests/open-hygiene-tests.lisp
+++ b/tests/open-hygiene-tests.lisp
@@ -484,3 +484,216 @@ warns, and deregisters the graph (GH #246)."
       (is (null (graph-db:lookup-graph :oh-graph))
           "the close must still deregister the graph")
       (collect-garbage))))
+
+;;; ---------------------------------------------------------------------------
+;;; GH #230: the memory constructors share the #222/#224 exposure.  Same
+;;; shapes as above, against MAKE-MEMORY-GRAPH/OPEN-MEMORY-GRAPH and
+;;; %ABORT-MEMORY-GRAPH-OPEN (memory-graph.lisp).  GH #238's attach-before-
+;;; replication ordering is covered at the end.
+;;; ---------------------------------------------------------------------------
+
+(def-vertex oh-mem-thing () ((label :type string)) :oh-mem-graph)
+
+(test memgraph-slashless-location-keeps-sidecars-inside-the-store
+  "A slashless LOCATION namestring must not scatter the memory graph's
+sidecars (.dirty, schema.dat, graph.img, tx/) into the store's parent
+directory, and the store must reopen and read back through the same
+slashless string (GH #222/#230)."
+  (with-temp-directory (dir)
+    (let* ((parent (uiop:pathname-parent-directory-pathname dir))
+           (inside (uiop:ensure-directory-pathname dir))
+           (slashless (string-right-trim "/" (namestring dir)))
+           id)
+      (let ((g (graph-db::make-memory-graph :oh-mem-graph slashless)))
+        (is (probe-file (%oh-dirty-file slashless))
+            "~A/.dirty must exist while the graph is open" slashless)
+        (is (not (probe-file (merge-pathnames ".dirty" parent)))
+            "no .dirty must leak into the parent directory")
+        (let ((*graph* g))
+          (with-transaction ()
+            (setq id (id (make-oh-mem-thing :label "inside")))))
+        (let ((*graph* g))
+          (close-graph g)))
+      (is (probe-file (merge-pathnames "graph.img" inside))
+          "the image checkpoint must land inside the store directory")
+      (is (not (probe-file (merge-pathnames "graph.img" parent)))
+          "graph.img must not leak into the parent directory")
+      (is (not (probe-file (merge-pathnames "schema.dat" parent)))
+          "schema.dat must not leak into the parent directory")
+      (is (uiop:directory-exists-p (merge-pathnames "tx/" inside))
+          "the journal directory must sit inside the store directory")
+      (is (not (uiop:directory-exists-p (merge-pathnames "tx/" parent)))
+          "the journal directory must not leak into the parent directory")
+      (let ((g2 (graph-db::open-memory-graph :oh-mem-graph slashless)))
+        (unwind-protect
+             (let ((*graph* g2))
+               (is (string= "inside"
+                            (slot-value (lookup-vertex id) 'label))
+                   "data written under the slashless location must ~
+                    survive a reopen through the same slashless string"))
+          (let ((*graph* g2))
+            (close-graph g2 :snapshot-p nil)))))
+    (collect-garbage)))
+
+(test aborted-make-memory-graph-cleans-up
+  "A MAKE-MEMORY-GRAPH aborted at INIT-REPLICATION-LOG -- registered,
+.dirty written, transaction-manager installed, but GRAPH-OPEN-P still
+NIL -- must deregister, delete the marker THIS call wrote, and leave the
+directory reusable: a retried MAKE-MEMORY-GRAPH succeeds (GH #230)."
+  (with-temp-directory (dir)
+    (let ((path (namestring dir)))
+      (%oh-with-injected-failure 'graph-db::init-replication-log
+        (signals error (graph-db::make-memory-graph :oh-mem-graph path)))
+      (is (null (graph-db:lookup-graph :oh-mem-graph))
+          "an aborted make-memory-graph must not leave a half-registered ~
+           graph")
+      (is (not (probe-file (%oh-dirty-file path)))
+          "the marker this aborted call wrote must be gone")
+      (let ((g (graph-db::make-memory-graph :oh-mem-graph path)))
+        (is (graph-db::graph-open-p g) "the retried make must succeed")
+        (let ((*graph* g))
+          (close-graph g :snapshot-p nil))))
+    (collect-garbage)))
+
+(test aborted-make-memory-graph-past-open-p-closes-via-normal-path
+  "A MAKE-MEMORY-GRAPH aborted in START-REPLICATION -- GRAPH-OPEN-P
+already set, journal/replication-log stream open -- must unwind through
+the NORMAL close path: deregistered, marker gone, no fd leaked, and a
+retry succeeds (GH #230)."
+  (%oh-skip-unless-linux
+    (with-temp-directory (dir)
+      (let* ((path (namestring dir))
+             (before (%oh-fd-count)))
+        (%oh-with-injected-failure 'graph-db::start-replication
+          (signals error (graph-db::make-memory-graph :oh-mem-graph path)))
+        (let ((after (%oh-fd-count)))
+          (is (<= after (+ before 3))
+              "fd count grew from ~D to ~D across an aborted ~
+               make-memory-graph (replication-log stream leaked?)"
+              before after))
+        (is (null (graph-db:lookup-graph :oh-mem-graph))
+            "the aborted make must not leave a half-registered graph")
+        (is (not (probe-file (%oh-dirty-file path)))
+            "the normal close path must have removed the marker")
+        (let ((g (graph-db::make-memory-graph :oh-mem-graph path)))
+          (is (graph-db::graph-open-p g) "the retried make must succeed")
+          (let ((*graph* g))
+            (close-graph g :snapshot-p nil))))
+      (collect-garbage))))
+
+(test aborted-open-memory-graph-cleans-up-and-retries
+  "An OPEN-MEMORY-GRAPH aborted at INSTALL-VIEWS -- after the image
+restore and journal replay, before the transaction-manager exists --
+must deregister, delete the marker THIS call wrote (the store was
+cleanly closed, so no marker pre-existed), and leave the store intact:
+an un-injected reopen reads the data back (GH #230)."
+  (with-temp-directory (dir)
+    (let ((path (namestring dir)) id)
+      (let ((g (graph-db::make-memory-graph :oh-mem-graph path)))
+        (let ((*graph* g))
+          (with-transaction ()
+            (setq id (id (make-oh-mem-thing :label "survives"))))
+          (close-graph g)))
+      (%oh-with-injected-failure 'graph-db::install-views
+        (signals error (graph-db::open-memory-graph :oh-mem-graph path)))
+      (is (null (graph-db:lookup-graph :oh-mem-graph))
+          "an aborted open-memory-graph must not leave a half-registered ~
+           graph")
+      (is (not (probe-file (%oh-dirty-file path)))
+          "the marker this aborted open wrote must be gone")
+      (let ((g2 (graph-db::open-memory-graph :oh-mem-graph path)))
+        (unwind-protect
+             (let ((*graph* g2))
+               (is (string= "survives"
+                            (slot-value (lookup-vertex id) 'label))
+                   "the un-injected reopen must still read the data back"))
+          (let ((*graph* g2))
+            (close-graph g2 :snapshot-p nil)))))
+    (collect-garbage)))
+
+(test aborted-open-memory-graph-keeps-preexisting-dirty-marker
+  "An OPEN-MEMORY-GRAPH aborted after superseding a PRE-EXISTING .dirty
+(an earlier crash's record) must leave the marker in place -- the abort
+did not recover anything, so it must not erase the crash evidence.  The
+store still reopens fine: a memory graph tolerates the marker and
+rebuilds from journal + image (GH #230)."
+  (with-temp-directory (dir)
+    (let ((path (namestring dir)) id)
+      (let ((g (graph-db::make-memory-graph :oh-mem-graph path)))
+        (let ((*graph* g))
+          (with-transaction ()
+            (setq id (id (make-oh-mem-thing :label "crashed"))))
+          (close-graph g)))
+      ;; Simulate the crash: re-plant the marker over the clean store.
+      (with-open-file (out (%oh-dirty-file path) :direction :output
+                           :if-does-not-exist :create)
+        (format out "~S" (get-universal-time)))
+      (%oh-with-injected-failure 'graph-db::install-views
+        (signals error (graph-db::open-memory-graph :oh-mem-graph path)))
+      (is (probe-file (%oh-dirty-file path))
+          "a pre-existing crash marker must survive the aborted open")
+      (let ((g2 (graph-db::open-memory-graph :oh-mem-graph path)))
+        (unwind-protect
+             (let ((*graph* g2))
+               (is (string= "crashed"
+                            (slot-value (lookup-vertex id) 'label))
+                   "the dirty store must still reopen and read back"))
+          (let ((*graph* g2))
+            (close-graph g2 :snapshot-p nil)))))
+    (collect-garbage)))
+
+(test memgraph-attach-precedes-replication-start
+  "GH #238: both memory constructors must attach to the system clock
+BEFORE START-REPLICATION runs, so an inbound push can never mint ids
+from the pre-attach counter, and a failed attach has no replication
+threads to tear down.  Traced by call-order spies, as in
+ABORTED-OPEN-GRAPH-STOPS-REPLICATION-BEFORE-OTHER-TEARDOWN."
+  (with-temp-directory (sysdir)
+    (with-temp-directory (cdir)
+      (with-temp-directory (mdir)
+        (let ((graph-db::*system-directory* (namestring sysdir))
+              (graph-db::*type-registry* nil)
+              (graph-db::*store-registry* nil)
+              (make-order nil) (open-order nil))
+          (let ((clock (open-system-clock (namestring cdir)))
+                (orig-attach
+                  (fdefinition 'graph-db::attach-to-system-clock))
+                (orig-start (fdefinition 'graph-db::start-replication))
+                (order nil))
+            (unwind-protect
+                 (progn
+                   (setf (fdefinition 'graph-db::attach-to-system-clock)
+                         (lambda (g c)
+                           (push :attach order)
+                           (funcall orig-attach g c)))
+                   (setf (fdefinition 'graph-db::start-replication)
+                         (lambda (g &rest args)
+                           (push :start-replication order)
+                           (apply orig-start g args)))
+                   (let ((mg (graph-db::make-memory-graph
+                              :oh-mem-clocked (namestring mdir)
+                              :system-clock clock)))
+                     (let ((*graph* mg))
+                       (close-graph mg :snapshot-p nil)))
+                   (setf make-order (nreverse order) order nil)
+                   (let ((mg2 (graph-db::open-memory-graph
+                               :oh-mem-clocked (namestring mdir)
+                               :system-clock clock)))
+                     (let ((*graph* mg2))
+                       (close-graph mg2 :snapshot-p nil)))
+                   (setf open-order (nreverse order)))
+              (setf (fdefinition 'graph-db::attach-to-system-clock)
+                    orig-attach)
+              (setf (fdefinition 'graph-db::start-replication) orig-start)
+              (close-system-clock clock)))
+          (dolist (pair (list (cons "MAKE-MEMORY-GRAPH" make-order)
+                              (cons "OPEN-MEMORY-GRAPH" open-order)))
+            (destructuring-bind (name . order) pair
+              (is (member :attach order)
+                  "~A must attach to the clock" name)
+              (is (member :start-replication order)
+                  "~A must start replication" name)
+              (is (< (position :attach order)
+                     (position :start-replication order))
+                  "~A must attach BEFORE start-replication" name))))))
+    (collect-garbage)))


### PR DESCRIPTION
Fixes #230 and #238 — both live in `make-memory-graph`/`open-memory-graph`, so they travel as one unit.

## What changed

- **#230 — mirror the disk side's open hygiene.** Both constructors normalize a slashless `location` namestring at the boundary (the #222 shape — the real damage was the `tx/` **journal directory** and `applied-ops/` sidecars landing in the store's *parent* directory, since `persistent-transaction-directory` merges against the location pathname), and both run under an abort guard (`%abort-memory-graph-open`, the #224 shape). A construction that fails partway closes the replication-log stream, a peer's applied-op-ids table, and any restored vector segments; deregisters from `*graphs*` and the open-store vector (identity-guarded); and removes the `.dirty` marker **only when this call wrote it** — a pre-existing crash marker is preserved as evidence. Past `graph-open-p` the guard unwinds through the normal `close-graph` path (checkpoint skipped — never checkpoint a half-open graph; the journal is retained, so durability is intact), subsuming the constructors' previous attach-only unwind — review traced the subsumption rigorously (same call, same dynamic binding, original condition propagates unchanged) and found it strictly stronger, since the old `ignore-errors` would have let a `storage-condition` mid-cleanup replace the original condition. `open-memory-graph`'s 90-line body is hoisted verbatim into `%open-memory-graph-1`, mirroring the disk `%open-graph-1` pattern (step-for-step fidelity verified in review).
- **#238 — attach before replication.** Both constructors now run `(setf (graph-open-p …) t)` → `attach-to-system-clock` → `start-replication`, closing the microseconds-wide window in which a memory peer hub's live listener could re-home an inbound push with ids minted from the pre-attach local counter (the #180 bug class) — and a failed attach now has zero replication threads to tear down, which is exactly what lets the abort guard's post-open branch be a plain close. All three safety claims verified independently in review (attach needs nothing replication establishes; nothing between depends on live replication; no `graph-open-p` reader couples open-ness to replication). The disk constructors already attached first and are unchanged.

## Verification

- Six new tests in tests/open-hygiene-tests.lisp: the slashless-scatter regression, three abort-path injections (pre-open-p, post-open-p with an fd-delta check, and open-path with data-survival on retry), the marker-ownership pin, and a call-order spy proving attach precedes `start-replication` through **both** constructors. Review empirically falsified them: **five of six fail on base**, and the marker test alone fails on a naive always-delete variant.
- Both multi-process peer harnesses (`peer-replication`, `peer-replication-push`) **PASS** under the reorder — real device-side memory-peer construction including a live push.
- **Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (source-registry pinned): 4,930 checks, Pass 4,920, Skip 10 (pre-existing GEOS environmental), Fail 0.** ECL skipped per the standing demotion directive.
- Review: APPROVE-WITH-NITS; the docstring qualification applied. The one adjacent asymmetry the review surfaced (`make-memory-graph` supersedes a pre-existing `.dirty` where disk `make-graph` now refuses per #246) is filed as #250, out of this unit's scope.

Fixes #230. Fixes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp