### PR TITLE
spacetime: split-claim-identity-key interns only canonical namespaces (#321 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ between releases; cutting a release renames it to the new version and dates it.
   them later gets producer, subject, relation, object and extent start
   back without re-implementing the escape rule. Arity and temporality
   follow from the field count; a string the encoder cannot have
-  produced signals `malformed-claim-identity-key`.
+  produced signals `malformed-claim-identity-key`, including a
+  namespace field that is not canonical (`[a-z0-9-]+`), which is
+  refused before anything is interned.
 
 - **`validate-transaction`, and `writes` exported** (#320): a consumer
   that stages writes in its own transaction can ask the #301 evaluator

--- a/spacetime/claim-query.lisp
+++ b/spacetime/claim-query.lisp
@@ -76,10 +76,17 @@ regeneration, which node ids do not (GH #303).  Fields join on |, with
     (nreverse fields)))
 
 (defun %identity-key-namespace (field key)
-  "FIELD as the keyword %IDENTITY-KEY-FIELD rendered, else signal."
-  (if (and (> (length field) 1) (char= (char field 0) #\:))
-      (intern (string-upcase (subseq field 1)) :keyword)
-      (error 'malformed-claim-identity-key :key key)))
+  "FIELD as the keyword %IDENTITY-KEY-FIELD rendered, else signal.
+Validated before interning: only a canonical name ([a-z0-9-]+, the
+RELATION rule) is interned, so a caller-supplied string cannot mint an
+arbitrary keyword through this path -- KEYWORD symbols are never
+collected.  The encoder downcases symbol names, so a non-canonical
+namespace never round-trips anyway (GH #321)."
+  (let ((name (and (> (length field) 1) (char= (char field 0) #\:)
+                   (subseq field 1))))
+    (if (and name (canonical-relation-p name))
+        (intern (string-upcase name) :keyword)
+        (error 'malformed-claim-identity-key :key key))))
 
 (defun %identity-key-extent-start (field key)
   "FIELD read back as EXTENT-SEXP-START-KEY data, *READ-EVAL* off."

--- a/tests/spacetime/claim-identity-tests.lisp
+++ b/tests/spacetime/claim-identity-tests.lisp
@@ -257,3 +257,16 @@ values driving CLAIMS-TOUCHING back to the same claim."
 its colon -- none is a key CLAIM-IDENTITY-KEY produced."
   (dolist (bad '("a|b|c" "a|:b|c|d|e|f|g|h" "a|:b|c\\" "a|b|c|d"))
     (signals malformed-claim-identity-key (split-claim-identity-key bad))))
+
+(test split-claim-identity-key-interns-only-canonical-namespaces
+  "GH #321 follow-up: a namespace field that is not [a-z0-9-]+ is
+refused BEFORE interning, so a caller string cannot grow the KEYWORD
+package -- proved by the keyword not existing afterwards."
+  (dolist (bad '("a|:Bad_NS|c|d" "a|:has space|c|d" "a|:pipe\\|x|c|d"))
+    (signals malformed-claim-identity-key (split-claim-identity-key bad)))
+  (is (null (find-symbol "BAD_NS" :keyword)))
+  (is (null (find-symbol "HAS SPACE" :keyword)))
+  ;; And the canonical case still interns, fresh image or not.
+  (is (eq :never-seen-before-ns
+          (nth-value 1 (split-claim-identity-key
+                        "a|:never-seen-before-ns|c|d")))))


### PR DESCRIPTION
## Summary

Follow-up to #325. \`split-claim-identity-key\` interned the namespace field as soon as it saw a leading colon. A tenant that delegates cite parsing to it (kraison/cl-llm#41) would lose its "validate, then intern" rule -- no caller string may mint an unbounded keyword, since KEYWORD symbols are never collected. The inverse now refuses a namespace field that is not canonical (\`[a-z0-9-]+\`, the RELATION rule) before anything is interned. The encoder downcases symbol names, so a non-canonical namespace never round-tripped anyway; this makes the contract honest.

## Test plan

- New test: three non-canonical fields signal \`malformed-claim-identity-key\`, and the would-be keywords do not exist afterwards (the interning is what the test rules out); a never-seen canonical namespace still interns.
- Spacetime suite from the branch worktree: 650 checks, 0 failures (644 before).
- Full suite: CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo