### PR TITLE
chore(spacetime): extents-disjoint-p comes from cl-temporal-extent 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,15 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Changed
 
+- **`extents-disjoint-p` is cl-temporal-extent's now** (kraison/cl-temporal-extent#1).
+  `graph-db/spacetime` drops its copy and re-exports the library's, with
+  `extents-intersect-p` beside it; the two rules (`:meets` is not disjoint,
+  an ambiguous pair is not disjoint) are unchanged and now live where the
+  algebra does. The library floor is declared: `cl-temporal-extent` >= 0.2.0.
+  The one behavioural difference is at the edge: the library version takes
+  two extents and refuses NIL, so `claims-touching`'s own NIL guard is what
+  keeps "a claim with no extent is never excluded" true, as before.
+
 - **`geometry-contains-point-p` stays native by decision** (#99, closing
   the characterised inconsistency 3.0.0 shipped). The even-odd ray-cast is
   the hot predicate behind `find-nodes-within` / `geo-within/3`, ~77x

--- a/docs/vivace-graph-v3-doc.org
+++ b/docs/vivace-graph-v3-doc.org
@@ -5590,7 +5590,8 @@ Three things change, and nothing else does:
   membership condition, and the audit reports only the overlapping
   members.
 
-*Disjoint* is ~extents-disjoint-p~: every Allen relation possible between
+*Disjoint* is ~extents-disjoint-p~ (cl-temporal-extent's since its 0.2.0,
+re-exported here): every Allen relation possible between
 the two extents is ~:before~ or ~:after~. So ~:meets~ is NOT disjoint —
 intervals are closed, and two runs that meet hold at their shared boundary
 instant — and an ambiguous pair (fuzzy bounds that might overlap) is not

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -501,7 +501,8 @@ and read-only neighborhood exploration."
   :name "VivaceGraph spacetime (temporal substrate)"
   :description "The claim record and source-onboarding contract over
 cl-temporal-extent."
-  :depends-on (:graph-db/core :local-time :cl-temporal-extent)
+  :depends-on (:graph-db/core :local-time
+               (:version :cl-temporal-extent "0.2.0"))
   :pathname "spacetime/"
   :serial t
   :components ((:file "package")

--- a/spacetime/claim-query.lisp
+++ b/spacetime/claim-query.lisp
@@ -3,17 +3,6 @@
 
 (in-package #:graph-db.spacetime)
 
-(defun extents-disjoint-p (a b)
-  "True when extents A and B certainly share no instant: every Allen
-relation possible between them is :BEFORE or :AFTER.  :MEETS is NOT
-disjoint -- intervals are closed, so meeting extents share their boundary
-instant -- and an ambiguous pair is not disjoint either.  A NIL extent
-overlaps everything, so the predicate is total (GH #296, design §2.3)."
-  (and a b
-       (every (lambda (r) (member r '(:before :after)))
-              (temporal-relation-relations (allen-relations a b)))
-       t))
-
 (defun %claim-validity-touches-p (claim probe)
   "True when CLAIM's extent possibly shares an instant with PROBE.  A
 claim with no extent makes no validity statement and never matches."

--- a/spacetime/package.lisp
+++ b/spacetime/package.lisp
@@ -66,7 +66,8 @@
    #:unknown-claim-family
    ;; temporal claim families (GH #296)
    #:claim-family-temporal-p #:extent-sexp-start-key
-   #:extents-disjoint-p #:extent-disjointness-violation
+   ;; extents-disjoint-p is cl-temporal-extent's since its 0.2.0 (#1 there)
+   #:extents-disjoint-p #:extents-intersect-p #:extent-disjointness-violation
    #:edv-claim-class #:edv-subject-namespace #:edv-subject-key
    #:edv-object-namespace #:edv-object-key #:edv-relation
    #:edv-conflicting-ids #:check-extent-disjointness

--- a/tests/spacetime/temporal-tests.lisp
+++ b/tests/spacetime/temporal-tests.lisp
@@ -276,9 +276,11 @@ and admitted outside it."
   (is-true (extents-disjoint-p
             (exact-interval (ts 2022 1 1) (ts 2022 3 31))
             (make-instant (exact-bound (ts 2022 4 1)))))
-  (is-false (extents-disjoint-p (exact-interval (ts 2022 1 1) (ts 2022 3 31))
-                                nil)
-            "no extent overlaps everything -- the predicate is total"))
+  ;; The NIL-overlaps-everything totality was this copy's; the algebra's
+  ;; version takes two extents (cl-temporal-extent#1), and CLAIMS-TOUCHING
+  ;; keeps the convention at its own call site.
+  (signals type-error
+    (extents-disjoint-p (exact-interval (ts 2022 1 1) (ts 2022 3 31)) nil)))
 
 ;;; --- membership per instant ----------------------------------------------
 


### PR DESCRIPTION
The vivace-graph half of kraison/cl-temporal-extent#1 — merge **after** kraison/cl-temporal-extent#4.

- `spacetime/claim-query.lisp`: the copy is gone; `graph-db.spacetime` re-exports the library's `extents-disjoint-p` and, new, `extents-intersect-p`.
- `graph-db.asd`: `graph-db/spacetime` declares `(:version :cl-temporal-extent "0.2.0")`.
- Semantics unchanged (`:meets` not disjoint, ambiguous not disjoint). The only edge that moved: the library version takes two extents and refuses NIL; `claims-touching` already guards NIL at its call site and the commit validators only see temporal claims, so no production path changes. The one test asserting NIL-totality on the predicate now asserts the library contract.
- CHANGELOG + manual ch. 18 note.

`graph-db/spacetime-test`: 572/572 against cl-temporal-extent `feat/extents-disjoint-p`.

⚠ CI precondition: `test.yml` resolves cl-temporal-extent from `~/src/cl-temporal-extent/` on the runner; that checkout must be at `master` with #4 merged before this PR's run can pass — otherwise the 0.2.0 floor fails at load, which is the floor doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ckNPmmeny7S9iTT4Hpiey