### PR TITLE
Release-baseline measurement record: v2.1.1 / v3.0.0 / experiment (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **Release-baseline measurement record** (#263). Three-tree perf
+  measurement (v2.1.1 / v3.0.0 / experiment, each running its own
+  suite; comparison over the byte-identical-verified intersection) on
+  one host, medians of three interleaved runs: reads/scans/queries
+  flat-to-better since 3.0.0, commit-heavy cells regressed 14-34% —
+  the #177 watermark cost, corroborating #237's fix. Raw reports and
+  the dated comparison live in `tests/perf/results/release-*` and
+  `release-comparison-2026-08-27.md`.
+
 - **Perf regression detection** (#253). Perf reports are now stamped
   with a suite generation (`*perf-suite-generation*`) and a sanitized
   host name; `bless-perf-baseline` copies a `:normal`-scale report to

--- a/tests/perf/results/release-comparison-2026-08-27.md
+++ b/tests/perf/results/release-comparison-2026-08-27.md
@@ -1,0 +1,82 @@
+# Release-baseline comparison: v2.1.1 / v3.0.0 / experiment (GH #263)
+
+Date 2026-08-27. Host `odm`, SBCL 2.6.6, fresh image per run, three
+`:normal` runs per tree, **round-robin interleaved** (v2.1.1 → v3.0.0 →
+experiment, ×3) so host-state drift spreads fairly. Each tree ran **its
+own** `tests/perf/` suite (the intersection method — see #263): trees
+at `v2.1.1` (18 labels), `v3.0.0` (24), `experiment@85496c3` (58).
+Every intersecting bench implementation was verified **byte-identical**
+across the three tags before the runs (Phase-0 survey on #263), with
+one exception, `reopen`, noted below. Values are medians of three;
+raw reports: `release-*-odm-r{1,2,3}.report` alongside this file.
+
+This is a dated judgment document over a verified intersection — NOT a
+`check-perf` gate. The never-compare-across-generations rule stands;
+this exercise defines its comparable subset explicitly.
+
+## Headline: experiment vs v3.0.0 (24-label intersection)
+
+Reads, scans, queries and index operations are flat to slightly better
+(±5%). **The commit-heavy cells regressed**, and the cause is known:
+
+| label | v3.0.0 | experiment | delta | note |
+|---|---|---|---|---|
+| commit-per-op-Ntxn (ops/s) | 1933 | 1272 | **−34.2%** | low variance; real |
+| concurrent-rw (ops/s) | 1520 | 1007 | **−33.8%** | real |
+| restore-replay (s) | 3.815 | 4.636 | **−21.5%** | real |
+| snapshot (s) | 1.726 | 1.966 | −13.9% | plausible, cause unconfirmed |
+| commit-batched-1txn (ops/s) | 6587 | 5688 | −13.6% | CV >10%, read with care |
+
+Attribution: #177 (landed post-3.0.0, PR #236) made
+`persist-highest-transaction-id` monotonic — a read + conditional
+write per commit under the process-global watermark lock. The #252
+microbenchmarks measured the isolated cost at ~120 µs/commit and the
+8-graph convoy at ~89% of commit latency; these release numbers are
+the same fingerprint in the wild (per-op commits, threaded r/w on one
+graph, and replay applying transactions one by one). **#237's fix
+(cached watermark + per-graph lock) is corroborated and elevated.**
+The `bench-multigraph-commit` control cell will measure the recovery
+when it lands.
+
+Everything else in the 24-label set (full table in the #263 comment):
+insert/scan/update/delete vertices, insert/scan edges, both prolog
+cells, all four index cells, both unique cells, the heap-bytes cells
+(byte-identical values), and `reopen` sit between −10% and +9%, most
+within ±5%. `lookup-by-id` measured −9.8% but its CV was 36–53% on
+ALL THREE trees this day — that cell's number is noise, not signal.
+
+## Three-way (18-label intersection)
+
+The published 3.0-vs-2.1.1 result reconfirms on this host at the same
+magnitudes: v3.0.0 over v2.1.1 ranges +13.8% (prolog-edge-join) to
++535% (update-vertices), `reopen` +71.5%. experiment over v2.1.1
+remains strongly positive everywhere (+14% to +539%) EXCEPT
+`commit-per-op-Ntxn` (+30.1%, eroded from +97.6% by the #237 cost)
+and `concurrent-rw` (−13.6%, inverted by it).
+
+## Caveats
+
+- **`reopen`** is the one EQUIVALENT-BUT-CHANGED label: its timed
+  region includes `update-schema` over the perf schema, which has 2
+  types at v2.1.1, 4 at v3.0.0, 5 at experiment — a small bias
+  *against* the newer trees. Recorded since the original A/B
+  (commit 72a07f7's note); the +2.7%/+71.5% readings above carry it.
+- **Same-day noise**: `lookup-by-id` (CV up to 53%) is excluded from
+  interpretation; other CV>10% cells are flagged in the #263 variance
+  data. Contended cells (`commit-batched-1txn`, the head-only
+  multigraph/clock-contended cells) wobble as their tolerance
+  overrides already record.
+- v2.1.1's suite has an unseeded-random scratch hazard: its runs were
+  strictly sequential with an isolated TMPDIR.
+
+## Reproducing
+
+Per tree: check out the tag in a worktree, pin ASDF with
+`(:source-registry (:directory <tree-root>) :inherit-configuration)`
+(the `:tree` form is ambiguous from the main checkout — it sees the
+release worktrees' `.asd`s), verify `system-source-directory`, run
+`(graph-db/perf-test:run-perf :tag ...)` under
+`--dynamic-space-size 16384` with an isolated TMPDIR, three fresh
+images, interleaved across trees. Compare with `compare-perf` (reads
+all report eras); `check-perf` correctly refuses cross-generation
+input.

--- a/tests/perf/results/release-experiment-85496c3-odm-r1.report
+++ b/tests/perf/results/release-experiment-85496c3-odm-r1.report
@@ -1,0 +1,138 @@
+;;;; graph-db perf report
+;;;; tag=rel-head-r1 impl=SBCL 2.6.6 scale=NORMAL generation=4 host=odm
+
+;; insert-vertices                        OPS 20000  SECONDS 3.005  OPS/S 6655  
+;; lookup-by-id                           OPS 20000  SECONDS 0.354  OPS/S 56494  
+;; scan-vertices                          OPS 20000  SECONDS 0.509  OPS/S 39291  
+;; update-vertices                        OPS 20000  SECONDS 1.671  OPS/S 11968  
+;; delete-vertices                        OPS 10000  SECONDS 0.707  OPS/S 14144  
+;; insert-edges                           OPS 20000  SECONDS 6.196  OPS/S 3228  
+;; scan-edges                             OPS 20000  SECONDS 1.517  OPS/S 13183  
+;; view-lookup                            OPS 20000  SECONDS 1.08  OPS/S 18518  
+;; unique-insert                          OPS 20000  SECONDS 4.92  OPS/S 4065  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.556  OPS/S 5624  
+;; indexed-insert                         OPS 20000  SECONDS 4.62  OPS/S 4329  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.846  OPS/S 23639  
+;; index-range-1pct                       OPS 2000  SECONDS 6.923  OPS/S 289  
+;; index-fullscan-eq                      OPS 200  SECONDS 55.911  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.154  OPS/S 64932  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.326  OPS/S 15337  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.879  OPS/S 5688  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 3.995  OPS/S 1251  
+;; concurrent-rw                          OPS 32000  SECONDS 31.415  OPS/S 1019  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3361034  PER-OP 168  
+;; snapshot                               SECONDS 1.979  
+;; restore-replay                         SECONDS 4.615  
+;; reopen                                 SECONDS 5.569  
+;; commit-multigraph-n1                   OPS 1000  SECONDS 0.862  OPS/S 1160  US/COMMIT 862.045  
+;; commit-multigraph-n2                   OPS 2000  SECONDS 0.794  OPS/S 2519  US/COMMIT 794.04  
+;; commit-multigraph-n4                   OPS 4000  SECONDS 2.473  OPS/S 1617  US/COMMIT 2473.128  
+;; commit-multigraph-n8                   OPS 8000  SECONDS 8.26  OPS/S 968  US/COMMIT 8260.43  
+;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.735  OPS/S 10884  US/COMMIT 735.04  
+;; watermark-persist-warm                 OPS 20000  SECONDS 5.695  OPS/S 3512  
+;; watermark-raw-write-warm               OPS 20000  SECONDS 1.596  OPS/S 12531  
+;; v5scan-f0-s1                           OPS 10000  SECONDS 0.44  OPS/S 22726  US/EDGE 44.002  EMITTED 2000  
+;; v5scan-f0-s2                           OPS 10000  SECONDS 0.427  OPS/S 23418  US/EDGE 42.702  EMITTED 2000  
+;; v5scan-f0-s4                           OPS 10000  SECONDS 0.414  OPS/S 24153  US/EDGE 41.402  EMITTED 2000  
+;; v5scan-f0-s8                           OPS 10000  SECONDS 0.405  OPS/S 24690  US/EDGE 40.502  EMITTED 2000  
+;; v5scan-f10-s1                          OPS 10000  SECONDS 0.487  OPS/S 20533  US/EDGE 48.703  EMITTED 1800  
+;; v5scan-f10-s2                          OPS 10000  SECONDS 0.534  OPS/S 18726  US/EDGE 53.403  EMITTED 1800  
+;; v5scan-f10-s4                          OPS 10000  SECONDS 0.443  OPS/S 22572  US/EDGE 44.302  EMITTED 1800  
+;; v5scan-f10-s8                          OPS 10000  SECONDS 0.479  OPS/S 20876  US/EDGE 47.903  EMITTED 1800  
+;; v5scan-f50-s1                          OPS 10000  SECONDS 0.399  OPS/S 25061  US/EDGE 39.902  EMITTED 1000  
+;; v5scan-f50-s2                          OPS 10000  SECONDS 0.462  OPS/S 21644  US/EDGE 46.202  EMITTED 1000  
+;; v5scan-f50-s4                          OPS 10000  SECONDS 0.532  OPS/S 18796  US/EDGE 53.203  EMITTED 1000  
+;; v5scan-f50-s8                          OPS 10000  SECONDS 0.674  OPS/S 14836  US/EDGE 67.403  EMITTED 1000  
+;; clock-commit-local                     OPS 2000  SECONDS 1.61  OPS/S 1242  US/COMMIT 805.042  
+;; clock-commit-clocked                   OPS 2000  SECONDS 1.619  OPS/S 1235  US/COMMIT 809.542  
+;; clock-epoch-alloc                      OPS 50000  SECONDS 0.005  OPS/S 9998000  
+;; clock-attach                           OPS 100  SECONDS 0.02  OPS/S 5000  
+;; clock-epoch-alloc-contended            OPS 20000  SECONDS 0.014  OPS/S 1428571  
+;; memory-open-rebuild                    SECONDS 1.316  
+;; memory-checkpoint                      SECONDS 0.231  
+;; memory-open-image-restore              SECONDS 0.501  
+;; compact-conservative                   SECONDS 1.172  COMPACTED 600  
+;; compact-trust-tags                     SECONDS 1.357  COMPACTED 800  
+;; peer-export-scope                      OPS 3601  SECONDS 0.359  OPS/S 10030  
+;; peer-apply                             OPS 3601  SECONDS 3.955  OPS/S 910  
+;; vector-insert                          OPS 5000  SECONDS 1.638  OPS/S 3052  
+;; vector-knn-k10                         OPS 200  SECONDS 1.238  OPS/S 162  
+;; vector-knn-k10-20k                     OPS 100  SECONDS 2.345  OPS/S 43  
+
+(:PERF-REPORT :TAG "rel-head-r1" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :GENERATION
+ 4 :HOST "odm" :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.005 :OPS/S 6655)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.354 :OPS/S 56494)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.509 :OPS/S 39291)
+  ("update-vertices" :OPS 20000 :SECONDS 1.671 :OPS/S 11968)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.707 :OPS/S 14144)
+  ("insert-edges" :OPS 20000 :SECONDS 6.196 :OPS/S 3228)
+  ("scan-edges" :OPS 20000 :SECONDS 1.517 :OPS/S 13183)
+  ("view-lookup" :OPS 20000 :SECONDS 1.08 :OPS/S 18518)
+  ("unique-insert" :OPS 20000 :SECONDS 4.92 :OPS/S 4065)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.556 :OPS/S 5624)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.62 :OPS/S 4329)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.846 :OPS/S 23639)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.923 :OPS/S 289)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 55.911 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.154 :OPS/S 64932)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.326 :OPS/S 15337)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.879 :OPS/S 5688)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 3.995 :OPS/S 1251)
+  ("concurrent-rw" :OPS 32000 :SECONDS 31.415 :OPS/S 1019)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3361034 :PER-OP 168)
+  ("snapshot" :SECONDS 1.979) ("restore-replay" :SECONDS 4.615)
+  ("reopen" :SECONDS 5.569)
+  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.862 :OPS/S 1160 :US/COMMIT
+   862.045)
+  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.794 :OPS/S 2519 :US/COMMIT
+   794.04)
+  ("commit-multigraph-n4" :OPS 4000 :SECONDS 2.473 :OPS/S 1617 :US/COMMIT
+   2473.128)
+  ("commit-multigraph-n8" :OPS 8000 :SECONDS 8.26 :OPS/S 968 :US/COMMIT
+   8260.43)
+  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.735 :OPS/S 10884
+   :US/COMMIT 735.04)
+  ("watermark-persist-warm" :OPS 20000 :SECONDS 5.695 :OPS/S 3512)
+  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.596 :OPS/S 12531)
+  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.44 :OPS/S 22726 :US/EDGE 44.002
+   :EMITTED 2000)
+  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.427 :OPS/S 23418 :US/EDGE 42.702
+   :EMITTED 2000)
+  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.414 :OPS/S 24153 :US/EDGE 41.402
+   :EMITTED 2000)
+  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.405 :OPS/S 24690 :US/EDGE 40.502
+   :EMITTED 2000)
+  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.487 :OPS/S 20533 :US/EDGE 48.703
+   :EMITTED 1800)
+  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.534 :OPS/S 18726 :US/EDGE 53.403
+   :EMITTED 1800)
+  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.443 :OPS/S 22572 :US/EDGE 44.302
+   :EMITTED 1800)
+  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.479 :OPS/S 20876 :US/EDGE 47.903
+   :EMITTED 1800)
+  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.399 :OPS/S 25061 :US/EDGE 39.902
+   :EMITTED 1000)
+  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.462 :OPS/S 21644 :US/EDGE 46.202
+   :EMITTED 1000)
+  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.532 :OPS/S 18796 :US/EDGE 53.203
+   :EMITTED 1000)
+  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.674 :OPS/S 14836 :US/EDGE 67.403
+   :EMITTED 1000)
+  ("clock-commit-local" :OPS 2000 :SECONDS 1.61 :OPS/S 1242 :US/COMMIT 805.042)
+  ("clock-commit-clocked" :OPS 2000 :SECONDS 1.619 :OPS/S 1235 :US/COMMIT
+   809.542)
+  ("clock-epoch-alloc" :OPS 50000 :SECONDS 0.005 :OPS/S 9998000)
+  ("clock-attach" :OPS 100 :SECONDS 0.02 :OPS/S 5000)
+  ("clock-epoch-alloc-contended" :OPS 20000 :SECONDS 0.014 :OPS/S 1428571)
+  ("memory-open-rebuild" :SECONDS 1.316) ("memory-checkpoint" :SECONDS 0.231)
+  ("memory-open-image-restore" :SECONDS 0.501)
+  ("compact-conservative" :SECONDS 1.172 :COMPACTED 600)
+  ("compact-trust-tags" :SECONDS 1.357 :COMPACTED 800)
+  ("peer-export-scope" :OPS 3601 :SECONDS 0.359 :OPS/S 10030)
+  ("peer-apply" :OPS 3601 :SECONDS 3.955 :OPS/S 910)
+  ("vector-insert" :OPS 5000 :SECONDS 1.638 :OPS/S 3052)
+  ("vector-knn-k10" :OPS 200 :SECONDS 1.238 :OPS/S 162)
+  ("vector-knn-k10-20k" :OPS 100 :SECONDS 2.345 :OPS/S 43)))

--- a/tests/perf/results/release-experiment-85496c3-odm-r2.report
+++ b/tests/perf/results/release-experiment-85496c3-odm-r2.report
@@ -1,0 +1,139 @@
+;;;; graph-db perf report
+;;;; tag=rel-head-r2 impl=SBCL 2.6.6 scale=NORMAL generation=4 host=odm
+
+;; insert-vertices                        OPS 20000  SECONDS 3.944  OPS/S 5071  
+;; lookup-by-id                           OPS 20000  SECONDS 0.925  OPS/S 21620  
+;; scan-vertices                          OPS 20000  SECONDS 0.538  OPS/S 37173  
+;; update-vertices                        OPS 20000  SECONDS 1.664  OPS/S 12019  
+;; delete-vertices                        OPS 10000  SECONDS 0.678  OPS/S 14748  
+;; insert-edges                           OPS 20000  SECONDS 5.795  OPS/S 3451  
+;; scan-edges                             OPS 20000  SECONDS 1.673  OPS/S 11954  
+;; view-lookup                            OPS 20000  SECONDS 0.943  OPS/S 21208  
+;; unique-insert                          OPS 20000  SECONDS 4.811  OPS/S 4157  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.256  OPS/S 6142  
+;; indexed-insert                         OPS 20000  SECONDS 4.647  OPS/S 4304  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.772  OPS/S 25905  
+;; index-range-1pct                       OPS 2000  SECONDS 6.48  OPS/S 309  
+;; index-fullscan-eq                      OPS 200  SECONDS 56.269  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.173  OPS/S 57800  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.357  OPS/S 14005  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.901  OPS/S 5549  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 3.93  OPS/S 1272  
+;; concurrent-rw                          OPS 32000  SECONDS 32.026  OPS/S 999  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3361034  PER-OP 168  
+;; snapshot                               SECONDS 1.966  
+;; restore-replay                         SECONDS 4.712  
+;; reopen                                 SECONDS 5.671  
+;; commit-multigraph-n1                   OPS 1000  SECONDS 0.833  OPS/S 1200  US/COMMIT 833.044  
+;; commit-multigraph-n2                   OPS 2000  SECONDS 0.832  OPS/S 2404  US/COMMIT 832.045  
+;; commit-multigraph-n4                   OPS 4000  SECONDS 3.229  OPS/S 1239  US/COMMIT 3229.168  
+;; commit-multigraph-n8                   OPS 8000  SECONDS 8.338  OPS/S 959  US/COMMIT 8338.434  
+;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.723  OPS/S 11064  US/COMMIT 723.037  
+;; watermark-persist-warm                 OPS 20000  SECONDS 6.002  OPS/S 3332  
+;; watermark-raw-write-warm               OPS 20000  SECONDS 1.435  OPS/S 13937  
+;; v5scan-f0-s1                           OPS 10000  SECONDS 0.47  OPS/S 21275  US/EDGE 47.002  EMITTED 2000  
+;; v5scan-f0-s2                           OPS 10000  SECONDS 0.452  OPS/S 22123  US/EDGE 45.202  EMITTED 2000  
+;; v5scan-f0-s4                           OPS 10000  SECONDS 0.462  OPS/S 21644  US/EDGE 46.202  EMITTED 2000  
+;; v5scan-f0-s8                           OPS 10000  SECONDS 0.464  OPS/S 21551  US/EDGE 46.402  EMITTED 2000  
+;; v5scan-f10-s1                          OPS 10000  SECONDS 0.44  OPS/S 22726  US/EDGE 44.002  EMITTED 1800  
+;; v5scan-f10-s2                          OPS 10000  SECONDS 0.415  OPS/S 24095  US/EDGE 41.502  EMITTED 1800  
+;; v5scan-f10-s4                          OPS 10000  SECONDS 0.456  OPS/S 21929  US/EDGE 45.602  EMITTED 1800  
+;; v5scan-f10-s8                          OPS 10000  SECONDS 0.484  OPS/S 20660  US/EDGE 48.402  EMITTED 1800  
+;; v5scan-f50-s1                          OPS 10000  SECONDS 0.438  OPS/S 22830  US/EDGE 43.802  EMITTED 1000  
+;; v5scan-f50-s2                          OPS 10000  SECONDS 0.492  OPS/S 20324  US/EDGE 49.202  EMITTED 1000  
+;; v5scan-f50-s4                          OPS 10000  SECONDS 0.514  OPS/S 19454  US/EDGE 51.403  EMITTED 1000  
+;; v5scan-f50-s8                          OPS 10000  SECONDS 0.658  OPS/S 15197  US/EDGE 65.803  EMITTED 1000  
+;; clock-commit-local                     OPS 2000  SECONDS 1.591  OPS/S 1257  US/COMMIT 795.542  
+;; clock-commit-clocked                   OPS 2000  SECONDS 1.621  OPS/S 1234  US/COMMIT 810.542  
+;; clock-epoch-alloc                      OPS 50000  SECONDS 0.006  OPS/S 8333334  
+;; clock-attach                           OPS 100  SECONDS 0.023  OPS/S 4347  
+;; clock-epoch-alloc-contended            OPS 20000  SECONDS 0.012  OPS/S 1666528  
+;; memory-open-rebuild                    SECONDS 1.363  
+;; memory-checkpoint                      SECONDS 0.188  
+;; memory-open-image-restore              SECONDS 0.505  
+;; compact-conservative                   SECONDS 1.132  COMPACTED 600  
+;; compact-trust-tags                     SECONDS 1.356  COMPACTED 800  
+;; peer-export-scope                      OPS 3601  SECONDS 0.366  OPS/S 9838  
+;; peer-apply                             OPS 3601  SECONDS 4.266  OPS/S 844  
+;; vector-insert                          OPS 5000  SECONDS 1.875  OPS/S 2667  
+;; vector-knn-k10                         OPS 200  SECONDS 1.384  OPS/S 145  
+;; vector-knn-k10-20k                     OPS 100  SECONDS 2.57  OPS/S 39  
+
+(:PERF-REPORT :TAG "rel-head-r2" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :GENERATION
+ 4 :HOST "odm" :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.944 :OPS/S 5071)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.925 :OPS/S 21620)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.538 :OPS/S 37173)
+  ("update-vertices" :OPS 20000 :SECONDS 1.664 :OPS/S 12019)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.678 :OPS/S 14748)
+  ("insert-edges" :OPS 20000 :SECONDS 5.795 :OPS/S 3451)
+  ("scan-edges" :OPS 20000 :SECONDS 1.673 :OPS/S 11954)
+  ("view-lookup" :OPS 20000 :SECONDS 0.943 :OPS/S 21208)
+  ("unique-insert" :OPS 20000 :SECONDS 4.811 :OPS/S 4157)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.256 :OPS/S 6142)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.647 :OPS/S 4304)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.772 :OPS/S 25905)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.48 :OPS/S 309)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 56.269 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.173 :OPS/S 57800)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.357 :OPS/S 14005)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.901 :OPS/S 5549)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 3.93 :OPS/S 1272)
+  ("concurrent-rw" :OPS 32000 :SECONDS 32.026 :OPS/S 999)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3361034 :PER-OP 168)
+  ("snapshot" :SECONDS 1.966) ("restore-replay" :SECONDS 4.712)
+  ("reopen" :SECONDS 5.671)
+  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.833 :OPS/S 1200 :US/COMMIT
+   833.044)
+  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.832 :OPS/S 2404 :US/COMMIT
+   832.045)
+  ("commit-multigraph-n4" :OPS 4000 :SECONDS 3.229 :OPS/S 1239 :US/COMMIT
+   3229.168)
+  ("commit-multigraph-n8" :OPS 8000 :SECONDS 8.338 :OPS/S 959 :US/COMMIT
+   8338.434)
+  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.723 :OPS/S 11064
+   :US/COMMIT 723.037)
+  ("watermark-persist-warm" :OPS 20000 :SECONDS 6.002 :OPS/S 3332)
+  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.435 :OPS/S 13937)
+  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.47 :OPS/S 21275 :US/EDGE 47.002
+   :EMITTED 2000)
+  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.452 :OPS/S 22123 :US/EDGE 45.202
+   :EMITTED 2000)
+  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.462 :OPS/S 21644 :US/EDGE 46.202
+   :EMITTED 2000)
+  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.464 :OPS/S 21551 :US/EDGE 46.402
+   :EMITTED 2000)
+  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.44 :OPS/S 22726 :US/EDGE 44.002
+   :EMITTED 1800)
+  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.415 :OPS/S 24095 :US/EDGE 41.502
+   :EMITTED 1800)
+  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.456 :OPS/S 21929 :US/EDGE 45.602
+   :EMITTED 1800)
+  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.484 :OPS/S 20660 :US/EDGE 48.402
+   :EMITTED 1800)
+  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.438 :OPS/S 22830 :US/EDGE 43.802
+   :EMITTED 1000)
+  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.492 :OPS/S 20324 :US/EDGE 49.202
+   :EMITTED 1000)
+  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.514 :OPS/S 19454 :US/EDGE 51.403
+   :EMITTED 1000)
+  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.658 :OPS/S 15197 :US/EDGE 65.803
+   :EMITTED 1000)
+  ("clock-commit-local" :OPS 2000 :SECONDS 1.591 :OPS/S 1257 :US/COMMIT
+   795.542)
+  ("clock-commit-clocked" :OPS 2000 :SECONDS 1.621 :OPS/S 1234 :US/COMMIT
+   810.542)
+  ("clock-epoch-alloc" :OPS 50000 :SECONDS 0.006 :OPS/S 8333334)
+  ("clock-attach" :OPS 100 :SECONDS 0.023 :OPS/S 4347)
+  ("clock-epoch-alloc-contended" :OPS 20000 :SECONDS 0.012 :OPS/S 1666528)
+  ("memory-open-rebuild" :SECONDS 1.363) ("memory-checkpoint" :SECONDS 0.188)
+  ("memory-open-image-restore" :SECONDS 0.505)
+  ("compact-conservative" :SECONDS 1.132 :COMPACTED 600)
+  ("compact-trust-tags" :SECONDS 1.356 :COMPACTED 800)
+  ("peer-export-scope" :OPS 3601 :SECONDS 0.366 :OPS/S 9838)
+  ("peer-apply" :OPS 3601 :SECONDS 4.266 :OPS/S 844)
+  ("vector-insert" :OPS 5000 :SECONDS 1.875 :OPS/S 2667)
+  ("vector-knn-k10" :OPS 200 :SECONDS 1.384 :OPS/S 145)
+  ("vector-knn-k10-20k" :OPS 100 :SECONDS 2.57 :OPS/S 39)))

--- a/tests/perf/results/release-experiment-85496c3-odm-r3.report
+++ b/tests/perf/results/release-experiment-85496c3-odm-r3.report
@@ -1,0 +1,139 @@
+;;;; graph-db perf report
+;;;; tag=rel-head-r3 impl=SBCL 2.6.6 scale=NORMAL generation=4 host=odm
+
+;; insert-vertices                        OPS 20000  SECONDS 3.888  OPS/S 5144  
+;; lookup-by-id                           OPS 20000  SECONDS 0.785  OPS/S 25477  
+;; scan-vertices                          OPS 20000  SECONDS 0.524  OPS/S 38166  
+;; update-vertices                        OPS 20000  SECONDS 1.759  OPS/S 11370  
+;; delete-vertices                        OPS 10000  SECONDS 0.773  OPS/S 12936  
+;; insert-edges                           OPS 20000  SECONDS 6.401  OPS/S 3124  
+;; scan-edges                             OPS 20000  SECONDS 1.688  OPS/S 11848  
+;; view-lookup                            OPS 20000  SECONDS 1.01  OPS/S 19801  
+;; unique-insert                          OPS 20000  SECONDS 4.836  OPS/S 4135  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.504  OPS/S 5708  
+;; indexed-insert                         OPS 20000  SECONDS 4.315  OPS/S 4635  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.801  OPS/S 24968  
+;; index-range-1pct                       OPS 2000  SECONDS 6.86  OPS/S 292  
+;; index-fullscan-eq                      OPS 200  SECONDS 55.068  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.164  OPS/S 60973  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.333  OPS/S 15014  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.816  OPS/S 6127  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 3.898  OPS/S 1283  
+;; concurrent-rw                          OPS 32000  SECONDS 31.768  OPS/S 1007  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3361034  PER-OP 168  
+;; snapshot                               SECONDS 1.885  
+;; restore-replay                         SECONDS 4.636  
+;; reopen                                 SECONDS 5.406  
+;; commit-multigraph-n1                   OPS 1000  SECONDS 0.784  OPS/S 1275  US/COMMIT 784.032  
+;; commit-multigraph-n2                   OPS 2000  SECONDS 0.81  OPS/S 2469  US/COMMIT 810.033  
+;; commit-multigraph-n4                   OPS 4000  SECONDS 2.25  OPS/S 1778  US/COMMIT 2250.091  
+;; commit-multigraph-n8                   OPS 8000  SECONDS 8.441  OPS/S 948  US/COMMIT 8441.343  
+;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.726  OPS/S 11019  US/COMMIT 726.029  
+;; watermark-persist-warm                 OPS 20000  SECONDS 5.288  OPS/S 3782  
+;; watermark-raw-write-warm               OPS 20000  SECONDS 1.574  OPS/S 12706  
+;; v5scan-f0-s1                           OPS 10000  SECONDS 0.518  OPS/S 19304  US/EDGE 51.802  EMITTED 2000  
+;; v5scan-f0-s2                           OPS 10000  SECONDS 0.478  OPS/S 20920  US/EDGE 47.802  EMITTED 2000  
+;; v5scan-f0-s4                           OPS 10000  SECONDS 0.456  OPS/S 21929  US/EDGE 45.602  EMITTED 2000  
+;; v5scan-f0-s8                           OPS 10000  SECONDS 0.468  OPS/S 21367  US/EDGE 46.802  EMITTED 2000  
+;; v5scan-f10-s1                          OPS 10000  SECONDS 0.487  OPS/S 20533  US/EDGE 48.702  EMITTED 1800  
+;; v5scan-f10-s2                          OPS 10000  SECONDS 0.445  OPS/S 22471  US/EDGE 44.502  EMITTED 1800  
+;; v5scan-f10-s4                          OPS 10000  SECONDS 0.49  OPS/S 20407  US/EDGE 49.002  EMITTED 1800  
+;; v5scan-f10-s8                          OPS 10000  SECONDS 0.521  OPS/S 19193  US/EDGE 52.102  EMITTED 1800  
+;; v5scan-f50-s1                          OPS 10000  SECONDS 0.454  OPS/S 22026  US/EDGE 45.402  EMITTED 1000  
+;; v5scan-f50-s2                          OPS 10000  SECONDS 0.452  OPS/S 22123  US/EDGE 45.202  EMITTED 1000  
+;; v5scan-f50-s4                          OPS 10000  SECONDS 0.596  OPS/S 16778  US/EDGE 59.602  EMITTED 1000  
+;; v5scan-f50-s8                          OPS 10000  SECONDS 0.67  OPS/S 14925  US/EDGE 67.003  EMITTED 1000  
+;; clock-commit-local                     OPS 2000  SECONDS 1.574  OPS/S 1271  US/COMMIT 787.032  
+;; clock-commit-clocked                   OPS 2000  SECONDS 1.508  OPS/S 1326  US/COMMIT 754.03  
+;; clock-epoch-alloc                      OPS 50000  SECONDS 0.005  OPS/S 10000000  
+;; clock-attach                           OPS 100  SECONDS 0.02  OPS/S 5000  
+;; clock-epoch-alloc-contended            OPS 20000  SECONDS 0.016  OPS/S 1249922  
+;; memory-open-rebuild                    SECONDS 1.22  
+;; memory-checkpoint                      SECONDS 0.193  
+;; memory-open-image-restore              SECONDS 0.424  
+;; compact-conservative                   SECONDS 1.101  COMPACTED 600  
+;; compact-trust-tags                     SECONDS 1.317  COMPACTED 800  
+;; peer-export-scope                      OPS 3601  SECONDS 0.338  OPS/S 10653  
+;; peer-apply                             OPS 3601  SECONDS 3.933  OPS/S 916  
+;; vector-insert                          OPS 5000  SECONDS 1.842  OPS/S 2714  
+;; vector-knn-k10                         OPS 200  SECONDS 1.296  OPS/S 154  
+;; vector-knn-k10-20k                     OPS 100  SECONDS 2.585  OPS/S 39  
+
+(:PERF-REPORT :TAG "rel-head-r3" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :GENERATION
+ 4 :HOST "odm" :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.888 :OPS/S 5144)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.785 :OPS/S 25477)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.524 :OPS/S 38166)
+  ("update-vertices" :OPS 20000 :SECONDS 1.759 :OPS/S 11370)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.773 :OPS/S 12936)
+  ("insert-edges" :OPS 20000 :SECONDS 6.401 :OPS/S 3124)
+  ("scan-edges" :OPS 20000 :SECONDS 1.688 :OPS/S 11848)
+  ("view-lookup" :OPS 20000 :SECONDS 1.01 :OPS/S 19801)
+  ("unique-insert" :OPS 20000 :SECONDS 4.836 :OPS/S 4135)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.504 :OPS/S 5708)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.315 :OPS/S 4635)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.801 :OPS/S 24968)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.86 :OPS/S 292)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 55.068 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.164 :OPS/S 60973)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.333 :OPS/S 15014)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.816 :OPS/S 6127)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 3.898 :OPS/S 1283)
+  ("concurrent-rw" :OPS 32000 :SECONDS 31.768 :OPS/S 1007)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3361034 :PER-OP 168)
+  ("snapshot" :SECONDS 1.885) ("restore-replay" :SECONDS 4.636)
+  ("reopen" :SECONDS 5.406)
+  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.784 :OPS/S 1275 :US/COMMIT
+   784.032)
+  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.81 :OPS/S 2469 :US/COMMIT
+   810.033)
+  ("commit-multigraph-n4" :OPS 4000 :SECONDS 2.25 :OPS/S 1778 :US/COMMIT
+   2250.091)
+  ("commit-multigraph-n8" :OPS 8000 :SECONDS 8.441 :OPS/S 948 :US/COMMIT
+   8441.343)
+  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.726 :OPS/S 11019
+   :US/COMMIT 726.029)
+  ("watermark-persist-warm" :OPS 20000 :SECONDS 5.288 :OPS/S 3782)
+  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.574 :OPS/S 12706)
+  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.518 :OPS/S 19304 :US/EDGE 51.802
+   :EMITTED 2000)
+  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.478 :OPS/S 20920 :US/EDGE 47.802
+   :EMITTED 2000)
+  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.456 :OPS/S 21929 :US/EDGE 45.602
+   :EMITTED 2000)
+  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.468 :OPS/S 21367 :US/EDGE 46.802
+   :EMITTED 2000)
+  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.487 :OPS/S 20533 :US/EDGE 48.702
+   :EMITTED 1800)
+  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.445 :OPS/S 22471 :US/EDGE 44.502
+   :EMITTED 1800)
+  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.49 :OPS/S 20407 :US/EDGE 49.002
+   :EMITTED 1800)
+  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.521 :OPS/S 19193 :US/EDGE 52.102
+   :EMITTED 1800)
+  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.454 :OPS/S 22026 :US/EDGE 45.402
+   :EMITTED 1000)
+  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.452 :OPS/S 22123 :US/EDGE 45.202
+   :EMITTED 1000)
+  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.596 :OPS/S 16778 :US/EDGE 59.602
+   :EMITTED 1000)
+  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.67 :OPS/S 14925 :US/EDGE 67.003
+   :EMITTED 1000)
+  ("clock-commit-local" :OPS 2000 :SECONDS 1.574 :OPS/S 1271 :US/COMMIT
+   787.032)
+  ("clock-commit-clocked" :OPS 2000 :SECONDS 1.508 :OPS/S 1326 :US/COMMIT
+   754.03)
+  ("clock-epoch-alloc" :OPS 50000 :SECONDS 0.005 :OPS/S 10000000)
+  ("clock-attach" :OPS 100 :SECONDS 0.02 :OPS/S 5000)
+  ("clock-epoch-alloc-contended" :OPS 20000 :SECONDS 0.016 :OPS/S 1249922)
+  ("memory-open-rebuild" :SECONDS 1.22) ("memory-checkpoint" :SECONDS 0.193)
+  ("memory-open-image-restore" :SECONDS 0.424)
+  ("compact-conservative" :SECONDS 1.101 :COMPACTED 600)
+  ("compact-trust-tags" :SECONDS 1.317 :COMPACTED 800)
+  ("peer-export-scope" :OPS 3601 :SECONDS 0.338 :OPS/S 10653)
+  ("peer-apply" :OPS 3601 :SECONDS 3.933 :OPS/S 916)
+  ("vector-insert" :OPS 5000 :SECONDS 1.842 :OPS/S 2714)
+  ("vector-knn-k10" :OPS 200 :SECONDS 1.296 :OPS/S 154)
+  ("vector-knn-k10-20k" :OPS 100 :SECONDS 2.585 :OPS/S 39)))

--- a/tests/perf/results/release-v2.1.1-odm-r1.report
+++ b/tests/perf/results/release-v2.1.1-odm-r1.report
@@ -1,0 +1,40 @@
+;;;; graph-db perf report
+;;;; tag=rel-v211-r1 impl=SBCL 2.6.6 scale=NORMAL
+
+;; insert-vertices                        OPS 20000  SECONDS 7.941  OPS/S 2518  
+;; lookup-by-id                           OPS 20000  SECONDS 1.443  OPS/S 13859  
+;; scan-vertices                          OPS 20000  SECONDS 0.759  OPS/S 26349  
+;; update-vertices                        OPS 20000  SECONDS 12.786  OPS/S 1564  
+;; delete-vertices                        OPS 10000  SECONDS 3.913  OPS/S 2555  
+;; insert-edges                           OPS 20000  SECONDS 12.308  OPS/S 1625  
+;; scan-edges                             OPS 20000  SECONDS 3.807  OPS/S 5253  
+;; view-lookup                            OPS 20000  SECONDS 2.219  OPS/S 9013  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.487  OPS/S 20533  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.375  OPS/S 13333  
+;; commit-batched-1txn                    OPS 5000  SECONDS 2.84  OPS/S 1760  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 4.911  OPS/S 1018  
+;; concurrent-rw                          OPS 32000  SECONDS 27.076  OPS/S 1182  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3201034  PER-OP 160  
+;; snapshot                               SECONDS 3.813  
+;; restore-replay                         SECONDS 7.661  
+;; reopen                                 SECONDS 19.853  
+
+(:PERF-REPORT :TAG "rel-v211-r1" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 7.941 :OPS/S 2518)
+  ("lookup-by-id" :OPS 20000 :SECONDS 1.443 :OPS/S 13859)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.759 :OPS/S 26349)
+  ("update-vertices" :OPS 20000 :SECONDS 12.786 :OPS/S 1564)
+  ("delete-vertices" :OPS 10000 :SECONDS 3.913 :OPS/S 2555)
+  ("insert-edges" :OPS 20000 :SECONDS 12.308 :OPS/S 1625)
+  ("scan-edges" :OPS 20000 :SECONDS 3.807 :OPS/S 5253)
+  ("view-lookup" :OPS 20000 :SECONDS 2.219 :OPS/S 9013)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.487 :OPS/S 20533)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.375 :OPS/S 13333)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 2.84 :OPS/S 1760)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 4.911 :OPS/S 1018)
+  ("concurrent-rw" :OPS 32000 :SECONDS 27.076 :OPS/S 1182)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3201034 :PER-OP 160)
+  ("snapshot" :SECONDS 3.813) ("restore-replay" :SECONDS 7.661)
+  ("reopen" :SECONDS 19.853)))

--- a/tests/perf/results/release-v2.1.1-odm-r2.report
+++ b/tests/perf/results/release-v2.1.1-odm-r2.report
@@ -1,0 +1,40 @@
+;;;; graph-db perf report
+;;;; tag=rel-v211-r2 impl=SBCL 2.6.6 scale=NORMAL
+
+;; insert-vertices                        OPS 20000  SECONDS 8.437  OPS/S 2370  
+;; lookup-by-id                           OPS 20000  SECONDS 2.749  OPS/S 7275  
+;; scan-vertices                          OPS 20000  SECONDS 2.29  OPS/S 8733  
+;; update-vertices                        OPS 20000  SECONDS 10.495  OPS/S 1906  
+;; delete-vertices                        OPS 10000  SECONDS 4.921  OPS/S 2032  
+;; insert-edges                           OPS 20000  SECONDS 12.9  OPS/S 1550  
+;; scan-edges                             OPS 20000  SECONDS 4.015  OPS/S 4981  
+;; view-lookup                            OPS 20000  SECONDS 1.605  OPS/S 12460  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.39  OPS/S 25640  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.425  OPS/S 11764  
+;; commit-batched-1txn                    OPS 5000  SECONDS 3.293  OPS/S 1518  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 5.322  OPS/S 939  
+;; concurrent-rw                          OPS 32000  SECONDS 27.454  OPS/S 1166  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3201034  PER-OP 160  
+;; snapshot                               SECONDS 3.769  
+;; restore-replay                         SECONDS 7.979  
+;; reopen                                 SECONDS 20.097  
+
+(:PERF-REPORT :TAG "rel-v211-r2" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 8.437 :OPS/S 2370)
+  ("lookup-by-id" :OPS 20000 :SECONDS 2.749 :OPS/S 7275)
+  ("scan-vertices" :OPS 20000 :SECONDS 2.29 :OPS/S 8733)
+  ("update-vertices" :OPS 20000 :SECONDS 10.495 :OPS/S 1906)
+  ("delete-vertices" :OPS 10000 :SECONDS 4.921 :OPS/S 2032)
+  ("insert-edges" :OPS 20000 :SECONDS 12.9 :OPS/S 1550)
+  ("scan-edges" :OPS 20000 :SECONDS 4.015 :OPS/S 4981)
+  ("view-lookup" :OPS 20000 :SECONDS 1.605 :OPS/S 12460)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.39 :OPS/S 25640)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.425 :OPS/S 11764)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 3.293 :OPS/S 1518)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 5.322 :OPS/S 939)
+  ("concurrent-rw" :OPS 32000 :SECONDS 27.454 :OPS/S 1166)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3201034 :PER-OP 160)
+  ("snapshot" :SECONDS 3.769) ("restore-replay" :SECONDS 7.979)
+  ("reopen" :SECONDS 20.097)))

--- a/tests/perf/results/release-v2.1.1-odm-r3.report
+++ b/tests/perf/results/release-v2.1.1-odm-r3.report
@@ -1,0 +1,40 @@
+;;;; graph-db perf report
+;;;; tag=rel-v211-r3 impl=SBCL 2.6.6 scale=NORMAL
+
+;; insert-vertices                        OPS 20000  SECONDS 9.333  OPS/S 2143  
+;; lookup-by-id                           OPS 20000  SECONDS 3.14  OPS/S 6369  
+;; scan-vertices                          OPS 20000  SECONDS 2.021  OPS/S 9896  
+;; update-vertices                        OPS 20000  SECONDS 10.679  OPS/S 1873  
+;; delete-vertices                        OPS 10000  SECONDS 4.492  OPS/S 2226  
+;; insert-edges                           OPS 20000  SECONDS 12.828  OPS/S 1559  
+;; scan-edges                             OPS 20000  SECONDS 3.468  OPS/S 5767  
+;; view-lookup                            OPS 20000  SECONDS 1.778  OPS/S 11248  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.549  OPS/S 18214  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.38  OPS/S 13157  
+;; commit-batched-1txn                    OPS 5000  SECONDS 3.123  OPS/S 1601  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 5.114  OPS/S 978  
+;; concurrent-rw                          OPS 32000  SECONDS 27.77  OPS/S 1152  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3201034  PER-OP 160  
+;; snapshot                               SECONDS 4.039  
+;; restore-replay                         SECONDS 8.643  
+;; reopen                                 SECONDS 20.435  
+
+(:PERF-REPORT :TAG "rel-v211-r3" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 9.333 :OPS/S 2143)
+  ("lookup-by-id" :OPS 20000 :SECONDS 3.14 :OPS/S 6369)
+  ("scan-vertices" :OPS 20000 :SECONDS 2.021 :OPS/S 9896)
+  ("update-vertices" :OPS 20000 :SECONDS 10.679 :OPS/S 1873)
+  ("delete-vertices" :OPS 10000 :SECONDS 4.492 :OPS/S 2226)
+  ("insert-edges" :OPS 20000 :SECONDS 12.828 :OPS/S 1559)
+  ("scan-edges" :OPS 20000 :SECONDS 3.468 :OPS/S 5767)
+  ("view-lookup" :OPS 20000 :SECONDS 1.778 :OPS/S 11248)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.549 :OPS/S 18214)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.38 :OPS/S 13157)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 3.123 :OPS/S 1601)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 5.114 :OPS/S 978)
+  ("concurrent-rw" :OPS 32000 :SECONDS 27.77 :OPS/S 1152)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3201034 :PER-OP 160)
+  ("snapshot" :SECONDS 4.039) ("restore-replay" :SECONDS 8.643)
+  ("reopen" :SECONDS 20.435)))

--- a/tests/perf/results/release-v3.0.0-odm-r1.report
+++ b/tests/perf/results/release-v3.0.0-odm-r1.report
@@ -1,0 +1,52 @@
+;;;; graph-db perf report
+;;;; tag=rel-v300-r1 impl=SBCL 2.6.6 scale=NORMAL
+
+;; insert-vertices                        OPS 20000  SECONDS 2.658  OPS/S 7524  
+;; lookup-by-id                           OPS 20000  SECONDS 0.256  OPS/S 78121  
+;; scan-vertices                          OPS 20000  SECONDS 0.523  OPS/S 38239  
+;; update-vertices                        OPS 20000  SECONDS 2.811  OPS/S 7115  
+;; delete-vertices                        OPS 10000  SECONDS 1.073  OPS/S 9319  
+;; insert-edges                           OPS 20000  SECONDS 6.874  OPS/S 2909  
+;; scan-edges                             OPS 20000  SECONDS 1.631  OPS/S 12262  
+;; view-lookup                            OPS 20000  SECONDS 0.889  OPS/S 22496  
+;; unique-insert                          OPS 20000  SECONDS 4.598  OPS/S 4349  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.368  OPS/S 5938  
+;; indexed-insert                         OPS 20000  SECONDS 4.42  OPS/S 4525  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.744  OPS/S 26880  
+;; index-range-1pct                       OPS 2000  SECONDS 6.164  OPS/S 324  
+;; index-fullscan-eq                      OPS 200  SECONDS 54.0  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.184  OPS/S 54345  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.308  OPS/S 16233  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.693  OPS/S 7215  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 2.586  OPS/S 1933  
+;; concurrent-rw                          OPS 32000  SECONDS 21.046  OPS/S 1520  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3201034  PER-OP 160  
+;; snapshot                               SECONDS 1.723  
+;; restore-replay                         SECONDS 3.815  
+;; reopen                                 SECONDS 5.564  
+
+(:PERF-REPORT :TAG "rel-v300-r1" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 2.658 :OPS/S 7524)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.256 :OPS/S 78121)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.523 :OPS/S 38239)
+  ("update-vertices" :OPS 20000 :SECONDS 2.811 :OPS/S 7115)
+  ("delete-vertices" :OPS 10000 :SECONDS 1.073 :OPS/S 9319)
+  ("insert-edges" :OPS 20000 :SECONDS 6.874 :OPS/S 2909)
+  ("scan-edges" :OPS 20000 :SECONDS 1.631 :OPS/S 12262)
+  ("view-lookup" :OPS 20000 :SECONDS 0.889 :OPS/S 22496)
+  ("unique-insert" :OPS 20000 :SECONDS 4.598 :OPS/S 4349)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.368 :OPS/S 5938)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.42 :OPS/S 4525)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.744 :OPS/S 26880)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.164 :OPS/S 324)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 54.0 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.184 :OPS/S 54345)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.308 :OPS/S 16233)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.693 :OPS/S 7215)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 2.586 :OPS/S 1933)
+  ("concurrent-rw" :OPS 32000 :SECONDS 21.046 :OPS/S 1520)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3201034 :PER-OP 160)
+  ("snapshot" :SECONDS 1.723) ("restore-replay" :SECONDS 3.815)
+  ("reopen" :SECONDS 5.564)))

--- a/tests/perf/results/release-v3.0.0-odm-r2.report
+++ b/tests/perf/results/release-v3.0.0-odm-r2.report
@@ -1,0 +1,52 @@
+;;;; graph-db perf report
+;;;; tag=rel-v300-r2 impl=SBCL 2.6.6 scale=NORMAL
+
+;; insert-vertices                        OPS 20000  SECONDS 3.877  OPS/S 5158  
+;; lookup-by-id                           OPS 20000  SECONDS 0.734  OPS/S 27247  
+;; scan-vertices                          OPS 20000  SECONDS 0.531  OPS/S 37663  
+;; update-vertices                        OPS 20000  SECONDS 1.68  OPS/S 11904  
+;; delete-vertices                        OPS 10000  SECONDS 0.746  OPS/S 13404  
+;; insert-edges                           OPS 20000  SECONDS 6.751  OPS/S 2962  
+;; scan-edges                             OPS 20000  SECONDS 1.74  OPS/S 11494  
+;; view-lookup                            OPS 20000  SECONDS 1.216  OPS/S 16447  
+;; unique-insert                          OPS 20000  SECONDS 4.608  OPS/S 4340  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.27  OPS/S 6116  
+;; indexed-insert                         OPS 20000  SECONDS 4.295  OPS/S 4656  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.802  OPS/S 24936  
+;; index-range-1pct                       OPS 2000  SECONDS 6.263  OPS/S 319  
+;; index-fullscan-eq                      OPS 200  SECONDS 55.622  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.157  OPS/S 63691  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.361  OPS/S 13850  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.924  OPS/S 5411  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 2.578  OPS/S 1939  
+;; concurrent-rw                          OPS 32000  SECONDS 21.102  OPS/S 1516  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3201034  PER-OP 160  
+;; snapshot                               SECONDS 1.899  
+;; restore-replay                         SECONDS 3.982  
+;; reopen                                 SECONDS 5.885  
+
+(:PERF-REPORT :TAG "rel-v300-r2" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.877 :OPS/S 5158)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.734 :OPS/S 27247)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.531 :OPS/S 37663)
+  ("update-vertices" :OPS 20000 :SECONDS 1.68 :OPS/S 11904)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.746 :OPS/S 13404)
+  ("insert-edges" :OPS 20000 :SECONDS 6.751 :OPS/S 2962)
+  ("scan-edges" :OPS 20000 :SECONDS 1.74 :OPS/S 11494)
+  ("view-lookup" :OPS 20000 :SECONDS 1.216 :OPS/S 16447)
+  ("unique-insert" :OPS 20000 :SECONDS 4.608 :OPS/S 4340)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.27 :OPS/S 6116)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.295 :OPS/S 4656)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.802 :OPS/S 24936)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.263 :OPS/S 319)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 55.622 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.157 :OPS/S 63691)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.361 :OPS/S 13850)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.924 :OPS/S 5411)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 2.578 :OPS/S 1939)
+  ("concurrent-rw" :OPS 32000 :SECONDS 21.102 :OPS/S 1516)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3201034 :PER-OP 160)
+  ("snapshot" :SECONDS 1.899) ("restore-replay" :SECONDS 3.982)
+  ("reopen" :SECONDS 5.885)))

--- a/tests/perf/results/release-v3.0.0-odm-r3.report
+++ b/tests/perf/results/release-v3.0.0-odm-r3.report
@@ -1,0 +1,52 @@
+;;;; graph-db perf report
+;;;; tag=rel-v300-r3 impl=SBCL 2.6.6 scale=NORMAL
+
+;; insert-vertices                        OPS 20000  SECONDS 3.838  OPS/S 5211  
+;; lookup-by-id                           OPS 20000  SECONDS 0.708  OPS/S 28247  
+;; scan-vertices                          OPS 20000  SECONDS 0.44  OPS/S 45453  
+;; update-vertices                        OPS 20000  SECONDS 1.567  OPS/S 12763  
+;; delete-vertices                        OPS 10000  SECONDS 0.71  OPS/S 14084  
+;; insert-edges                           OPS 20000  SECONDS 6.139  OPS/S 3258  
+;; scan-edges                             OPS 20000  SECONDS 1.67  OPS/S 11976  
+;; view-lookup                            OPS 20000  SECONDS 0.906  OPS/S 22074  
+;; unique-insert                          OPS 20000  SECONDS 4.748  OPS/S 4212  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.414  OPS/S 5858  
+;; indexed-insert                         OPS 20000  SECONDS 4.409  OPS/S 4536  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.905  OPS/S 22099  
+;; index-range-1pct                       OPS 2000  SECONDS 6.573  OPS/S 304  
+;; index-fullscan-eq                      OPS 200  SECONDS 55.327  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.171  OPS/S 58477  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.334  OPS/S 14970  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.759  OPS/S 6587  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 2.764  OPS/S 1809  
+;; concurrent-rw                          OPS 32000  SECONDS 20.77  OPS/S 1541  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3201034  PER-OP 160  
+;; snapshot                               SECONDS 1.726  
+;; restore-replay                         SECONDS 3.776  
+;; reopen                                 SECONDS 5.723  
+
+(:PERF-REPORT :TAG "rel-v300-r3" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.838 :OPS/S 5211)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.708 :OPS/S 28247)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.44 :OPS/S 45453)
+  ("update-vertices" :OPS 20000 :SECONDS 1.567 :OPS/S 12763)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.71 :OPS/S 14084)
+  ("insert-edges" :OPS 20000 :SECONDS 6.139 :OPS/S 3258)
+  ("scan-edges" :OPS 20000 :SECONDS 1.67 :OPS/S 11976)
+  ("view-lookup" :OPS 20000 :SECONDS 0.906 :OPS/S 22074)
+  ("unique-insert" :OPS 20000 :SECONDS 4.748 :OPS/S 4212)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.414 :OPS/S 5858)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.409 :OPS/S 4536)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.905 :OPS/S 22099)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.573 :OPS/S 304)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 55.327 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.171 :OPS/S 58477)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.334 :OPS/S 14970)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.759 :OPS/S 6587)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 2.764 :OPS/S 1809)
+  ("concurrent-rw" :OPS 32000 :SECONDS 20.77 :OPS/S 1541)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3201034 :PER-OP 160)
+  ("snapshot" :SECONDS 1.726) ("restore-replay" :SECONDS 3.776)
+  ("reopen" :SECONDS 5.723)))


### PR DESCRIPTION
Phase 1 of the release-baseline exercise (#263; the discussion Kevin parked on #253 and green-lit 2026-08-27). Serves all three purposes decided there: the dev-cycle drift check, release-notes evidence in the original A/B's mold, and a standing trend record.

## Method

Nine `:normal` runs on host odm (SBCL 2.6.6, fresh image each, round-robin interleaved across trees so host drift spreads fairly): v2.1.1, v3.0.0, and experiment@85496c3 each running **its own** `tests/perf/` suite. The Phase-0 survey verified every intersecting bench implementation **byte-identical** across the three tags (24 labels vs v3.0.0; 18 three-way), with one EQUIVALENT-BUT-CHANGED exception (`reopen`, schema-size caveat — the same caveat the original A/B's commit recorded). Medians of three; this is a dated judgment document, never a `check-perf` gate.

## Findings

- **Drift check:** flat-to-better on every read/scan/query/index cell since 3.0.0 — but the commit-heavy cells regressed (`commit-per-op-Ntxn` −34.2%, `concurrent-rw` −33.8%, `restore-replay` −21.5%, `snapshot` −13.9%). The fingerprint matches **#237** (the #177 monotonic-watermark read+write under the process-global lock) exactly, independently corroborating the #252 microbenchmarks (~120 µs/commit isolated; convoy under contention). #237's fix is doubly justified; the bench control cell will measure the recovery when it lands. `snapshot`'s −13.9% has no confirmed cause and is flagged for the post-#237 re-run.
- **Record:** the published 3.0-vs-2.1.1 result reconfirms on this host at the same magnitudes (+14% to +535% across the 18-label set).
- **Noise honesty:** `lookup-by-id` had CV 36–53% on *all three* trees this day and is excluded from interpretation; other CV>10% cells flagged in the #263 tables.

## Contents

Raw reports committed unedited (`release-{v2.1.1,v3.0.0,experiment-85496c3}-odm-r{1,2,3}.report`), the dated comparison `release-comparison-2026-08-27.md` (method, tables, caveats, and the reproduction recipe — including the `:directory`-not-`:tree` ASDF pin needed when release worktrees live inside the main checkout), and one CHANGELOG entry.

Fixes #263. Refs #253, #256, #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp