### PR TITLE
GUI U2: cockpit frame frontend -- roster + stats panes (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **`graph-db/gui`: the cockpit frame frontend** (#270, epic #106).
+  The placeholder page is now the real single-page frame: a roster
+  pane (every known store with open/closed badge, recorded location,
+  per-graph Open/Close buttons, manual Refresh — no polling; engine
+  error text, including the dirty-store 409 report, surfaces verbatim
+  in a dismissible error strip) and a stats pane for the selected
+  graph (totals, per-type count table, views, indexes, human-readable
+  on-disk size, schema summary). Plain HTML/CSS/ES modules under
+  `gui/static/` — no build step, no framework, no external assets.
+  The explorer canvas and inspector regions are placeholders U3
+  (#271) fills. A new gui-test check pins each shipped asset's path
+  and content type. The manual's GUI section now describes the served
+  page and warns that a non-loopback `:bind` (e.g. a tailnet address)
+  exposes the unauthenticated API and management verbs to that
+  network; the `start-gui` docstring carries the same caveat.
+
 - **`graph-db/gui`: the web cockpit's backend** (#269, epic #106).
   A new optional subsystem serving a JSON management/exploration API
   and static frontend assets over ningle/clack: `start-gui`/`stop-gui`

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -1851,7 +1851,23 @@ handlers call engine internals directly rather than proxying REST.
 #+END_SRC
 
 Both calls are idempotent. The GUI binds loopback by default —
-localhost is the v1 security boundary. Static assets under
+localhost is the v1 security boundary. Binding a non-loopback address
+via ~:bind~ (e.g. a private VPN/tailnet address such as a Tailscale
+~100.x~ address) serves the *unauthenticated* API — including the
+open/close management verbs — to everything that can reach that
+network: bind only to interfaces whose peers you trust. Auth is a
+later-version item per the design.
+
+The page served at ~/~ (GH #270) is the cockpit frame: a roster pane
+listing every known store (open/closed badge, recorded location) with
+per-graph Open/Close buttons and a manual Refresh — engine errors,
+including the dirty-store 409 report, surface verbatim in a
+dismissible error strip — and a stats pane for the selected graph
+(totals, per-type counts, views, indexes, on-disk size, schema).
+Nothing polls; the panes re-render from each server response. The
+explorer canvas and node inspector arrive in U3 (GH #271).
+
+Static assets under
 ~gui/static/~ are served at ~/~ (resolved via
 ~asdf:system-relative-pathname~); every request path must resolve, by
 ~truename~, to a file *inside* the static root — ~..~, ~~~-expansion

--- a/gui/server.lisp
+++ b/gui/server.lisp
@@ -113,9 +113,11 @@ the static tree, with index.html at /."
 
 (defun start-gui (&key (port *gui-port*) (bind "127.0.0.1"))
   "Start the GUI HTTP server on PORT, bound to BIND (loopback by
-default -- localhost is the v1 security boundary).  Returns the clack
-handler.  Idempotent: a second call while running returns the running
-handler unchanged."
+default -- localhost is the v1 security boundary).  A non-loopback
+BIND serves the UNAUTHENTICATED API and open/close verbs to that
+network: bind only interfaces whose peers you trust.  Returns the
+clack handler.  Idempotent: a second call while running returns the
+running handler unchanged."
   (or *gui-handler*
       (let* ((app (%make-gui-app))
              (root (gui-static-root))

--- a/gui/static/css/gui.css
+++ b/gui/static/css/gui.css
@@ -1,0 +1,298 @@
+/* VivaceGraph GUI frame styling (GH #270).
+   Operator cockpit: dark, quiet, legible at laptop widths.
+   No framework, no external fonts. */
+
+:root {
+  --bg: #14181d;
+  --bg-pane: #1b2129;
+  --bg-raised: #232b35;
+  --border: #303a46;
+  --text: #d7dde4;
+  --text-dim: #8b96a3;
+  --accent: #4fa3d1;
+  --ok: #4cb782;
+  --warn: #d1a04f;
+  --err-bg: #3a2226;
+  --err-border: #8a4550;
+  --err-text: #f0b9c0;
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 system-ui, sans-serif;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) 1fr auto;
+  height: 100%;
+}
+
+/* --- sidebar ------------------------------------------------------- */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-pane);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+}
+
+.brand {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.pane {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px 14px;
+}
+
+.pane-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.pane-header h2 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+button {
+  font: inherit;
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+button:hover { border-color: var(--accent); }
+button:disabled { opacity: 0.5; cursor: default; }
+
+/* --- error strip --------------------------------------------------- */
+
+.error-strip {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  background: var(--err-bg);
+  border: 1px solid var(--err-border);
+  border-radius: 4px;
+  color: var(--err-text);
+  font-family: var(--mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.error-strip span { flex: 1; }
+
+.error-strip button {
+  flex: none;
+  padding: 0 6px;
+  line-height: 1.3;
+  background: transparent;
+  border-color: var(--err-border);
+  color: var(--err-text);
+}
+
+/* --- roster -------------------------------------------------------- */
+
+.roster-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.roster-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.roster-item:hover { background: var(--bg-raised); }
+
+.roster-item.selected {
+  background: var(--bg-raised);
+  outline: 1px solid var(--accent);
+}
+
+.roster-name-block {
+  flex: 1;
+  min-width: 0;
+}
+
+.roster-name {
+  font-family: var(--mono);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roster-location {
+  color: var(--text-dim);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 7px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+.badge.open {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+
+.roster-empty {
+  padding: 6px 8px;
+  color: var(--text-dim);
+}
+
+/* --- stats --------------------------------------------------------- */
+
+.stats-body { font-size: 13px; }
+
+.stats-totals {
+  display: flex;
+  gap: 18px;
+  margin-bottom: 10px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat .stat-value {
+  font-family: var(--mono);
+  font-size: 17px;
+}
+
+.stat .stat-label {
+  color: var(--text-dim);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stats-body h3 {
+  margin: 12px 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.type-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.type-table td {
+  padding: 3px 4px;
+  border-top: 1px solid var(--border);
+}
+
+.type-table td.count { text-align: right; }
+
+.type-table tr[data-type]:hover { background: var(--bg-raised); }
+
+.kind-tag {
+  color: var(--text-dim);
+  font-size: 10px;
+  padding-right: 6px;
+}
+
+.stats-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.stats-list li {
+  padding: 2px 0;
+  overflow-wrap: anywhere;
+}
+
+.stats-list .dim { color: var(--text-dim); }
+
+.schema-slots { color: var(--text-dim); }
+
+.stats-error {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--warn);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* --- main / inspector regions (U3 placeholders) -------------------- */
+
+.main-canvas {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.inspector-dock {
+  width: 0;
+  border-left: 1px solid var(--border);
+}
+
+.placeholder {
+  color: var(--text-dim);
+  margin: 0;
+  padding: 8px;
+  text-align: center;
+}

--- a/gui/static/css/gui.css
+++ b/gui/static/css/gui.css
@@ -20,6 +20,10 @@
 
 * { box-sizing: border-box; }
 
+/* An author display rule beats the UA's [hidden] { display: none },
+   so hidden elements (error strip, inspector dock) need this. */
+[hidden] { display: none !important; }
+
 html, body {
   height: 100%;
   margin: 0;

--- a/gui/static/index.html
+++ b/gui/static/index.html
@@ -1,15 +1,53 @@
 <!DOCTYPE html>
-<!-- Placeholder page proving static serving works (GH #269).
-     The real frontend lands in U2/U3 (GH #270, #271). -->
+<!-- VivaceGraph GUI frame (GH #270): roster + stats panes.
+     The explorer canvas and inspector dock land in U3 (GH #271);
+     their regions below are placeholders U3 fills. -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>VivaceGraph GUI</title>
+  <link rel="stylesheet" href="/css/gui.css">
 </head>
 <body>
-  <h1>VivaceGraph GUI</h1>
-  <p>The backend is up. The frontend arrives in a later unit;
-     meanwhile the JSON API lives under <code>/api/</code>
-     (start at <a href="/api/graphs"><code>/api/graphs</code></a>).</p>
+  <div class="app">
+    <aside class="sidebar">
+      <header class="brand">
+        <h1>VivaceGraph</h1>
+      </header>
+      <section class="pane" id="roster-pane" aria-label="Graph roster">
+        <div class="pane-header">
+          <h2>Graphs</h2>
+          <button id="roster-refresh" type="button"
+                  title="Reload the roster from the server">Refresh</button>
+        </div>
+        <div id="error-strip" class="error-strip" hidden>
+          <span id="error-strip-text"></span>
+          <button id="error-strip-dismiss" type="button"
+                  aria-label="Dismiss error">&#215;</button>
+        </div>
+        <ul id="roster-list" class="roster-list"></ul>
+      </section>
+      <section class="pane" id="stats-pane" aria-label="Graph statistics">
+        <div class="pane-header">
+          <h2>Stats</h2>
+        </div>
+        <div id="stats-body" class="stats-body">
+          <p class="placeholder">Select a graph.</p>
+        </div>
+      </section>
+    </aside>
+    <main id="main-canvas" class="main-canvas" aria-label="Explorer">
+      <!-- U3 (GH #271) mounts the explorer canvas here. -->
+      <p class="placeholder">
+        Select a node type to explore &mdash; arrives in U3.
+      </p>
+    </main>
+    <aside id="inspector-dock" class="inspector-dock" hidden
+           aria-label="Node inspector">
+      <!-- U3 (GH #271) mounts the node inspector here. -->
+    </aside>
+  </div>
+  <script type="module" src="/js/main.js"></script>
 </body>
 </html>

--- a/gui/static/js/api.js
+++ b/gui/static/js/api.js
@@ -1,0 +1,47 @@
+// Tiny JSON fetch wrapper (GH #270).  Every failure -- a network
+// error or an {error, message} body -- rejects with an ApiError whose
+// .message carries the server's text verbatim.
+
+export class ApiError extends Error {
+  constructor(message, { code = "network-error", status = 0 } = {}) {
+    super(message);
+    this.name = "ApiError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+async function request(path, options = {}) {
+  let response;
+  try {
+    response = await fetch(path, options);
+  } catch (err) {
+    throw new ApiError(`Cannot reach the server: ${err.message}`);
+  }
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    // Non-JSON body (e.g. the static handler's plain-text 404).
+  }
+  if (!response.ok) {
+    const message = body && body.message
+      ? body.message
+      : `HTTP ${response.status} from ${path}`;
+    const code = body && body.error ? body.error : "http-error";
+    throw new ApiError(message, { code, status: response.status });
+  }
+  return body;
+}
+
+const graphPath = (name, tail) =>
+  `/api/graphs/${encodeURIComponent(name)}/${tail}`;
+
+export const api = {
+  graphs: () => request("/api/graphs"),
+  openGraph: (name) =>
+    request(graphPath(name, "open"), { method: "POST" }),
+  closeGraph: (name) =>
+    request(graphPath(name, "close"), { method: "POST" }),
+  stats: (name) => request(graphPath(name, "stats")),
+};

--- a/gui/static/js/main.js
+++ b/gui/static/js/main.js
@@ -1,0 +1,38 @@
+// Frame wiring (GH #270).  All app state -- just the selected graph
+// name -- lives here; the panes render from server responses and
+// report events back.  Nothing is attached to window.
+
+import { createRosterPane } from "./roster.js";
+import { createStatsPane } from "./stats.js";
+
+const state = { selected: null };
+
+const stats = createStatsPane({
+  bodyEl: document.getElementById("stats-body"),
+});
+
+const roster = createRosterPane({
+  listEl: document.getElementById("roster-list"),
+  refreshBtn: document.getElementById("roster-refresh"),
+  errorStrip: document.getElementById("error-strip"),
+  errorText: document.getElementById("error-strip-text"),
+  errorDismiss: document.getElementById("error-strip-dismiss"),
+  onSelect: (name) => {
+    state.selected = name;
+    roster.setSelected(name);
+    stats.showGraph(name);
+  },
+  onRosterChange: (graphs) => {
+    // Selection survives a refresh while its graph is still listed;
+    // the stats pane re-renders either way (open state may have
+    // changed under it).
+    if (state.selected &&
+        !graphs.some((g) => g.name === state.selected)) {
+      state.selected = null;
+    }
+    roster.setSelected(state.selected);
+    stats.showGraph(state.selected);
+  },
+});
+
+roster.refresh();

--- a/gui/static/js/roster.js
+++ b/gui/static/js/roster.js
@@ -1,0 +1,114 @@
+// Roster pane (GH #270): graph list with open/closed badges, the
+// open/close verbs, and the dismissible error strip.  No polling --
+// the list re-renders from the server after each verb and on the
+// manual Refresh button.  Selection state lives in main.js; this
+// module reports events through the callbacks it is given.
+
+import { api } from "./api.js";
+
+export function createRosterPane({ listEl, refreshBtn, errorStrip,
+                                   errorText, errorDismiss,
+                                   onSelect, onRosterChange }) {
+  let graphs = [];
+  let selected = null;
+  let busy = false;
+
+  function showError(message) {
+    errorText.textContent = message;
+    errorStrip.hidden = false;
+  }
+
+  function clearError() {
+    errorStrip.hidden = true;
+    errorText.textContent = "";
+  }
+
+  errorDismiss.addEventListener("click", clearError);
+
+  function render() {
+    refreshBtn.disabled = busy;
+    listEl.textContent = "";
+    if (graphs.length === 0) {
+      const li = document.createElement("li");
+      li.className = "roster-empty";
+      li.textContent = "No graphs known to this image.";
+      listEl.appendChild(li);
+      return;
+    }
+    for (const g of graphs) {
+      const li = document.createElement("li");
+      li.className = "roster-item" +
+        (g.name === selected ? " selected" : "");
+      li.dataset.graph = g.name;
+      if (g.location) li.title = g.location;
+
+      const block = document.createElement("div");
+      block.className = "roster-name-block";
+      const name = document.createElement("div");
+      name.className = "roster-name";
+      name.textContent = g.name;
+      block.appendChild(name);
+      if (g.location) {
+        const loc = document.createElement("div");
+        loc.className = "roster-location";
+        loc.textContent = g.location;
+        block.appendChild(loc);
+      }
+
+      const badge = document.createElement("span");
+      badge.className = "badge" + (g.open ? " open" : "");
+      badge.textContent = g.open ? "open" : "closed";
+
+      const verb = document.createElement("button");
+      verb.type = "button";
+      verb.textContent = g.open ? "Close" : "Open";
+      verb.disabled = busy;
+      verb.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        runVerb(g.name, g.open ? "close" : "open");
+      });
+
+      li.append(block, badge, verb);
+      li.addEventListener("click", () => onSelect(g.name));
+      listEl.appendChild(li);
+    }
+  }
+
+  async function refresh() {
+    try {
+      const body = await api.graphs();
+      graphs = body.graphs || [];
+    } catch (err) {
+      graphs = [];
+      showError(err.message);
+    }
+    render();
+    onRosterChange(graphs);
+  }
+
+  async function runVerb(name, verb) {
+    if (busy) return;
+    busy = true;
+    render();
+    clearError();
+    try {
+      await (verb === "open" ? api.openGraph(name)
+                             : api.closeGraph(name));
+    } catch (err) {
+      // Engine error text verbatim -- e.g. the dirty-store 409 report.
+      showError(err.message);
+    }
+    busy = false;
+    await refresh();
+  }
+
+  function setSelected(name) {
+    selected = name;
+    render();
+  }
+
+  refreshBtn.addEventListener("click", () => refresh());
+
+  return { refresh, setSelected,
+           getGraph: (name) => graphs.find((g) => g.name === name) };
+}

--- a/gui/static/js/roster.js
+++ b/gui/static/js/roster.js
@@ -75,6 +75,10 @@ export function createRosterPane({ listEl, refreshBtn, errorStrip,
   }
 
   async function refresh() {
+    // Visible feedback: an unchanged roster re-renders identically,
+    // so without this the button appears to do nothing.
+    refreshBtn.disabled = true;
+    refreshBtn.textContent = "Refreshing\u2026";
     try {
       const body = await api.graphs();
       graphs = body.graphs || [];
@@ -82,6 +86,7 @@ export function createRosterPane({ listEl, refreshBtn, errorStrip,
       graphs = [];
       showError(err.message);
     }
+    refreshBtn.textContent = "Refresh";
     render();
     onRosterChange(graphs);
   }

--- a/gui/static/js/stats.js
+++ b/gui/static/js/stats.js
@@ -1,0 +1,161 @@
+// Stats pane (GH #270): totals, per-type counts, views, indexes,
+// on-disk size and schema for the selected graph.  Per-type rows
+// carry data-type / data-kind attributes -- U3's explorer entry ramp
+// hooks them (GH #271).  A closed or unknown graph shows the API's
+// error message, never a blank pane.
+
+import { api } from "./api.js";
+
+export function humanBytes(n) {
+  if (typeof n !== "number" || !isFinite(n) || n < 0) return "?";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let i = 0;
+  let v = n;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return i === 0 ? `${v} B` : `${v.toFixed(1)} ${units[i]}`;
+}
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function heading(text) {
+  return el("h3", null, text);
+}
+
+function statBox(value, label) {
+  const box = el("div", "stat");
+  box.appendChild(el("span", "stat-value", String(value)));
+  box.appendChild(el("span", "stat-label", label));
+  return box;
+}
+
+function typeTable(vertexCounts, edgeCounts) {
+  const table = el("table", "type-table");
+  const body = document.createElement("tbody");
+  const addRows = (counts, kind) => {
+    for (const [type, count] of Object.entries(counts || {})) {
+      const tr = document.createElement("tr");
+      tr.dataset.type = type;
+      tr.dataset.kind = kind;
+      const name = el("td");
+      name.appendChild(el("span", "kind-tag", kind === "vertex"
+                          ? "V" : "E"));
+      name.appendChild(document.createTextNode(type));
+      tr.appendChild(name);
+      tr.appendChild(el("td", "count", String(count)));
+      body.appendChild(tr);
+    }
+  };
+  addRows(vertexCounts, "vertex");
+  addRows(edgeCounts, "edge");
+  table.appendChild(body);
+  return table;
+}
+
+function listOf(items, renderItem) {
+  const ul = el("ul", "stats-list");
+  if (!items || items.length === 0) {
+    ul.appendChild(el("li", "dim", "none"));
+    return ul;
+  }
+  for (const item of items) ul.appendChild(renderItem(item));
+  return ul;
+}
+
+function viewItem(v) {
+  const li = el("li");
+  li.appendChild(document.createTextNode(`${v.name} `));
+  li.appendChild(el("span", "dim", `on ${v.class}`));
+  return li;
+}
+
+function indexItem(ix) {
+  const slots = (ix.slots || []).join(", ");
+  const li = el("li");
+  li.appendChild(document.createTextNode(`${ix.owner}(${slots}) `));
+  li.appendChild(el("span", "dim", ix.kind));
+  return li;
+}
+
+function schemaItem(t) {
+  const li = el("li");
+  li.appendChild(document.createTextNode(t.name));
+  const slots = (t.slots || []).join(", ");
+  li.appendChild(el("span", "schema-slots",
+                    slots ? ` → ${slots}` : " → (no slots)"));
+  return li;
+}
+
+export function createStatsPane({ bodyEl }) {
+  // Monotonic token: a slow response for a graph the user has since
+  // navigated away from must not overwrite the newer render.
+  let requestToken = 0;
+
+  function showPlaceholder(text) {
+    bodyEl.textContent = "";
+    bodyEl.appendChild(el("p", "placeholder", text));
+  }
+
+  function showErrorMessage(message) {
+    bodyEl.textContent = "";
+    bodyEl.appendChild(el("p", "stats-error", message));
+  }
+
+  function renderStats(stats) {
+    bodyEl.textContent = "";
+    const totals = el("div", "stats-totals");
+    totals.appendChild(statBox(stats.vertexCount, "vertices"));
+    totals.appendChild(statBox(stats.edgeCount, "edges"));
+    totals.appendChild(statBox(humanBytes(stats.onDiskBytes),
+                               "on disk"));
+    bodyEl.appendChild(totals);
+
+    bodyEl.appendChild(heading("Counts by type"));
+    bodyEl.appendChild(typeTable(stats.vertexCountsByType,
+                                 stats.edgeCountsByType));
+
+    bodyEl.appendChild(heading("Views"));
+    bodyEl.appendChild(listOf(stats.views, viewItem));
+
+    bodyEl.appendChild(heading("Indexes"));
+    bodyEl.appendChild(listOf(stats.indexes, indexItem));
+
+    bodyEl.appendChild(heading("Schema"));
+    const schema = stats.schema || {};
+    const types = [...(schema.vertexTypes || []),
+                   ...(schema.edgeTypes || [])];
+    bodyEl.appendChild(listOf(types, schemaItem));
+  }
+
+  async function showGraph(name) {
+    const token = ++requestToken;
+    if (!name) {
+      showPlaceholder("Select a graph.");
+      return;
+    }
+    try {
+      const stats = await api.stats(name);
+      if (token !== requestToken) return; // stale response, drop it
+      renderStats(stats);
+    } catch (err) {
+      if (token !== requestToken) return;
+      // 404 "Graph X is not open", etc. -- the API's message, as-is.
+      showErrorMessage(err.message);
+    }
+  }
+
+  return {
+    showGraph,
+    clear: () => {
+      requestToken += 1; // invalidate any in-flight fetch
+      showPlaceholder("Select a graph.");
+    },
+  };
+}

--- a/tests/gui/gui-tests.lisp
+++ b/tests/gui/gui-tests.lisp
@@ -38,6 +38,25 @@ already stopped."
       (is (eql 0 (search "text/html" ctype)))
       (is (search "VivaceGraph GUI" raw)))))
 
+(test static-frame-assets-serve
+  "Every asset the frame page loads serves 200 with the right content
+type -- pins the file layout index.html depends on (GH #270)."
+  (with-gui-server ()
+    (flet ((asset (path ctype)
+             (multiple-value-bind (json status actual)
+                 (gui-request path)
+               (declare (ignore json))
+               (is (= 200 status) "~A did not serve 200" path)
+               (is (eql 0 (search ctype actual))
+                   "~A served content type ~A, wanted ~A"
+                   path actual ctype))))
+      (asset "/" "text/html")
+      (asset "/css/gui.css" "text/css")
+      (asset "/js/api.js" "application/javascript")
+      (asset "/js/roster.js" "application/javascript")
+      (asset "/js/stats.js" "application/javascript")
+      (asset "/js/main.js" "application/javascript"))))
+
 (test static-missing-file-404
   "A missing static path yields 404."
   (with-gui-server ()


### PR DESCRIPTION
Unit 2 of epic #106 (spec: `docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md`). Closes #270.

Replaces the U1 placeholder page with the real cockpit frame: a roster pane (open/closed badges, recorded locations, per-graph Open/Close verbs, manual Refresh — no polling; engine error text including the dirty-store 409 report shown **verbatim** in a dismissible error strip) and a stats pane for the selected graph (totals, per-type count table whose rows carry `data-type`/`data-kind` hooks for U3's explorer ramp, views, indexes, human-readable on-disk size, schema summary). Explorer canvas and inspector dock are marked placeholders for U3 (#271); no cytoscape vendored yet.

Plain HTML/CSS/ES modules under `gui/static/` — no build step, no framework, no external assets. Adversarial review found **no blockers or majors**: every DOM write goes through `textContent`/`createElement` (XSS-audited sink by sink), and the api.js wrapper covers JSON-4xx, non-JSON-4xx, and network-failure shapes without unhandled rejections. Two review minors fixed: stale stats responses dropped via a monotonic request token; Refresh disabled while a verb is in flight.

Also included (requested): the non-loopback `:bind` documentation — the manual and `start-gui` docstring now state that binding e.g. a tailnet address serves the unauthenticated API and management verbs to that network (the `:bind` keyword itself shipped in U1, so remote tailnet use works today).

Tests: new `static-frame-assets-serve` pins every shipped asset's path + content type; gui-test **117/117**; main suite **4,986 checks, 0 failures** (10 pre-existing skips), fresh images. Live curl smoke test verified all pane-consumed JSON round trips. Stated honestly: frontend JS has no automated harness in v1 — verified by `node --check`, API-contract fidelity, and curl, not by clicking. Follow-up filed: #274 (sparse-file `onDiskBytes`). SBCL only; ECL skipped per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp