### PR TITLE
spacetime: the four engine findings from the agent-memory tenant (#320 #321 #323 #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **`validate-transaction`, and `writes` exported** (#320): a consumer
+  that stages writes in its own transaction can ask the #301 evaluator
+  about them -- `(validate-transaction graph)` over the ambient
+  transaction, or `(validate-writes graph (writes tx))` -- and commit or
+  roll back on the report, without reaching for an internal symbol.
+
 - **B+ tree cursors stopped consing a page per level and per crossing**
   (#97): `%bpt-read-page` reuses a caller buffer; a descent threads one
   buffer down the internal levels and a leaf crossing reuses the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **A transaction reads its own claim writes** (#324): `claims-touching`
+  and `claims-by-producer` overlay the open transaction's write set --
+  the commit view validation already uses -- so retract-then-assert on
+  one series inside one `with-transaction` no longer re-finds the
+  retracted claim as current. `:as-of` still answers committed history
+  only.
+
 - **`split-claim-identity-key`** (#321): the inverse of
   `claim-identity-key`, so a consumer that stores keys and resolves
   them later gets producer, subject, relation, object and extent start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,15 @@ between releases; cutting a release renames it to the new version and dates it.
   index every claim family now declares (`claim-subject-relation`), so a
   one-relation read of a busy endpoint touches only that relation's rows.
 
+### Fixed
+
+- **`def-claim-classes` derived its class names in `*package*`** (#323):
+  a declaration read from another package minted a second
+  `<parent>-binary` there and silently overwrote the family registry,
+  orphaning every existing claim of the family. Names now derive in the
+  parent symbol's package, and registering a family whose classes
+  differ from the registered ones signals `claim-family-conflict`.
+
 ## [4.0.1] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **`split-claim-identity-key`** (#321): the inverse of
+  `claim-identity-key`, so a consumer that stores keys and resolves
+  them later gets producer, subject, relation, object and extent start
+  back without re-implementing the escape rule. Arity and temporality
+  follow from the field count; a string the encoder cannot have
+  produced signals `malformed-claim-identity-key`.
+
 - **`validate-transaction`, and `writes` exported** (#320): a consumer
   that stages writes in its own transaction can ask the #301 evaluator
   about them -- `(validate-transaction graph)` over the ambient

--- a/evaluator.lisp
+++ b/evaluator.lisp
@@ -130,3 +130,12 @@ the enforcement (GH #301)."
          :family-counts counts
          :checked-counts checked
          :spec-counts (%evaluator-spec-counts graph))))))
+
+(defun validate-transaction (graph &optional (tx *transaction*))
+  "VALIDATE-WRITES over TX's write set -- the open transaction by
+default -- so a consumer that stages writes and asks before committing
+need not reach for the write set itself (GH #320).  Signals when no
+transaction is open: an empty set would validate clean and mislead."
+  (unless tx
+    (error "VALIDATE-TRANSACTION: no transaction is open."))
+  (validate-writes graph (writes tx)))

--- a/package.lisp
+++ b/package.lisp
@@ -433,6 +433,7 @@
            #:make-commit-view #:view-node #:view-old-node #:view-writes
            ;; GH #301: the evaluator entry point
            #:validate-writes #:validation-report
+           #:validate-transaction #:writes                 ; GH #320
            #:validation-report-violations #:validation-report-family-counts
            #:validation-report-checked-counts #:validation-report-spec-counts
            #:commit-view-graph #:*commit-validators*

--- a/spacetime/claim-query.lisp
+++ b/spacetime/claim-query.lisp
@@ -184,6 +184,31 @@ cut (the REST envelope's one-past-the-cap rule, GH #302)."
                 (> (length rest) limit))
         (values rest nil))))
 
+(defun %overlay-transaction (graph all family admit)
+  "ALL as the open transaction will commit it (GH #324): a candidate the
+transaction updated is replaced by its written version, one it deleted
+drops out, and a claim of FAMILY it created that satisfies ADMIT is
+added.  ALL itself outside a transaction.  The commit view is the same
+\"store with this transaction's writes on top\" that validation reads."
+  (let ((tx graph-db::*transaction*))
+    (if (null tx)
+        all
+        (let* ((view (graph-db:make-commit-view graph tx))
+               (out '()))
+          (dolist (c all)
+            (let ((v (graph-db:view-node view (graph-db:id c))))
+              (when v (push v out))))
+          (dolist (w (graph-db:view-writes view))
+            (let ((n (graph-db:view-node view (graph-db:id w))))
+              (when (and n
+                         (typep n (claim-family-parent family))
+                         (null (graph-db:view-old-node view n))
+                         (funcall admit n)
+                         (not (find (graph-db:id n) out
+                                    :key #'graph-db:id :test #'equalp)))
+                (push n out))))
+          (nreverse out)))))
+
 (defun claims-touching (graph claim-class namespace key
                         &key (role :either) current at during
                              relation limit offset as-of)
@@ -220,6 +245,12 @@ side it rides the (subject-namespace subject-key relation) index (GH
 :OFFSET cut the FINAL filtered result; the second return value is T when
 more claims existed past the cut (NIL without :LIMIT).
 
+Inside an open transaction the answer is what THAT transaction will
+commit (GH #324): its own retractions, updates and new claims are
+visible, so retract-then-assert on one series reads correctly before
+the commit.  :AS-OF is the exception -- it answers committed history
+only, since an uncommitted change is not yet history.
+
 An out-of-range ROLE signals rather than silently returning NIL -- NIL is
 also the correct answer for \"no claims touch this endpoint\", and this
 subsystem exists to keep those two cases from being confused."
@@ -251,10 +282,24 @@ subsystem exists to keep those two cases from being confused."
                    (remove-duplicates (append subjects objects)
                                       :key #'graph-db:id :test #'equalp)
                    (or subjects objects))))
-      (when as-of
-        (setf all (loop for c in all
-                        for v = (%claim-as-of graph c as-of)
-                        when v collect v)))
+      (if as-of
+          (setf all (loop for c in all
+                          for v = (%claim-as-of graph c as-of)
+                          when v collect v))
+          (setf all (%overlay-transaction
+                     graph all family
+                     (lambda (c)
+                       (or (and (member role '(:subject :either))
+                                (equal namespace
+                                       (claim-subject-namespace c))
+                                (equal key (claim-subject-key c))
+                                (or (null relation)
+                                    (equal relation (claim-relation c))))
+                           (and (member role '(:object :either))
+                                (typep c (claim-family-binary family))
+                                (equal namespace
+                                       (claim-object-namespace c))
+                                (equal key (claim-object-key c))))))))
       (when current
         (setf all (remove-if-not (lambda (c)
                                    (or (reaped-claim-p c)
@@ -384,10 +429,13 @@ when more claims existed past the cut (NIL without :LIMIT) (GH #302)."
   (let* ((family (claim-family claim-class))
          (all (graph-db:index-lookup graph (claim-family-parent family)
                                      '(producer) producer)))
-    (when as-of
-      (setf all (loop for c in all
-                      for v = (%claim-as-of graph c as-of)
-                      when v collect v)))
+    (if as-of
+        (setf all (loop for c in all
+                        for v = (%claim-as-of graph c as-of)
+                        when v collect v))
+        (setf all (%overlay-transaction
+                   graph all family
+                   (lambda (c) (equal producer (claim-producer c))))))
     (%paginate all limit offset)))
 
 (defun delete-claims-by-producer (graph claim-class producer)

--- a/spacetime/claim-query.lisp
+++ b/spacetime/claim-query.lisp
@@ -57,6 +57,70 @@ regeneration, which node ids do not (GH #303).  Fields join on |, with
                         (claim-extent-sexp claim)))))))))
     (format nil "~{~a~^|~}" fields)))
 
+(defun %split-identity-key-fields (key)
+  "KEY's fields: split on unescaped |, with \\| and \\\\ unescaped."
+  (let ((fields '()) (buf (make-string-output-stream))
+        (i 0) (n (length key)))
+    (loop while (< i n) do
+      (let ((ch (char key i)))
+        (cond ((char= ch #\\)
+               (when (= (1+ i) n)
+                 (error 'malformed-claim-identity-key :key key))
+               (write-char (char key (1+ i)) buf)
+               (incf i 2))
+              ((char= ch #\|)
+               (push (get-output-stream-string buf) fields)
+               (incf i))
+              (t (write-char ch buf) (incf i)))))
+    (push (get-output-stream-string buf) fields)
+    (nreverse fields)))
+
+(defun %identity-key-namespace (field key)
+  "FIELD as the keyword %IDENTITY-KEY-FIELD rendered, else signal."
+  (if (and (> (length field) 1) (char= (char field 0) #\:))
+      (intern (string-upcase (subseq field 1)) :keyword)
+      (error 'malformed-claim-identity-key :key key)))
+
+(defun %identity-key-extent-start (field key)
+  "FIELD read back as EXTENT-SEXP-START-KEY data, *READ-EVAL* off."
+  (handler-case
+      (with-standard-io-syntax
+        (let ((*read-eval* nil)
+              (*package* (find-package :graph-db.spacetime)))
+          (read-from-string field)))
+    (error () (error 'malformed-claim-identity-key :key key))))
+
+(defun split-claim-identity-key (key)
+  "The inverse of CLAIM-IDENTITY-KEY (GH #321): (VALUES PRODUCER
+SUBJECT-NAMESPACE SUBJECT-KEY RELATION OBJECT-NAMESPACE OBJECT-KEY
+EXTENT-START), NIL for the fields a unary or non-temporal key lacks.
+Arity and temporality follow from the field count -- 4, 5, 6 or 7 --
+so the string alone suffices.  Namespaces come back as keywords, keys
+and relations as strings (an integer key encodes as its decimal string
+and decodes as one), EXTENT-START as EXTENT-SEXP-START-KEY's data.  The
+escape rule lives here and in %IDENTITY-KEY-FIELD, nowhere else.
+Signals MALFORMED-CLAIM-IDENTITY-KEY for any other shape."
+  (let* ((fields (%split-identity-key-fields key))
+         (n (length fields)))
+    (unless (<= 4 n 7)
+      (error 'malformed-claim-identity-key :key key))
+    (let* ((binary-p (>= n 6))
+           (temporal-p (oddp n))
+           (after-subject (cdddr fields))
+           (object-namespace (and binary-p
+                                  (%identity-key-namespace
+                                   (first after-subject) key)))
+           (object-key (and binary-p (second after-subject)))
+           (tail (if binary-p (cddr after-subject) after-subject)))
+      (values (first fields)
+              (%identity-key-namespace (second fields) key)
+              (third fields)
+              (first tail)
+              object-namespace
+              object-key
+              (and temporal-p
+                   (%identity-key-extent-start (second tail) key))))))
+
 (defstruct (reaped-claim (:constructor %make-reaped-claim (id)))
   "An :AS-OF answer the store can no longer give: the claim existed at
 the asked instant, but every version stamped then is past the family's

--- a/spacetime/claim.lisp
+++ b/spacetime/claim.lisp
@@ -31,6 +31,22 @@ identity tuple and live runs must be pairwise disjoint (GH #296)."
   (or (gethash parent *claim-families*)
       (error 'unknown-claim-family :parent parent)))
 
+(defun %register-claim-family (parent unary binary temporal-p)
+  "Register PARENT's family.  Re-declaring with the same UNARY and
+BINARY names replaces silently (a flipped :TEMPORAL included); different
+names signal CLAIM-FAMILY-CONFLICT and leave the entry as it was, since
+replacing it would orphan every existing claim of the family (GH #323)."
+  (let ((old (gethash parent *claim-families*)))
+    (when (and old
+               (not (and (eq (claim-family-unary old) unary)
+                         (eq (claim-family-binary old) binary))))
+      (error 'claim-family-conflict :parent parent
+             :existing (list (claim-family-unary old)
+                             (claim-family-binary old))
+             :proposed (list unary binary))))
+  (setf (gethash parent *claim-families*)
+        (%make-claim-family parent unary binary temporal-p)))
+
 ;;; RELATION and PRODUCER are canonical strings (GH #160).  Both are in
 ;;; the DEF-UNIQUE identity tuple and compared with EQUAL, so a second
 ;;; spelling of one name (:x, "X", " x") is a second claim, never an
@@ -342,8 +358,9 @@ joins both identity tuples (EXTENT-SEXP-START-KEY), an extent is required
 at construction and at commit, and live claims sharing a base tuple must
 have pairwise disjoint validity (spacetime/temporal.lisp).  Same
 declaration names, so flipping the flag re-declares rather than stacks."
-  (let* ((unary (intern (format nil "~A-UNARY" parent)))
-         (binary (intern (format nil "~A-BINARY" parent)))
+  (let* ((home (symbol-package parent))
+         (unary (intern (format nil "~A-UNARY" parent) home))
+         (binary (intern (format nil "~A-BINARY" parent) home))
          (extent-slot (when temporal '(extent-sexp)))
          (unary-slots (append '(producer subject-namespace subject-key
                                 relation)
@@ -431,12 +448,12 @@ declaration names, so flipping the flag re-declares rather than stacks."
        (graph-db:def-index ,parent (subject-namespace subject-key
                                     relation)
            ,graph-name :name claim-subject-relation)
-       (fmakunbound ',(intern (format nil "MAKE-~A" parent)))
+       (fmakunbound ',(intern (format nil "MAKE-~A" parent) home))
        ;; DEF-VERTEX redefines each raw constructor on every expansion, so
        ;; this cannot double-wrap on a re-evaluated DEF-CLAIM-CLASSES form.
        ,@(mapcar
           (lambda (class identity-keys)
-            (let ((ctor (intern (format nil "MAKE-~A" class))))
+            (let ((ctor (intern (format nil "MAKE-~A" class) home)))
               `(let ((%raw (fdefinition ',ctor)))
                  (setf (fdefinition ',ctor)
                        (lambda (&rest args)
@@ -463,7 +480,6 @@ declaration names, so flipping the flag re-declares rather than stacks."
        (defmethod graph-db:save :before ((c ,parent) &key graph)
          (declare (ignore graph))
          (setf (claim-version-stamp c) (%st-now)))
-       (setf (gethash ',parent *claim-families*)
-             (%make-claim-family ',parent ',unary ',binary
-                                 ,(and temporal t)))
+       (%register-claim-family ',parent ',unary ',binary
+                               ,(and temporal t))
        ',parent))))

--- a/spacetime/conditions.lisp
+++ b/spacetime/conditions.lisp
@@ -91,3 +91,16 @@ given another.  Accessor-level only; see the design's immutability note."))
                      (malformed-claim-identity-key-key c))))
   (:documentation "SPLIT-CLAIM-IDENTITY-KEY was handed a string that
 CLAIM-IDENTITY-KEY cannot have produced (GH #321)."))
+
+(define-condition claim-family-conflict (spacetime-error)
+  ((parent :initarg :parent :reader claim-family-conflict-parent)
+   (existing :initarg :existing :reader claim-family-conflict-existing)
+   (proposed :initarg :proposed :reader claim-family-conflict-proposed))
+  (:report (lambda (c s)
+             (format s "Claim family ~s is registered with classes ~s; ~
+refusing to replace them with ~s"
+                     (claim-family-conflict-parent c)
+                     (claim-family-conflict-existing c)
+                     (claim-family-conflict-proposed c))))
+  (:documentation "A DEF-CLAIM-CLASSES for a parent already registered
+with different unary/binary classes (GH #323)."))

--- a/spacetime/conditions.lisp
+++ b/spacetime/conditions.lisp
@@ -83,3 +83,11 @@ transaction is single-graph; resolve before opening it."
   (:documentation
    "Signalled when a claim that already carries a transaction extent is
 given another.  Accessor-level only; see the design's immutability note."))
+
+(define-condition malformed-claim-identity-key (spacetime-error)
+  ((key :initarg :key :reader malformed-claim-identity-key-key))
+  (:report (lambda (c s)
+             (format s "Not a CLAIM-IDENTITY-KEY: ~s"
+                     (malformed-claim-identity-key-key c))))
+  (:documentation "SPLIT-CLAIM-IDENTITY-KEY was handed a string that
+CLAIM-IDENTITY-KEY cannot have produced (GH #321)."))

--- a/spacetime/package.lisp
+++ b/spacetime/package.lisp
@@ -69,6 +69,7 @@
    #:mdv-name #:mdv-subject-namespace #:mdv-subject-key #:mdv-members
    #:check-disjoint-memberships
    #:unknown-claim-family
+   #:claim-family-conflict                             ; GH #323
    ;; temporal claim families (GH #296)
    #:claim-family-temporal-p #:extent-sexp-start-key
    ;; extents-disjoint-p is cl-temporal-extent's since its 0.2.0 (#1 there)

--- a/spacetime/package.lisp
+++ b/spacetime/package.lisp
@@ -52,6 +52,8 @@
    #:claim-precision-m #:claim-fraction                 ; GH #138
    #:claim-extent #:claims-touching
    #:claim-identity-key                                ; GH #303
+   #:split-claim-identity-key                          ; GH #321
+   #:malformed-claim-identity-key
    #:claim-version-stamp                               ; GH #300
    #:reaped-claim #:reaped-claim-p #:reaped-claim-id   ; GH #300
    #:claim-transaction-extent-sexp                     ; GH #148

--- a/tests/evaluator-tests.lisp
+++ b/tests/evaluator-tests.lisp
@@ -107,3 +107,30 @@ unchanged and the same graph still accepts a clean commit."
       (make-ev-item :sku "second" :grade "b"))
     (is (= 2 (length (map-vertices #'identity g :collect-p t
                                    :vertex-type (quote ev-item)))))))
+
+(test validate-transaction-reads-the-ambient-write-set
+  "GH #320: a consumer that stages writes in its own transaction asks
+the evaluator about them through the exported reader, then commits or
+rolls back.  The report equals VALIDATE-WRITES over GRAPH-DB:WRITES,
+and the commit that follows refuses what the report named."
+  (with-ev-graph (g)
+    (with-transaction ()
+      (make-ev-item :sku "taken" :grade "a"))
+    (signals unique-constraint-violation
+      (with-transaction ()
+        (make-ev-item :sku "taken" :grade "z")
+        (let* ((report (graph-db:validate-transaction g))
+               (direct (validate-writes g (graph-db:writes *transaction*)))
+               (families (mapcar #'first
+                                 (validation-report-violations report))))
+          (is (= 1 (length (graph-db:writes *transaction*))))
+          (is (null (set-exclusive-or '(:unique :value) families)))
+          (is (equal (mapcar #'first
+                             (validation-report-violations direct))
+                     families)))))))
+
+(test validate-transaction-needs-an-open-transaction
+  "Outside a transaction there is no write set to read; say so rather
+than validate an empty one and report clean (GH #320)."
+  (with-ev-graph (g)
+    (signals error (graph-db:validate-transaction g))))

--- a/tests/spacetime/claim-identity-tests.lisp
+++ b/tests/spacetime/claim-identity-tests.lisp
@@ -220,3 +220,40 @@ never go through MAKE-<NAME> -- here, SETF on an existing claim (GH #160)."
             (graph-db::save copy))))
       (is (equal "r" (claim-relation
                       (first (claims-touching g 'ct-claim :ns "s1"))))))))
+
+(test split-claim-identity-key-round-trips-unary-and-binary
+  "GH #321: the inverse of CLAIM-IDENTITY-KEY, with the escape rule
+exercised by keys holding both | and \\, and the split's first three
+values driving CLAIMS-TOUCHING back to the same claim."
+  (with-claim-graph (g)
+    (let (u b)
+      (with-transaction ()
+        (setq u (make-u :producer "rule-a" :subject "s|1\\x" :relation "r")
+              b (make-b :producer "rule-b" :subject "s2" :object "o|2"
+                        :relation "rel")))
+      (multiple-value-bind (producer ns key relation ons okey start)
+          (split-claim-identity-key (claim-identity-key u))
+        (is (string= "rule-a" producer))
+        (is (eq :ns ns))
+        (is (string= "s|1\\x" key))
+        (is (string= "r" relation))
+        (is (null ons)) (is (null okey)) (is (null start))
+        (is (string= (claim-identity-key u)
+                     (claim-identity-key
+                      (first (claims-touching g 'ct-claim ns key
+                                              :role :subject))))))
+      (multiple-value-bind (producer ns key relation ons okey start)
+          (split-claim-identity-key (claim-identity-key b))
+        (is (string= "rule-b" producer))
+        (is (eq :ns ns))
+        (is (string= "s2" key))
+        (is (string= "rel" relation))
+        (is (eq :ns ons))
+        (is (string= "o|2" okey))
+        (is (null start))))))
+
+(test split-claim-identity-key-refuses-other-shapes
+  "GH #321: three, eight, a dangling escape, a namespace field without
+its colon -- none is a key CLAIM-IDENTITY-KEY produced."
+  (dolist (bad '("a|b|c" "a|:b|c|d|e|f|g|h" "a|:b|c\\" "a|b|c|d"))
+    (signals malformed-claim-identity-key (split-claim-identity-key bad))))

--- a/tests/spacetime/claim-query-tests.lisp
+++ b/tests/spacetime/claim-query-tests.lisp
@@ -222,3 +222,53 @@ answering NIL, which is also the correct answer for 'wrote nothing'."
   (with-claim-graph (g)
     (signals unknown-claim-family
       (claims-by-producer g 'no-such-claim "rule-a"))))
+
+(test a-transaction-reads-its-own-retraction-and-assertion
+  "GH #324: retract-then-assert in one WITH-TRANSACTION -- the idiom
+RETRACT-CLAIM's docstring recommends -- reads back inside the
+transaction as it will commit: the retracted claim no longer current,
+the new one present, both in CLAIMS-TOUCHING and CLAIMS-BY-PRODUCER."
+  (with-claim-graph (g)
+    (with-transaction () (make-b :object "old"))
+    (with-transaction ()
+      (let ((c (first (claims-touching g 'ct-claim :ns "s1"
+                                       :role :subject :current t))))
+        (retract-claim c)
+        (is (null (claims-touching g 'ct-claim :ns "s1"
+                                   :role :subject :current t)))
+        (make-b :object "new")
+        (let ((live (claims-touching g 'ct-claim :ns "s1"
+                                     :role :subject :current t)))
+          (is (= 1 (length live)))
+          (is (equal "new" (claim-object-key (first live)))))
+        (is (= 2 (length (claims-touching g 'ct-claim :ns "s1"
+                                          :role :subject))))
+        ;; The object side has no index on the new claim yet: the
+        ;; overlay is what admits it.
+        (is (= 1 (length (claims-touching g 'ct-claim :ns "new"
+                                          :role :object))))
+        (is (= 1 (length (claims-touching g 'ct-claim :ns "old"
+                                          :role :object))))
+        (is (null (claims-touching g 'ct-claim :ns "old"
+                                   :role :object :current t)))
+        (is (= 2 (length (claims-by-producer g 'ct-claim "rule-a"))))))
+    (let ((live (claims-touching g 'ct-claim :ns "s1"
+                                 :role :subject :current t)))
+      (is (= 1 (length live)))
+      (is (equal "new" (claim-object-key (first live)))))))
+
+(test as-of-answers-committed-history-only
+  "GH #324: the overlay is for the present.  An :AS-OF read inside a
+transaction still answers from committed versions, so an uncommitted
+retraction does not rewrite history the transaction may yet abandon."
+  (with-claim-graph (g)
+    (with-transaction () (make-b :object "old"))
+    (let ((then (local-time:now)))
+      (sleep 0.01)
+      (with-transaction ()
+        (retract-claim (first (claims-touching g 'ct-claim :ns "s1"
+                                               :role :subject)))
+        (let ((hist (claims-touching g 'ct-claim :ns "s1" :role :subject
+                                     :as-of then)))
+          (is (= 1 (length hist)))
+          (is (claim-current-p (first hist))))))))

--- a/tests/spacetime/claim-tests.lisp
+++ b/tests/spacetime/claim-tests.lisp
@@ -327,3 +327,43 @@ and a claim swept by delete-claims-by-producer is invisible."
       (delete-claims-by-producer g 'kr-claim "audit")
       (is (null (claims-touching g 'kr-claim :region "kr" :role :subject
                                  :as-of t0))))))
+
+;;; GH #323: derived names live with the PARENT, and the registry refuses
+;;; a family whose classes differ from the ones already registered.
+
+(defpackage #:graph-db/spacetime-test.elsewhere
+  (:use)
+  (:documentation "An empty package standing in for a tenant that
+declares a claim family from somewhere other than where the parent
+symbol lives (GH #323)."))
+
+(test def-claim-classes-names-live-with-the-parent
+  "GH #323: a declaration read in THIS package for a parent interned
+ELSEWHERE derives its class and constructor names in ELSEWHERE, so the
+same declaration means the same thing from any package."
+  (let* ((elsewhere (find-package :graph-db/spacetime-test.elsewhere))
+         (parent (intern "PK-CLAIM" elsewhere)))
+    (eval `(def-claim-classes ,parent :graph-db-claim-test))
+    (let ((family (claim-family parent)))
+      (is (eq elsewhere (symbol-package (claim-family-unary family))))
+      (is (eq elsewhere (symbol-package (claim-family-binary family))))
+      (is (fboundp (find-symbol "MAKE-PK-CLAIM-BINARY" elsewhere)))
+      (is (null (find-symbol "PK-CLAIM-UNARY" :graph-db/spacetime-test))))))
+
+(test registering-a-family-with-different-classes-is-refused
+  "GH #323: the registry entry for a parent is replaced silently only by
+a family naming the same unary and binary classes; anything else would
+orphan every existing claim of the family, so it signals and leaves the
+entry as it was."
+  (let ((old (claim-family 'ct-claim)))
+    (unwind-protect
+         (progn
+           (signals claim-family-conflict
+             (graph-db.spacetime::%register-claim-family
+              'ct-claim 'ct-claim-other-unary 'ct-claim-other-binary nil))
+           (is (eq old (claim-family 'ct-claim)))
+           (finishes
+             (graph-db.spacetime::%register-claim-family
+              'ct-claim (claim-family-unary old) (claim-family-binary old)
+              nil)))
+      (setf (gethash 'ct-claim graph-db.spacetime::*claim-families*) old))))

--- a/tests/spacetime/temporal-tests.lisp
+++ b/tests/spacetime/temporal-tests.lisp
@@ -462,3 +462,20 @@ disjoint later run is still admitted."
                (is (= 2 (length (%tt-runs g2 "r17")))))
           (close-graph g2)
           (collect-garbage))))))
+
+(test split-claim-identity-key-round-trips-a-temporal-key
+  "GH #321: a temporal family's seventh field reads back as the
+EXTENT-SEXP-START-KEY data the identity tuple canonicalises."
+  (with-claim-graph (g)
+    (with-transaction ()
+      (%tt-run "r1" "a" (ts 2022 1 1) (ts 2022 3 31)))
+    (let ((c (first (%tt-runs g "r1"))))
+      (multiple-value-bind (producer ns key relation ons okey start)
+          (split-claim-identity-key (claim-identity-key c))
+        (is (string= "series" producer))
+        (is (eq :region ns))
+        (is (string= "r1" key))
+        (is (string= "in-state" relation))
+        (is (eq :state ons))
+        (is (string= "a" okey))
+        (is (equal (extent-sexp-start-key (claim-extent-sexp c)) start))))))


### PR DESCRIPTION
## Summary

Four findings kraison/cl-llm#14 filed while building the agent-memory tenant, one commit each, in the order they were built:

- **#320** `validate-transaction`, and `writes` exported -- a consumer staging writes in its own transaction asks the #301 evaluator about them without `graph-db::writes`; signals when no transaction is open so an empty set never reads clean.
- **#321** `split-claim-identity-key` -- the inverse of `claim-identity-key`; arity and temporality follow from the field count (4..7), the escape rule lives in one place with `%identity-key-field`; `malformed-claim-identity-key` for anything else.
- **#324** a transaction reads its own claim writes -- `claims-touching` and `claims-by-producer` overlay the open transaction's write set through the commit view validation already uses, so retract-then-assert on one series inside one `with-transaction` (the idiom `retract-claim` recommends) reads correctly before commit. `:as-of` still answers committed history only.
- **#323** `def-claim-classes` derives its names in the parent symbol's package, not `*package*`, so a wrapper macro invoked from elsewhere no longer mints a second `<parent>-binary` and overwrites the family registry; a registration whose classes differ from the registered ones signals `claim-family-conflict`.

Nothing in `graph-db/core` changed except the evaluator entry point and two exports. CHANGELOG `[Unreleased]` carries all four.

## Test plan

- Spacetime suite from the branch worktree: **644 checks, 0 failures** (baseline 599). Each new test was run against the unfixed code first: the ten new checks for #323/#324 failed there and only there.
- Evaluator suite (core): 14 checks, 0 failures.
- Downstream: cl-llm's claims (24), memory (271) and agent (137) suites pass against this branch's engine; kraison/cl-llm#41 tracks dropping the tenant's four workarounds afterwards.
- Full suite: CI on this PR.

Closes #320, closes #321, closes #323, closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo