### PR TITLE
Perf regression detection: blessed baselines, tolerance bands, check-perf (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **Perf regression detection** (#253). Perf reports are now stamped
+  with a suite generation (`*perf-suite-generation*`) and a sanitized
+  host name; `bless-perf-baseline` copies a `:normal`-scale report to
+  the committed per-host/per-generation baseline
+  (`tests/perf/results/baseline-<host>-g<gen>.report`), and
+  `check-perf` gates a run against it with per-metric-class tolerance
+  bands (15% default, per-label overrides for known-noisy benches;
+  missing labels fail, new labels are reported unbaselined). Comparing
+  across host, generation, or scale is refused. Measurement-only
+  remains the default (`:error-p t` opts into signalling). Ritual in
+  `docs/perf-baselines.md`; first blessed baseline (host `odm`, g4)
+  committed.
+
 - **`store-not-closed-cleanly-error`** (#246). The `.dirty` refusal is
   now a named, exported condition with a `store-not-closed-location`
   reader, signalled by both `open-graph` and `make-graph`; its report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,9 @@ subdirectories, **3,359 checks** as of 2026-08-08. Run a suite through ASDF:
 with "Heap exhausted, game over" partway in — `make-graph`'s type index eagerly builds
 131,072 index-lists, and a suite creates many graphs in one image.
 
+Perf regression checking (per-host/per-generation baselines, `check-perf`) is
+documented in `docs/perf-baselines.md`.
+
 Each `test-op` errors on failure, so they are safe to gate on. Run the main suite before
 committing an engine change; the app that consumes this engine has its own 5115-check suite
 that will not catch a defect in here.

--- a/docs/perf-baselines.md
+++ b/docs/perf-baselines.md
@@ -1,0 +1,100 @@
+# Perf baselines and regression checks (GH #253)
+
+The perf suite (`tests/perf/`, system `graph-db/perf-test`) is
+measurement-only by default. This document is the ritual that turns its
+reports into regression gates.
+
+## Running the suite
+
+```
+sbcl --dynamic-space-size 16384
+```
+
+```lisp
+(ql:quickload :graph-db/perf-test)
+(graph-db/perf-test:run-perf :tag "my-tag")   ; :normal scale by default
+```
+
+`run-perf` writes a report file (path printed at the end) stamped with
+tag, impl, scale, **suite generation** and **host**.
+
+On a fresh host, make sure ASDF resolves `graph-db` to the intended
+checkout (Quicklisp `local-projects` symlink, or push the repo dir onto
+`asdf:*central-registry*`) and verify with
+`(asdf:system-source-directory :graph-db)` before trusting a run.
+
+## The comparability rule
+
+Never compare across suite generations or hosts (learned in the 3.0
+A/B). `*perf-suite-generation*` in `tests/perf/suite.lisp` is bumped
+whenever a change alters an existing bench's work or labels (adding a
+new bench does not bump). Baselines are therefore per-host AND
+per-generation files:
+
+```
+tests/perf/results/baseline-<host>-g<generation>.report
+```
+
+`check-perf` refuses to compare reports whose generation, host, or
+scale differ — that is a setup mistake, not a perf result.
+
+## Blessing a baseline
+
+```lisp
+(graph-db/perf-test:bless-perf-baseline "/path/to/run.report")
+```
+
+Copies the report to the blessed path above. It refuses a
+wrong-generation or non-`:normal` report. Blessing is deliberate: the
+new baseline file **must be committed via a reviewed diff**, never
+automatically — re-blessing after an intentional perf change is part of
+that change's review.
+
+## Checking a run
+
+```lisp
+(graph-db/perf-test:check-perf "/path/to/run.report")
+;; => (values pass-p failures), prints a per-label table
+```
+
+- Finds the blessed baseline for the report's host + generation
+  (`:baseline` overrides explicitly).
+- Per-label primary metric: `:us/commit`/`:us/edge` where recorded,
+  else `:ops/s`, else `:bytes`, else `:seconds`. Throughput regresses
+  on a drop, latency/bytes on a rise.
+- Tolerance: `*perf-tolerance*` (15%) — generous on purpose; natural
+  run-to-run variance at `:normal` scale is ~5–10% on most benches
+  (see `variance.py`). Known-noisy labels get per-label overrides in
+  `*perf-tolerance-overrides*` (seeded with the `v5scan-f0-*` /
+  `v5scan-f10-*` rows, ~17–20% swing in the #252 evidence runs and
+  the first bless/check pair) rather than widening the global band.
+- A label in the baseline but missing from the run **fails** (a bench
+  silently vanished); a new label not in the baseline is reported as
+  "new, unbaselined", not a failure.
+- Never signals on regression by default (measurement culture:
+  report, don't crash); pass `:error-p t` for gating callers — a CLI
+  gate wraps the resulting `perf-regression-error` into a nonzero
+  exit code (e.g. `handler-case` → `(uiop:quit 1)`).
+- If the candidate lost the baseline's primary metric, the next
+  shared comparable metric is gated instead; a row sharing no
+  comparable metric fails as `:metric-vanished`. `index-fullscan-eq`
+  gates `:seconds` (its ~4 ops/s quantizes at 25% per step) via
+  `*perf-primary-metric-overrides*`.
+
+## Release ritual
+
+Before cutting a release (the `experiment` → `master` merge + tag):
+
+1. Fresh SBCL, `--dynamic-space-size 16384`, `run-perf` at `:normal`
+   on the baseline host.
+2. `check-perf` the report against the blessed baseline. A failure is
+   either a real regression (fix it or record the accepted trade-off in
+   the CHANGELOG) or an intentional change (re-bless — reviewed diff).
+3. After a release that bumped the suite generation, run + bless a
+   fresh baseline so the next cycle has one.
+
+New benches added since the last bless show as "new, unbaselined" —
+re-bless to adopt them.
+
+(The perf-suite vs `profiling/` harness split is documented separately —
+GH #255.)

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -288,6 +288,8 @@
   :components ((:file "package")
                (:file "suite")
                (:file "benchmarks")
+               ;; baseline blessing + regression gating (GH #253)
+               (:file "check")
                ;; B+ tree vs skip-list side-by-side (in-package :graph-db so it can
                ;; trace both read paths); entry point (graph-db::bplus-bench).
                (:file "bplus-bench"))
@@ -480,7 +482,10 @@ cl-temporal-extent."
 (defsystem graph-db/test
   :name "VivaceGraph test suite"
   :description "FiveAM unit tests for graph-db."
-  :depends-on (:graph-db :graph-db/test-scratch :fiveam :drakma)
+  ;; :graph-db/perf-test is load-only here: perf/check-tests exercises the
+  ;; pure check-perf comparison logic (GH #253); no benchmark ever runs.
+  :depends-on (:graph-db :graph-db/test-scratch :graph-db/perf-test
+               :fiveam :drakma)
   :pathname "tests/"
   :serial t
   :components ((:file "package")
@@ -581,7 +586,8 @@ cl-temporal-extent."
                (:file "peer-unique-tests")
                (:file "peer-index-tests")
                (:file "open-hygiene-tests")    ; GH #222, #224
-               (:file "scratch-cleanup-tests")) ; GH #214
+               (:file "scratch-cleanup-tests")  ; GH #214
+               (:file "perf/check-tests"))      ; GH #253
   :perform (test-op (op c)
                     (unless (uiop:symbol-call :graph-db/test :run-tests)
                       (error "graph-db test suite failed."))))

--- a/tests/perf/check-tests.lisp
+++ b/tests/perf/check-tests.lisp
@@ -1,0 +1,258 @@
+;;;; check-perf comparison-logic tests (GH #253).  Pure report-file
+;;;; comparison only -- no benchmark runs.  Loaded into graph-db/test.
+
+(in-package #:graph-db/test)
+
+(def-suite perf-check-suite :in graph-db-suite
+  :description "check-perf / bless-perf-baseline gating logic.")
+(in-suite perf-check-suite)
+
+(defvar *pc-gen* graph-db/perf-test:*perf-suite-generation*)
+
+(defun %pc-write-report (dir name &key (gen *pc-gen*) (host "test-host")
+                                       (scale :normal) (tag name) entries)
+  "Fabricate a perf report file; ENTRIES = list of (label . plist)."
+  (let ((path (merge-pathnames (format nil "~A.report" name) dir)))
+    (with-open-file (s path :direction :output :if-exists :supersede)
+      (format s ";;;; graph-db perf report (fabricated for tests)~%~%")
+      (format s "~S~%" (list :perf-report :tag tag :impl "TEST" :scale scale
+                             :generation gen :host host :entries entries)))
+    path))
+
+(defparameter *pc-base-entries*
+  '(("insert-vertices" :ops 100 :seconds 1.0 :ops/s 1000)
+    ("commit-multigraph-n8" :ops 100 :seconds 1.0 :ops/s 500 :us/commit 640.0)
+    ("heap-used-after-inserts" :bytes 100000 :per-op 5)
+    ("snapshot" :seconds 2.0)))
+
+(test check-perf-identical-reports-pass
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+          (c (%pc-write-report d "cand" :entries *pc-base-entries*)))
+      (multiple-value-bind (pass failures)
+          (graph-db/perf-test:check-perf c :baseline b)
+        (is-true pass)
+        (is (null failures))))))
+
+(test check-perf-throughput-regress-fails
+  ;; :ops/s drop of 30% > 15% band.
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*))
+           (row (assoc "insert-vertices" cand :test #'equal)))
+      (setf (getf (cdr row) :ops/s) 700)
+      (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+            (c (%pc-write-report d "cand" :entries cand)))
+        (multiple-value-bind (pass failures)
+            (graph-db/perf-test:check-perf c :baseline b)
+          (is-false pass)
+          (is (= 1 (length failures)))
+          (destructuring-bind (label metric bv cv pct) (first failures)
+            (is (equal "insert-vertices" label))
+            (is (eq :ops/s metric))
+            (is (= 1000 bv))
+            (is (= 700 cv))
+            (is (< 29.0 pct 31.0))))))))
+
+(test check-perf-latency-regress-fails
+  ;; :us/commit is the primary metric where present; a 30% rise fails
+  ;; even though :ops/s is unchanged.
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*))
+           (row (assoc "commit-multigraph-n8" cand :test #'equal)))
+      (setf (getf (cdr row) :us/commit) 832.0)
+      (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+            (c (%pc-write-report d "cand" :entries cand)))
+        (multiple-value-bind (pass failures)
+            (graph-db/perf-test:check-perf c :baseline b)
+          (is-false pass)
+          (is (eq :us/commit (second (first failures)))))))))
+
+(test check-perf-improvement-passes
+  ;; A big :ops/s gain and a :seconds drop are not regressions.
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*)))
+      (setf (getf (cdr (assoc "insert-vertices" cand :test #'equal))
+                  :ops/s)
+            2000)
+      (setf (getf (cdr (assoc "snapshot" cand :test #'equal)) :seconds) 1.0)
+      (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+            (c (%pc-write-report d "cand" :entries cand)))
+        (is-true (graph-db/perf-test:check-perf c :baseline b))))))
+
+(test check-perf-missing-label-fails
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+          (c (%pc-write-report d "cand"
+                               :entries (remove "snapshot" *pc-base-entries*
+                                                :key #'car :test #'equal))))
+      (multiple-value-bind (pass failures)
+          (graph-db/perf-test:check-perf c :baseline b)
+        (is-false pass)
+        (is (equal '("snapshot" :missing)
+                   (subseq (first failures) 0 2)))))))
+
+(test check-perf-new-label-not-a-failure
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+          (c (%pc-write-report
+              d "cand"
+              :entries (append *pc-base-entries*
+                               '(("brand-new-bench" :ops 10 :seconds 0.1
+                                  :ops/s 100))))))
+      (multiple-value-bind (pass failures)
+          (graph-db/perf-test:check-perf c :baseline b)
+        (is-true pass)
+        (is (null failures))))))
+
+(test check-perf-collapse-with-lost-primary-fails
+  ;; The candidate row loses the baseline's primary metric (:us/commit)
+  ;; while :ops/s collapses 100x.  The fallback must catch it -- this
+  ;; scenario silently PASSED before the comparison-metric fallback.
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*))
+           (row (assoc "commit-multigraph-n8" cand :test #'equal)))
+      (setf (cdr row) '(:ops 100 :seconds 100.0 :ops/s 5))
+      (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+            (c (%pc-write-report d "cand" :entries cand)))
+        (multiple-value-bind (pass failures)
+            (graph-db/perf-test:check-perf c :baseline b)
+          (is-false pass)
+          (is (= 1 (length failures)))
+          (is (eq :ops/s (second (first failures)))))))))
+
+(test check-perf-all-metrics-vanished-fails
+  ;; A candidate row sharing NO comparable metric with the baseline row
+  ;; is a failure, never a silent skip.
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*))
+           (row (assoc "commit-multigraph-n8" cand :test #'equal)))
+      (setf (cdr row) '(:emitted 100))
+      (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+            (c (%pc-write-report d "cand" :entries cand)))
+        (multiple-value-bind (pass failures)
+            (graph-db/perf-test:check-perf c :baseline b)
+          (is-false pass)
+          (is (equal '("commit-multigraph-n8" :metric-vanished)
+                     (subseq (first failures) 0 2))))))))
+
+(test check-perf-bytes-rise-fails-drop-passes
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :entries *pc-base-entries*)))
+      (flet ((with-bytes (v)
+               (let* ((e (copy-tree *pc-base-entries*))
+                      (row (assoc "heap-used-after-inserts" e
+                                  :test #'equal)))
+                 (setf (getf (cdr row) :bytes) v)
+                 e)))
+        (multiple-value-bind (pass failures)
+            (graph-db/perf-test:check-perf
+             (%pc-write-report d "rise" :entries (with-bytes 130000))
+             :baseline b)
+          (is-false pass)
+          (is (eq :bytes (second (first failures)))))
+        (is-true (graph-db/perf-test:check-perf
+                  (%pc-write-report d "drop" :entries (with-bytes 70000))
+                  :baseline b))))))
+
+(test check-perf-latency-improvement-passes
+  ;; A large :us/commit drop is an improvement, not a regression.
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*))
+           (row (assoc "commit-multigraph-n8" cand :test #'equal)))
+      (setf (getf (cdr row) :us/commit) 320.0)
+      (is-true (graph-db/perf-test:check-perf
+                (%pc-write-report d "cand" :entries cand)
+                :baseline (%pc-write-report d "base"
+                                            :entries *pc-base-entries*))))))
+
+(test check-perf-primary-metric-override
+  ;; With ~4 ops/s one integer step is 25% quantization noise; the
+  ;; per-label primary override gates :seconds instead.
+  (with-temp-directory (d)
+    (let* ((base '(("index-fullscan-eq" :ops 200 :seconds 50.0 :ops/s 4)))
+           (cand '(("index-fullscan-eq" :ops 200 :seconds 51.0 :ops/s 3)))
+           (b (%pc-write-report d "base" :entries base))
+           (c (%pc-write-report d "cand" :entries cand)))
+      ;; default primary would be :ops/s: 4 -> 3 = 25% "regression"
+      (multiple-value-bind (pass failures)
+          (graph-db/perf-test:check-perf c :baseline b)
+        (declare (ignore failures))
+        (is-true pass)))))
+
+(test check-perf-stampless-report-refused
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+          (c (%pc-write-report d "cand" :host nil
+                               :entries *pc-base-entries*)))
+      (signals error (graph-db/perf-test:check-perf c :baseline b)))))
+
+(test check-perf-generation-mismatch-refused
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :gen (1- *pc-gen*)
+                               :entries *pc-base-entries*))
+          (c (%pc-write-report d "cand" :entries *pc-base-entries*)))
+      (signals error (graph-db/perf-test:check-perf c :baseline b)))))
+
+(test check-perf-host-mismatch-refused
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :host "other-host"
+                               :entries *pc-base-entries*))
+          (c (%pc-write-report d "cand" :entries *pc-base-entries*)))
+      (signals error (graph-db/perf-test:check-perf c :baseline b)))))
+
+(test check-perf-scale-mismatch-refused
+  (with-temp-directory (d)
+    (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+          (c (%pc-write-report d "cand" :scale :small
+                               :entries *pc-base-entries*)))
+      (signals error (graph-db/perf-test:check-perf c :baseline b)))))
+
+(test check-perf-per-label-override
+  ;; A 25% drop on a label with a 30% override passes; the same drop on
+  ;; an un-overridden label fails.
+  (with-temp-directory (d)
+    (let* ((base '(("noisy-bench" :ops 100 :seconds 1.0 :ops/s 1000)
+                   ("quiet-bench" :ops 100 :seconds 1.0 :ops/s 1000)))
+           (cand '(("noisy-bench" :ops 100 :seconds 1.0 :ops/s 750)
+                   ("quiet-bench" :ops 100 :seconds 1.0 :ops/s 750)))
+           (graph-db/perf-test:*perf-tolerance-overrides*
+             '(("noisy-bench" . 0.30)))
+           (b (%pc-write-report d "base" :entries base))
+           (c (%pc-write-report d "cand" :entries cand)))
+      (multiple-value-bind (pass failures)
+          (graph-db/perf-test:check-perf c :baseline b)
+        (is-false pass)
+        (is (= 1 (length failures)))
+        (is (equal "quiet-bench" (first (first failures))))))))
+
+(test check-perf-error-p-signals
+  (with-temp-directory (d)
+    (let* ((cand (copy-tree *pc-base-entries*))
+           (row (assoc "insert-vertices" cand :test #'equal)))
+      (setf (getf (cdr row) :ops/s) 100)
+      (let ((b (%pc-write-report d "base" :entries *pc-base-entries*))
+            (c (%pc-write-report d "cand" :entries cand)))
+        (signals graph-db/perf-test:perf-regression-error
+          (graph-db/perf-test:check-perf c :baseline b :error-p t))))))
+
+(test bless-refuses-wrong-generation-and-scale
+  ;; Baseline dir bound to scratch so even a broken refusal cannot
+  ;; strand a file in the source tree.
+  (with-temp-directory (d)
+    (let ((graph-db/perf-test::*perf-results-directory* d)
+          (old (%pc-write-report d "old" :gen (1- *pc-gen*)
+                                 :entries *pc-base-entries*))
+          (small (%pc-write-report d "small" :scale :small
+                                   :entries *pc-base-entries*)))
+      (signals error (graph-db/perf-test:bless-perf-baseline old))
+      (signals error (graph-db/perf-test:bless-perf-baseline small)))))
+
+(test bless-writes-sanitized-baseline
+  (with-temp-directory (d)
+    (let* ((graph-db/perf-test::*perf-results-directory* d)
+           (r (%pc-write-report d "good" :host "Test_Host.9"
+                                :entries *pc-base-entries*))
+           (target (graph-db/perf-test:bless-perf-baseline r)))
+      (is (equal (format nil "baseline-test-host-9-g~D" *pc-gen*)
+                 (pathname-name target)))
+      (is-true (probe-file target)))))

--- a/tests/perf/check.lisp
+++ b/tests/perf/check.lisp
@@ -1,0 +1,240 @@
+;;;; Perf regression gating: blessed baselines + check-perf (GH #253).
+;;;;
+;;;; Baselines are per-host AND per-suite-generation artifacts (the 3.0
+;;;; A/B rule: never compare across either).  A blessed baseline lives in
+;;;; tests/perf/results/baseline-<host>-g<generation>.report and is
+;;;; committed via a reviewed diff, never automatically.
+
+(in-package #:graph-db/perf-test)
+
+(defparameter *perf-tolerance* 0.15
+  "Default allowed regression fraction per metric (GH #253).  Generous on
+purpose; tighten per-label as variance.py data accumulates.")
+
+(defparameter *perf-tolerance-overrides*
+  ;; v5scan f0/f10 rows swing ~17-20% run-to-run at :normal scale (the
+  ;; GH #244 evidence table + this branch's bless/check runs); widen
+  ;; those alone rather than the global band.  f50 rows are calm.
+  '(("v5scan-f0-s1" . 0.30)
+    ("v5scan-f0-s2" . 0.30)
+    ("v5scan-f0-s4" . 0.30)
+    ("v5scan-f0-s8" . 0.30)
+    ("v5scan-f10-s1" . 0.30)
+    ("v5scan-f10-s2" . 0.30)
+    ("v5scan-f10-s4" . 0.30)
+    ("v5scan-f10-s8" . 0.30))
+  "Alist of (label . tolerance) for known-noisy benches.  An entry here
+takes precedence over CHECK-PERF's :TOLERANCE argument for its label.")
+
+(defun label-tolerance (label &optional (default *perf-tolerance*))
+  (or (cdr (assoc label *perf-tolerance-overrides* :test #'equal))
+      default))
+
+;;; ---------------------------------------------------------------------------
+;;; Metric classes
+;;; ---------------------------------------------------------------------------
+
+(defparameter +metric-preference+ '(:us/commit :us/edge :ops/s :bytes :seconds)
+  "Comparable metric keys, most preferred first.")
+
+(defparameter *perf-primary-metric-overrides*
+  ;; index-fullscan-eq records ~4 ops/s: one integer step is 25%, pure
+  ;; quantization noise.  Gate its :seconds instead.
+  '(("index-fullscan-eq" . :seconds))
+  "Alist of (label . metric) forcing the compared metric for a label.")
+
+(defun primary-metric (plist)
+  "The most preferred metric key PLIST records, or NIL."
+  (find-if (lambda (m) (getf plist m)) +metric-preference+))
+
+(defun comparison-metric (label bplist cplist)
+  "The metric CHECK-PERF compares for LABEL: the per-label override or
+the baseline's primary metric, falling back down +METRIC-PREFERENCE+ to
+the first key BOTH rows record with a nonzero numeric baseline value.
+NIL if no such key is shared.  Latency metrics outrank :ops/s (matches
+the units the #237/#244 evidence tables were argued in); either
+direction is monotone-equivalent."
+  (let ((primary (or (cdr (assoc label *perf-primary-metric-overrides*
+                                 :test #'equal))
+                     (primary-metric bplist))))
+    (when primary
+      (loop for m in (cons primary (remove primary +metric-preference+))
+            for bv = (getf bplist m)
+            for cv = (getf cplist m)
+            when (and (numberp bv) (not (zerop bv)) (numberp cv))
+              do (return m)))))
+
+(defun metric-regression (metric baseline current)
+  "Signed regression fraction: positive = worse.  :ops/s regresses on a
+drop; latency/bytes metrics regress on a rise."
+  (if (eq metric :ops/s)
+      (/ (- baseline current) baseline)
+      (/ (- current baseline) baseline)))
+
+;;; ---------------------------------------------------------------------------
+;;; Baseline convention + blessing
+;;; ---------------------------------------------------------------------------
+
+(defparameter *perf-results-directory* nil
+  "Override for the baseline directory (tests bind it to scratch);
+NIL = tests/perf/results/ in the source tree.")
+
+(defun results-directory ()
+  (or *perf-results-directory*
+      (asdf:system-relative-pathname :graph-db "tests/perf/results/")))
+
+(defun sanitize-host (name)
+  "Lowercase NAME, [a-z0-9-] only."
+  (string-downcase
+   (substitute-if #\- (lambda (c) (not (or (alphanumericp c) (char= c #\-))))
+                  name)))
+
+(defun baseline-pathname (host generation)
+  (merge-pathnames (format nil "baseline-~A-g~D.report"
+                           (sanitize-host host) generation)
+                   (results-directory)))
+
+(defun report-meta (report key) (getf (cdr report) key))
+
+(defun bless-perf-baseline (report-file)
+  "Copy REPORT-FILE to the blessed baseline path for its host + the
+CURRENT suite generation.  Refuses a wrong-generation or non-:normal
+report.  The copy is deliberate state: commit it via a reviewed diff."
+  (let* ((report (read-perf-report report-file))
+         (gen (report-meta report :generation))
+         (host (report-meta report :host))
+         (scale (report-meta report :scale)))
+    (unless report
+      (error "~A is not a perf report file." report-file))
+    (unless (eql gen *perf-suite-generation*)
+      (error "Refusing to bless ~A: report generation ~S /= current ~S."
+             report-file gen *perf-suite-generation*))
+    (unless host
+      (error "Refusing to bless ~A: no host stamp (pre-generation report)."
+             report-file))
+    (unless (eq scale :normal)
+      (error "Refusing to bless ~A: scale ~S; baselines are :normal only."
+             report-file scale))
+    (let ((target (baseline-pathname host gen)))
+      (uiop:copy-file report-file target)
+      (format t "~&Blessed baseline: ~A~%" target)
+      (format t "~&Reminder: a blessed baseline is a reviewed diff -- ~
+                 commit it deliberately.~%")
+      target)))
+
+;;; ---------------------------------------------------------------------------
+;;; check-perf
+;;; ---------------------------------------------------------------------------
+
+(define-condition perf-regression-error (error)
+  ((failures :initarg :failures :reader perf-regression-failures))
+  (:report (lambda (c s)
+             (format s "check-perf: ~D metric~:P regressed past tolerance."
+                     (length (perf-regression-failures c))))))
+
+(defun %require-comparable (base cand baseline-path report-path)
+  "Signal unless BASE and CAND share generation, host and scale.  Always
+an error -- comparing incomparable reports is a setup mistake, not a perf
+result."
+  (flet ((need (key)
+           (let ((b (report-meta base key)) (c (report-meta cand key)))
+             (unless (equalp b c)
+               (error "check-perf: ~(~A~) mismatch: baseline ~A has ~S, ~
+                       report ~A has ~S.  Baselines are per-host, ~
+                       per-generation, per-scale artifacts."
+                      key baseline-path b report-path c)))))
+    (need :generation)
+    (need :host)
+    (need :scale)))
+
+(defun %fail-row (label key status)
+  (format t "~&~38A ~10A ~12A ~12A ~9A ~6A ~A~%"
+          label key "-" "-" "-" "-" status))
+
+(defun check-perf (report-file &key baseline (tolerance *perf-tolerance*)
+                                    error-p)
+  "Compare REPORT-FILE against the blessed baseline for its host and
+generation (or an explicit :BASELINE file).  Returns (values pass-p
+failures); failures = list of (label metric baseline current pct).  A
+label present in the baseline but missing from the report fails with
+metric :MISSING; a label whose shared comparable metrics all vanished
+fails with :METRIC-VANISHED.  New unbaselined labels are reported, not
+failed.  :TOLERANCE replaces the 15% default; *PERF-TOLERANCE-OVERRIDES*
+entries take precedence over it per label.  Never signals on regression
+unless :ERROR-P is true; incomparable reports (host/generation/scale
+mismatch, or a stampless pre-#253 report) always signal."
+  (let ((cand (read-perf-report report-file)))
+    (unless cand
+      (error "~A is not a perf report file." report-file))
+    (unless (and (report-meta cand :generation) (report-meta cand :host))
+      (error "check-perf: ~A lacks generation/host stamps (pre-#253 report ~
+              format).  Re-run run-perf on current sources." report-file))
+    (let ((bpath (or baseline
+                     (baseline-pathname (report-meta cand :host)
+                                        (report-meta cand :generation)))))
+      (unless (probe-file bpath)
+        (error "check-perf: no blessed baseline at ~A.  Run run-perf at ~
+                :normal on this host and bless-perf-baseline the report."
+               bpath))
+      (let ((base (read-perf-report bpath)))
+        (%require-comparable base cand bpath report-file)
+        (let ((be (getf (cdr base) :entries))
+              (ce (getf (cdr cand) :entries))
+              (failures '())
+              (new-labels '()))
+          (format t "~&=== check-perf: ~A  vs baseline ~A ===~%"
+                  (report-meta cand :tag) (report-meta base :tag))
+          (format t "~&~38A ~10A ~12A ~12A ~9A ~6A ~A~%"
+                  "metric" "key" "baseline" "current" "regress%" "tol%"
+                  "status")
+          (format t "~&(regress% is signed toward worse: a drop for ~
+                     ops/s, a rise for us/*, bytes, seconds)~%")
+          (dolist (b be)
+            (let* ((label (car b))
+                   (c (assoc label ce :test #'equal))
+                   (tol (label-tolerance label tolerance)))
+              (cond
+                ((null c)
+                 (push (list label :missing nil nil nil) failures)
+                 (%fail-row label :missing "FAIL (bench vanished)"))
+                ;; baseline row records nothing comparable: nothing to gate
+                ((null (primary-metric (cdr b))))
+                (t
+                 (let ((metric (comparison-metric label (cdr b) (cdr c))))
+                   (if (null metric)
+                       (progn
+                         (push (list label :metric-vanished
+                                     (primary-metric (cdr b)) nil nil)
+                               failures)
+                         (%fail-row label :vanished
+                                    "FAIL (no shared metric)"))
+                       (let* ((bv (getf (cdr b) metric))
+                              (cv (getf (cdr c) metric))
+                              (reg (metric-regression metric bv cv))
+                              (bad (> reg tol)))
+                         (when bad
+                           (push (list label metric bv cv (* 100.0 reg))
+                                 failures))
+                         (format t "~&~38A ~10A ~12A ~12A ~8,1F% ~5D% ~A~%"
+                                 label metric bv cv (* 100.0 reg)
+                                 (round (* 100 tol))
+                                 (if bad "FAIL" "ok")))))))))
+          (dolist (c ce)
+            (unless (assoc (car c) be :test #'equal)
+              (push (car c) new-labels)
+              (format t "~&~38A ~10A ~12A ~12A ~9A ~6A ~A~%"
+                      (car c) (or (primary-metric (cdr c)) "-") "-"
+                      (let ((m (primary-metric (cdr c))))
+                        (if m (getf (cdr c) m) "-"))
+                      "-" "-" "new, unbaselined")))
+          (setf failures (nreverse failures))
+          (if failures
+              (format t "~&=== check-perf: FAIL (~D regression~:P)"
+                      (length failures))
+              (format t "~&=== check-perf: PASS"))
+          (when new-labels
+            (format t "; ~D new unbaselined label~:P" (length new-labels)))
+          (format t " ===~%")
+          (when (and error-p failures)
+            (error 'perf-regression-error :failures failures))
+          (values (null failures) failures))))))

--- a/tests/perf/package.lisp
+++ b/tests/perf/package.lisp
@@ -46,4 +46,13 @@
   (:export #:run-perf
            #:compare-perf
            #:perf-suite              ; alias entry point used by the headless driver
-           #:*perf-scale*))
+           #:*perf-scale*
+           ;; regression gating (GH #253)
+           #:*perf-suite-generation*
+           #:*perf-tolerance*
+           #:*perf-tolerance-overrides*
+           #:*perf-primary-metric-overrides*
+           #:write-perf-report
+           #:bless-perf-baseline
+           #:check-perf
+           #:perf-regression-error))

--- a/tests/perf/results/baseline-odm-g4.report
+++ b/tests/perf/results/baseline-odm-g4.report
@@ -1,0 +1,108 @@
+;;;; graph-db perf report
+;;;; tag=run1 impl=SBCL 2.6.6 scale=NORMAL generation=4 host=odm
+
+;; insert-vertices                        OPS 20000  SECONDS 3.765  OPS/S 5312  
+;; lookup-by-id                           OPS 20000  SECONDS 0.888  OPS/S 22521  
+;; scan-vertices                          OPS 20000  SECONDS 0.531  OPS/S 37661  
+;; update-vertices                        OPS 20000  SECONDS 1.725  OPS/S 11593  
+;; delete-vertices                        OPS 10000  SECONDS 0.714  OPS/S 14004  
+;; insert-edges                           OPS 20000  SECONDS 6.448  OPS/S 3102  
+;; scan-edges                             OPS 20000  SECONDS 1.699  OPS/S 11771  
+;; view-lookup                            OPS 20000  SECONDS 0.94  OPS/S 21275  
+;; unique-insert                          OPS 20000  SECONDS 4.983  OPS/S 4013  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.473  OPS/S 5758  
+;; indexed-insert                         OPS 20000  SECONDS 4.676  OPS/S 4277  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.867  OPS/S 23066  
+;; index-range-1pct                       OPS 2000  SECONDS 6.655  OPS/S 301  
+;; index-fullscan-eq                      OPS 200  SECONDS 54.822  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.168  OPS/S 59519  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.383  OPS/S 13054  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.714  OPS/S 7002  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 3.408  OPS/S 1467  
+;; concurrent-rw                          OPS 32000  SECONDS 26.066  OPS/S 1228  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3361034  PER-OP 168  
+;; snapshot                               SECONDS 1.746  
+;; restore-replay                         SECONDS 4.189  
+;; reopen                                 SECONDS 5.965  
+;; commit-multigraph-n1                   OPS 1000  SECONDS 0.724  OPS/S 1381  US/COMMIT 724.058  
+;; commit-multigraph-n2                   OPS 2000  SECONDS 0.708  OPS/S 2825  US/COMMIT 708.056  
+;; commit-multigraph-n4                   OPS 4000  SECONDS 1.085  OPS/S 3686  US/COMMIT 1085.085  
+;; commit-multigraph-n8                   OPS 8000  SECONDS 6.216  OPS/S 1287  US/COMMIT 6216.487  
+;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.655  OPS/S 12213  US/COMMIT 655.051  
+;; watermark-persist-warm                 OPS 20000  SECONDS 3.886  OPS/S 5146  
+;; watermark-raw-write-warm               OPS 20000  SECONDS 1.291  OPS/S 15491  
+;; v5scan-f0-s1                           OPS 10000  SECONDS 0.416  OPS/S 24037  US/EDGE 41.603  EMITTED 2000  
+;; v5scan-f0-s2                           OPS 10000  SECONDS 0.425  OPS/S 23528  US/EDGE 42.503  EMITTED 2000  
+;; v5scan-f0-s4                           OPS 10000  SECONDS 0.439  OPS/S 22777  US/EDGE 43.904  EMITTED 2000  
+;; v5scan-f0-s8                           OPS 10000  SECONDS 0.506  OPS/S 19761  US/EDGE 50.604  EMITTED 2000  
+;; v5scan-f10-s1                          OPS 10000  SECONDS 0.412  OPS/S 24270  US/EDGE 41.203  EMITTED 1800  
+;; v5scan-f10-s2                          OPS 10000  SECONDS 0.4  OPS/S 24998  US/EDGE 40.003  EMITTED 1800  
+;; v5scan-f10-s4                          OPS 10000  SECONDS 0.432  OPS/S 23146  US/EDGE 43.203  EMITTED 1800  
+;; v5scan-f10-s8                          OPS 10000  SECONDS 0.43  OPS/S 23254  US/EDGE 43.003  EMITTED 1800  
+;; v5scan-f50-s1                          OPS 10000  SECONDS 0.403  OPS/S 24812  US/EDGE 40.303  EMITTED 1000  
+;; v5scan-f50-s2                          OPS 10000  SECONDS 0.51  OPS/S 19606  US/EDGE 51.004  EMITTED 1000  
+;; v5scan-f50-s4                          OPS 10000  SECONDS 0.518  OPS/S 19304  US/EDGE 51.804  EMITTED 1000  
+;; v5scan-f50-s8                          OPS 10000  SECONDS 0.633  OPS/S 15797  US/EDGE 63.305  EMITTED 1000  
+
+(:PERF-REPORT :TAG "run1" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :GENERATION 4 :HOST
+ "odm" :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.765 :OPS/S 5312)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.888 :OPS/S 22521)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.531 :OPS/S 37661)
+  ("update-vertices" :OPS 20000 :SECONDS 1.725 :OPS/S 11593)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.714 :OPS/S 14004)
+  ("insert-edges" :OPS 20000 :SECONDS 6.448 :OPS/S 3102)
+  ("scan-edges" :OPS 20000 :SECONDS 1.699 :OPS/S 11771)
+  ("view-lookup" :OPS 20000 :SECONDS 0.94 :OPS/S 21275)
+  ("unique-insert" :OPS 20000 :SECONDS 4.983 :OPS/S 4013)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.473 :OPS/S 5758)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.676 :OPS/S 4277)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.867 :OPS/S 23066)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.655 :OPS/S 301)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 54.822 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.168 :OPS/S 59519)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.383 :OPS/S 13054)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.714 :OPS/S 7002)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 3.408 :OPS/S 1467)
+  ("concurrent-rw" :OPS 32000 :SECONDS 26.066 :OPS/S 1228)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3361034 :PER-OP 168)
+  ("snapshot" :SECONDS 1.746) ("restore-replay" :SECONDS 4.189)
+  ("reopen" :SECONDS 5.965)
+  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.724 :OPS/S 1381 :US/COMMIT
+   724.058)
+  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.708 :OPS/S 2825 :US/COMMIT
+   708.056)
+  ("commit-multigraph-n4" :OPS 4000 :SECONDS 1.085 :OPS/S 3686 :US/COMMIT
+   1085.085)
+  ("commit-multigraph-n8" :OPS 8000 :SECONDS 6.216 :OPS/S 1287 :US/COMMIT
+   6216.487)
+  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.655 :OPS/S 12213
+   :US/COMMIT 655.051)
+  ("watermark-persist-warm" :OPS 20000 :SECONDS 3.886 :OPS/S 5146)
+  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.291 :OPS/S 15491)
+  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.416 :OPS/S 24037 :US/EDGE 41.603
+   :EMITTED 2000)
+  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.425 :OPS/S 23528 :US/EDGE 42.503
+   :EMITTED 2000)
+  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.439 :OPS/S 22777 :US/EDGE 43.904
+   :EMITTED 2000)
+  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.506 :OPS/S 19761 :US/EDGE 50.604
+   :EMITTED 2000)
+  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.412 :OPS/S 24270 :US/EDGE 41.203
+   :EMITTED 1800)
+  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.4 :OPS/S 24998 :US/EDGE 40.003
+   :EMITTED 1800)
+  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.432 :OPS/S 23146 :US/EDGE 43.203
+   :EMITTED 1800)
+  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.43 :OPS/S 23254 :US/EDGE 43.003
+   :EMITTED 1800)
+  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.403 :OPS/S 24812 :US/EDGE 40.303
+   :EMITTED 1000)
+  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.51 :OPS/S 19606 :US/EDGE 51.004
+   :EMITTED 1000)
+  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.518 :OPS/S 19304 :US/EDGE 51.804
+   :EMITTED 1000)
+  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.633 :OPS/S 15797 :US/EDGE 63.305
+   :EMITTED 1000)))

--- a/tests/perf/suite.lisp
+++ b/tests/perf/suite.lisp
@@ -22,6 +22,18 @@
 (defparameter *lisp-impl*
   (format nil "~A ~A" (lisp-implementation-type) (lisp-implementation-version)))
 
+(defparameter *perf-suite-generation* 4
+  "Suite generation for baseline comparability (GH #253).  Bump when any
+change alters an existing bench's work or its labels; adding a new bench
+does not bump.  Generations 1-3 retroactively cover the pre-#252 report
+eras still visible in results/ (2.1.1 / 3.0 A-B / mvcc phase runs).")
+
+(defun perf-host ()
+  "Sanitized (machine-instance): lowercase, [a-z0-9-] only."
+  (string-downcase
+   (substitute-if #\- (lambda (c) (not (or (alphanumericp c) (char= c #\-))))
+                  (machine-instance))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Report collection
 ;;; ---------------------------------------------------------------------------
@@ -161,11 +173,13 @@ MVCC-relevant signal).  If :DIR is given, bind it to the graph's temp dir."
     (with-open-file (s path :direction :output :if-exists :supersede
                             :if-does-not-exist :create)
       (format s ";;;; graph-db perf report~%")
-      (format s ";;;; tag=~A impl=~A scale=~A~%~%" tag *lisp-impl* *perf-scale*)
+      (format s ";;;; tag=~A impl=~A scale=~A generation=~D host=~A~%~%"
+              tag *lisp-impl* *perf-scale* *perf-suite-generation* (perf-host))
       (dolist (e entries)
         (format s ";; ~38A ~{~A ~A  ~}~%" (car e) (cdr e)))
       (format s "~%~S~%"
               (list :perf-report :tag tag :impl *lisp-impl* :scale *perf-scale*
+                    :generation *perf-suite-generation* :host (perf-host)
                     :entries entries)))
     (format t "~&~%Wrote perf report: ~A~%" path)
     path))


### PR DESCRIPTION
Unit 2 of the perf-suite expansion (tracker #256). Fixes #253.

## What changed

- **Suite generation + host stamps** on every perf report (`*perf-suite-generation*` = 4, with the bump rule in its docstring; generations 1–3 retroactively cover the historical report eras in `results/`). `compare-perf` still reads old files.
- **`bless-perf-baseline`**: copies a `:normal` report to the committed per-host/per-generation baseline (`tests/perf/results/baseline-<host>-g<gen>.report`), refusing wrong-generation, stampless, or non-`:normal` input, with sanitized host naming. Blessing is deliberately a reviewed-diff act — and this PR *is* the first one: **`baseline-odm-g4.report`** (43 labels, SBCL 2.6.6) is included.
- **`check-perf`**: finds the blessed baseline for the report's own host + generation (explicit `:baseline` override available), **refuses** host/generation/scale mismatches — the never-compare-across rule from the 3.0 A/B, now enforced in code rather than remembered. Comparison is regression-positive per metric class (throughput drop / latency-bytes-seconds rise), 15% default tolerance with per-label overrides for the empirically-noisy `v5scan` f0/f10 rows, a per-label primary-metric override giving quantized `index-fullscan-eq` a `:seconds` gate, missing-label = failure, and — the review-caught hole — a row whose shared comparable metrics vanished fails as `:metric-vanished` instead of silently skipping (the fallback walks the preference order over metrics both rows record; the reviewer's 100×-collapse probe now fails, pinned by test). New labels report as "unbaselined". Measurement-only stays the default; `:error-p t` opts into `perf-regression-error` for gating callers.
- **19 fabricated-report tests** pin every metric class in both directions plus all refusal paths, registered into `graph-db/test` (the perf system is a load-only dependency — no benchmark ever runs in the suite).
- **`docs/perf-baselines.md`** carries the full ritual, including the pre-release check-perf step and re-blessing discipline; CLAUDE.md points at it.

**Live proof:** run 2 checked against the blessed run-1 baseline passes all 43 labels; the worst rows are exactly the pre-identified noisy cells sitting inside their per-label overrides, vindicating per-label (not global) widening.

## Method & verification

Implementer → adversarial review (NEEDS-FIXES: the silent false-PASS on vanished metrics; direction logic itself verified correct in all four classes empirically) → fix round (fallback + `:metric-vanished`, both-direction pins for every class, stampless refusal clarity, sanitized bless paths, scratch-redirected bless tests, `regress%` header) → scoped re-review APPROVE with the fallback attack-tested (it gates the most-preferred *shared* metric, so a collapse cannot hide behind flat seconds).

**Gate: fresh-image `(asdf:test-system :graph-db)` on SBCL (source-registry pinned): 4,968 checks, Pass 4,958, Skip 10 (pre-existing GEOS environmental), Fail 0** — the full suite, since this unit registered tests into `graph-db/test`. ECL skipped per the standing demotion directive.

Fixes #253. Refs #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp