### PR TITLE
Perf evidence benches: multi-graph commit contention, v5 cross-store scan (#252)

### DIFF
--- a/tests/perf/benchmarks.lisp
+++ b/tests/perf/benchmarks.lisp
@@ -233,6 +233,190 @@ useless here -- we read (memory-pointer (heap g))."
               (close-graph g3 :snapshot-p nil)))))))
   (collect-garbage))
 
+(defun %run-multigraph-cell (n per-thread label)
+  "One multigraph-commit cell: N graphs, one committing thread per
+graph, PER-THREAD one-vertex txns each, spawned behind a start gate so
+the timer excludes thread creation.  Asserts every worker's commits
+landed, then records LABEL."
+  (let ((graphs '()) (dirs '()))
+    (unwind-protect
+         (progn
+           (dotimes (i n)
+             (let ((d (make-temp-directory)))
+               (push d dirs)
+               ;; No :buffer-pool-size -- the pool is process-global
+               ;; and already sized by the first bench that ran.
+               (push (make-graph (intern (format nil "PERF-MG-~D" i)
+                                         :keyword)
+                                 (namestring d))
+                     graphs)))
+           ;; One warm-up commit per graph, in THIS thread: adopts
+           ;; p-node into each store (needs *SYSTEM-DIRECTORY*,
+           ;; thread-local) and keeps adoption out of the timing.
+           (dolist (g graphs)
+             (let ((*graph* g))
+               (with-transaction ()
+                 (make-p-node :val -1 :label "w" :graph g))))
+           (let* ((gate (bordeaux-threads:make-semaphore))
+                  (ts (mapcar
+                       (lambda (g)
+                         (bordeaux-threads:make-thread
+                          (lambda ()
+                            (bordeaux-threads:wait-on-semaphore gate)
+                            (let ((*graph* g))
+                              (dotimes (i per-thread)
+                                (with-transaction ()
+                                  (make-p-node :val i :label "m"
+                                               :graph g)))))
+                          :name "perf-mg-commit"))
+                       graphs))
+                  (start (get-internal-real-time)))
+             (bordeaux-threads:signal-semaphore gate :count n)
+             (mapc #'bordeaux-threads:join-thread ts)
+             (let* ((elapsed (/ (- (get-internal-real-time) start)
+                                (float internal-time-units-per-second)))
+                    (ops (* n per-thread)))
+               (dolist (g graphs)
+                 (let ((got (count-vertices g)))
+                   (assert (= (1+ per-thread) got) ()
+                           "~A: expected ~D vertices in ~A, counted ~D"
+                           label (1+ per-thread) g got)))
+               (record label
+                       :ops ops :seconds (float-3 elapsed)
+                       :ops/s (if (zerop elapsed)
+                                  0
+                                  (round (/ ops elapsed)))
+                       :us/commit (float-3 (/ (* elapsed 1e6)
+                                              per-thread))))))
+      (dolist (g graphs) (ignore-errors (close-graph g :snapshot-p nil)))
+      (collect-garbage)
+      (dolist (d dirs)
+        (uiop:delete-directory-tree d :validate t
+                                    :if-does-not-exist :ignore)))))
+
+(defun bench-multigraph-commit ()
+  "Multi-graph commit contention (GH #237, #252): N graphs, one
+committing thread per graph.  An nN cell measures EVERYTHING the
+graphs share -- the global watermark lock, the process-global buffer
+pool, GC, one filesystem -- so the n8:n1 ratio alone does not
+implicate the lock.  The nN-rawwm control reruns the largest cell
+with PERSIST-HIGHEST-TRANSACTION-ID swapped for the raw writer
+(unconditional write, no global lock, no re-read): nN minus nN-rawwm
+is the watermark lock+read's share.  The watermark-* pair prices one
+call in isolation -- single-threaded, ascending ids, warm OS cache."
+  (let* ((per-thread (scale 1000))
+         (ns (if (eq *perf-scale* :small) '(1 4) '(1 2 4 8)))
+         (n-max (car (last ns))))
+    (dolist (n ns)
+      (%run-multigraph-cell n per-thread
+                            (format nil "commit-multigraph-n~D" n)))
+    ;; Control cell: same load, watermark persist bypassed.
+    (let ((orig (fdefinition 'graph-db::persist-highest-transaction-id)))
+      (unwind-protect
+           (progn
+             (setf (fdefinition
+                    'graph-db::persist-highest-transaction-id)
+                   (lambda (transaction-id graph)
+                     (graph-db::%write-highest-transaction-id
+                      transaction-id graph)))
+             (%run-multigraph-cell
+              n-max per-thread
+              (format nil "commit-multigraph-n~D-rawwm" n-max)))
+        (setf (fdefinition 'graph-db::persist-highest-transaction-id)
+              orig)))
+    ;; The watermark call in isolation (GH #237's concrete suspect).
+    (let ((iters (scale 20000)))
+      (with-perf-graph (g)
+        (timed-ops ("watermark-persist-warm" iters)
+          (loop for i from 1 to iters
+                do (graph-db::persist-highest-transaction-id i g)))
+        (timed-ops ("watermark-raw-write-warm" iters)
+          (loop for i from 1 to iters
+                do (graph-db::%write-highest-transaction-id i g)))))))
+
+(defun %insert-v5-mix (e dead-pct batch)
+  "Insert E p-knows edges; DEAD-PCT percent get a fresh never-created
+v5 :to id (untagged -> the all-open-stores scan on emit, GH #244)."
+  (let* ((v (min e 500))
+         (ids (insert-p-nodes v :batch batch))
+         (i 0))
+    (loop while (< i e) do
+      (with-transaction ()
+        (dotimes (k (min batch (- e i)))
+          (make-p-knows
+           :from (lookup-vertex (aref ids (mod i v)))
+           :to (if (< (mod i 100) dead-pct)
+                   (graph-db::gen-vertex-id)
+                   (lookup-vertex (aref ids (mod (1+ i) v)))))
+          (incf i))))))
+
+(defun %sweep-p-knows (g)
+  "Emitted-edge count of one full typed map-edges sweep over G."
+  (let ((c 0))
+    (map-edges (lambda (e) (declare (ignore e)) (incf c)) g
+               :edge-type 'p-knows)
+    c))
+
+(defun bench-v5-cross-store-scan ()
+  "map-edges emit cost when a fraction F of edges carry a dead v5
+endpoint, vs the number of open stores S (GH #244, #252).  Since PR
+#243 a v5 endpoint miss in %ACTIVE-ENDPOINT-STATUS scans every open
+store; F=0 should stay flat in S (hit path untouched), high F should
+grow linearly in S.  Labels: v5scan-fF-sS with S = TOTAL open stores."
+  (let ((e (scale 2000)) (sweeps 5) (batch 500))
+    (dolist (dead-pct '(0 10 50))
+      (with-perf-graph (g)
+        (%insert-v5-mix e dead-pct batch)
+        (let* ((live (- e (loop for i below e
+                                count (< (mod i 100) dead-pct))))
+               ;; Untimed warm sweep: first-touch table/cache faults
+               ;; stay out of the s=1 cell.
+               (warm (%sweep-p-knows g))
+               (extras '())
+               (extra-dirs '()))
+          (assert (= live warm) ()
+                  "v5scan-f~D: expected ~D live edges, warm sweep saw ~D"
+                  dead-pct live warm)
+          (unwind-protect
+               (dolist (total '(1 2 4 8))
+                 (loop while (< (1+ (length extras)) total)
+                       do (let ((d (make-temp-directory))
+                                (name (intern (format nil "PERF-VS-~D"
+                                                      (length extras))
+                                              :keyword)))
+                            (push d extra-dirs)
+                            ;; No :buffer-pool-size -- process-global,
+                            ;; already sized (see %RUN-MULTIGRAPH-CELL).
+                            (push (make-graph name (namestring d))
+                                  extras)))
+                 (collect-garbage)
+                 (let ((start (get-internal-real-time))
+                       (emitted 0))
+                   (dotimes (r sweeps)
+                     (setf emitted (%sweep-p-knows g)))
+                   (let* ((elapsed (/ (- (get-internal-real-time) start)
+                                      (float
+                                       internal-time-units-per-second)))
+                          (ops (* e sweeps)))
+                     (assert (= live emitted) ()
+                             "v5scan-f~D-s~D: expected ~D live edges, ~
+                              emitted ~D"
+                             dead-pct total live emitted)
+                     (record (format nil "v5scan-f~D-s~D" dead-pct total)
+                             :ops ops :seconds (float-3 elapsed)
+                             :ops/s (if (zerop elapsed)
+                                        0
+                                        (round (/ ops elapsed)))
+                             :us/edge (float-3 (/ (* elapsed 1e6) ops))
+                             :emitted emitted))))
+            (dolist (x extras)
+              (ignore-errors (close-graph x :snapshot-p nil)))
+            (collect-garbage)
+            (dolist (d extra-dirs)
+              (uiop:delete-directory-tree d :validate t
+                                          :if-does-not-exist
+                                          :ignore))))))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Entry point
 ;;; ---------------------------------------------------------------------------
@@ -261,6 +445,8 @@ Measurement-only; always returns T."
            (bench-concurrent-rw)
            (bench-disk-growth)
            (bench-snapshot-restore-reopen)
+           (bench-multigraph-commit)
+           (bench-v5-cross-store-scan)
            (write-perf-report output :tag tag))
       ;; system-dir and all bench scratch live under the shared per-run
       ;; parent; drop it whole (GH #214).


### PR DESCRIPTION
Unit 1 of the perf-suite expansion (tracker #256). Fixes #252. Two benches added to `tests/perf/benchmarks.lisp` (`graph-db/perf-test`), producing the measurements #237 and #244 are gated on.

## The benches

- **`bench-multigraph-commit`** (→ #237): N graphs (1/2/4/8), one committing thread each, spawned behind a semaphore start gate with per-worker commit-count assertions — plus the **control cell** the review demanded: the largest N rerun with `persist-highest-transaction-id` swapped for the raw writer (bench-scoped `fdefinition` swap, restore verified in-image), so the watermark lock's share is *measured by subtraction*, not inferred from the raw ratio. A single-threaded watermark A/B prices the call in isolation.
- **`bench-v5-cross-store-scan`** (→ #244): `map-edges` emit cost over dead-v5-endpoint fractions {0, 10, 50}% × {1, 2, 4, 8} open stores, with an untimed warm sweep, GC discipline between cells, and emitted-count assertions. The dead endpoints are genuinely v5 (review verified bare `gen-vertex-id` is always untagged, so this exercises the PR #243 scan path, not `:absent-in-store`).

## The evidence (`:normal`, this host, two fresh images)

- **#237:** n1 ≈ 645 µs/commit; n8 ≈ 6.3 ms (9.8×) — and **n8 with the raw writer collapses to ≈ 680 µs**: ~89% of 8-graph commit latency is the watermark persist path itself (mechanism: the critical section does file opens and allocation while holding the process-global lock — GC pauses under the hold charge serially to all waiters). Isolated call: 182 µs monotonic vs 65 µs raw (~2.8×).
- **#244:** flat in S at F=0 (the hit path is untouched, as PR #243 claimed); ~5.4–6.7 µs per open store per dead-endpoint edge at F=50. Headline variance under 9% on all cells that matter.

Both issues receive the numbers and a disposition recommendation as comments on merge.

## Method & verification

Implementer → adversarial review focused on **measurement validity** (NEEDS-FIXES: the raw n8:n1 ratio could not attribute to the lock — shared buffer pool/GC/filesystem were confounded; also a cold-cache s=1 outlier) → fix round (control cell, warm sweep, GC discipline, start gate, assertions) → re-review APPROVE with the swap-restore verified empirically and the convoy mechanism endorsed.

Gate: fresh-image `graph-db/perf-test` load + full `run-perf :scale :small` (all 12 benches, assertions passing, exit 0). `tests/perf` is outside `:graph-db` and its test system; the full main suite passed at this exact base (4,930 checks / 0 failures). ECL skipped per the standing demotion directive.

Fixes #252. Refs #237, #244, #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp