### PR TITLE
GUI U1: graph-db/gui backend -- system, lifecycle, endpoints, tests (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **`graph-db/gui`: the web cockpit's backend** (#269, epic #106).
+  A new optional subsystem serving a JSON management/exploration API
+  and static frontend assets over ningle/clack: `start-gui`/`stop-gui`
+  (port 4270, loopback-bound by default), a store roster derived from
+  the store registry + clock-journal `:attach` records (falling back
+  to the open-graph table without a system directory), open/close
+  management verbs (dirty stores answer 409 with the condition's
+  report), per-graph stats, type inventory, bounded node samples, node
+  inspection, and a snapshot-consistent `neighborhood` batch endpoint
+  for the explorer. Reads resolve the graph by name per request — the
+  GUI holds no graph state — and `rest.lisp` is untouched. Tested by
+  the new `graph-db/gui-test` FiveAM suite over real HTTP (drakma).
+  Manual: the "GUI cockpit" section beside Chapter 9.
+
 - **The perf-vs-profiling split is documented** (#255). Chapter 19 of
   the manual (`docs/vivace-graph-v3-doc.org`) now states which
   measurement system answers which question — `tests/perf/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ The system is layered. Lower layers know nothing of graph semantics; higher laye
 5. **Transactions** — `transactions.lisp` (ACID with read-set/write-set validation and retry; `*maximum-transaction-attempts*` then exclusive lock), `transaction-restore.lisp`, `transaction-log-streaming.lisp`, `transaction-streaming.lisp`. Replication: `backup.lisp`, `replication.lisp`, `txn-log.lisp`.
 6. **Query** — a full embedded Prolog engine: `functor.lisp`, `prologc.lisp` (compiler), `prolog-functors.lisp` (built-in predicates). `select` / `select-flat` / `select-one` / `do-query` are the query entry points. `interface.lisp` + `traverse.lisp` provide the Lisp-method query API (`map-vertices`, `map-edges`, `traverse`, `outgoing-edges`, etc.).
 7. **REST** — `rest.lisp` exposes the graph over HTTP (hunchentoot/ningle/clack); `start-rest` / `stop-rest` / `def-rest-procedure`.
+8. **GUI** — optional `graph-db/gui` subsystem (`gui/`): the web cockpit backend (`start-gui`/`stop-gui`, roster/stats/explorer JSON API + static assets); separate from `rest.lisp`, tested by `graph-db/gui-test` over real HTTP (GH #269).
 
 ### On-disk layout
 

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -1833,6 +1833,53 @@ Let's assume our graph `:social-app` is running.
   #+END_SRC
 
 
+*** The GUI cockpit (~graph-db/gui~, optional)
+
+Alongside the public REST API, the optional ~graph-db/gui~ subsystem
+serves a web cockpit for operators: a store roster with open/close
+management, per-graph stats, and a read-only neighborhood explorer
+(GH #269, epic #106; design:
+~docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md~). It is a
+separate ningle/clack app — ~rest.lisp~ is untouched — and its
+handlers call engine internals directly rather than proxying REST.
+
+#+BEGIN_SRC lisp
+  (ql:quickload :graph-db/gui)
+  (graph-db.gui:start-gui)                  ; port 4270, 127.0.0.1
+  (graph-db.gui:start-gui :port 8090 :bind "127.0.0.1")
+  (graph-db.gui:stop-gui)
+#+END_SRC
+
+Both calls are idempotent. The GUI binds loopback by default —
+localhost is the v1 security boundary. Static assets under
+~gui/static/~ are served at ~/~ (resolved via
+~asdf:system-relative-pathname~); every request path must resolve, by
+~truename~, to a file *inside* the static root — ~..~, ~~~-expansion
+and symlink escapes are refused — and the JSON API lives under
+~/api/~.
+The GUI holds no graph state: every request resolves its graph by
+name at request time, so a graph closed mid-session yields a clean
+404, never a stale handle.
+
+| Endpoint                                   | Method | Purpose                                                          |
+|--------------------------------------------+--------+------------------------------------------------------------------|
+| ~/api/graphs~                              | GET    | Roster: name, location, open/closed (registry + clock journal, falling back to the open-graph table) |
+| ~/api/graphs/:name/open~                   | POST   | Open at the roster's recorded location only; dirty store = 409 with the condition's report |
+| ~/api/graphs/:name/close~                  | POST   | Close; a not-open graph is a 409                                 |
+| ~/api/graphs/:name/stats~                  | GET    | Vertex/edge totals, per-type counts, view + index inventories, on-disk size, schema summary |
+| ~/api/graphs/:name/types~                  | GET    | Vertex/edge type inventory                                       |
+| ~/api/graphs/:name/nodes?type=X&limit=N~   | GET    | Bounded node sample (default limit 50)                           |
+| ~/api/graphs/:name/node/:id~               | GET    | Node inspection: type, slots as a JSON object, in/out edge counts |
+| ~/api/graphs/:name/neighborhood/:id?limit=N~ | GET  | One-round-trip ~{nodes, edges, truncated}~ batch, both directions, under a read snapshot (default limit 100) |
+
+Node ids on the wire are the engine's 32-hex-character ~string-id~
+form; a malformed id is a 400. Every handler answers errors as JSON
+~{error, message}~ — 404 unknown graph/node/type, 409 dirty/conflict,
+400 malformed, 500 with the condition's report — and never a
+backtrace; details go to the log4cl log. The two management verbs
+serialize through one lock. Tests: ~(asdf:test-system
+:graph-db/gui-test)~ drives the whole surface over real HTTP.
+
 ** Chapter 10: Replication and High Availability (~replication.lisp~)
 
 For production environments, relying on a single database instance creates a single point of failure. If the machine hosting the database goes down, your application becomes unavailable. To solve this, VivaceGraph provides a built-in *master-slave replication* system, implemented primarily in ~replication.lisp~ and ~transaction-streaming.lisp~.

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -197,6 +197,43 @@
   :components ((:file "rest"))
   :in-order-to ((test-op (test-op :graph-db/test))))
 
+;; OPTIONAL GUI cockpit backend (GH #269, design doc
+;; docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md).  Own subsystem,
+;; NOT an extension of rest.lisp: an operational, private surface
+;; (roster/open/close/stats + the explorer's batch endpoints) on a
+;; different evolution clock than the public REST API.  Static frontend
+;; assets live in gui/static/ and resolve via
+;; asdf:system-relative-pathname.
+(defsystem graph-db/gui
+  :name "VivaceGraph GUI backend"
+  :description "Web cockpit for VivaceGraph: roster, open/close, stats,
+and read-only neighborhood exploration."
+  :maintainer "Kevin Raison"
+  :author "Kevin Raison <last name @ chatsubo dot net>"
+  :version "3.0.0"
+  :depends-on (:graph-db :ningle :clack :cl-json :lack-component)
+  :pathname "gui/"
+  :serial t
+  :components ((:file "package")
+               (:file "api")
+               (:file "server"))
+  :in-order-to ((test-op (test-op :graph-db/gui-test))))
+
+(defsystem graph-db/gui-test
+  :name "VivaceGraph GUI test suite"
+  :description "FiveAM + drakma tests driving the GUI API over real HTTP."
+  :depends-on (:graph-db/gui :graph-db/test-scratch :fiveam :drakma
+               :usocket :flexi-streams :bordeaux-threads)
+  :pathname "tests/gui/"
+  :serial t
+  :components ((:file "package")
+               (:file "suite")
+               (:file "gui-tests"))
+  :perform (test-op (op c)
+                    (unless (uiop:symbol-call :graph-db/gui-test
+                                              :run-gui-tests)
+                      (error "graph-db GUI tests failed."))))
+
 (defsystem graph-db/test-scratch
   :name "VivaceGraph shared test scratch-space manager"
   :description "Per-run scratch parent + stale sweep for all suites (GH #214)."

--- a/gui/api.lisp
+++ b/gui/api.lisp
@@ -1,0 +1,556 @@
+;;;; GUI API endpoints (GH #269).
+;;;;
+;;;; Every handler resolves its graph BY NAME at request time -- the GUI
+;;;; holds no graph state.  Reads call engine internals directly
+;;;; (lookup-vertex, outgoing-edges/incoming-edges, the type table);
+;;;; nothing proxies through rest.lisp.  Error contract: handler-case ->
+;;;; JSON {error, message}; 404 unknown graph/node/type, 409
+;;;; dirty/conflict, 400 malformed, 500 with the condition's report.  No
+;;;; backtraces to the browser; details go to log4cl.
+
+(in-package #:graph-db.gui)
+
+;;; ---------------------------------------------------------------------
+;;; Request/response helpers
+;;; ---------------------------------------------------------------------
+
+(defun param (params name)
+  "PARAMS value under NAME (a keyword route capture or a string query
+parameter), as ningle delivers them."
+  (cdr (assoc name params :test #'equalp)))
+
+;;; Responses use cl-json's EXPLICIT encoder: the default guessing
+;;; encoder renders an alist as a JSON object only when it stumbles on
+;;; a dotted pair, so an alist whose values are all lists/NIL silently
+;;; becomes an ARRAY.  Every nested object/array/boolean is tagged
+;;; with %OBJ / %ARR / %BOOL below.
+
+(defun %obj (alist) (cons :object alist))
+(defun %arr (list) (cons :array list))
+(defun %bool (x) (json:json-bool x))
+(defun %maybe (x) (json:json-or-null x))
+
+(defun %json-value (v)
+  "An arbitrary slot value in explicit-encoder terms: atoms pass (NIL
+as null), proper lists become arrays, anything else prints."
+  (typecase v
+    (null (%maybe nil))
+    ((or string number keyword symbol) v)
+    (cons (if (ignore-errors (list-length v))
+              (%arr (mapcar #'%json-value v))
+              (princ-to-string v)))
+    (t (princ-to-string v))))
+
+(defun %json-response (alist &key (status 200))
+  (setf (lack.response:response-status ningle:*response*) status)
+  (setf (lack.response:response-headers ningle:*response*)
+        (list* :content-type "application/json; charset=utf-8"
+               (lack.response:response-headers ningle:*response*)))
+  (json:with-explicit-encoder
+    (json:encode-json-to-string (%obj alist))))
+
+(defun gui-error (status code message)
+  "The uniform error body: {error, message} with an honest STATUS."
+  (%json-response (list (cons :error code) (cons :message message))
+                  :status status))
+
+(defmacro def-gui-handler (name (params) &body body)
+  "Define ningle handler NAME with the GUI error contract wrapped
+around BODY.  A dirty store surfaces its report verbatim as a 409; any
+other condition is a 500 whose report reaches the client and whose
+details go to the log."
+  `(defun ,name (,params)
+     (declare (ignorable ,params))
+     (handler-case (progn ,@body)
+       (graph-db::store-not-closed-cleanly-error (c)
+         (gui-error 409 "dirty-store" (princ-to-string c)))
+       (error (c)
+         (log:error "GUI ~A: ~A" ',name c)
+         (gui-error 500 "internal-error" (princ-to-string c))))))
+
+;;; ---------------------------------------------------------------------
+;;; Roster: what stores does this system know?
+;;; ---------------------------------------------------------------------
+
+(defun %wire-name (name)
+  "NAME (symbol or string) as its URL/JSON spelling."
+  (if (symbolp name)
+      (string-downcase (symbol-name name))
+      (princ-to-string name)))
+
+(defun %name-key (name)
+  "Dedupe key for NAME across registry/journal/*graphs* spellings."
+  (graph-db::%store-name-key name))
+
+(defstruct roster-entry
+  name          ; raw name, usable with open-graph
+  location      ; namestring or NIL
+  open-p)
+
+(defun %journal-attach-locations ()
+  "Keyword store name -> latest :ATTACH location from the clock
+journal.  Reads via *SYSTEM-CLOCK* when bound, else an unowned clock
+over *SYSTEM-DIRECTORY* (JOURNAL-RECORDS never truncates unowned)."
+  (let ((table (make-hash-table :test 'equal))
+        (clock (or graph-db::*system-clock*
+                   (and graph-db::*system-directory*
+                        (graph-db::%make-system-clock
+                         :location graph-db::*system-directory*)))))
+    (when clock
+      (handler-case
+          (dolist (r (graph-db::journal-records clock))
+            (when (and (eq (getf r :kind) :attach) (getf r :location))
+              (setf (gethash (%name-key (getf r :store)) table)
+                    (getf r :location))))
+        (error (c)
+          (log:warn "GUI roster: unreadable system journal: ~A" c))))
+    table))
+
+(defun gui-roster ()
+  "The store roster: registry names + journal :ATTACH locations,
+deduped, overlaid with the open graphs in *GRAPHS*.  Falls back to
+*GRAPHS* alone when no *SYSTEM-DIRECTORY* is bound.  Cheap by design:
+name, location, open/closed -- no stats."
+  (let ((entries (make-hash-table :test 'equal)))
+    (flet ((entry (name)
+             (or (gethash (%name-key name) entries)
+                 (setf (gethash (%name-key name) entries)
+                       (make-roster-entry :name name)))))
+      (when graph-db::*system-directory*
+        (handler-case
+            (maphash (lambda (name id)
+                       (declare (ignore id))
+                       (entry name))
+                     (graph-db::store-registry-names
+                      (graph-db::ensure-store-registry)))
+          (error (c)
+            (log:warn "GUI roster: store registry unreadable: ~A" c)))
+        (maphash (lambda (key location)
+                   (setf (roster-entry-location (entry key))
+                         (namestring location)))
+                 (%journal-attach-locations)))
+      (maphash (lambda (name graph)
+                 (when (and (typep graph 'graph-db::graph)
+                            (graph-db::graph-open-p graph))
+                   (let ((e (entry name)))
+                     (setf (roster-entry-name e) name
+                           (roster-entry-open-p e) t
+                           (roster-entry-location e)
+                           (namestring (graph-db::location graph))))))
+               graph-db::*graphs*))
+    (let ((result '()))
+      (maphash (lambda (key e) (declare (ignore key)) (push e result))
+               entries)
+      (sort result #'string< :key (lambda (e)
+                                    (%wire-name (roster-entry-name e)))))))
+
+(defun find-roster-entry (wire-name)
+  (find wire-name (gui-roster)
+        :key (lambda (e) (%wire-name (roster-entry-name e)))
+        :test #'string-equal))
+
+(defun find-open-graph (wire-name)
+  "The OPEN graph whose name spells WIRE-NAME, or NIL."
+  (maphash (lambda (name graph)
+             (when (and (typep graph 'graph-db::graph)
+                        (graph-db::graph-open-p graph)
+                        (string-equal (%wire-name name) wire-name))
+               (return-from find-open-graph graph)))
+           graph-db::*graphs*)
+  nil)
+
+(defun %roster-json (entry)
+  (%obj (list (cons :name (%wire-name (roster-entry-name entry)))
+              (cons :location (%maybe (roster-entry-location entry)))
+              (cons :open (%bool (roster-entry-open-p entry))))))
+
+(def-gui-handler api-graphs (params)
+  (%json-response
+   (list (cons :graphs (%arr (mapcar #'%roster-json (gui-roster)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Management verbs: open / close.  Both serialize through the ONE
+;;; exclusive side of *GUI-RW-LOCK*, so a race surfaces as a clean 409,
+;;; never as two concurrent opens.
+;;; ---------------------------------------------------------------------
+
+;; GUI-local reader/writer coordination (GH #269): CLOSE-GRAPH unmaps
+;; the store's mmaps, so a read handler racing an in-flight close would
+;; fault or read freed bytes.  Every graph-read handler holds the
+;; shared side across resolve+read; open/close hold the exclusive side.
+;; CLOSE-GRAPH itself is untouched.
+(defvar *gui-rw-lock* (graph-db::make-rw-lock))
+
+(def-gui-handler api-open-graph (params)
+  (let ((wire (param params :name)))
+    (graph-db::with-write-lock (*gui-rw-lock*)
+      (let ((open (find-open-graph wire)))
+        (if open
+            (%json-response (list (cons :name wire) (cons :open t)
+                                  (cons :status "already-open")))
+            (let ((entry (find-roster-entry wire)))
+              (cond
+                ((null entry)
+                 (gui-error 404 "unknown-graph"
+                            (format nil "Unknown graph ~A" wire)))
+                ((null (roster-entry-location entry))
+                 (gui-error 404 "no-recorded-location"
+                            (format nil "No recorded location for ~
+graph ~A; the GUI opens stores only at their roster location" wire)))
+                ((not (uiop:directory-exists-p
+                       (roster-entry-location entry)))
+                 (gui-error 404 "location-missing"
+                            (format nil "Recorded location ~A for ~
+graph ~A no longer exists"
+                                    (roster-entry-location entry)
+                                    wire)))
+                (t
+                 ;; Strictly at the recorded location -- no free-form
+                 ;; paths.  A dirty store signals STORE-NOT-CLOSED-
+                 ;; CLEANLY-ERROR, which DEF-GUI-HANDLER maps to 409.
+                 (graph-db:open-graph (roster-entry-name entry)
+                                      (roster-entry-location entry))
+                 (%json-response
+                  (list (cons :name wire) (cons :open t)
+                        (cons :status "opened")))))))))))
+
+(def-gui-handler api-close-graph (params)
+  (let ((wire (param params :name)))
+    (graph-db::with-write-lock (*gui-rw-lock*)
+      (let ((graph (find-open-graph wire)))
+        (if graph
+            (progn
+              (graph-db:close-graph graph)
+              (%json-response (list (cons :name wire)
+                                    (cons :open (%bool nil))
+                                    (cons :status "closed"))))
+            (gui-error 409 "not-open"
+                       (format nil "Graph ~A is not open" wire)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Read endpoints.  Each resolves its graph per request; a closed or
+;;; unknown graph is a 404.
+;;; ---------------------------------------------------------------------
+
+(defmacro with-gui-graph ((var params) &body body)
+  "Bind VAR to the open graph named by PARAMS' :name, or answer 404.
+Holds *GUI-RW-LOCK*'s shared side across resolve+read so an in-flight
+close cannot unmap the store mid-read (GH #269)."
+  `(graph-db::with-read-lock (*gui-rw-lock*)
+     (let ((,var (find-open-graph (param ,params :name))))
+       (if ,var
+           (progn ,@body)
+           (gui-error 404 "unknown-graph"
+                      (format nil "Graph ~A is not open"
+                              (param ,params :name)))))))
+
+(defun %schema-type-names (graph parent)
+  "Node-type names (class symbols) registered for PARENT (:vertex or
+:edge) in GRAPH's schema, sorted by name."
+  (let ((names '()))
+    (maphash (lambda (key meta)
+               (when (numberp key)
+                 (push (graph-db::node-type-name meta) names)))
+             (gethash parent (graph-db::schema-type-table
+                             (graph-db::schema graph))))
+    (sort names #'string< :key #'symbol-name)))
+
+(defun %camel (symbol)
+  (json:lisp-to-camel-case (symbol-name symbol)))
+
+(defun %per-type-counts (graph)
+  "(values vertex-alist edge-alist) of (class-name . count), one sweep
+of each table."
+  (let ((v (make-hash-table :test 'eq))
+        (e (make-hash-table :test 'eq)))
+    (graph-db:map-vertices
+     (lambda (x) (incf (gethash (class-name (class-of x)) v 0))) graph)
+    (graph-db:map-edges
+     (lambda (x) (incf (gethash (class-name (class-of x)) e 0))) graph)
+    (flet ((as-alist (table)
+             (let ((acc '()))
+               (maphash (lambda (k n) (push (cons k n) acc)) table)
+               (sort acc #'string< :key (lambda (c)
+                                          (symbol-name (car c)))))))
+      (values (as-alist v) (as-alist e)))))
+
+(defun %on-disk-size (graph)
+  "Total bytes of the files under GRAPH's directory; unreadable files
+count zero."
+  (let ((total 0))
+    (fad:walk-directory
+     (graph-db::location graph)
+     (lambda (file)
+       (incf total
+             (or (ignore-errors
+                  (with-open-file (s file :element-type
+                                       '(unsigned-byte 8))
+                    (file-length s)))
+                 0)))
+     :directories nil)
+    total))
+
+(defun %schema-summary (graph parent)
+  "[{name, slots:[...]}] for PARENT's node types."
+  (mapcar (lambda (type-name)
+            (let ((meta (graph-db::lookup-node-type-by-name
+                         (intern (symbol-name type-name) :keyword)
+                         parent :graph graph)))
+              (%obj
+               (list (cons :name (%camel type-name))
+                     (cons :slots
+                           (%arr
+                            (mapcar (lambda (slot-def)
+                                      (%camel (if (consp slot-def)
+                                                  (first slot-def)
+                                                  slot-def)))
+                                    (and meta
+                                         (graph-db::node-type-slots
+                                          meta)))))))))
+          (%schema-type-names graph parent)))
+
+(defun %index-inventory (graph)
+  "DEF-INDEX specs + spatial indexes registered for GRAPH."
+  (append
+   (mapcar (lambda (spec)
+             (%obj
+              (list (cons :kind "ordered")
+                    (cons :owner
+                          (%camel
+                           (graph-db::index-spec-owner-name spec)))
+                    (cons :slots
+                          (%arr
+                           (mapcar #'%camel
+                                   (graph-db::index-spec-slot-names
+                                    spec)))))))
+           (graph-db::%registered-index-specs graph))
+   (let ((acc '()))
+     (maphash (lambda (key idx)
+                (declare (ignore idx))
+                (push (%obj
+                       (list (cons :kind "spatial")
+                             (cons :owner (%camel (car key)))
+                             (cons :slots
+                                   (%arr (list (%camel (cdr key)))))))
+                      acc))
+              (graph-db::spatial-indexes graph))
+     (nreverse acc))))
+
+(def-gui-handler api-graph-stats (params)
+  (with-gui-graph (graph params)
+    (multiple-value-bind (v-counts e-counts) (%per-type-counts graph)
+      (%json-response
+       (list (cons :name (param params :name))
+             (cons :vertex-count
+                   (graph-db::read-lhash-count
+                    (graph-db::vertex-table graph)))
+             (cons :edge-count
+                   (graph-db::read-lhash-count
+                    (graph-db::edge-table graph)))
+             (cons :vertex-counts-by-type (%obj v-counts))
+             (cons :edge-counts-by-type (%obj e-counts))
+             (cons :views
+                   (%arr
+                    (mapcar (lambda (pair)
+                              (%obj
+                               (list (cons :class (%camel (car pair)))
+                                     (cons :name (%camel (cdr pair))))))
+                            (graph-db::list-views graph))))
+             (cons :indexes (%arr (%index-inventory graph)))
+             (cons :on-disk-bytes (%on-disk-size graph))
+             (cons :schema
+                   (%obj
+                    (list (cons :vertex-types
+                                (%arr (%schema-summary graph :vertex)))
+                          (cons :edge-types
+                                (%arr (%schema-summary
+                                       graph :edge)))))))))))
+
+(def-gui-handler api-graph-types (params)
+  (with-gui-graph (graph params)
+    (%json-response
+     (list (cons :vertex-types
+                 (%arr (mapcar #'%camel
+                               (%schema-type-names graph :vertex))))
+           (cons :edge-types
+                 (%arr (mapcar #'%camel
+                               (%schema-type-names graph :edge))))))))
+
+;;; ---------------------------------------------------------------------
+;;; Node sample, inspection, neighborhood
+;;; ---------------------------------------------------------------------
+
+(defparameter *default-node-limit* 50)
+(defparameter *default-neighborhood-limit* 100)
+
+(defun %parse-limit (params default)
+  "The \"limit\" query parameter as a positive integer, else DEFAULT."
+  (let* ((raw (param params "limit"))
+         (n (and raw (ignore-errors (parse-integer raw)))))
+    (if (and n (plusp n)) n default)))
+
+(defun %resolve-vertex-type (graph wire-type)
+  "WIRE-TYPE (camelCase) as a vertex class symbol of GRAPH, or NIL."
+  (let ((meta (handler-case
+                  (graph-db::lookup-node-type-by-name
+                   (intern (json:camel-case-to-lisp wire-type) :keyword)
+                   :vertex :graph graph)
+                (error () nil))))
+    (and meta (graph-db::node-type-name meta))))
+
+(defun %vertex-brief (v)
+  (list (cons :id (graph-db:string-id v))
+        (cons :type (%camel (class-name (class-of v))))))
+
+(def-gui-handler api-graph-nodes (params)
+  (with-gui-graph (graph params)
+    (let ((wire-type (param params "type"))
+          (limit (%parse-limit params *default-node-limit*)))
+      (if (null wire-type)
+          (gui-error 400 "missing-type"
+                     "The \"type\" query parameter is required")
+          (let ((type (%resolve-vertex-type graph wire-type)))
+            (if (null type)
+                (gui-error 404 "unknown-type"
+                           (format nil "Unknown vertex type ~A"
+                                   wire-type))
+                (let ((nodes '()) (count 0) (truncated nil))
+                  (block sample
+                    (graph-db:map-vertices
+                     (lambda (v)
+                       (when (>= count limit)
+                         (setq truncated t)
+                         (return-from sample))
+                       (push (%vertex-brief v) nodes)
+                       (incf count))
+                     graph :vertex-type type))
+                  (%json-response
+                   (list (cons :type wire-type)
+                         (cons :nodes
+                               (%arr (mapcar #'%obj
+                                             (nreverse nodes))))
+                         (cons :truncated (%bool truncated)))))))))))
+
+(defun %parse-node-id (string)
+  "STRING as a 16-byte id array, or NIL when malformed.  Wire ids are
+the engine's 32-hex-character STRING-ID form."
+  (and (stringp string)
+       (= 32 (length string))
+       (every (lambda (ch) (digit-char-p ch 16)) string)
+       (graph-db::read-id-array-from-string string)))
+
+(defun %node-slots-alist (node)
+  "NODE's data slots as an alist keyed by camelCase slot names.  The
+underlying node data is an ALIST of (:SLOT . value) conses -- this is
+the JSON-object rendering of it."
+  (mapcar (lambda (slot-name)
+            (cons (%camel slot-name)
+                  (%json-value (slot-value node slot-name))))
+          (graph-db::data-slots (class-of node))))
+
+(def-gui-handler api-graph-node (params)
+  (with-gui-graph (graph params)
+    (let ((id (%parse-node-id (param params :id))))
+      (if (null id)
+          (gui-error 400 "malformed-id"
+                     (format nil "Malformed node id ~A"
+                             (param params :id)))
+          (let ((v (graph-db:lookup-vertex id :graph graph)))
+            (cond
+              (v (%json-response
+                  (list (cons :id (graph-db:string-id v))
+                        (cons :type (%camel (class-name (class-of v))))
+                        (cons :slots (%obj (%node-slots-alist v)))
+                        (cons :in-edge-count
+                              (length (graph-db:incoming-edges
+                                       v :graph graph)))
+                        (cons :out-edge-count
+                              (length (graph-db:outgoing-edges
+                                       v :graph graph))))))
+              (t
+               (let ((e (graph-db:lookup-edge id :graph graph)))
+                 (if e
+                     (%json-response
+                      (list (cons :id (graph-db:string-id e))
+                            (cons :type (%camel
+                                         (class-name (class-of e))))
+                            (cons :from (graph-db:string-id
+                                         (graph-db::from e)))
+                            (cons :to (graph-db:string-id
+                                       (graph-db::to e)))
+                            (cons :slots
+                                  (%obj (%node-slots-alist e)))))
+                     (gui-error 404 "unknown-node"
+                                (format nil "Unknown node ~A"
+                                        (param params :id))))))))))))
+
+(def-gui-handler api-graph-neighborhood (params)
+  (with-gui-graph (graph params)
+    (let ((id (%parse-node-id (param params :id)))
+          (limit (%parse-limit params *default-neighborhood-limit*)))
+      (if (null id)
+          (gui-error 400 "malformed-id"
+                     (format nil "Malformed node id ~A"
+                             (param params :id)))
+          ;; One consistent snapshot for the whole batch: the node, its
+          ;; edges in both directions, and every neighbor endpoint.
+          (graph-db:with-read-snapshot (graph)
+            (let ((center (graph-db:lookup-vertex id :graph graph)))
+              (if (null center)
+                  (gui-error 404 "unknown-node"
+                             (format nil "Unknown node ~A"
+                                     (param params :id)))
+                  (let* ((out (graph-db:outgoing-edges
+                               center :graph graph))
+                         (in (graph-db:incoming-edges
+                              center :graph graph))
+                         (all (append out in))
+                         (truncated (> (length all) limit))
+                         (edges (if truncated
+                                    (subseq all 0 limit)
+                                    all))
+                         (nodes (make-hash-table :test 'equal)))
+                    (setf (gethash (graph-db:string-id center) nodes)
+                          (%vertex-brief center))
+                    (dolist (e edges)
+                      (dolist (end (list (graph-db::from e)
+                                         (graph-db::to e)))
+                        (let ((sid (graph-db:string-id end)))
+                          (unless (gethash sid nodes)
+                            (let ((v (graph-db:lookup-vertex
+                                      end :graph graph)))
+                              (when v
+                                (setf (gethash sid nodes)
+                                      (%vertex-brief v))))))))
+                    (let ((node-list '()))
+                      (maphash (lambda (k v)
+                                 (declare (ignore k))
+                                 (push v node-list))
+                               nodes)
+                      (%json-response
+                       (list
+                        (cons :nodes
+                              (%arr
+                               (mapcar
+                                #'%obj
+                                (sort node-list #'string<
+                                      :key (lambda (n)
+                                             (cdr (assoc :id n)))))))
+                        (cons :edges
+                              (%arr
+                               (mapcar
+                                (lambda (e)
+                                  (%obj
+                                   (list
+                                    (cons :id (graph-db:string-id e))
+                                    (cons :type
+                                          (%camel
+                                           (class-name (class-of e))))
+                                    (cons :from
+                                          (graph-db:string-id
+                                           (graph-db::from e)))
+                                    (cons :to
+                                          (graph-db:string-id
+                                           (graph-db::to e))))))
+                                edges)))
+                        (cons :truncated (%bool truncated)))))))))))))

--- a/gui/package.lisp
+++ b/gui/package.lisp
@@ -1,0 +1,13 @@
+;;;; Package for the graph-db/gui subsystem (GH #269).
+;;;;
+;;;; The GUI is an operational cockpit over engine internals, so it
+;;;; reads GRAPH-DB's unexported machinery directly (always via explicit
+;;;; GRAPH-DB:: qualification -- greppable, and no import list to rot).
+
+(in-package #:cl-user)
+
+(defpackage #:graph-db.gui
+  (:use #:cl)
+  (:export #:start-gui
+           #:stop-gui
+           #:*gui-port*))

--- a/gui/server.lisp
+++ b/gui/server.lisp
@@ -1,0 +1,141 @@
+;;;; GUI server lifecycle + static file serving (GH #269).
+;;;;
+;;;; Mirrors START-REST's ningle/clack shape.  The GUI holds NO graph
+;;;; state: every request resolves its graph by name at request time
+;;;; (see api.lisp), so a graph closed mid-session yields a clean JSON
+;;;; error, never a stale handle.
+
+(in-package #:graph-db.gui)
+
+(defvar *gui-port* 4270)
+(defvar *gui-app* nil)
+(defvar *gui-handler* nil
+  "The running clack handler, or NIL when the GUI is stopped.")
+
+(defun gui-static-root ()
+  "The gui/static/ directory of the loaded graph-db source tree.
+The binary future swaps this serving strategy, not the layout."
+  (asdf:system-relative-pathname :graph-db/gui "gui/static/"))
+
+(defparameter *static-content-types*
+  '(("html" . "text/html; charset=utf-8")
+    ("css"  . "text/css; charset=utf-8")
+    ("js"   . "application/javascript; charset=utf-8")
+    ("mjs"  . "application/javascript; charset=utf-8")
+    ("json" . "application/json; charset=utf-8")
+    ("svg"  . "image/svg+xml")
+    ("png"  . "image/png")
+    ("ico"  . "image/x-icon")
+    ("map"  . "application/json"))
+  "File extension -> Content-Type for static assets.")
+
+(defun %static-content-type (path)
+  (or (cdr (assoc (string-downcase (or (pathname-type path) ""))
+                  *static-content-types* :test #'equal))
+      "application/octet-stream"))
+
+(defun %pathname-under-p (path root)
+  "True when truename PATH sits inside truename directory ROOT."
+  (let ((pd (pathname-directory path))
+        (rd (pathname-directory root)))
+    (and (>= (length pd) (length rd))
+         (equal (subseq pd 0 (length rd)) rd))))
+
+(defun %safe-static-path (path-info root)
+  "PATH-INFO resolved to an existing file strictly under ROOT, or NIL.
+Component screen (.., empty, leading ~) plus a TRUENAME containment
+check: PROBE-FILE resolves ~ to the home directory and follows
+symlinks, so the request string alone proves nothing -- only the
+resolved truename's prefix against ROOT's does (GH #269)."
+  (let* ((rel (string-left-trim "/" (if (string= path-info "/")
+                                        "index.html"
+                                        path-info)))
+         (parts (uiop:split-string rel :separator "/")))
+    (when (and (plusp (length rel))
+               (notany (lambda (p)
+                         (or (string= p "..") (string= p "")
+                             (char= (char p 0) #\~)))
+                       parts))
+      (let* ((merged (ignore-errors (merge-pathnames rel root)))
+             (file (and merged
+                        (not (wild-pathname-p merged))
+                        (ignore-errors (probe-file merged))))
+             (true-root (ignore-errors (truename root))))
+        (when (and file true-root (%pathname-under-p file true-root))
+          file)))))
+
+(defun %static-response (path-info root)
+  "A clack response serving PATH-INFO from ROOT, or NIL when no file
+matches (a pathname body is streamed by the handler)."
+  (let ((file (%safe-static-path path-info root)))
+    (when (and file (not (uiop:directory-pathname-p file)))
+      (list 200
+            (list :content-type (%static-content-type file))
+            file))))
+
+(defun %gui-dispatch (env ningle-fn root)
+  "Route ENV: /api/* to the ningle app, everything else (GET/HEAD) to
+the static tree, with index.html at /."
+  (let ((path (getf env :path-info)))
+    (if (and (member (getf env :request-method) '(:get :head))
+             (not (eql 0 (search "/api/" path))))
+        (or (%static-response path root)
+            '(404 (:content-type "text/plain") ("not found")))
+        (funcall ningle-fn env))))
+
+(defun %make-gui-app ()
+  (let ((app (make-instance 'ningle:<app>)))
+    (setf (ningle:route app "/api/graphs" :method :get)
+          'api-graphs
+
+          (ningle:route app "/api/graphs/:name/open" :method :post)
+          'api-open-graph
+
+          (ningle:route app "/api/graphs/:name/close" :method :post)
+          'api-close-graph
+
+          (ningle:route app "/api/graphs/:name/stats" :method :get)
+          'api-graph-stats
+
+          (ningle:route app "/api/graphs/:name/types" :method :get)
+          'api-graph-types
+
+          (ningle:route app "/api/graphs/:name/nodes" :method :get)
+          'api-graph-nodes
+
+          (ningle:route app "/api/graphs/:name/node/:id" :method :get)
+          'api-graph-node
+
+          (ningle:route app "/api/graphs/:name/neighborhood/:id"
+                        :method :get)
+          'api-graph-neighborhood)
+    app))
+
+(defun start-gui (&key (port *gui-port*) (bind "127.0.0.1"))
+  "Start the GUI HTTP server on PORT, bound to BIND (loopback by
+default -- localhost is the v1 security boundary).  Returns the clack
+handler.  Idempotent: a second call while running returns the running
+handler unchanged."
+  (or *gui-handler*
+      (let* ((app (%make-gui-app))
+             (root (gui-static-root))
+             (ningle-fn (lack.component:to-app app)))
+        (setq *gui-app* app)
+        (setq *gui-port* port)
+        (setq *gui-handler*
+              ;; :debug nil -- a handler bug must never put a backtrace
+              ;; in the browser; api.lisp logs details via log4cl.
+              (clack:clackup
+               (lambda (env) (%gui-dispatch env ningle-fn root))
+               :port port :address bind :debug nil :silent t)))))
+
+(defun stop-gui ()
+  "Stop the GUI server.  Idempotent: a no-op when not running.
+Returns T when a server was stopped, NIL otherwise.  The handle is
+nulled only after CLACK:STOP returns -- if the stop signals, the
+handle survives so a retry can still stop it."
+  (let ((handler *gui-handler*))
+    (when handler
+      (clack:stop handler)
+      (setq *gui-handler* nil *gui-app* nil)
+      t)))

--- a/gui/static/index.html
+++ b/gui/static/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<!-- Placeholder page proving static serving works (GH #269).
+     The real frontend lands in U2/U3 (GH #270, #271). -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>VivaceGraph GUI</title>
+</head>
+<body>
+  <h1>VivaceGraph GUI</h1>
+  <p>The backend is up. The frontend arrives in a later unit;
+     meanwhile the JSON API lives under <code>/api/</code>
+     (start at <a href="/api/graphs"><code>/api/graphs</code></a>).</p>
+</body>
+</html>

--- a/tests/gui/gui-tests.lisp
+++ b/tests/gui/gui-tests.lisp
@@ -1,0 +1,449 @@
+;;;; graph-db/gui backend tests over real HTTP (GH #269).
+;;;;
+;;;; Each test stands up the full stack: a populated on-disk graph
+;;;; attached to a system clock, START-GUI on an ephemeral loopback
+;;;; port, and drakma as the client.  Covers the spec's contract:
+;;;; roster (incl. the no-system-dir fallback), open/close (incl. the
+;;;; dirty 409), stats, types/nodes sampling, node inspection
+;;;; (alist -> JSON fidelity), neighborhood shape/caps/truncated, the
+;;;; error contract, and start/stop idempotence.
+
+(in-package #:graph-db/gui-test)
+
+(in-suite gui-suite)
+
+;;; ---------------------------------------------------------------------
+;;; Lifecycle + static serving
+;;; ---------------------------------------------------------------------
+
+(test start-stop-idempotent
+  "start-gui twice returns the same handler; stop-gui is a no-op when
+already stopped."
+  (let ((port (free-tcp-port)))
+    (unwind-protect
+         (let ((h1 (start-gui :port port :bind "127.0.0.1"))
+               (h2 (start-gui :port port :bind "127.0.0.1")))
+           (is (eq h1 h2))
+           (is-true (stop-gui))
+           (is-false (stop-gui)))
+      (ignore-errors (stop-gui)))))
+
+(test static-index-at-root
+  "GET / serves gui/static/index.html with a text/html content type."
+  (with-gui-server ()
+    (multiple-value-bind (json status ctype raw)
+        (gui-request "/")
+      (declare (ignore json))
+      (is (= 200 status))
+      (is (eql 0 (search "text/html" ctype)))
+      (is (search "VivaceGraph GUI" raw)))))
+
+(test static-missing-file-404
+  "A missing static path yields 404."
+  (with-gui-server ()
+    (multiple-value-bind (json status) (gui-request "/no-such.css")
+      (declare (ignore json))
+      (is (= 404 status)))))
+
+(test static-head-request
+  "HEAD on a static asset answers 200 with no meaningful body."
+  (with-gui-server ()
+    (multiple-value-bind (json status) (gui-request "/" :method :head)
+      (declare (ignore json))
+      (is (= 200 status)))))
+
+(test static-traversal-rejected
+  "Escape attempts never leave the static root: ~ home-dir expansion,
+~user, dot-dot (plain and percent-encoded), and absolute-ish paths all
+answer 4xx, and never file contents (GH #269)."
+  (with-gui-server ()
+    (flet ((refused-p (path &key preserve-uri)
+             (multiple-value-bind (json status)
+                 (gui-request path :preserve-uri preserve-uri)
+               (declare (ignore json))
+               (member status '(400 404)))))
+      ;; SBCL's probe-file expands a leading ~ to $HOME.
+      (is-true (refused-p "/~/.bashrc"))
+      (is-true (refused-p "/~root/.bashrc"))
+      (is-true (refused-p "/../graph-db.asd" :preserve-uri t))
+      (is-true (refused-p "/%2e%2e/graph-db.asd" :preserve-uri t))
+      (is-true (refused-p "/etc/passwd"))
+      ;; the legitimate file still serves
+      (multiple-value-bind (json status) (gui-request "/index.html")
+        (declare (ignore json))
+        (is (= 200 status))))))
+
+#+sbcl
+(test static-symlink-escape-rejected
+  "A symlink inside the static root that points outside it is refused
+by the truename containment check -- the one escape the component
+screen cannot catch (GH #269)."
+  (with-gui-server ()
+    (let* ((root (asdf:system-relative-pathname :graph-db "gui/static/"))
+           (link (merge-pathnames "esc-test.css" root))
+           (target (asdf:system-relative-pathname :graph-db
+                                                  "CHANGELOG.md")))
+      (ignore-errors (delete-file link))
+      (sb-posix:symlink (namestring target) (namestring link))
+      (unwind-protect
+           (multiple-value-bind (json status)
+               (gui-request "/esc-test.css")
+             (declare (ignore json))
+             (is (= 404 status)))
+        (ignore-errors (delete-file link))))))
+
+;;; ---------------------------------------------------------------------
+;;; Roster
+;;; ---------------------------------------------------------------------
+
+(defun roster-entry (name)
+  (multiple-value-bind (json status) (gui-request "/api/graphs")
+    (values (find name (jref json :graphs)
+                  :key (lambda (e) (jref e :name))
+                  :test #'string=)
+            status)))
+
+(test roster-lists-open-graph
+  "GET /api/graphs lists the open fixture graph: name, location, open."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (entry status) (roster-entry "gui-test-graph")
+        (is (= 200 status))
+        (is-true entry)
+        (is-true (jref entry :open))
+        (is (string= (getf *fixture* :location)
+                     (jref entry :location)))))))
+
+(test roster-fallback-without-system-dir
+  "With no *SYSTEM-DIRECTORY* bound the roster falls back to *GRAPHS*."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (let ((saved-dir graph-db::*system-directory*)
+            (saved-reg graph-db::*store-registry*))
+        (unwind-protect
+             (progn
+               ;; Globals, because the handler thread reads them.
+               (setf graph-db::*system-directory* nil
+                     graph-db::*store-registry* nil)
+               (multiple-value-bind (entry status)
+                   (roster-entry "gui-test-graph")
+                 (is (= 200 status))
+                 (is-true entry)
+                 (is-true (jref entry :open))))
+          (setf graph-db::*system-directory* saved-dir
+                graph-db::*store-registry* saved-reg))))))
+
+;;; ---------------------------------------------------------------------
+;;; Open / close management verbs
+;;; ---------------------------------------------------------------------
+
+(test close-then-reopen-cycle
+  "Close and reopen through the API; roster tracks state; a second
+open is idempotent; a closed graph 404s on reads (no stale handle)."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/close" :method :post)
+        (is (= 200 status))
+        (is (string= "closed" (jref json :status))))
+      (let ((entry (roster-entry "gui-test-graph")))
+        (is-true entry)
+        (is-false (jref entry :open))
+        ;; The journal's :ATTACH record still knows the location.
+        (is (string= (getf *fixture* :location)
+                     (jref entry :location))))
+      ;; Closed mid-session: reads answer 404, never a stale handle.
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/stats")
+        (is (= 404 status))
+        (is (string= "unknown-graph" (jref json :error))))
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/open" :method :post)
+        (is (= 200 status))
+        (is (string= "opened" (jref json :status))))
+      (is-true (jref (roster-entry "gui-test-graph") :open))
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/open" :method :post)
+        (is (= 200 status))
+        (is (string= "already-open" (jref json :status)))))))
+
+(test dirty-store-open-409
+  "A .dirty marker turns open into a 409 carrying the condition's
+report verbatim; removing it lets the open succeed."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (gui-request "/api/graphs/gui-test-graph/close" :method :post)
+      (let ((dirty (format nil "~A.dirty" (getf *fixture* :location))))
+        (with-open-file (s dirty :direction :output
+                                 :if-does-not-exist :create)
+          (write-string "test" s))
+        (unwind-protect
+             (multiple-value-bind (json status)
+                 (gui-request "/api/graphs/gui-test-graph/open"
+                              :method :post)
+               (is (= 409 status))
+               (is (string= "dirty-store" (jref json :error)))
+               (is (search "not closed properly" (jref json :message))))
+          (ignore-errors (delete-file dirty))))
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/open" :method :post)
+        (declare (ignore json))
+        (is (= 200 status))))))
+
+(test open-location-missing-404
+  "Opening a roster entry whose recorded directory has vanished is a
+clean 404 (location-missing), not a 500."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (gui-request "/api/graphs/gui-test-graph/close" :method :post)
+      (let* ((loc (getf *fixture* :location))
+             (aside (format nil "~Aaside/"
+                            (namestring
+                             (uiop:pathname-parent-directory-pathname
+                              loc)))))
+        (rename-file (uiop:ensure-directory-pathname loc)
+                     (uiop:ensure-directory-pathname aside))
+        (unwind-protect
+             (multiple-value-bind (json status)
+                 (gui-request "/api/graphs/gui-test-graph/open"
+                              :method :post)
+               (is (= 404 status))
+               (is (string= "location-missing" (jref json :error))))
+          (rename-file (uiop:ensure-directory-pathname aside)
+                       (uiop:ensure-directory-pathname loc)))))))
+
+(test reads-race-close-cleanly
+  "Reads racing in-flight close/open cycles never crash or fault: with
+the GUI rw-lock every response is a clean 200 or 404 (GH #269)."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (let* (;; Full URL captured lexically: the reader thread does not
+             ;; inherit this thread's *GUI-TEST-PORT* binding.
+             (url (gui-url (node-path (getf *fixture* :alice)
+                                      "neighborhood")))
+             (statuses '())
+             (lock (bordeaux-threads:make-lock "race-statuses"))
+             (reader
+               (bordeaux-threads:make-thread
+                (lambda ()
+                  (dotimes (i 40)
+                    (let ((status (nth-value
+                                   1 (drakma:http-request url))))
+                      (bordeaux-threads:with-lock-held (lock)
+                        (push status statuses)))))
+                :name "gui race reader")))
+        (dotimes (i 3)
+          (gui-request "/api/graphs/gui-test-graph/close" :method :post)
+          (gui-request "/api/graphs/gui-test-graph/open" :method :post))
+        (bordeaux-threads:join-thread reader)
+        (is (= 40 (length statuses)))
+        (is (every (lambda (s) (member s '(200 404))) statuses))))))
+
+(test open-unknown-graph-404
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/no-such-graph/open" :method :post)
+        (is (= 404 status))
+        (is (string= "unknown-graph" (jref json :error)))))))
+
+(test close-not-open-409
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (gui-request "/api/graphs/gui-test-graph/close" :method :post)
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/close" :method :post)
+        (is (= 409 status))
+        (is (string= "not-open" (jref json :error)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Stats + types
+;;; ---------------------------------------------------------------------
+
+(test stats-against-known-fixture
+  "Totals, per-type counts, view + index inventories, on-disk size and
+schema summary for the known fixture."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/stats")
+        (is (= 200 status))
+        (is (= 4 (jref json :vertex-count)))
+        (is (= 3 (jref json :edge-count)))
+        (let ((by-type (jref json :vertex-counts-by-type)))
+          (is (= 2 (jref by-type :gui-person)))
+          (is (= 2 (jref by-type :gui-city))))
+        (is (= 3 (jref (jref json :edge-counts-by-type) :gui-visited)))
+        (is (find "peopleByName" (jref json :views)
+                  :key (lambda (v) (jref v :name)) :test #'string=))
+        (is (listp (jref json :indexes)))
+        (is (plusp (jref json :on-disk-bytes)))
+        (let* ((schema (jref json :schema))
+               (person (find "guiPerson" (jref schema :vertex-types)
+                             :key (lambda (v) (jref v :name))
+                             :test #'string=)))
+          (is-true person)
+          (is (find "name" (jref person :slots) :test #'string=))
+          (is (find "age" (jref person :slots) :test #'string=))
+          (is (find "guiVisited" (jref schema :edge-types)
+                    :key (lambda (v) (jref v :name))
+                    :test #'string=)))))))
+
+(test types-inventory
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/types")
+        (is (= 200 status))
+        (is (find "guiPerson" (jref json :vertex-types) :test #'string=))
+        (is (find "guiCity" (jref json :vertex-types) :test #'string=))
+        (is (find "guiVisited" (jref json :edge-types)
+                  :test #'string=))))))
+
+;;; ---------------------------------------------------------------------
+;;; Node sample
+;;; ---------------------------------------------------------------------
+
+(test nodes-sample-with-limit
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/nodes?type=guiPerson")
+        (is (= 200 status))
+        (is (= 2 (length (jref json :nodes))))
+        (is-false (jref json :truncated))
+        (is (every (lambda (n)
+                     (and (stringp (jref n :id))
+                          (string= "guiPerson" (jref n :type))))
+                   (jref json :nodes))))
+      (multiple-value-bind (json status)
+          (gui-request
+           "/api/graphs/gui-test-graph/nodes?type=guiPerson&limit=1")
+        (is (= 200 status))
+        (is (= 1 (length (jref json :nodes))))
+        (is-true (jref json :truncated))))))
+
+(test nodes-unknown-type-404
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/nodes?type=noSuch")
+        (is (= 404 status))
+        (is (string= "unknown-type" (jref json :error)))))))
+
+(test nodes-missing-type-400
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/nodes")
+        (is (= 400 status))
+        (is (string= "missing-type" (jref json :error)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Node inspection
+;;; ---------------------------------------------------------------------
+
+(defun node-path (node &optional (endpoint "node"))
+  (format nil "/api/graphs/gui-test-graph/~A/~A"
+          endpoint (string-id node)))
+
+(test node-inspection-alist-fidelity
+  "A node's data (an alist of (:SLOT . value) conses) serializes as a
+JSON object with the slot values intact; in/out edge counts are right."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request (node-path (getf *fixture* :alice)))
+        (is (= 200 status))
+        (is (string= (string-id (getf *fixture* :alice))
+                     (jref json :id)))
+        (is (string= "guiPerson" (jref json :type)))
+        (let ((slots (jref json :slots)))
+          (is (string= "Alice" (jref slots :name)))
+          (is (= 34 (jref slots :age))))
+        (is (= 2 (jref json :out-edge-count)))
+        (is (= 0 (jref json :in-edge-count))))
+      (multiple-value-bind (json status)
+          (gui-request (node-path (getf *fixture* :paris)))
+        (is (= 200 status))
+        (is (= 0 (jref json :out-edge-count)))
+        (is (= 2 (jref json :in-edge-count)))))))
+
+(test node-malformed-id-400
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/node/not-hex")
+        (is (= 400 status))
+        (is (string= "malformed-id" (jref json :error)))))))
+
+(test node-unknown-id-404
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request
+           (format nil "/api/graphs/gui-test-graph/node/~A"
+                   (make-string 32 :initial-element #\f)))
+        (is (= 404 status))
+        (is (string= "unknown-node" (jref json :error)))))))
+
+;;; ---------------------------------------------------------------------
+;;; Neighborhood
+;;; ---------------------------------------------------------------------
+
+(test neighborhood-shape-both-directions
+  "One round trip returns viz-shaped {nodes, edges} covering both
+directions, type-labeled."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      ;; Alice: two outgoing edges.
+      (multiple-value-bind (json status)
+          (gui-request (node-path (getf *fixture* :alice)
+                                  "neighborhood"))
+        (is (= 200 status))
+        (is (= 3 (length (jref json :nodes))))
+        (is (= 2 (length (jref json :edges))))
+        (is-false (jref json :truncated))
+        (is (every (lambda (e)
+                     (and (string= "guiVisited" (jref e :type))
+                          (stringp (jref e :from))
+                          (stringp (jref e :to))))
+                   (jref json :edges))))
+      ;; Paris: two INCOMING edges -- both directions are covered.
+      (multiple-value-bind (json status)
+          (gui-request (node-path (getf *fixture* :paris)
+                                  "neighborhood"))
+        (is (= 200 status))
+        (is (= 3 (length (jref json :nodes))))
+        (is (= 2 (length (jref json :edges))))))))
+
+(test neighborhood-cap-sets-truncated
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request (format nil "~A?limit=1"
+                               (node-path (getf *fixture* :alice)
+                                          "neighborhood")))
+        (is (= 200 status))
+        (is (= 1 (length (jref json :edges))))
+        (is-true (jref json :truncated))))))
+
+(test neighborhood-error-contract
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status)
+          (gui-request "/api/graphs/gui-test-graph/neighborhood/zzz")
+        (is (= 400 status))
+        (is (string= "malformed-id" (jref json :error))))
+      (multiple-value-bind (json status)
+          (gui-request
+           (format nil "/api/graphs/gui-test-graph/neighborhood/~A"
+                   (make-string 32 :initial-element #\f)))
+        (is (= 404 status))
+        (is (string= "unknown-node" (jref json :error))))
+      (multiple-value-bind (json status)
+          (gui-request
+           (format nil "/api/graphs/no-such/neighborhood/~A"
+                   (string-id (getf *fixture* :alice))))
+        (is (= 404 status))
+        (is (string= "unknown-graph" (jref json :error)))))))

--- a/tests/gui/package.lisp
+++ b/tests/gui/package.lisp
@@ -1,0 +1,18 @@
+;;;; Test package for the graph-db/gui backend (GH #269).
+
+(in-package #:cl-user)
+
+;; The symlink-escape regression test plants a real symlink (GH #269).
+#+sbcl
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (require :sb-posix))
+
+(defpackage #:graph-db/gui-test
+  (:use #:cl #:fiveam #:graph-db)
+  ;; graph-db's Prolog cut must win over fiveam's ! helper, exactly as
+  ;; the main suite's package does.
+  (:shadowing-import-from #:graph-db #:!)
+  (:import-from #:graph-db.gui
+                #:start-gui
+                #:stop-gui)
+  (:export #:run-gui-tests))

--- a/tests/gui/suite.lisp
+++ b/tests/gui/suite.lisp
@@ -1,0 +1,159 @@
+;;;; GUI suite runner + fixtures (GH #269).
+;;;;
+;;;; Standalone suite -- NOT :in graph-db-suite, so the main
+;;;; (asdf:test-system :graph-db) run does not pick it up.
+;;;;
+;;;; ⚠ The HTTP handlers run in server threads, which see the GLOBAL
+;;;; values of *SYSTEM-DIRECTORY* / *SYSTEM-CLOCK*, not this thread's
+;;;; LET bindings -- so the runner SETFs the globals for the run and
+;;;; restores them after (a fresh test image, so nothing else owns
+;;;; them).
+
+(in-package #:graph-db/gui-test)
+
+(def-suite gui-suite
+  :description "graph-db/gui backend over real HTTP.")
+
+(defun run-gui-tests ()
+  "Run the GUI suite.  Returns T when every check passed.  Invoked by
+(asdf:test-system :graph-db/gui-test)."
+  (log:config :error)
+  (let ((old-dir graph-db::*system-directory*)
+        (old-reg graph-db::*store-registry*)
+        (old-type-reg graph-db::*type-registry*)
+        (system-dir (graph-db-test-scratch:make-scratch-directory
+                     "graph-db-gui-sys")))
+    (setf graph-db::*system-directory* (namestring system-dir)
+          graph-db::*store-registry* nil
+          graph-db::*type-registry* nil)
+    (unwind-protect
+         (let ((results (run 'gui-suite)))
+           (explain! results)
+           (results-status results))
+      (ignore-errors (stop-gui))
+      (setf graph-db::*system-directory* old-dir
+            graph-db::*store-registry* old-reg
+            graph-db::*type-registry* old-type-reg)
+      (graph-db-test-scratch:cleanup-scratch-run))))
+
+;;; ---------------------------------------------------------------------
+;;; Schema (domain-neutral, per repo policy #197)
+;;; ---------------------------------------------------------------------
+
+(defparameter *gui-graph-name* :gui-test-graph)
+
+;; Clean slate so reloading this file doesn't double-register.
+(eval-when (:load-toplevel :execute)
+  (setf (gethash *gui-graph-name* graph-db::*schema-node-metadata*) nil))
+
+(def-vertex gui-person ()
+  ((name :type string)
+   (age))
+  :gui-test-graph)
+
+(def-vertex gui-city ()
+  ((name :type string))
+  :gui-test-graph)
+
+(def-edge gui-visited ()
+  ((year))
+  :gui-test-graph)
+
+(defun define-gui-views ()
+  "One map view on the live *graph*, for the stats view inventory."
+  (def-view people-by-name :lessp (gui-person :gui-test-graph)
+    (:map (lambda (p)
+            (when (slot-value p 'name)
+              (yield (slot-value p 'name) nil))))))
+
+;;; ---------------------------------------------------------------------
+;;; Graph fixture: a populated store attached to a system clock, so the
+;;; clock journal records its :ATTACH location (the roster's source for
+;;; closed stores).
+;;; ---------------------------------------------------------------------
+
+(defvar *fixture* nil
+  "Plist for the current fixture: :graph :location :alice :bob :paris
+:tokyo, set by WITH-GUI-FIXTURE for the tests' convenience.")
+
+(defun populate-fixture (graph)
+  (let ((*graph* graph) alice bob paris tokyo)
+    (define-gui-views)
+    (with-transaction ()
+      (setq alice (make-gui-person :name "Alice" :age 34)
+            bob (make-gui-person :name "Bob" :age 41)
+            paris (make-gui-city :name "Paris")
+            tokyo (make-gui-city :name "Tokyo"))
+      (make-gui-visited :from alice :to paris :year 2019)
+      (make-gui-visited :from alice :to tokyo :year 2023)
+      (make-gui-visited :from bob :to paris :year 2021))
+    (list :graph graph :location (namestring (graph-db::location graph))
+          :alice alice :bob bob :paris paris :tokyo tokyo)))
+
+(defmacro with-gui-fixture (() &body body)
+  "Open a system clock on the run's system directory, build a fresh
+populated :GUI-TEST-GRAPH attached to it, run BODY, then tear down
+graph and clock (globals, not LET -- see the file header)."
+  `(let ((dir (graph-db-test-scratch:make-scratch-directory
+               "graph-db-gui")))
+     (setf graph-db::*system-clock*
+           (graph-db::open-system-clock graph-db::*system-directory*))
+     (let ((graph (make-graph *gui-graph-name* (namestring dir)
+                              :buffer-pool-size 1000)))
+       (unwind-protect
+            (let ((*fixture* (populate-fixture graph)))
+              ,@body)
+         (let ((live (lookup-graph *gui-graph-name*)))
+           (when live
+             (ignore-errors (close-graph live :snapshot-p nil))))
+         (ignore-errors
+          (graph-db::close-system-clock graph-db::*system-clock*))
+         (setf graph-db::*system-clock* nil)
+         (ignore-errors
+          (uiop:delete-directory-tree dir :validate t
+                                          :if-does-not-exist :ignore))))))
+
+;;; ---------------------------------------------------------------------
+;;; HTTP plumbing
+;;; ---------------------------------------------------------------------
+
+(defparameter *gui-test-port* nil)
+
+(defun free-tcp-port ()
+  "An unused loopback port: bind port 0, read the OS's pick, release."
+  (let ((s (usocket:socket-listen "127.0.0.1" 0 :reuse-address t)))
+    (unwind-protect (usocket:get-local-port s)
+      (usocket:socket-close s))))
+
+(defmacro with-gui-server (() &body body)
+  `(let ((*gui-test-port* (free-tcp-port)))
+     (unwind-protect
+          (progn
+            (start-gui :port *gui-test-port* :bind "127.0.0.1")
+            (sleep 0.3)                 ; let the listener bind
+            ,@body)
+       (ignore-errors (stop-gui)))))
+
+(defun gui-url (path)
+  (format nil "http://127.0.0.1:~D~A" *gui-test-port* path))
+
+(defun gui-request (path &key (method :get) preserve-uri)
+  "Request PATH; (values decoded-json status content-type raw-body).
+DRAKMA returns 4xx/5xx without signaling, so status is always there.
+:PRESERVE-URI T sends PATH byte-for-byte (no client-side dot-segment
+or percent normalization) -- for the traversal tests."
+  (multiple-value-bind (body status headers)
+      (drakma:http-request (gui-url path) :method method
+                           :preserve-uri preserve-uri)
+    (let ((string (cond ((null body) "")
+                        ((stringp body) body)
+                        (t (flexi-streams:octets-to-string
+                            body :external-format :utf-8)))))
+      (values (when (plusp (length string))
+                (ignore-errors (json:decode-json-from-string string)))
+              status
+              (cdr (assoc :content-type headers))
+              string))))
+
+(defun jref (alist key)
+  (cdr (assoc key alist)))


### PR DESCRIPTION
Closes #269 (unit 1 of epic #106; spec: `docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md`).

The web cockpit's backend as an optional subsystem: `graph-db/gui` (`gui/{package,server,api}.lisp` + a static placeholder page), `start-gui`/`stop-gui` (idempotent, 127.0.0.1:4270 by default — localhost is the v1 security boundary), and the full endpoint set: roster (store registry + clock-journal `:attach` locations, `*graphs*` fallback), open/close verbs (strictly at the roster's recorded location; dirty store answers 409 with the condition's report verbatim), stats, type inventory, bounded node samples, node/edge inspection (alist → JSON object), and the snapshot-consistent `neighborhood` batch with a `truncated` flag. Handlers resolve graphs by name per request — the GUI holds no graph state — and `rest.lisp` is untouched.

Hardening from the adversarial review round:
- **Path traversal (blocker, live-confirmed):** `GET /~/.bashrc` served the real file via SBCL's `probe-file` `~`-expansion. Static serving now requires the resolved truename to sit under the static root (also stopping symlink escapes), plus component screening of `..`/`~`/empty and wild/malformed rejection. Regression tests include a planted-symlink case.
- **Read vs. in-flight close (major):** read handlers now hold the shared side of a GUI-local rw-lock while open/close hold the exclusive side, so a close can no longer unmap mmaps under a running read. `close-graph` itself untouched; race exerciser test included.
- Minors: vanished journal location → clean 404, `stop-gui` keeps its handle if the stop signals, explicit test deps, HEAD coverage.

Tests: new `graph-db/gui-test` (FiveAM + drakma over real HTTP on an ephemeral port) — **105/105**. Main suite regression gate: **4,986 checks, 0 failures** (10 pre-existing skips). SBCL only; ECL skipped per the standing periodic-catch-up policy.

Docs: manual section "The GUI cockpit" (endpoint table + lifecycle), CHANGELOG entry, CLAUDE.md architecture pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp