### PR TITLE
Workbench A: schema names go kebab on the wire (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (`graph-db/gui` wire format): schema names ship as the
+  engine spells them, in kebab-case** (#277, tracker #272). Every JSON
+  *value* naming a schema entity — vertex and edge type names, slot
+  names, view names and classes, index owners and slots — was
+  camelCased on the way out (`"guiPerson"`, `"peopleByName"`) and
+  turned back with `camel-case-to-lisp` on the way in, for
+  `/nodes?type=`. That round trip is not bijective: names with
+  consecutive capitals or digits (`HTTP-URL`, `FOO-BAR2`) do not
+  survive it. Those values are now the engine's own lowercase kebab
+  spelling (`"gui-person"`, `"people-by-name"`, `"home-city"`), and
+  `?type=` interns the incoming string directly — so a type name the
+  API emits is accepted back verbatim. This is the naming prerequisite
+  for the query workbench: what the UI shows is what a query types.
+  JSON *keys* are unchanged and stay camelCase (`vertexCount`,
+  `onDiskBytes`, `inEdgeCount`) — they are protocol, and nobody types
+  them. The one deliberate exception is the node inspector's `slots`
+  object, whose keys ARE slot names and therefore go kebab too.
+  `rest.lisp` is untouched and keeps its own JSON conventions.
+  Consumers are all in-tree — the bundled frontend (which renders
+  these values verbatim; explorer node colors are derived from the
+  type string and shift accordingly) and the `graph-db/gui-test`
+  suite, both updated here. Any out-of-tree client of the GUI API
+  must be updated.
+
 ### Fixed
 
 - **Peer pull manifest accumulation is O(ops), not O(ops²)** (#260).

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -1915,6 +1915,45 @@ backtrace; details go to the log4cl log. The two management verbs
 serialize through one lock. Tests: ~(asdf:test-system
 :graph-db/gui-test)~ drives the whole surface over real HTTP.
 
+**** Naming on the wire
+
+Two vocabularies share one JSON body, and the split is deliberate
+(GH #277). JSON *keys* are protocol — nobody types them — and stay
+camelCase, produced automatically by cl-json's keyword encoding:
+~vertexCount~, ~onDiskBytes~, ~inEdgeCount~. *Values that name schema
+entities* — vertex and edge types, slot names, view names and classes,
+index owners and slots — are domain identifiers a query author types,
+and ship exactly as the engine spells them: lowercase kebab,
+~gui-person~, ~gui-visited~, ~home-city~. The one place a *key*
+follows the value rule is the node inspector's ~slots~ object, whose
+keys are slot names.
+
+#+BEGIN_SRC js
+  // GET /api/graphs/demo/stats  (excerpt)
+  { "vertexCount": 4,
+    "vertexCountsByType": { "gui-city": 2, "gui-person": 2 },
+    "views": [ { "class": "gui-person", "name": "people-by-name" } ],
+    "onDiskBytes": 2260992,
+    "schema": { "vertexTypes": [ { "name": "gui-person",
+                                   "slots": ["name", "age",
+                                             "home-city"] } ] } }
+
+  // GET /api/graphs/demo/node/:id  (excerpt)
+  { "type": "gui-person",
+    "slots": { "name": "Alice", "home-city": "Paris" },
+    "inEdgeCount": 0, "outEdgeCount": 2 }
+#+END_SRC
+
+A type name the API emits is therefore accepted verbatim by ~?type=~:
+the round trip is exact for every type name the standard reader
+produces (~?type=~ upcases and interns, so case does not matter). A
+type deliberately defined with a pipe-quoted mixed-case symbol —
+~|weird Name|~ — is the one exception, and always was. It was worse
+before: names were camelized out and ~camel-case-to-lisp~-d back, a
+transform that loses consecutive capitals and digits (~HTTP-URL~,
+~FOO-BAR2~) for *ordinary* names. The rule is the GUI's alone;
+~rest.lisp~ keeps its own JSON conventions.
+
 ** Chapter 10: Replication and High Availability (~replication.lisp~)
 
 For production environments, relying on a single database instance creates a single point of failure. If the machine hosting the database goes down, your application becomes unavailable. To solve this, VivaceGraph provides a built-in *master-slave replication* system, implemented primarily in ~replication.lisp~ and ~transaction-streaming.lisp~.

--- a/gui/api.lisp
+++ b/gui/api.lisp
@@ -7,6 +7,12 @@
 ;;;; JSON {error, message}; 404 unknown graph/node/type, 409
 ;;;; dirty/conflict, 400 malformed, 500 with the condition's report.  No
 ;;;; backtraces to the browser; details go to log4cl.
+;;;;
+;;;; Naming on the wire (GH #277): JSON KEYS are protocol and stay
+;;;; camelCase (cl-json's keyword encoding).  VALUES naming schema
+;;;; entities -- types, slots, views, index owners -- ship as the engine
+;;;; spells them, lowercase kebab, so what the UI shows is what a query
+;;;; types.  See %WIRE-SYMBOL and %NODE-SLOTS-ALIST.
 
 (in-package #:graph-db.gui)
 
@@ -255,12 +261,15 @@ close cannot unmap the store mid-read (GH #269)."
                              (graph-db::schema graph))))
     (sort names #'string< :key #'symbol-name)))
 
-(defun %camel (symbol)
-  (json:lisp-to-camel-case (symbol-name symbol)))
+(defun %wire-symbol (symbol)
+  "SYMBOL as its wire spelling: the engine's own name, downcased kebab
+\(GUI-PERSON -> \"gui-person\").  Schema names are NOT camelized -- a
+query author types them as the engine spells them (GH #277)."
+  (string-downcase (symbol-name symbol)))
 
 (defun %per-type-counts (graph)
-  "(values vertex-alist edge-alist) of (class-name . count), one sweep
-of each table."
+  "(values vertex-alist edge-alist) of (wire-type-name . count), one
+sweep of each table."
   (let ((v (make-hash-table :test 'eq))
         (e (make-hash-table :test 'eq)))
     (graph-db:map-vertices
@@ -268,10 +277,13 @@ of each table."
     (graph-db:map-edges
      (lambda (x) (incf (gethash (class-name (class-of x)) e 0))) graph)
     (flet ((as-alist (table)
+             ;; Keys here are type names, not protocol -- string keys
+             ;; so cl-json emits them verbatim (GH #277).
              (let ((acc '()))
-               (maphash (lambda (k n) (push (cons k n) acc)) table)
-               (sort acc #'string< :key (lambda (c)
-                                          (symbol-name (car c)))))))
+               (maphash (lambda (k n)
+                          (push (cons (%wire-symbol k) n) acc))
+                        table)
+               (sort acc #'string< :key #'car))))
       (values (as-alist v) (as-alist e)))))
 
 (defun %on-disk-size (graph)
@@ -297,13 +309,14 @@ count zero."
                          (intern (symbol-name type-name) :keyword)
                          parent :graph graph)))
               (%obj
-               (list (cons :name (%camel type-name))
+               (list (cons :name (%wire-symbol type-name))
                      (cons :slots
                            (%arr
                             (mapcar (lambda (slot-def)
-                                      (%camel (if (consp slot-def)
-                                                  (first slot-def)
-                                                  slot-def)))
+                                      (%wire-symbol
+                                       (if (consp slot-def)
+                                           (first slot-def)
+                                           slot-def)))
                                     (and meta
                                          (graph-db::node-type-slots
                                           meta)))))))))
@@ -316,11 +329,11 @@ count zero."
              (%obj
               (list (cons :kind "ordered")
                     (cons :owner
-                          (%camel
+                          (%wire-symbol
                            (graph-db::index-spec-owner-name spec)))
                     (cons :slots
                           (%arr
-                           (mapcar #'%camel
+                           (mapcar #'%wire-symbol
                                    (graph-db::index-spec-slot-names
                                     spec)))))))
            (graph-db::%registered-index-specs graph))
@@ -329,9 +342,10 @@ count zero."
                 (declare (ignore idx))
                 (push (%obj
                        (list (cons :kind "spatial")
-                             (cons :owner (%camel (car key)))
+                             (cons :owner (%wire-symbol (car key)))
                              (cons :slots
-                                   (%arr (list (%camel (cdr key)))))))
+                                   (%arr
+                                    (list (%wire-symbol (cdr key)))))))
                       acc))
               (graph-db::spatial-indexes graph))
      (nreverse acc))))
@@ -353,8 +367,10 @@ count zero."
                    (%arr
                     (mapcar (lambda (pair)
                               (%obj
-                               (list (cons :class (%camel (car pair)))
-                                     (cons :name (%camel (cdr pair))))))
+                               (list (cons :class
+                                           (%wire-symbol (car pair)))
+                                     (cons :name
+                                           (%wire-symbol (cdr pair))))))
                             (graph-db::list-views graph))))
              (cons :indexes (%arr (%index-inventory graph)))
              (cons :on-disk-bytes (%on-disk-size graph))
@@ -370,10 +386,10 @@ count zero."
   (with-gui-graph (graph params)
     (%json-response
      (list (cons :vertex-types
-                 (%arr (mapcar #'%camel
+                 (%arr (mapcar #'%wire-symbol
                                (%schema-type-names graph :vertex))))
            (cons :edge-types
-                 (%arr (mapcar #'%camel
+                 (%arr (mapcar #'%wire-symbol
                                (%schema-type-names graph :edge))))))))
 
 ;;; ---------------------------------------------------------------------
@@ -390,17 +406,19 @@ count zero."
     (if (and n (plusp n)) n default)))
 
 (defun %resolve-vertex-type (graph wire-type)
-  "WIRE-TYPE (camelCase) as a vertex class symbol of GRAPH, or NIL."
+  "WIRE-TYPE (the engine's own kebab spelling) as a vertex class symbol
+of GRAPH, or NIL.  Interned directly -- the old camel-case round trip
+was not bijective (GH #277)."
   (let ((meta (handler-case
                   (graph-db::lookup-node-type-by-name
-                   (intern (json:camel-case-to-lisp wire-type) :keyword)
+                   (intern (string-upcase wire-type) :keyword)
                    :vertex :graph graph)
                 (error () nil))))
     (and meta (graph-db::node-type-name meta))))
 
 (defun %vertex-brief (v)
   (list (cons :id (graph-db:string-id v))
-        (cons :type (%camel (class-name (class-of v))))))
+        (cons :type (%wire-symbol (class-name (class-of v))))))
 
 (def-gui-handler api-graph-nodes (params)
   (with-gui-graph (graph params)
@@ -414,7 +432,10 @@ count zero."
                 (gui-error 404 "unknown-type"
                            (format nil "Unknown vertex type ~A"
                                    wire-type))
-                (let ((nodes '()) (count 0) (truncated nil))
+                ;; Echo the canonical spelling, not the raw parameter:
+                ;; the response's type must be re-usable as ?type=.
+                (let ((nodes '()) (count 0) (truncated nil)
+                      (canonical (%wire-symbol type)))
                   (block sample
                     (graph-db:map-vertices
                      (lambda (v)
@@ -425,7 +446,7 @@ count zero."
                        (incf count))
                      graph :vertex-type type))
                   (%json-response
-                   (list (cons :type wire-type)
+                   (list (cons :type canonical)
                          (cons :nodes
                                (%arr (mapcar #'%obj
                                              (nreverse nodes))))
@@ -440,11 +461,14 @@ the engine's 32-hex-character STRING-ID form."
        (graph-db::read-id-array-from-string string)))
 
 (defun %node-slots-alist (node)
-  "NODE's data slots as an alist keyed by camelCase slot names.  The
+  "NODE's data slots as an alist keyed by the engine's slot names.  The
 underlying node data is an ALIST of (:SLOT . value) conses -- this is
-the JSON-object rendering of it."
+the JSON-object rendering of it.
+
+The one place the keys-stay-camelCase rule is overridden: these keys
+are domain identifiers a query author types, not protocol (GH #277)."
   (mapcar (lambda (slot-name)
-            (cons (%camel slot-name)
+            (cons (%wire-symbol slot-name)
                   (%json-value (slot-value node slot-name))))
           (graph-db::data-slots (class-of node))))
 
@@ -464,7 +488,8 @@ the JSON-object rendering of it."
               ((typep v 'graph-db::vertex)
                (%json-response
                 (list (cons :id (graph-db:string-id v))
-                      (cons :type (%camel (class-name (class-of v))))
+                      (cons :type
+                            (%wire-symbol (class-name (class-of v))))
                       (cons :slots (%obj (%node-slots-alist v)))
                       (cons :in-edge-count
                             (length (graph-db:incoming-edges
@@ -479,8 +504,9 @@ the JSON-object rendering of it."
                  (if (typep e 'graph-db::edge)
                      (%json-response
                       (list (cons :id (graph-db:string-id e))
-                            (cons :type (%camel
-                                         (class-name (class-of e))))
+                            (cons :type
+                                  (%wire-symbol
+                                   (class-name (class-of e))))
                             (cons :from (graph-db:string-id
                                          (graph-db::from e)))
                             (cons :to (graph-db:string-id
@@ -555,7 +581,7 @@ the JSON-object rendering of it."
                                    (list
                                     (cons :id (graph-db:string-id e))
                                     (cons :type
-                                          (%camel
+                                          (%wire-symbol
                                            (class-name (class-of e))))
                                     (cons :from
                                           (graph-db:string-id

--- a/gui/static/js/explorer.js
+++ b/gui/static/js/explorer.js
@@ -14,6 +14,8 @@ const NEIGHBORHOOD_LIMIT = 100; // truncation notices can name it
 
 // Deterministic type -> hue: djb2 over the type name, mod 360.
 // Stable across sessions by construction (no randomness, no state).
+// Hues moved once when type names went kebab on the wire (GH #277) --
+// the mapping is over whatever string the API sends, by design.
 export function typeHue(type) {
   let h = 5381;
   for (let i = 0; i < type.length; i += 1) {

--- a/gui/static/js/stats.js
+++ b/gui/static/js/stats.js
@@ -3,6 +3,10 @@
 // carry data-type / data-kind attributes -- U3's explorer entry ramp
 // hooks them (GH #271).  A closed or unknown graph shows the API's
 // error message, never a blank pane.
+//
+// Schema names render verbatim: the API sends the engine's own kebab
+// spelling and data-type rides straight back out as ?type= (GH #277).
+// Never case-fold them here.
 
 import { api } from "./api.js";
 

--- a/tests/gui/gui-tests.lisp
+++ b/tests/gui/gui-tests.lisp
@@ -314,20 +314,73 @@ schema summary for the known fixture."
           (is (= 2 (jref by-type :gui-person)))
           (is (= 2 (jref by-type :gui-city))))
         (is (= 3 (jref (jref json :edge-counts-by-type) :gui-visited)))
-        (is (find "peopleByName" (jref json :views)
+        (is (find "people-by-name" (jref json :views)
                   :key (lambda (v) (jref v :name)) :test #'string=))
         (is (listp (jref json :indexes)))
         (is (plusp (jref json :on-disk-bytes)))
         (let* ((schema (jref json :schema))
-               (person (find "guiPerson" (jref schema :vertex-types)
+               (person (find "gui-person" (jref schema :vertex-types)
                              :key (lambda (v) (jref v :name))
                              :test #'string=)))
           (is-true person)
           (is (find "name" (jref person :slots) :test #'string=))
           (is (find "age" (jref person :slots) :test #'string=))
-          (is (find "guiVisited" (jref schema :edge-types)
+          (is (find "home-city" (jref person :slots) :test #'string=))
+          (is (find "gui-visited" (jref schema :edge-types)
                     :key (lambda (v) (jref v :name))
                     :test #'string=)))))))
+
+(test wire-names-are-kebab
+  "Schema names ship as the engine spells them and JSON keys stay
+camelCase; a type value the API emits is accepted verbatim by ?type=
+\(GH #277).  Asserted on the RAW body -- the decoder folds both
+spellings together, so JREF cannot see the difference."
+  (with-gui-fixture ()
+    (with-gui-server ()
+      (multiple-value-bind (json status ctype raw)
+          (gui-request "/api/graphs/gui-test-graph/stats")
+        (declare (ignore json ctype))
+        (is (= 200 status))
+        ;; Values naming schema entities: the engine's own spelling.
+        (dolist (kebab '("\"gui-person\"" "\"gui-city\""
+                         "\"gui-visited\"" "\"people-by-name\""
+                         "\"home-city\""))
+          (is-true (search kebab raw) "~A missing from stats" kebab))
+        (dolist (camel '("guiPerson" "guiCity" "guiVisited"
+                         "peopleByName" "homeCity"))
+          (is-false (search camel raw) "~A still on the wire" camel))
+        ;; Keys are protocol and stay camelCase.
+        (dolist (key '("\"vertexCount\"" "\"edgeCount\""
+                       "\"onDiskBytes\"" "\"vertexCountsByType\""
+                       "\"vertexTypes\""))
+          (is-true (search key raw) "key ~A is not camelCase" key)))
+      ;; Round trip: take a type value verbatim, feed it to ?type=.
+      (let ((type (multiple-value-bind (json status)
+                      (gui-request "/api/graphs/gui-test-graph/types")
+                    (is (= 200 status))
+                    (first (jref json :vertex-types)))))
+        (is (string= "gui-city" type))
+        (multiple-value-bind (json status)
+            (gui-request
+             (format nil "/api/graphs/gui-test-graph/nodes?type=~A"
+                     type))
+          (is (= 200 status))
+          (is (string= type (jref json :type)))
+          (is (plusp (length (jref json :nodes))))))
+      ;; Inspector slot names are dynamic KEYS built from domain
+      ;; identifiers -- kebab by decision (GH #277).
+      (multiple-value-bind (json status ctype raw)
+          (gui-request
+           (format nil "/api/graphs/gui-test-graph/node/~A"
+                   (string-id (getf *fixture* :alice))))
+        (declare (ignore ctype))
+        (is (= 200 status))
+        (is-true (search "\"home-city\"" raw))
+        (is-false (search "homeCity" raw))
+        (is (string= "Paris" (jref (jref json :slots) :home-city)))
+        ;; ...while the body's own keys stay camelCase.
+        (is-true (search "\"inEdgeCount\"" raw))
+        (is-true (search "\"outEdgeCount\"" raw))))))
 
 (test types-inventory
   (with-gui-fixture ()
@@ -335,9 +388,10 @@ schema summary for the known fixture."
       (multiple-value-bind (json status)
           (gui-request "/api/graphs/gui-test-graph/types")
         (is (= 200 status))
-        (is (find "guiPerson" (jref json :vertex-types) :test #'string=))
-        (is (find "guiCity" (jref json :vertex-types) :test #'string=))
-        (is (find "guiVisited" (jref json :edge-types)
+        (is (find "gui-person" (jref json :vertex-types)
+                  :test #'string=))
+        (is (find "gui-city" (jref json :vertex-types) :test #'string=))
+        (is (find "gui-visited" (jref json :edge-types)
                   :test #'string=))))))
 
 ;;; ---------------------------------------------------------------------
@@ -348,17 +402,18 @@ schema summary for the known fixture."
   (with-gui-fixture ()
     (with-gui-server ()
       (multiple-value-bind (json status)
-          (gui-request "/api/graphs/gui-test-graph/nodes?type=guiPerson")
+          (gui-request
+           "/api/graphs/gui-test-graph/nodes?type=gui-person")
         (is (= 200 status))
         (is (= 2 (length (jref json :nodes))))
         (is-false (jref json :truncated))
         (is (every (lambda (n)
                      (and (stringp (jref n :id))
-                          (string= "guiPerson" (jref n :type))))
+                          (string= "gui-person" (jref n :type))))
                    (jref json :nodes))))
       (multiple-value-bind (json status)
           (gui-request
-           "/api/graphs/gui-test-graph/nodes?type=guiPerson&limit=1")
+           "/api/graphs/gui-test-graph/nodes?type=gui-person&limit=1")
         (is (= 200 status))
         (is (= 1 (length (jref json :nodes))))
         (is-true (jref json :truncated))))))
@@ -367,7 +422,7 @@ schema summary for the known fixture."
   (with-gui-fixture ()
     (with-gui-server ()
       (multiple-value-bind (json status)
-          (gui-request "/api/graphs/gui-test-graph/nodes?type=noSuch")
+          (gui-request "/api/graphs/gui-test-graph/nodes?type=no-such")
         (is (= 404 status))
         (is (string= "unknown-type" (jref json :error)))))))
 
@@ -397,10 +452,11 @@ JSON object with the slot values intact; in/out edge counts are right."
         (is (= 200 status))
         (is (string= (string-id (getf *fixture* :alice))
                      (jref json :id)))
-        (is (string= "guiPerson" (jref json :type)))
+        (is (string= "gui-person" (jref json :type)))
         (let ((slots (jref json :slots)))
           (is (string= "Alice" (jref slots :name)))
-          (is (= 34 (jref slots :age))))
+          (is (= 34 (jref slots :age)))
+          (is (string= "Paris" (jref slots :home-city))))
         (is (= 2 (jref json :out-edge-count)))
         (is (= 0 (jref json :in-edge-count))))
       (multiple-value-bind (json status)
@@ -444,7 +500,7 @@ makes LOOKUP-VERTEX return the cached edge -- the path that used to
                (format nil "/api/graphs/gui-test-graph/node/~A"
                        edge-id))
             (is (= 200 status))
-            (is (string= "guiVisited" (jref json :type)))
+            (is (string= "gui-visited" (jref json :type)))
             (is (stringp (jref json :from)))
             (is (stringp (jref json :to)))
             (is (numberp (jref (jref json :slots) :year))))))
@@ -492,7 +548,7 @@ directions, type-labeled."
         (is (= 2 (length (jref json :edges))))
         (is-false (jref json :truncated))
         (is (every (lambda (e)
-                     (and (string= "guiVisited" (jref e :type))
+                     (and (string= "gui-visited" (jref e :type))
                           (stringp (jref e :from))
                           (stringp (jref e :to))))
                    (jref json :edges))))

--- a/tests/gui/suite.lisp
+++ b/tests/gui/suite.lisp
@@ -46,9 +46,12 @@
 (eval-when (:load-toplevel :execute)
   (setf (gethash *gui-graph-name* graph-db::*schema-node-metadata*) nil))
 
+;; HOME-CITY is deliberately multi-word: it is the only slot whose
+;; wire spelling can tell kebab from camelCase (GH #277).
 (def-vertex gui-person ()
   ((name :type string)
-   (age))
+   (age)
+   (home-city))
   :gui-test-graph)
 
 (def-vertex gui-city ()
@@ -80,7 +83,8 @@
   (let ((*graph* graph) alice bob paris tokyo)
     (define-gui-views)
     (with-transaction ()
-      (setq alice (make-gui-person :name "Alice" :age 34)
+      (setq alice (make-gui-person :name "Alice" :age 34
+                                   :home-city "Paris")
             bob (make-gui-person :name "Bob" :age 41)
             paris (make-gui-city :name "Paris")
             tokyo (make-gui-city :name "Tokyo"))
@@ -156,4 +160,8 @@ or percent normalization) -- for the traversal tests."
               string))))
 
 (defun jref (alist key)
+  "Decoded-body lookup.  ⚠ cl-json's decoder folds BOTH \"guiPerson\"
+and \"gui-person\" to :GUI-PERSON, so a JREF assertion cannot pin the
+wire spelling -- assert on GUI-REQUEST's raw fourth value for that
+\(GH #277)."
   (cdr (assoc key alist)))


### PR DESCRIPTION
Unit A of the query workbench (#272). Closes #277. **Breaking change to the `graph-db/gui` wire format** — all consumers are in-tree and updated here.

Schema identifiers now ship as the engine spells them: `gui-person`, `people-by-name`, `home-city`. JSON *keys* are untouched and stay camelCase (`vertexCount`, `onDiskBytes`) — they're protocol and nobody types them. The one deliberate exception is the node inspector's `slots` object, whose keys *are* slot names.

Two reasons, one immediate and one latent:

- **The workbench needs one vocabulary.** A query author types `gui-person`; the cockpit was showing `guiPerson`.
- **The old round trip was lossy.** `lisp-to-camel-case` out and `camel-case-to-lisp` back does not survive consecutive capitals or digits (`HTTP-URL`, `FOO-BAR2`), so a type the API emitted could fail to resolve when handed back to `?type=`. It's now interned directly, and the round trip is exact for every name the standard reader produces.

Two things the work surfaced that are worth knowing:

- **cl-json's decoder folds both spellings together** (`"gui-person"` and `"guiPerson"` both decode to `:GUI-PERSON`), so every existing `jref`-based assertion was blind to the wire spelling and would have passed against either. The new `wire-names-are-kebab` test asserts on the raw response body instead; the reviewer proved it has teeth by reverting `%wire-symbol` in a live image (16 of 27 checks fail). `jref`'s docstring now records the trap.
- **Per-type count keys were camelCase too, and load-bearing**: `stats.js` feeds them into `tr.dataset.type` and straight back out as `?type=`, so leaving them alone would have silently broken the stats-pane→explorer seeding path the moment the resolver stopped un-camelizing.

Review: **no blockers or majors**; all five judgment calls verified empirically (decoder folding, cl-json string-vs-symbol key handling, canonical `/nodes` echo, `?type=` upcasing, frontend being pure pass-through). Both minors were documentation-accuracy nits and are fixed.

Tests: gui-test **164/164**; main suite **4,986 checks, 0 failures** (10 pre-existing skips), fresh images. Visible on next click-through: explorer node colors shift, since hues are hashed from the type string. SBCL only; ECL skipped per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFb9kQSHJP47V8KdNbgkRp