### PR TITLE
Docs: Chapter 19, the perf-vs-profiling split (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **The perf-vs-profiling split is documented** (#255). Chapter 19 of
+  the manual (`docs/vivace-graph-v3-doc.org`) now states which
+  measurement system answers which question — `tests/perf/`
+  (throughput trends, "did it get slower?", baselines + `check-perf`)
+  vs `profiling/` (where-time-goes, "why is it slow?",
+  sprof/sb-profile harness) — and how to run each. New
+  `tests/perf/README.md`; `profiling/README.md` and CLAUDE.md point at
+  the chapter and at `docs/perf-baselines.md`.
+
 - **Release-baseline measurement record** (#263). Three-tree perf
   measurement (v2.1.1 / v3.0.0 / experiment, each running its own
   suite; comparison over the byte-identical-verified intersection) on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,10 @@ subdirectories, **3,359 checks** as of 2026-08-08. Run a suite through ASDF:
 with "Heap exhausted, game over" partway in — `make-graph`'s type index eagerly builds
 131,072 index-lists, and a suite creates many graphs in one image.
 
-Perf regression checking (per-host/per-generation baselines, `check-perf`) is
+Two perf measurement systems coexist — `tests/perf/` (throughput trends, "did it
+get slower?") vs `profiling/` ("why is it slow?" — sprof/sb-profile harness).
+The split and how to run each is Chapter 19 of `docs/vivace-graph-v3-doc.org`;
+regression checking (per-host/per-generation baselines, `check-perf`) is
 documented in `docs/perf-baselines.md`.
 
 Each `test-op` errors on failure, so they are safe to gate on. Run the main suite before

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -5053,6 +5053,99 @@ bounds. Without GEOS, ~register-geometry~ refuses an extended geometry
 outright (above) rather than approximating and then trying to confirm
 the approximation; build that step only if a backend ever needs it.
 
+** Chapter 19: Measuring Performance
+
+The repository carries two performance measurement systems, and they
+answer different questions. Reaching for the wrong one wastes an
+afternoon, so the split is worth stating plainly:
+
+- ~tests/perf/~ (system ~graph-db/perf-test~) measures *throughput
+  trends over time* — "did it get slower?" A fixed set of benchmarks
+  writes a report file; reports are compared against blessed
+  per-host baselines to catch regressions.
+- ~profiling/~ (system ~graph-db/profiler~) measures *where the time
+  goes* — "why is it slow?" Per-subsystem workload modules run under
+  ~sb-sprof~ statistical sampling and ~sb-profile~ deterministic
+  tracing, with console tables and an optional PDF report.
+
+Detect with the perf suite; diagnose with the profiler. Both are
+SBCL-focused.
+
+*** The throughput suite (~tests/perf/~)
+
+Run it in a fresh SBCL with the enlarged heap every suite in this
+repository needs:
+
+#+BEGIN_SRC sh
+  sbcl --dynamic-space-size 16384
+#+END_SRC
+
+#+BEGIN_SRC lisp
+  (ql:quickload :graph-db/perf-test)
+  (graph-db/perf-test:run-perf :tag "my-tag")
+#+END_SRC
+
+~run-perf~ is measurement-only — it always returns ~T~ and never
+fails a build. It runs every benchmark at ~:normal~ scale (pass
+~:scale :small~ for a ~10x-smaller quick loop; only ~:normal~ runs
+are comparable) and writes a report — the path is printed at the
+end — stamped with tag, implementation, scale, host, and the *suite
+generation*, the counter in ~tests/perf/suite.lisp~ that is bumped
+whenever a change alters an existing bench's work or labels.
+
+Regression checking is a separate, deliberate step:
+~check-perf~ compares a report against the blessed baseline for its
+host and generation
+(~tests/perf/results/baseline-<host>-g<gen>.report~, committed);
+~bless-perf-baseline~ adopts a new one. The rule that governs every
+comparison: *never compare reports across suite generations or
+hosts* — ~check-perf~ refuses to, because such a diff is a setup
+mistake, not a perf result. The full ritual — blessing discipline,
+tolerance bands, release gating — lives in [[file:perf-baselines.md]];
+that document, not this chapter, is authoritative.
+
+One case necessarily crosses generations: comparing *releases*, whose
+trees ship different suites. The method there is the intersection: run
+each tag's own suite on one host, interleaved, and compare only labels
+whose bench implementations were first verified identical across the
+trees. ~tests/perf/results/release-comparison-2026-08-27.md~ is the
+worked example, and its preamble is the recipe.
+
+*** The profiler (~profiling/~)
+
+#+BEGIN_SRC lisp
+  (ql:quickload :graph-db/profiler)
+
+  ;; All subsystem workloads, report at the REPL:
+  (graph-db/profiler:run-full-profiling-suite)
+
+  ;; Same, plus a multi-page PDF report:
+  (graph-db/profiler:profile-and-generate-pdf
+   :output-file "/tmp/vg-profiling.pdf" :scale 1.0)
+
+  ;; Production-shaped workloads (measured application shapes):
+  (graph-db/profiler:run-real-world-profiling-suite)
+#+END_SRC
+
+To profile your own code rather than a canned workload, wrap it in
+the harness macro (~profiling/harness.lisp~):
+
+#+BEGIN_SRC lisp
+  (graph-db/profiler:profile-block
+      (:name "my hot path" :subsystems '(:serialization))
+    (my-workload))
+#+END_SRC
+
+Two things to know before trusting a run: call
+~subsystem-coverage-report~ first to see what will actually be traced
+(inlined functions never are; use the sampler for those), and heed
+the ~!~ overhead flag in the output — on functions called millions of
+times, ~sb-profile~'s reported time is mostly the profiler observing
+itself. ~profiling/README.md~ carries these caveats in full and
+describes the workload modules; ~docs/profiler-guide.md~ is the
+complete usage guide. Note ~graph-db/geos~ is a hard dependency of
+the profiler.
+
 ** API Reference
 
 This chapter provides a categorized reference for the most important exported symbols from the ~graph-db~ package. It is not an exhaustive list of every internal function but focuses on the public API you will use most often when building applications.

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -2,19 +2,29 @@
 
 This directory contains the source code for the **Vivace-Graph Performance Profiling Tool**, a modular benchmarking and PDF reporting suite built using SBCL's `sb-sprof` and `sb-profile` tools alongside `cl-typesetting` and `cl-pdf`.
 
+This harness answers **"why is it slow?"** (where the time goes). The
+throughput suite in `tests/perf/` (`graph-db/perf-test`) answers the other
+question — **"did it get slower?"** — with report files, per-host baselines
+and `check-perf` gating. See:
+
+- Chapter 19 of [`docs/vivace-graph-v3-doc.org`](../docs/vivace-graph-v3-doc.org)
+  — the perf-vs-profiling split and how to run each.
+- [`docs/perf-baselines.md`](../docs/perf-baselines.md) — the baseline /
+  regression-gating ritual for the throughput suite.
+
 For the complete usage guide, API reference, and examples, see:
-- [`docs/profiler-guide.md`](file:///Users/kraison/work/vivace-graph-v3/docs/profiler-guide.md)
+- [`docs/profiler-guide.md`](../docs/profiler-guide.md)
 
 ---
 
 ## Directory Layout
 
-- [`package.lisp`](file:///Users/kraison/work/vivace-graph-v3/profiling/package.lisp): Package definition (`graph-db/profiler`) and exports.
-- [`registry.lisp`](file:///Users/kraison/work/vivace-graph-v3/profiling/registry.lisp): Subsystem function registry for function tracing.
-- [`sprof.lisp`](file:///Users/kraison/work/vivace-graph-v3/profiling/sprof.lisp): `sb-sprof` statistical sample profiling wrapper and parser.
-- [`profile.lisp`](file:///Users/kraison/work/vivace-graph-v3/profiling/profile.lisp): `sb-profile` deterministic tracing wrapper and parser.
-- [`harness.lisp`](file:///Users/kraison/work/vivace-graph-v3/profiling/harness.lisp): Core unified `profile-block` macro harness.
-- [`modules/`](file:///Users/kraison/work/vivace-graph-v3/profiling/modules/): Subsystem-specific profiler modules:
+- [`package.lisp`](./package.lisp): Package definition (`graph-db/profiler`) and exports.
+- [`registry.lisp`](./registry.lisp): Subsystem function registry for function tracing.
+- [`sprof.lisp`](./sprof.lisp): `sb-sprof` statistical sample profiling wrapper and parser.
+- [`profile.lisp`](./profile.lisp): `sb-profile` deterministic tracing wrapper and parser.
+- [`harness.lisp`](./harness.lisp): Core unified `profile-block` macro harness.
+- [`modules/`](./modules/): Subsystem-specific profiler modules:
   - `mmap.lisp` (SAP byte access & memory arena allocation)
   - `serialization.lisp` (Binary codecs & key encoders)
   - `index.lisp` (Skip-List & B+ Tree index backends)
@@ -24,7 +34,7 @@ For the complete usage guide, API reference, and examples, see:
   - `spatial.lisp` (Geohash cell math & GEOS CFFI operations)
   - `prolog.lisp` (Prolog engine, predicate compilation, & unification)
   - `suite.lisp` (Full suite runner `run-full-profiling-suite`)
-- [`reporting/`](file:///Users/kraison/work/vivace-graph-v3/profiling/reporting/):
+- [`reporting/`](./reporting/):
   - `pdf.lisp` (PDF generation & 2-pass vector graph rendering engine)
 
 ---

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,50 @@
+# tests/perf/ — the throughput benchmark suite
+
+System `graph-db/perf-test`. Answers **"did it get slower?"** — throughput
+trends over time. It does not tell you *why* something is slow; that is the
+`profiling/` harness (`graph-db/profiler`). The split, and how to run each,
+is Chapter 19 of `docs/vivace-graph-v3-doc.org`.
+
+```
+sbcl --dynamic-space-size 16384
+```
+
+```lisp
+(ql:quickload :graph-db/perf-test)
+(graph-db/perf-test:run-perf :tag "my-tag")
+```
+
+Measurement-only by default: `run-perf` always returns T and writes a report
+file (path printed at the end). Regression *gating* is the separate
+`check-perf` / `bless-perf-baseline` step — the ritual, tolerance bands and
+release wiring are in `docs/perf-baselines.md` (GH #253).
+
+## What lives here
+
+- `suite.lisp` — harness: scale knob, report schema/IO, `compare-perf`, and
+  `*perf-suite-generation*` (see below).
+- `benchmarks.lisp` — the benches themselves; `run-perf` is the entry point.
+- `check.lisp` — `check-perf` + `bless-perf-baseline` (GH #253).
+- `check-tests.lisp` — FiveAM tests for the checker (run by the main suite).
+- `bplus-bench.lisp` — B+ tree vs skip-list side-by-side (`graph-db::bplus-bench`).
+- `variance.py` — run-to-run variance analysis over report files.
+- `results/` — committed report files (see below).
+
+## Generations, and the one comparison rule
+
+Every report is stamped with host, impl, scale and **suite generation**
+(`*perf-suite-generation*` in `suite.lisp`, bumped whenever a change alters
+an existing bench's work or labels). **Never compare reports across suite
+generations or hosts** — `check-perf` refuses to; such a diff is a setup
+mistake, not a perf result.
+
+## results/
+
+- `baseline-<host>-g<gen>.report` — the blessed baselines `check-perf` gates
+  against; committed via reviewed diff only (`docs/perf-baselines.md`).
+- `release-<tag>-<host>-r<N>.report` + `release-comparison-<date>.md` — the
+  release-measurement records: each tag runs its *own* suite and only
+  verified-identical benches are compared (the intersection method — the
+  comparison doc is the worked example and recipe).
+- Everything else is historical runs (2.1.1/3.0 A-B, MVCC phases), kept as
+  the record their era's analysis cites.


### PR DESCRIPTION
The perf-suite expansion's final unit (tracker #256). Fixes #255 — closes the epic on merge.

## What changed (doc-only)

- **Chapter 19 — Measuring Performance** in the manual: the split stated plainly (detect with the perf suite, diagnose with the profiler), verified invocations for both systems (including the profiler's `run-full-profiling-suite` / `profile-and-generate-pdf` / `run-real-world-profiling-suite` / `profile-block` and its trust-before-you-run caveats), the suite-generation concept and the one comparison rule, `docs/perf-baselines.md` as the authoritative ritual, and the release-intersection method with `release-comparison-2026-08-27.md` as the worked example and recipe.
- **New `tests/perf/README.md`**: contents map, the generation rule, and the `results/` file taxonomy (blessed baselines / release records / historical runs).
- **`profiling/README.md`**: the see-also block — and its nine absolute `file:///Users/...` links (the old macOS checkout path, broken on Linux and GitHub) fixed to relative.
- **CLAUDE.md**: the tests-section pointer now names both systems and the chapter.

Every cited path, exported symbol, and invocation was grep-verified against HEAD (g5, `baseline-odm-g5.report`, 17 benches); no drifting numbers are restated in prose. No code changes; no suite run required.

Fixes #255. Refs #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp