### PR TITLE
Peer pull manifest: O(ops) accumulation, harnesses made self-evidencing (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **Peer pull manifest accumulation is O(ops), not O(ops²)** (#260).
+  The device writer loop accumulated the created-node manifest with a
+  `pushnew ... :test #'equalp` list — a linear scan of 16-byte id
+  arrays per state-create op, ~N²/2 compares on an N-node first sync.
+  It is now an id-keyed hash table, keeping the ack bounded and
+  duplicate-free across resumes (unacked creates are re-shipped after
+  a dropped connection and the accumulator survives it); the ack list
+  is materialized at the barrier, and its consumer folds it into a
+  set, so semantics are unchanged. The `peer-apply` bench now measures
+  the (now-cheap) accumulation it used to exclude (the #260 carve-out)
+  — suite generation bumps to 5.
+
 - **Watermark persistence no longer convoys commits** (#237). The #177
   monotonic fix made `persist-highest-transaction-id` re-read
   `transaction-id.dat` on every commit under one process-global lock;

--- a/peer-streaming.lisp
+++ b/peer-streaming.lisp
@@ -1394,7 +1394,12 @@ Accumulates the ids it durably holds/removed for the pull ack; a :barrier op
 reports + resets that accumulator, a :shutdown op ends the thread."
   (let ((*graph* graph)
         (mailbox (peer-writer-mailbox graph))
-        (created '())     ; state-create node-ids -> manifest additions this pull
+        ;; state-create node-ids -> manifest additions this pull.  An id table,
+        ;; not a PUSHNEW list: it keeps the ack bounded and duplicate-free
+        ;; across resumes (unacked creates re-ship after a dropped connection,
+        ;; and the accumulator survives it), and a list scan per op made a
+        ;; first sync O(ops^2) (GH #260).
+        (created (make-id-table))
         (purged '()))     ; purge node-ids -> manifest removals this pull
     (loop
       (let ((op (receive-message mailbox :timeout 1)))
@@ -1409,7 +1414,7 @@ reports + resets that accumulator, a :shutdown op ends the thread."
              (apply-peer-create-writes graph (peer-op-tx-id op) (peer-op-writes op)
                                        (peer-op-origin op))
              (dolist (w (peer-op-writes op))
-               (pushnew (id (node w)) created :test #'equalp)))
+               (setf (gethash (id (node w)) created) t)))
             (:authored
              ;; An edit to a node the device already HOLDS: apply (op-id-deduped),
              ;; but membership is unchanged -- it does NOT join CREATED.
@@ -1418,7 +1423,7 @@ reports + resets that accumulator, a :shutdown op ends the thread."
              (apply-peer-purge graph (peer-op-ids op))
              (dolist (pid (peer-op-ids op))
                (push pid purged)
-               (setf created (remove pid created :test #'equalp))))
+               (remhash pid created)))
             (:barrier
              ;; Advance the pull-cursor to the hub's frontier T (carried in TX-ID),
              ;; so it moves even when no authored op touched a held node.  Kept
@@ -1430,10 +1435,14 @@ reports + resets that accumulator, a :shutdown op ends the thread."
                ;; The frontier T dominates every epoch applied this pull; keep the
                ;; live counter above it so local edits can see all pulled nodes.
                (peer-observe-epoch graph frontier))
+             ;; Hub folds the ack into a set (PEER-PULL-PHASE), so the
+             ;; materialized list's order is free.
              (send-message (peer-op-reply op)
-                           (list :created (copy-list created)
+                           (list :created (loop for id being the hash-keys
+                                                  of created collect id)
                                  :purged (copy-list purged)))
-             (setf created '() purged '()))
+             (clrhash created)
+             (setf purged '()))
             (:local-write
              ;; A user/app write funneled here (WP-8) so it runs on the SAME thread as
              ;; the replication apply -- never a second writer contending with this loop

--- a/tests/peer-replication-push/device.lisp
+++ b/tests/peer-replication-push/device.lisp
@@ -34,6 +34,9 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+;; Provenance: prove WHICH tree this process loaded (GH #260).
+(format t "~&SOURCE: ~A~%" (asdf:system-source-directory :graph-db))
+(finish-output)
 
 ;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
 ;;; #186), so this process needs one before it opens anything.  Its OWN,

--- a/tests/peer-replication-push/hub.lisp
+++ b/tests/peer-replication-push/hub.lisp
@@ -39,6 +39,9 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+;; Provenance: prove WHICH tree this process loaded (GH #260).
+(format t "~&SOURCE: ~A~%" (asdf:system-source-directory :graph-db))
+(finish-output)
 
 ;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
 ;;; #186), so this process needs one before it opens anything.  Its OWN,

--- a/tests/peer-replication-push/run-push-test.sh
+++ b/tests/peer-replication-push/run-push-test.sh
@@ -45,9 +45,9 @@ HUB_CODE=$?
 kill "$HPID" 2>/dev/null
 
 echo "--- hub output ---"
-grep -E 'HUB|  ok|  FAIL' "$WORK/hub.out" 2>/dev/null || cat "$WORK/hub.out"
+grep -E 'SOURCE|HUB|  ok|  FAIL' "$WORK/hub.out" 2>/dev/null || cat "$WORK/hub.out"
 echo "--- device output ---"
-grep -E '  ok|  FAIL|DEVICE|ERROR' "$WORK/device.out" 2>/dev/null || cat "$WORK/device.out"
+grep -E 'SOURCE|  ok|  FAIL|DEVICE|ERROR' "$WORK/device.out" 2>/dev/null || cat "$WORK/device.out"
 
 if [ "$DEVICE_CODE" -eq 0 ] && [ "$HUB_CODE" -eq 0 ]; then
   echo "RESULT: PASS"

--- a/tests/peer-replication/device.lisp
+++ b/tests/peer-replication/device.lisp
@@ -47,6 +47,9 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+;; Provenance: prove WHICH tree this process loaded (GH #260).
+(format t "~&SOURCE: ~A~%" (asdf:system-source-directory :graph-db))
+(finish-output)
 
 ;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
 ;;; #186), so this process needs one before it opens anything.  Its OWN,

--- a/tests/peer-replication/hub.lisp
+++ b/tests/peer-replication/hub.lisp
@@ -46,6 +46,9 @@
   (let ((*standard-output* s) (*error-output* s))
     (ql:quickload :graph-db :silent t)))
 (in-package :graph-db)
+;; Provenance: prove WHICH tree this process loaded (GH #260).
+(format t "~&SOURCE: ~A~%" (asdf:system-source-directory :graph-db))
+(finish-output)
 
 ;;; Type-ids come from the image-level registry in *SYSTEM-DIRECTORY* (GH
 ;;; #186), so this process needs one before it opens anything.  Its OWN,

--- a/tests/peer-replication/run-peer-test.sh
+++ b/tests/peer-replication/run-peer-test.sh
@@ -56,9 +56,9 @@ HUB_CODE=$?
 kill "$HPID" 2>/dev/null   # belt and suspenders
 
 echo "--- hub output ---"
-grep -E 'HUB' "$WORK/hub.out" 2>/dev/null || cat "$WORK/hub.out"
+grep -E 'SOURCE|HUB' "$WORK/hub.out" 2>/dev/null || cat "$WORK/hub.out"
 echo "--- device output ---"
-grep -E '  ok|  FAIL|DEVICE|ERROR' "$WORK/device.out" 2>/dev/null || cat "$WORK/device.out"
+grep -E 'SOURCE|  ok|  FAIL|DEVICE|ERROR' "$WORK/device.out" 2>/dev/null || cat "$WORK/device.out"
 
 if [ "$DEVICE_CODE" -eq 0 ]; then
   echo "RESULT: PASS"

--- a/tests/perf/benchmarks.lisp
+++ b/tests/perf/benchmarks.lisp
@@ -762,12 +762,15 @@ of a socket: the sockets-free export half."
 (defun %peer-apply-wire-file (dev path)
   "Device-side decode + apply of the state-create packet file at PATH
 into DEV -- PEER-READ-AND-ENQUEUE's decode and the writer-loop's
-:state-create decode+apply work (mailbox hop and manifest accumulation
-excluded -- GH #260), single-threaded.  Returns the op count."
-  ;; Two deliberate exclusions vs the real writer loop: the mailbox
-  ;; hop (connection thread -> writer thread), and the created-manifest
-  ;; PUSHNEW accumulation -- O(ops^2) in production, filed as GH #260.
-  (let ((*graph* dev) (applied 0))
+:state-create decode+apply work including the created-manifest
+accumulation (mailbox hop still excluded), single-threaded.  Returns
+the op count."
+  ;; One deliberate exclusion vs the real writer loop: the mailbox hop
+  ;; (connection thread -> writer thread).  The created-manifest
+  ;; accumulation, excluded while it was an O(ops^2) PUSHNEW list, is
+  ;; measured since it became an id-table insert (GH #260).
+  (let ((*graph* dev) (applied 0)
+        (created (graph-db::make-id-table)))
     (with-open-file (in path :element-type '(unsigned-byte 8))
       (loop
         (let ((meta (graph-db::read-stream-packet in)))
@@ -783,6 +786,8 @@ excluded -- GH #260), single-threaded.  Returns the op count."
                                     (graph-db::read-stream-packet in)))))
               (graph-db::apply-peer-create-writes
                dev (graph-db::transaction-id txh) writes origin)
+              (dolist (w writes)
+                (setf (gethash (id (graph-db::node w)) created) t))
               (incf applied))))))))
 
 (defun bench-peer-replication ()

--- a/tests/perf/results/baseline-odm-g5.report
+++ b/tests/perf/results/baseline-odm-g5.report
@@ -1,0 +1,139 @@
+;;;; graph-db perf report
+;;;; tag=260-g5 impl=SBCL 2.6.6 scale=NORMAL generation=5 host=odm
+
+;; insert-vertices                        OPS 20000  SECONDS 3.948  OPS/S 5066  
+;; lookup-by-id                           OPS 20000  SECONDS 0.853  OPS/S 23445  
+;; scan-vertices                          OPS 20000  SECONDS 0.489  OPS/S 40898  
+;; update-vertices                        OPS 20000  SECONDS 1.714  OPS/S 11668  
+;; delete-vertices                        OPS 10000  SECONDS 0.764  OPS/S 13088  
+;; insert-edges                           OPS 20000  SECONDS 6.344  OPS/S 3152  
+;; scan-edges                             OPS 20000  SECONDS 1.623  OPS/S 12322  
+;; view-lookup                            OPS 20000  SECONDS 0.957  OPS/S 20898  
+;; unique-insert                          OPS 20000  SECONDS 4.736  OPS/S 4223  
+;; unique-baseline-plain-insert           OPS 20000  SECONDS 3.372  OPS/S 5931  
+;; indexed-insert                         OPS 20000  SECONDS 4.753  OPS/S 4208  
+;; index-lookup-eq                        OPS 20000  SECONDS 0.889  OPS/S 22496  
+;; index-range-1pct                       OPS 2000  SECONDS 6.861  OPS/S 291  
+;; index-fullscan-eq                      OPS 200  SECONDS 58.541  OPS/S 3  
+;; prolog-is-a-scan                       OPS 10000  SECONDS 0.155  OPS/S 64513  
+;; prolog-edge-join                       OPS 5000  SECONDS 0.296  OPS/S 16891  
+;; commit-batched-1txn                    OPS 5000  SECONDS 0.814  OPS/S 6142  
+;; commit-per-op-Ntxn                     OPS 5000  SECONDS 2.545  OPS/S 1965  
+;; concurrent-rw                          OPS 32000  SECONDS 18.802  OPS/S 1702  
+;; heap-used-after-inserts                BYTES 1601034  PER-OP 80  
+;; heap-used-after-updates                BYTES 3361034  PER-OP 168  
+;; snapshot                               SECONDS 1.612  
+;; restore-replay                         SECONDS 4.035  
+;; reopen                                 SECONDS 5.17  
+;; commit-multigraph-n1                   OPS 1000  SECONDS 0.48  OPS/S 2083  US/COMMIT 480.025  
+;; commit-multigraph-n2                   OPS 2000  SECONDS 0.531  OPS/S 3766  US/COMMIT 531.026  
+;; commit-multigraph-n4                   OPS 4000  SECONDS 0.572  OPS/S 6993  US/COMMIT 572.03  
+;; commit-multigraph-n8                   OPS 8000  SECONDS 0.677  OPS/S 11816  US/COMMIT 677.035  
+;; commit-multigraph-n8-rawwm             OPS 8000  SECONDS 0.664  OPS/S 12048  US/COMMIT 664.036  
+;; watermark-persist-warm                 OPS 20000  SECONDS 1.362  OPS/S 14684  
+;; watermark-raw-write-warm               OPS 20000  SECONDS 1.205  OPS/S 16597  
+;; v5scan-f0-s1                           OPS 10000  SECONDS 0.423  OPS/S 23639  US/EDGE 42.302  EMITTED 2000  
+;; v5scan-f0-s2                           OPS 10000  SECONDS 0.395  OPS/S 25315  US/EDGE 39.502  EMITTED 2000  
+;; v5scan-f0-s4                           OPS 10000  SECONDS 0.414  OPS/S 24153  US/EDGE 41.402  EMITTED 2000  
+;; v5scan-f0-s8                           OPS 10000  SECONDS 0.433  OPS/S 23094  US/EDGE 43.302  EMITTED 2000  
+;; v5scan-f10-s1                          OPS 10000  SECONDS 0.412  OPS/S 24271  US/EDGE 41.202  EMITTED 1800  
+;; v5scan-f10-s2                          OPS 10000  SECONDS 0.452  OPS/S 22123  US/EDGE 45.202  EMITTED 1800  
+;; v5scan-f10-s4                          OPS 10000  SECONDS 0.521  OPS/S 19193  US/EDGE 52.103  EMITTED 1800  
+;; v5scan-f10-s8                          OPS 10000  SECONDS 0.47  OPS/S 21275  US/EDGE 47.003  EMITTED 1800  
+;; v5scan-f50-s1                          OPS 10000  SECONDS 0.451  OPS/S 22172  US/EDGE 45.102  EMITTED 1000  
+;; v5scan-f50-s2                          OPS 10000  SECONDS 0.489  OPS/S 20449  US/EDGE 48.902  EMITTED 1000  
+;; v5scan-f50-s4                          OPS 10000  SECONDS 0.545  OPS/S 18348  US/EDGE 54.503  EMITTED 1000  
+;; v5scan-f50-s8                          OPS 10000  SECONDS 0.705  OPS/S 14184  US/EDGE 70.504  EMITTED 1000  
+;; clock-commit-local                     OPS 2000  SECONDS 1.087  OPS/S 1840  US/COMMIT 543.528  
+;; clock-commit-clocked                   OPS 2000  SECONDS 1.018  OPS/S 1965  US/COMMIT 509.027  
+;; clock-epoch-alloc                      OPS 50000  SECONDS 0.006  OPS/S 8331945  
+;; clock-attach                           OPS 100  SECONDS 0.014  OPS/S 7142  
+;; clock-epoch-alloc-contended            OPS 20000  SECONDS 0.008  OPS/S 2500000  
+;; memory-open-rebuild                    SECONDS 1.0  
+;; memory-checkpoint                      SECONDS 0.176  
+;; memory-open-image-restore              SECONDS 0.404  
+;; compact-conservative                   SECONDS 1.083  COMPACTED 600  
+;; compact-trust-tags                     SECONDS 1.101  COMPACTED 800  
+;; peer-export-scope                      OPS 3601  SECONDS 0.387  OPS/S 9304  
+;; peer-apply                             OPS 3601  SECONDS 4.133  OPS/S 871  
+;; vector-insert                          OPS 5000  SECONDS 1.773  OPS/S 2820  
+;; vector-knn-k10                         OPS 200  SECONDS 1.192  OPS/S 168  
+;; vector-knn-k10-20k                     OPS 100  SECONDS 2.318  OPS/S 43  
+
+(:PERF-REPORT :TAG "260-g5" :IMPL "SBCL 2.6.6" :SCALE :NORMAL :GENERATION 5
+ :HOST "odm" :ENTRIES
+ (("insert-vertices" :OPS 20000 :SECONDS 3.948 :OPS/S 5066)
+  ("lookup-by-id" :OPS 20000 :SECONDS 0.853 :OPS/S 23445)
+  ("scan-vertices" :OPS 20000 :SECONDS 0.489 :OPS/S 40898)
+  ("update-vertices" :OPS 20000 :SECONDS 1.714 :OPS/S 11668)
+  ("delete-vertices" :OPS 10000 :SECONDS 0.764 :OPS/S 13088)
+  ("insert-edges" :OPS 20000 :SECONDS 6.344 :OPS/S 3152)
+  ("scan-edges" :OPS 20000 :SECONDS 1.623 :OPS/S 12322)
+  ("view-lookup" :OPS 20000 :SECONDS 0.957 :OPS/S 20898)
+  ("unique-insert" :OPS 20000 :SECONDS 4.736 :OPS/S 4223)
+  ("unique-baseline-plain-insert" :OPS 20000 :SECONDS 3.372 :OPS/S 5931)
+  ("indexed-insert" :OPS 20000 :SECONDS 4.753 :OPS/S 4208)
+  ("index-lookup-eq" :OPS 20000 :SECONDS 0.889 :OPS/S 22496)
+  ("index-range-1pct" :OPS 2000 :SECONDS 6.861 :OPS/S 291)
+  ("index-fullscan-eq" :OPS 200 :SECONDS 58.541 :OPS/S 3)
+  ("prolog-is-a-scan" :OPS 10000 :SECONDS 0.155 :OPS/S 64513)
+  ("prolog-edge-join" :OPS 5000 :SECONDS 0.296 :OPS/S 16891)
+  ("commit-batched-1txn" :OPS 5000 :SECONDS 0.814 :OPS/S 6142)
+  ("commit-per-op-Ntxn" :OPS 5000 :SECONDS 2.545 :OPS/S 1965)
+  ("concurrent-rw" :OPS 32000 :SECONDS 18.802 :OPS/S 1702)
+  ("heap-used-after-inserts" :BYTES 1601034 :PER-OP 80)
+  ("heap-used-after-updates" :BYTES 3361034 :PER-OP 168)
+  ("snapshot" :SECONDS 1.612) ("restore-replay" :SECONDS 4.035)
+  ("reopen" :SECONDS 5.17)
+  ("commit-multigraph-n1" :OPS 1000 :SECONDS 0.48 :OPS/S 2083 :US/COMMIT
+   480.025)
+  ("commit-multigraph-n2" :OPS 2000 :SECONDS 0.531 :OPS/S 3766 :US/COMMIT
+   531.026)
+  ("commit-multigraph-n4" :OPS 4000 :SECONDS 0.572 :OPS/S 6993 :US/COMMIT
+   572.03)
+  ("commit-multigraph-n8" :OPS 8000 :SECONDS 0.677 :OPS/S 11816 :US/COMMIT
+   677.035)
+  ("commit-multigraph-n8-rawwm" :OPS 8000 :SECONDS 0.664 :OPS/S 12048
+   :US/COMMIT 664.036)
+  ("watermark-persist-warm" :OPS 20000 :SECONDS 1.362 :OPS/S 14684)
+  ("watermark-raw-write-warm" :OPS 20000 :SECONDS 1.205 :OPS/S 16597)
+  ("v5scan-f0-s1" :OPS 10000 :SECONDS 0.423 :OPS/S 23639 :US/EDGE 42.302
+   :EMITTED 2000)
+  ("v5scan-f0-s2" :OPS 10000 :SECONDS 0.395 :OPS/S 25315 :US/EDGE 39.502
+   :EMITTED 2000)
+  ("v5scan-f0-s4" :OPS 10000 :SECONDS 0.414 :OPS/S 24153 :US/EDGE 41.402
+   :EMITTED 2000)
+  ("v5scan-f0-s8" :OPS 10000 :SECONDS 0.433 :OPS/S 23094 :US/EDGE 43.302
+   :EMITTED 2000)
+  ("v5scan-f10-s1" :OPS 10000 :SECONDS 0.412 :OPS/S 24271 :US/EDGE 41.202
+   :EMITTED 1800)
+  ("v5scan-f10-s2" :OPS 10000 :SECONDS 0.452 :OPS/S 22123 :US/EDGE 45.202
+   :EMITTED 1800)
+  ("v5scan-f10-s4" :OPS 10000 :SECONDS 0.521 :OPS/S 19193 :US/EDGE 52.103
+   :EMITTED 1800)
+  ("v5scan-f10-s8" :OPS 10000 :SECONDS 0.47 :OPS/S 21275 :US/EDGE 47.003
+   :EMITTED 1800)
+  ("v5scan-f50-s1" :OPS 10000 :SECONDS 0.451 :OPS/S 22172 :US/EDGE 45.102
+   :EMITTED 1000)
+  ("v5scan-f50-s2" :OPS 10000 :SECONDS 0.489 :OPS/S 20449 :US/EDGE 48.902
+   :EMITTED 1000)
+  ("v5scan-f50-s4" :OPS 10000 :SECONDS 0.545 :OPS/S 18348 :US/EDGE 54.503
+   :EMITTED 1000)
+  ("v5scan-f50-s8" :OPS 10000 :SECONDS 0.705 :OPS/S 14184 :US/EDGE 70.504
+   :EMITTED 1000)
+  ("clock-commit-local" :OPS 2000 :SECONDS 1.087 :OPS/S 1840 :US/COMMIT
+   543.528)
+  ("clock-commit-clocked" :OPS 2000 :SECONDS 1.018 :OPS/S 1965 :US/COMMIT
+   509.027)
+  ("clock-epoch-alloc" :OPS 50000 :SECONDS 0.006 :OPS/S 8331945)
+  ("clock-attach" :OPS 100 :SECONDS 0.014 :OPS/S 7142)
+  ("clock-epoch-alloc-contended" :OPS 20000 :SECONDS 0.008 :OPS/S 2500000)
+  ("memory-open-rebuild" :SECONDS 1.0) ("memory-checkpoint" :SECONDS 0.176)
+  ("memory-open-image-restore" :SECONDS 0.404)
+  ("compact-conservative" :SECONDS 1.083 :COMPACTED 600)
+  ("compact-trust-tags" :SECONDS 1.101 :COMPACTED 800)
+  ("peer-export-scope" :OPS 3601 :SECONDS 0.387 :OPS/S 9304)
+  ("peer-apply" :OPS 3601 :SECONDS 4.133 :OPS/S 871)
+  ("vector-insert" :OPS 5000 :SECONDS 1.773 :OPS/S 2820)
+  ("vector-knn-k10" :OPS 200 :SECONDS 1.192 :OPS/S 168)
+  ("vector-knn-k10-20k" :OPS 100 :SECONDS 2.318 :OPS/S 43)))

--- a/tests/perf/suite.lisp
+++ b/tests/perf/suite.lisp
@@ -22,11 +22,13 @@
 (defparameter *lisp-impl*
   (format nil "~A ~A" (lisp-implementation-type) (lisp-implementation-version)))
 
-(defparameter *perf-suite-generation* 4
+(defparameter *perf-suite-generation* 5
   "Suite generation for baseline comparability (GH #253).  Bump when any
 change alters an existing bench's work or its labels; adding a new bench
 does not bump.  Generations 1-3 retroactively cover the pre-#252 report
-eras still visible in results/ (2.1.1 / 3.0 A-B / mvcc phase runs).")
+eras still visible in results/ (2.1.1 / 3.0 A-B / mvcc phase runs).
+g4->g5: peer-apply now includes the created-manifest accumulation its
+#260 exclusion note used to carve out.")
 
 (defun perf-host ()
   "Sanitized (machine-instance): lowercase, [a-z0-9-] only."


### PR DESCRIPTION
Fixes #260 — the O(ops²) created-manifest accumulation the #254 bench review discovered in the production pull path.

## The fix

The device writer loop's `created` accumulator becomes an **id-keyed hash table** (`make-id-table` — the portable idiom the peer path already uses; ECL branch verified for the Android device): `gethash` per state-create, `remhash` on purge (the purge branch's own O(n) `remove` was the sibling shape, fixed in the same stroke), hash-keys materialized at the `:barrier`. Measured accumulation cost at 50k ids: **20.1 s → 0.029 s**.

Dedup is retained deliberately, and the justification was review-verified against the writer loop's actual lifetime: one loop per graph, surviving reconnects — a dropped connection means no barrier and no reset, and the hub's fail-closed manifest re-ships unacked creates into the still-live accumulator on resume. The table keeps the ack bounded and duplicate-free across those resumes; correctness never depended on it (the hub folds the ack into a set — the Kotlin device's dedup-free ack already exercises that tolerance), and the wire's ack shape is unchanged.

## Bench + generation

`%peer-apply-wire-file`'s documented #260 carve-out is lifted — `peer-apply` now measures the (now-cheap) accumulation. Under our own rule that changing a bench's work bumps the suite generation, `*perf-suite-generation*` → **5**, with `baseline-odm-g5.report` blessed from a post-fix run (g4 kept as history). `peer-apply` measures strictly more of the real path and still improved: 826 (g4 baseline) → 871–908 nodes/s.

## Verification — with a process improvement

The first review round returned NEEDS-FIXES on verification honesty: the multi-process harness PASSes could not be *proven* to have loaded the fixed code (the harness processes quickload against the ambient registry, which resolves to the main checkout). Fixed permanently: all four harness lisp files now print their resolved `graph-db` source directory after quickload, and the runner scripts pass those lines through. The re-runs show **all four processes on the worktree** — pull harness 12/12, push harness 6/6, both PASS. Otherwise the review verified the lifecycle claim true, set-equivalence exact in every path, lock-free of wire changes, and the g5 baseline in-family.

**Gate: full main suite fresh-image, 4,986 checks, 0 failures.** ECL skipped per the standing demotion directive.

Fixes #260. Refs #254, #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp