### PR TITLE
Per-graph cached watermark: the commit convoy is gone (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Watermark persistence no longer convoys commits** (#237). The #177
+  monotonic fix made `persist-highest-transaction-id` re-read
+  `transaction-id.dat` on every commit under one process-global lock;
+  the #252 microbenchmarks measured that at ~89% of 8-graph commit
+  latency (aggregate throughput *inverting* past 4 committers), and
+  the #263 release comparison showed the same fingerprint in the wild:
+  commit-per-op −34%, concurrent-rw −34%, restore-replay −21% since
+  3.0.0. The durable watermark is now cached on the graph object (an
+  already-covered id returns lock-free with no I/O; steady state is
+  one compare + one write, the disk read happens once per graph
+  object) and the lock is per-graph — each graph has its own watermark
+  file, so the global lock protected nothing cross-graph and is
+  removed. The raw test writer `%write-highest-transaction-id` keeps
+  the cache mirroring disk, so fabricated rewinds stay honest.
+  Monotonic semantics are unchanged.
+
 ### Added
 
 - **Release-baseline measurement record** (#263). Three-tree perf

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -4145,10 +4145,16 @@ is one lower than before, closing a gap that was always wasted.
 
 The persisted watermark itself is now *monotonic* (GH #177):
 ~persist-highest-transaction-id~ takes its lock around the whole
-read-compare-write and writes only when the new id is *greater* than
-what ~transaction-id.dat~ already holds, returning whatever is on disk
-after the call — two racing committers can no longer let the lower id
-land last and silently rewind the file.
+compare-and-write and writes only when the new id is *greater* than
+the standing watermark, returning whatever stands after the call — two
+racing committers can no longer let the lower id land last and
+silently rewind the file. The standing watermark is *cached on the
+graph object* and the lock is *per graph* (GH #237): an id the cache
+already covers returns lock-free with no file I/O, the steady-state
+commit does one compare plus one write (the disk re-read happens once
+per graph object, to seed the cache), and committers on different
+graphs no longer serialize against each other — each graph has its own
+~transaction-id.dat~, so nothing cross-graph was ever protected.
 
 *** Cross-store snapshots pin every store they touch
 

--- a/graph-class.lisp
+++ b/graph-class.lisp
@@ -238,6 +238,20 @@ received an UNRESOLVED-NODE marker instead (GH #169, D8)."
    ;; receives.
    (shadow-p :accessor graph-shadow-p :initform nil)
    (epoch-lease :accessor graph-epoch-lease :initform nil)
+   ;; Durable-watermark cache + per-graph lock for transaction-id.dat
+   ;; (GH #237).  CACHE: NIL = unknown; otherwise the value the locked
+   ;; writer (or the raw test writer) last put on disk.  Read lock-free
+   ;; on the commit fast path -- a stale-low read only forces the locked
+   ;; slow path, and nothing but the writers ever raises it, so the fast
+   ;; path can skip work but never skip a needed write.  LOCK: each
+   ;; graph has its own watermark file; the old process-global lock
+   ;; convoyed every committing graph in the image.  Load-bearing
+   ;; assumption: ONE live graph object per store directory (the
+   ;; .dirty sentinel enforces it) -- two objects on one file would
+   ;; have disjoint locks/caches and resurrect the #177 race.
+   (watermark-cache :accessor watermark-cache :initform nil)
+   (watermark-lock :accessor watermark-lock
+                   :initform (make-recursive-lock "watermark"))
    ;; WAL-suppressed fast path (GH #170 Task 4).  T only on a shadow opened
    ;; via OPEN-SHADOW-GRAPH :FAST-LOAD T against a :DERIVABLE-policy source;
    ;; PERSIST-TRANSACTION's callers skip the .txn file and replication log

--- a/tests/detach-tests.lisp
+++ b/tests/detach-tests.lisp
@@ -1629,11 +1629,110 @@ crash states (see CRASH-RECOVERY-RESEEDS-THE-TX-ID-WATERMARK)."
                  (is (= 150 (graph-db::persist-highest-transaction-id
                              150 g)))
                  (is (= 150 (load-highest-transaction-id g)))
-                 ;; The raw writer is the deliberate escape hatch.
+                 ;; The raw writer is the deliberate escape hatch --
+                 ;; and it must rewind the cache along with the file,
+                 ;; or the next persist would answer from a watermark
+                 ;; the rewind erased (GH #237).
                  (graph-db::%write-highest-transaction-id 10 g)
-                 (is (= 10 (load-highest-transaction-id g))))
+                 (is (= 10 (load-highest-transaction-id g)))
+                 (is (= 20 (graph-db::persist-highest-transaction-id
+                            20 g))
+                     "persist after a raw rewind must see the rewound ~
+watermark, not a stale cached 150")
+                 (is (= 20 (load-highest-transaction-id g))))
             (let ((graph-db:*graph* g))
               (ignore-errors (close-graph g :snapshot-p nil)))))))))
+
+(test watermark-fast-path-touches-no-file
+  "GH #237: once the cache holds a watermark >= the id, PERSIST-HIGHEST-
+TRANSACTION-ID answers from the cache with no lock and no I/O.  Proof:
+delete transaction-id.dat after seeding -- a lower-id persist must
+still answer correctly WITHOUT recreating the file."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil))
+        (let ((g (make-graph :gh-237-fastpath (namestring dir)
+                             :buffer-pool-size 1000)))
+          (unwind-protect
+               (let ((file (graph-db::highest-transaction-id-file g)))
+                 (is (= 100 (graph-db::persist-highest-transaction-id
+                             100 g)))
+                 (delete-file file)
+                 (is (= 100 (graph-db::persist-highest-transaction-id
+                             50 g))
+                     "fast path answers from the cache")
+                 (is (null (probe-file file))
+                     "and performed no file I/O at all")
+                 ;; A higher id takes the slow path and writes again.
+                 (is (= 150 (graph-db::persist-highest-transaction-id
+                             150 g)))
+                 (is (= 150 (load-highest-transaction-id g))))
+            (let ((graph-db:*graph* g))
+              (ignore-errors (close-graph g :snapshot-p nil)))))))))
+
+(test watermark-cache-seeds-from-disk-after-reopen
+  "GH #237: a fresh graph object has an unknown cache; the first
+persist seeds it from transaction-id.dat, so monotonicity holds
+across close/open exactly as it did against the bare file."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir)
+      (let ((graph-db::*system-directory* (namestring sys))
+            (graph-db::*store-registry* nil)
+            (path (namestring dir)))
+        (let ((g (make-graph :gh-237-reseed path
+                             :buffer-pool-size 1000)))
+          (graph-db::persist-highest-transaction-id 100 g)
+          (let ((graph-db:*graph* g))
+            (close-graph g :snapshot-p nil)))
+        (let ((g2 (open-graph :gh-237-reseed path)))
+          (unwind-protect
+               (let ((base (load-highest-transaction-id g2)))
+                 (is (>= base 100)
+                     "the durable watermark survived the reopen")
+                 (is (= base (graph-db::persist-highest-transaction-id
+                              1 g2))
+                     "a low persist on the fresh object seeds from ~
+disk and refuses to rewind")
+                 (is (= base (load-highest-transaction-id g2)))
+                 (is (= (+ base 50)
+                        (graph-db::persist-highest-transaction-id
+                         (+ base 50) g2))))
+            (let ((graph-db:*graph* g2))
+              (ignore-errors (close-graph g2 :snapshot-p nil)))))))))
+
+(test watermarks-are-per-graph
+  "GH #237: each graph carries its own watermark lock and cache --
+interleaved persists on two graphs never observe each other."
+  (with-temp-directory (sys)
+    (with-temp-directory (dir-a)
+      (with-temp-directory (dir-b)
+        (let ((graph-db::*system-directory* (namestring sys))
+              (graph-db::*store-registry* nil))
+          (let ((ga (make-graph :gh-237-per-graph-a (namestring dir-a)
+                                :buffer-pool-size 1000))
+                (gb (make-graph :gh-237-per-graph-b (namestring dir-b)
+                                :buffer-pool-size 1000)))
+            (unwind-protect
+                 (progn
+                   (is (not (eq (graph-db::watermark-lock ga)
+                                (graph-db::watermark-lock gb)))
+                       "no shared lock between graphs")
+                   (is (= 100 (graph-db::persist-highest-transaction-id
+                               100 ga)))
+                   (is (= 5 (graph-db::persist-highest-transaction-id
+                             5 gb)))
+                   (is (= 100 (graph-db::persist-highest-transaction-id
+                               50 ga))
+                       "graph A's watermark unmoved by graph B's")
+                   (is (= 200 (graph-db::persist-highest-transaction-id
+                               200 gb)))
+                   (is (= 100 (load-highest-transaction-id ga)))
+                   (is (= 200 (load-highest-transaction-id gb))))
+              (let ((graph-db:*graph* gb))
+                (ignore-errors (close-graph gb :snapshot-p nil)))
+              (let ((graph-db:*graph* ga))
+                (ignore-errors (close-graph ga :snapshot-p nil))))))))))
 
 (defun %mock-clock-failing-ceiling (journal-file)
   "A real SYSTEM-CLOCK struct whose JOURNAL-APPEND works (the journal

--- a/tests/perf/benchmarks.lisp
+++ b/tests/perf/benchmarks.lisp
@@ -297,12 +297,13 @@ landed, then records LABEL."
 (defun bench-multigraph-commit ()
   "Multi-graph commit contention (GH #237, #252): N graphs, one
 committing thread per graph.  An nN cell measures EVERYTHING the
-graphs share -- the global watermark lock, the process-global buffer
-pool, GC, one filesystem -- so the n8:n1 ratio alone does not
-implicate the lock.  The nN-rawwm control reruns the largest cell
-with PERSIST-HIGHEST-TRANSACTION-ID swapped for the raw writer
-(unconditional write, no global lock, no re-read): nN minus nN-rawwm
-is the watermark lock+read's share.  The watermark-* pair prices one
+graphs share -- the process-global buffer pool, GC, one filesystem.
+It originally measured the pre-#237 global watermark lock's convoy
+(~89% of n8 commit latency); that fix landed, and the cell stays as
+a regression sentinel for it.  The nN-rawwm control reruns the
+largest cell with PERSIST-HIGHEST-TRANSACTION-ID swapped for the raw
+writer: nN minus nN-rawwm now bounds any residual per-commit
+watermark cost (~nothing post-fix).  The watermark-* pair prices one
 call in isolation -- single-threaded, ascending ids, warm OS cache."
   (let* ((per-thread (scale 1000))
          (ns (if (eq *perf-scale* :small) '(1 4) '(1 2 4 8)))

--- a/tests/perf/results/baseline-odm-g4.report
+++ b/tests/perf/results/baseline-odm-g4.report
@@ -1,138 +1,139 @@
 ;;;; graph-db perf report
-;;;; tag=rebless-g4-r2 impl=SBCL 2.6.6 scale=NORMAL generation=4 host=odm
+;;;; tag=237-watermark-fix impl=SBCL 2.6.6 scale=NORMAL generation=4 host=odm
 
-;; insert-vertices                        OPS 20000  SECONDS 3.575  OPS/S 5594  
-;; lookup-by-id                           OPS 20000  SECONDS 0.867  OPS/S 23067  
-;; scan-vertices                          OPS 20000  SECONDS 0.453  OPS/S 44148  
-;; update-vertices                        OPS 20000  SECONDS 1.644  OPS/S 12165  
-;; delete-vertices                        OPS 10000  SECONDS 0.726  OPS/S 13773  
-;; insert-edges                           OPS 20000  SECONDS 5.927  OPS/S 3374  
-;; scan-edges                             OPS 20000  SECONDS 1.513  OPS/S 13218  
-;; view-lookup                            OPS 20000  SECONDS 0.951  OPS/S 21029  
-;; unique-insert                          OPS 20000  SECONDS 4.822  OPS/S 4147  
-;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.418  OPS/S 5851  
-;; indexed-insert                         OPS 20000  SECONDS 4.37  OPS/S 4576  
-;; index-lookup-eq                        OPS 20000  SECONDS 0.77  OPS/S 25973  
-;; index-range-1pct                       OPS 2000  SECONDS 6.167  OPS/S 324  
-;; index-fullscan-eq                      OPS 200  SECONDS 52.189  OPS/S 4  
-;; prolog-is-a-scan                       OPS 10000  SECONDS 0.147  OPS/S 68024  
+;; insert-vertices                        OPS 20000  SECONDS 3.624  OPS/S 5518  
+;; lookup-by-id                           OPS 20000  SECONDS 0.806  OPS/S 24813  
+;; scan-vertices                          OPS 20000  SECONDS 0.504  OPS/S 39680  
+;; update-vertices                        OPS 20000  SECONDS 1.755  OPS/S 11395  
+;; delete-vertices                        OPS 10000  SECONDS 0.81  OPS/S 12345  
+;; insert-edges                           OPS 20000  SECONDS 6.643  OPS/S 3011  
+;; scan-edges                             OPS 20000  SECONDS 1.751  OPS/S 11421  
+;; view-lookup                            OPS 20000  SECONDS 1.015  OPS/S 19703  
+;; unique-insert                          OPS 20000  SECONDS 4.816  OPS/S 4153  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.338  OPS/S 5991  
+;; indexed-insert                         OPS 20000  SECONDS 4.755  OPS/S 4206  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.885  OPS/S 22598  
+;; index-range-1pct                       OPS 2000  SECONDS 6.4  OPS/S 312  
+;; index-fullscan-eq                      OPS 200  SECONDS 56.615  OPS/S 4  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.151  OPS/S 66221  
 ;; prolog-edge-join                       OPS 5000  SECONDS 0.32  OPS/S 15624  
-;; commit-batched-1txn                    OPS 5000  SECONDS 0.77  OPS/S 6493  
-;; commit-per-op-Ntxn                     OPS 5000  SECONDS 3.06  OPS/S 1634  
-;; concurrent-rw                          OPS 32000  SECONDS 26.366  OPS/S 1214  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.823  OPS/S 6075  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 2.738  OPS/S 1826  
+;; concurrent-rw                          OPS 32000  SECONDS 21.699  OPS/S 1475  
 ;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
 ;; heap-used-after-updates                BYTES 3361034  PER-OP 168  
-;; snapshot                               SECONDS 1.704  
-;; restore-replay                         SECONDS 3.947  
-;; reopen                                 SECONDS 5.117  
-;; commit-multigraph-n1                   OPS 1000  SECONDS 0.6  OPS/S 1667  US/COMMIT 600.032  
-;; commit-multigraph-n2                   OPS 2000  SECONDS 0.644  OPS/S 3105  US/COMMIT 644.035  
-;; commit-multigraph-n4                   OPS 4000  SECONDS 0.932  OPS/S 4292  US/COMMIT 932.049  
-;; commit-multigraph-n8                   OPS 8000  SECONDS 6.43  OPS/S 1244  US/COMMIT 6430.337  
-;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.673  OPS/S 11886  US/COMMIT 673.035  
-;; watermark-persist-warm                 OPS 20000  SECONDS 3.733  OPS/S 5357  
-;; watermark-raw-write-warm               OPS 20000  SECONDS 1.367  OPS/S 14630  
-;; v5scan-f0-s1                           OPS 10000  SECONDS 0.421  OPS/S 23752  US/EDGE 42.102  EMITTED 2000  
-;; v5scan-f0-s2                           OPS 10000  SECONDS 0.427  OPS/S 23418  US/EDGE 42.702  EMITTED 2000  
-;; v5scan-f0-s4                           OPS 10000  SECONDS 0.43  OPS/S 23255  US/EDGE 43.002  EMITTED 2000  
-;; v5scan-f0-s8                           OPS 10000  SECONDS 0.392  OPS/S 25509  US/EDGE 39.202  EMITTED 2000  
-;; v5scan-f10-s1                          OPS 10000  SECONDS 0.407  OPS/S 24569  US/EDGE 40.702  EMITTED 1800  
-;; v5scan-f10-s2                          OPS 10000  SECONDS 0.42  OPS/S 23808  US/EDGE 42.002  EMITTED 1800  
-;; v5scan-f10-s4                          OPS 10000  SECONDS 0.464  OPS/S 21551  US/EDGE 46.402  EMITTED 1800  
-;; v5scan-f10-s8                          OPS 10000  SECONDS 0.488  OPS/S 20491  US/EDGE 48.802  EMITTED 1800  
-;; v5scan-f50-s1                          OPS 10000  SECONDS 0.396  OPS/S 25251  US/EDGE 39.602  EMITTED 1000  
-;; v5scan-f50-s2                          OPS 10000  SECONDS 0.439  OPS/S 22778  US/EDGE 43.902  EMITTED 1000  
-;; v5scan-f50-s4                          OPS 10000  SECONDS 0.518  OPS/S 19304  US/EDGE 51.803  EMITTED 1000  
-;; v5scan-f50-s8                          OPS 10000  SECONDS 0.624  OPS/S 16025  US/EDGE 62.403  EMITTED 1000  
-;; clock-commit-local                     OPS 2000  SECONDS 1.19  OPS/S 1681  US/COMMIT 595.031  
-;; clock-commit-clocked                   OPS 2000  SECONDS 1.252  OPS/S 1597  US/COMMIT 626.032  
-;; clock-epoch-alloc                      OPS 50000  SECONDS 0.005  OPS/S 9998000  
-;; clock-attach                           OPS 100  SECONDS 0.015  OPS/S 6666  
-;; clock-epoch-alloc-contended            OPS 20000  SECONDS 0.011  OPS/S 1818182  
-;; memory-open-rebuild                    SECONDS 1.441  
-;; memory-checkpoint                      SECONDS 0.233  
-;; memory-open-image-restore              SECONDS 0.471  
-;; compact-conservative                   SECONDS 0.949  COMPACTED 600  
-;; compact-trust-tags                     SECONDS 1.138  COMPACTED 800  
-;; peer-export-scope                      OPS 3601  SECONDS 0.386  OPS/S 9329  
-;; peer-apply                             OPS 3601  SECONDS 3.728  OPS/S 966  
-;; vector-insert                          OPS 5000  SECONDS 1.79  OPS/S 2793  
-;; vector-knn-k10                         OPS 200  SECONDS 1.211  OPS/S 165  
-;; vector-knn-k10-20k                     OPS 100  SECONDS 2.302  OPS/S 43  
+;; snapshot                               SECONDS 1.822  
+;; restore-replay                         SECONDS 4.186  
+;; reopen                                 SECONDS 5.6  
+;; commit-multigraph-n1                   OPS 1000  SECONDS 0.611  OPS/S 1637  US/COMMIT 611.014  
+;; commit-multigraph-n2                   OPS 2000  SECONDS 0.606  OPS/S 3300  US/COMMIT 606.016  
+;; commit-multigraph-n4                   OPS 4000  SECONDS 0.678  OPS/S 5900  US/COMMIT 678.016  
+;; commit-multigraph-n8                   OPS 8000  SECONDS 0.74  OPS/S 10811  US/COMMIT 740.017  
+;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.723  OPS/S 11065  US/COMMIT 723.017  
+;; watermark-persist-warm                 OPS 20000  SECONDS 1.422  OPS/S 14064  
+;; watermark-raw-write-warm               OPS 20000  SECONDS 1.375  OPS/S 14545  
+;; v5scan-f0-s1                           OPS 10000  SECONDS 0.43  OPS/S 23255  US/EDGE 43.001  EMITTED 2000  
+;; v5scan-f0-s2                           OPS 10000  SECONDS 0.434  OPS/S 23041  US/EDGE 43.401  EMITTED 2000  
+;; v5scan-f0-s4                           OPS 10000  SECONDS 0.401  OPS/S 24937  US/EDGE 40.101  EMITTED 2000  
+;; v5scan-f0-s8                           OPS 10000  SECONDS 0.44  OPS/S 22727  US/EDGE 44.001  EMITTED 2000  
+;; v5scan-f10-s1                          OPS 10000  SECONDS 0.501  OPS/S 19960  US/EDGE 50.101  EMITTED 1800  
+;; v5scan-f10-s2                          OPS 10000  SECONDS 0.551  OPS/S 18148  US/EDGE 55.101  EMITTED 1800  
+;; v5scan-f10-s4                          OPS 10000  SECONDS 0.51  OPS/S 19607  US/EDGE 51.001  EMITTED 1800  
+;; v5scan-f10-s8                          OPS 10000  SECONDS 0.533  OPS/S 18761  US/EDGE 53.301  EMITTED 1800  
+;; v5scan-f50-s1                          OPS 10000  SECONDS 0.433  OPS/S 23094  US/EDGE 43.301  EMITTED 1000  
+;; v5scan-f50-s2                          OPS 10000  SECONDS 0.505  OPS/S 19802  US/EDGE 50.501  EMITTED 1000  
+;; v5scan-f50-s4                          OPS 10000  SECONDS 0.581  OPS/S 17211  US/EDGE 58.101  EMITTED 1000  
+;; v5scan-f50-s8                          OPS 10000  SECONDS 0.669  OPS/S 14947  US/EDGE 66.902  EMITTED 1000  
+;; clock-commit-local                     OPS 2000  SECONDS 1.091  OPS/S 1833  US/COMMIT 545.514  
+;; clock-commit-clocked                   OPS 2000  SECONDS 1.115  OPS/S 1794  US/COMMIT 557.514  
+;; clock-epoch-alloc                      OPS 50000  SECONDS 0.006  OPS/S 8333334  
+;; clock-attach                           OPS 100  SECONDS 0.017  OPS/S 5882  
+;; clock-epoch-alloc-contended            OPS 20000  SECONDS 0.013  OPS/S 1538343  
+;; memory-open-rebuild                    SECONDS 1.155  
+;; memory-checkpoint                      SECONDS 0.187  
+;; memory-open-image-restore              SECONDS 0.467  
+;; compact-conservative                   SECONDS 0.913  COMPACTED 600  
+;; compact-trust-tags                     SECONDS 1.163  COMPACTED 800  
+;; peer-export-scope                      OPS 3601  SECONDS 0.411  OPS/S 8761  
+;; peer-apply                             OPS 3601  SECONDS 4.359  OPS/S 826  
+;; vector-insert                          OPS 5000  SECONDS 1.747  OPS/S 2862  
+;; vector-knn-k10                         OPS 200  SECONDS 1.166  OPS/S 172  
+;; vector-knn-k10-20k                     OPS 100  SECONDS 2.369  OPS/S 42  
 
-(:PERF-REPORT :TAG "rebless-g4-r2" :IMPL "SBCL 2.6.6" :SCALE :NORMAL
+(:PERF-REPORT :TAG "237-watermark-fix" :IMPL "SBCL 2.6.6" :SCALE :NORMAL
  :GENERATION 4 :HOST "odm" :ENTRIES
- (("insert-vertices" :OPS 20000 :SECONDS 3.575 :OPS/S 5594)
-  ("lookup-by-id" :OPS 20000 :SECONDS 0.867 :OPS/S 23067)
-  ("scan-vertices" :OPS 20000 :SECONDS 0.453 :OPS/S 44148)
-  ("update-vertices" :OPS 20000 :SECONDS 1.644 :OPS/S 12165)
-  ("delete-vertices" :OPS 10000 :SECONDS 0.726 :OPS/S 13773)
-  ("insert-edges" :OPS 20000 :SECONDS 5.927 :OPS/S 3374)
-  ("scan-edges" :OPS 20000 :SECONDS 1.513 :OPS/S 13218)
-  ("view-lookup" :OPS 20000 :SECONDS 0.951 :OPS/S 21029)
-  ("unique-insert" :OPS 20000 :SECONDS 4.822 :OPS/S 4147)
-  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.418 :OPS/S 5851)
-  ("indexed-insert" :OPS 20000 :SECONDS 4.37 :OPS/S 4576)
-  ("index-lookup-eq" :OPS 20000 :SECONDS 0.77 :OPS/S 25973)
-  ("index-range-1pct" :OPS 2000 :SECONDS 6.167 :OPS/S 324)
-  ("index-fullscan-eq" :OPS 200 :SECONDS 52.189 :OPS/S 4)
-  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.147 :OPS/S 68024)
+ (("insert-vertices" :OPS 20000 :SECONDS 3.624 :OPS/S 5518)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.806 :OPS/S 24813)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.504 :OPS/S 39680)
+  ("update-vertices" :OPS 20000 :SECONDS 1.755 :OPS/S 11395)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.81 :OPS/S 12345)
+  ("insert-edges" :OPS 20000 :SECONDS 6.643 :OPS/S 3011)
+  ("scan-edges" :OPS 20000 :SECONDS 1.751 :OPS/S 11421)
+  ("view-lookup" :OPS 20000 :SECONDS 1.015 :OPS/S 19703)
+  ("unique-insert" :OPS 20000 :SECONDS 4.816 :OPS/S 4153)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.338 :OPS/S 5991)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.755 :OPS/S 4206)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.885 :OPS/S 22598)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.4 :OPS/S 312)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 56.615 :OPS/S 4)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.151 :OPS/S 66221)
   ("prolog-edge-join" :OPS 5000 :SECONDS 0.32 :OPS/S 15624)
-  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.77 :OPS/S 6493)
-  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 3.06 :OPS/S 1634)
-  ("concurrent-rw" :OPS 32000 :SECONDS 26.366 :OPS/S 1214)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.823 :OPS/S 6075)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 2.738 :OPS/S 1826)
+  ("concurrent-rw" :OPS 32000 :SECONDS 21.699 :OPS/S 1475)
   ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
   ("heap-used-after-updates" :BYTES 3361034 :PER-OP 168)
-  ("snapshot" :SECONDS 1.704) ("restore-replay" :SECONDS 3.947)
-  ("reopen" :SECONDS 5.117)
-  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.6 :OPS/S 1667 :US/COMMIT
-   600.032)
-  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.644 :OPS/S 3105 :US/COMMIT
-   644.035)
-  ("commit-multigraph-n4" :OPS 4000 :SECONDS 0.932 :OPS/S 4292 :US/COMMIT
-   932.049)
-  ("commit-multigraph-n8" :OPS 8000 :SECONDS 6.43 :OPS/S 1244 :US/COMMIT
-   6430.337)
-  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.673 :OPS/S 11886
-   :US/COMMIT 673.035)
-  ("watermark-persist-warm" :OPS 20000 :SECONDS 3.733 :OPS/S 5357)
-  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.367 :OPS/S 14630)
-  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.421 :OPS/S 23752 :US/EDGE 42.102
+  ("snapshot" :SECONDS 1.822) ("restore-replay" :SECONDS 4.186)
+  ("reopen" :SECONDS 5.6)
+  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.611 :OPS/S 1637 :US/COMMIT
+   611.014)
+  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.606 :OPS/S 3300 :US/COMMIT
+   606.016)
+  ("commit-multigraph-n4" :OPS 4000 :SECONDS 0.678 :OPS/S 5900 :US/COMMIT
+   678.016)
+  ("commit-multigraph-n8" :OPS 8000 :SECONDS 0.74 :OPS/S 10811 :US/COMMIT
+   740.017)
+  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.723 :OPS/S 11065
+   :US/COMMIT 723.017)
+  ("watermark-persist-warm" :OPS 20000 :SECONDS 1.422 :OPS/S 14064)
+  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.375 :OPS/S 14545)
+  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.43 :OPS/S 23255 :US/EDGE 43.001
    :EMITTED 2000)
-  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.427 :OPS/S 23418 :US/EDGE 42.702
+  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.434 :OPS/S 23041 :US/EDGE 43.401
    :EMITTED 2000)
-  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.43 :OPS/S 23255 :US/EDGE 43.002
+  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.401 :OPS/S 24937 :US/EDGE 40.101
    :EMITTED 2000)
-  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.392 :OPS/S 25509 :US/EDGE 39.202
+  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.44 :OPS/S 22727 :US/EDGE 44.001
    :EMITTED 2000)
-  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.407 :OPS/S 24569 :US/EDGE 40.702
+  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.501 :OPS/S 19960 :US/EDGE 50.101
    :EMITTED 1800)
-  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.42 :OPS/S 23808 :US/EDGE 42.002
+  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.551 :OPS/S 18148 :US/EDGE 55.101
    :EMITTED 1800)
-  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.464 :OPS/S 21551 :US/EDGE 46.402
+  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.51 :OPS/S 19607 :US/EDGE 51.001
    :EMITTED 1800)
-  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.488 :OPS/S 20491 :US/EDGE 48.802
+  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.533 :OPS/S 18761 :US/EDGE 53.301
    :EMITTED 1800)
-  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.396 :OPS/S 25251 :US/EDGE 39.602
+  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.433 :OPS/S 23094 :US/EDGE 43.301
    :EMITTED 1000)
-  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.439 :OPS/S 22778 :US/EDGE 43.902
+  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.505 :OPS/S 19802 :US/EDGE 50.501
    :EMITTED 1000)
-  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.518 :OPS/S 19304 :US/EDGE 51.803
+  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.581 :OPS/S 17211 :US/EDGE 58.101
    :EMITTED 1000)
-  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.624 :OPS/S 16025 :US/EDGE 62.403
+  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.669 :OPS/S 14947 :US/EDGE 66.902
    :EMITTED 1000)
-  ("clock-commit-local" :OPS 2000 :SECONDS 1.19 :OPS/S 1681 :US/COMMIT 595.031)
-  ("clock-commit-clocked" :OPS 2000 :SECONDS 1.252 :OPS/S 1597 :US/COMMIT
-   626.032)
-  ("clock-epoch-alloc" :OPS 50000 :SECONDS 0.005 :OPS/S 9998000)
-  ("clock-attach" :OPS 100 :SECONDS 0.015 :OPS/S 6666)
-  ("clock-epoch-alloc-contended" :OPS 20000 :SECONDS 0.011 :OPS/S 1818182)
-  ("memory-open-rebuild" :SECONDS 1.441) ("memory-checkpoint" :SECONDS 0.233)
-  ("memory-open-image-restore" :SECONDS 0.471)
-  ("compact-conservative" :SECONDS 0.949 :COMPACTED 600)
-  ("compact-trust-tags" :SECONDS 1.138 :COMPACTED 800)
-  ("peer-export-scope" :OPS 3601 :SECONDS 0.386 :OPS/S 9329)
-  ("peer-apply" :OPS 3601 :SECONDS 3.728 :OPS/S 966)
-  ("vector-insert" :OPS 5000 :SECONDS 1.79 :OPS/S 2793)
-  ("vector-knn-k10" :OPS 200 :SECONDS 1.211 :OPS/S 165)
-  ("vector-knn-k10-20k" :OPS 100 :SECONDS 2.302 :OPS/S 43)))
+  ("clock-commit-local" :OPS 2000 :SECONDS 1.091 :OPS/S 1833 :US/COMMIT
+   545.514)
+  ("clock-commit-clocked" :OPS 2000 :SECONDS 1.115 :OPS/S 1794 :US/COMMIT
+   557.514)
+  ("clock-epoch-alloc" :OPS 50000 :SECONDS 0.006 :OPS/S 8333334)
+  ("clock-attach" :OPS 100 :SECONDS 0.017 :OPS/S 5882)
+  ("clock-epoch-alloc-contended" :OPS 20000 :SECONDS 0.013 :OPS/S 1538343)
+  ("memory-open-rebuild" :SECONDS 1.155) ("memory-checkpoint" :SECONDS 0.187)
+  ("memory-open-image-restore" :SECONDS 0.467)
+  ("compact-conservative" :SECONDS 0.913 :COMPACTED 600)
+  ("compact-trust-tags" :SECONDS 1.163 :COMPACTED 800)
+  ("peer-export-scope" :OPS 3601 :SECONDS 0.411 :OPS/S 8761)
+  ("peer-apply" :OPS 3601 :SECONDS 4.359 :OPS/S 826)
+  ("vector-insert" :OPS 5000 :SECONDS 1.747 :OPS/S 2862)
+  ("vector-knn-k10" :OPS 200 :SECONDS 1.166 :OPS/S 172)
+  ("vector-knn-k10-20k" :OPS 100 :SECONDS 2.369 :OPS/S 42)))

--- a/transactions.lisp
+++ b/transactions.lisp
@@ -1002,8 +1002,10 @@ APPLY-TRANSACTION)."
 
 ;;; Applying the transaction
 
-(defvar *highest-transaction-id-lock*
-  (make-recursive-lock "transaction id file"))
+;; The former process-global *HIGHEST-TRANSACTION-ID-LOCK* is gone:
+;; each graph has its own transaction-id.dat, so the watermark now
+;; locks per graph -- (WATERMARK-LOCK graph) -- and nothing cross-graph
+;; was ever protected (GH #237).
 
 (defgeneric highest-transaction-id-file (graph)
   (:method (graph)
@@ -1014,7 +1016,10 @@ APPLY-TRANSACTION)."
 (defgeneric %write-highest-transaction-id (transaction-id graph)
   (:documentation "Unconditional raw overwrite of transaction-id.dat --
 no max, no lock.  For crash-fabricating tests; production writers go
-through PERSIST-HIGHEST-TRANSACTION-ID (GH #177).")
+through PERSIST-HIGHEST-TRANSACTION-ID (GH #177).  Sets GRAPH's
+watermark cache to the written value -- a deliberate rewind must not
+leave a stale higher cache behind (GH #237).  Not concurrency-safe;
+never call it on a graph with live committers.")
   (:method (transaction-id graph)
     (let ((persist-file (highest-transaction-id-file graph))
           (serialized (make-byte-vector 8)))
@@ -1025,26 +1030,41 @@ through PERSIST-HIGHEST-TRANSACTION-ID (GH #177).")
                               :if-does-not-exist :create
                               :if-exists :overwrite)
         (write-sequence serialized stream))
+      (setf (watermark-cache graph) transaction-id)
       transaction-id)))
 
 (defgeneric persist-highest-transaction-id (transaction-id graph)
   (:documentation "Persist TRANSACTION-ID as GRAPH's durable watermark
-unless a higher one is already on disk -- the file only ever moves
-forward.  Returns the id actually on disk after the call (GH #177).")
+unless a higher one is already recorded -- the file only ever moves
+forward.  Returns the watermark standing after the call (GH #177).
+Steady state is one lock-free cache compare, or compare + write under
+GRAPH's own lock; the disk re-read happens once per graph object, to
+seed the cache (GH #237).")
   (:method (transaction-id graph)
-    ;; Lock spans read-compare-write: two racing writers must not let
-    ;; the lower id land last (GH #177).
-    (with-recursive-lock-held (*highest-transaction-id-lock*)
-      (let ((current (load-highest-transaction-id graph)))
-        (if (> transaction-id current)
-            (%write-highest-transaction-id transaction-id graph)
-            current)))))
+    ;; Fast path, no lock, no I/O: the cache only ever holds a value a
+    ;; writer put on disk, so cache >= id proves the file already holds
+    ;; >= id and the pre-#237 code would have skipped the write too.
+    ;; The slot is NIL or an integer -- a plain CLOS slot read cannot
+    ;; tear -- and a stale-low read just falls into the locked path.
+    (let ((cached (watermark-cache graph)))
+      (if (and cached (<= transaction-id cached))
+          cached
+          ;; Lock spans compare-write: two racing writers must not let
+          ;; the lower id land last (GH #177).
+          (with-recursive-lock-held ((watermark-lock graph))
+            (let ((current (or (watermark-cache graph)
+                               (load-highest-transaction-id graph))))
+              (setf (watermark-cache graph)
+                    (if (> transaction-id current)
+                        (%write-highest-transaction-id transaction-id
+                                                       graph)
+                        current))))))))
 
 (defgeneric load-highest-transaction-id (graph)
   (:method (graph)
     (let ((persist-file (highest-transaction-id-file graph))
           (serialized (make-byte-vector 8)))
-      (with-recursive-lock-held (*highest-transaction-id-lock*)
+      (with-recursive-lock-held ((watermark-lock graph))
         (if (probe-file persist-file)
             (with-open-file (stream persist-file
                                     :direction :input


### PR DESCRIPTION
Fixes #237 — the watermark-persistence cost introduced by #177's monotonic fix, justified by two independent evidence sets (the #252 microbenchmarks: ~89% of 8-graph commit latency, throughput inversion past 4 committers; the #263 release drift check: commit-per-op −34%, concurrent-rw −34%, restore-replay −21% since 3.0.0) — and with its recovery measured, not asserted.

## The fix

The durable watermark is **cached on the graph object** and the lock is **per-graph**:

- **Fast path** — cache known and `id ≤ cached` → return the cached value with no lock and no I/O. Safe by construction: the cache only ever holds a value a writer already put on disk (raised *after* the file write completes), so a lock-free reader can be stale-low — harmless, it takes the locked slow path — but never stale-high. The pre-#237 code would have skipped the write for such an id anyway; monotonic semantics are unchanged.
- **Slow path** under `(watermark-lock graph)` — seed the cache from disk once per graph object, write iff greater, cache updated. Steady-state commit: one compare + one write, zero reads.
- The process-global `*highest-transaction-id-lock*` is **removed** — review independently re-verified its only users were these two functions, and traced the shadow/restore rename machinery to confirm no two live graph objects can ever share one `transaction-id.dat` (the load-bearing one-object-per-directory assumption, enforced by `.dirty`, is documented at the slots).
- `%write-highest-transaction-id` (the crash-fabrication test writer) keeps the cache mirroring disk; documented non-concurrent (the perf bench's control cell is safe — each thread owns its graph).

## Measured recovery (`:normal`, vs the blessed baseline; re-blessed per the ritual)

| cell | before | after |
|---|---|---|
| commit-multigraph-n8 | 6,430 µs/commit | **~735 µs (−88.5%)** — now ≈ the raw-writer control |
| watermark-persist (isolated) | ~182 µs | **~68 µs (2.7×)** — ≈ raw write |
| concurrent-rw | 1,214 ops/s | 1,475–1,495 (+22%) |
| commit-per-op-Ntxn | 1,634 ops/s | 1,710–1,826 (+12%) |
| restore-replay | 4.62–4.71 s (same-day pre-fix) | 4.19–4.32 s |

All back within noise of the v3.0.0 release numbers. `snapshot`'s −13.9% did **not** move — not watermark-caused, now tracked as #265. The re-blessed `baseline-odm-g4.report` is in this diff (candidate eyeballed against norms first, per the g4 lesson).

## Verification

Adversarial review (APPROVE-WITH-NITS, applied): the fast-path memory-model argument verified and **empirically probed** (8 threads × 5,000 interleaved persists — every return ≥ its argument, final disk = cache = max); lock ordering confirmed a strict leaf (nests inside the TM lock only, one direction); four new/extended tests including the zero-I/O proof (`watermark-fast-path-touches-no-file`: file deleted after seeding, a lower-id persist answers correctly and the file stays absent). **Gate: full main suite fresh-image, 4,986 checks, 0 failures.** ECL skipped per the standing demotion directive.

Fixes #237. Refs #177, #252, #263, #265, #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp