### PR TITLE
query: graph-db/query, the web-free guarded query subsystem; heads resolve in their own package (#322)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 # The full suite in CI (see docs/ci.md): main, concurrency,
-# ACID, spacetime, geos, algorithms, gui.  The habit this replaces:
-# running 35+ minutes of tests by hand on every change.  Local runs
-# are the affected subsystem's tests; every push here gets the full
-# matrix, and experiment -> master promotion waits for green.
+# ACID, spacetime, query, geos, algorithms, gui.  The habit this
+# replaces: running 35+ minutes of tests by hand on every change.
+# Local runs are the affected subsystem's tests; every push here
+# gets the full matrix, and experiment -> master promotion waits
+# for green.
 name: test
 on:
   push:
@@ -89,6 +90,20 @@ jobs:
                             :ignore-inherited-configuration))' \
             --eval '(ql:quickload :graph-db/spacetime-test :silent t)' \
             --eval '(asdf:test-system :graph-db/spacetime-test)'
+      - name: query suite
+        run: |
+          sbcl --dynamic-space-size 12288 --non-interactive \
+            --load "$HOME/quicklisp/setup.lisp" \
+            --eval '(setf ql:*local-project-directories* nil)' \
+            --eval '(asdf:initialize-source-registry
+                      (list :source-registry
+                            (list :tree (uiop:getcwd))
+                            (list :directory
+                                  (merge-pathnames "ci-deps-vivace-graph/cl-temporal-extent/"
+                                                   (user-homedir-pathname)))
+                            :ignore-inherited-configuration))' \
+            --eval '(ql:quickload :graph-db/query-test :silent t)' \
+            --eval '(asdf:test-system :graph-db/query-test)'
       - name: geos suite
         run: |
           sbcl --dynamic-space-size 12288 --non-interactive \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Added
 
+- **`graph-db/query`, a web-free subsystem for guarded queries** (#322):
+  the JSON pattern DSL and the free-text Prolog guard move out of
+  `graph-db/gui` into a subsystem depending only on `graph-db/core`, so
+  a consumer wanting a bounded query tool no longer pulls in a web
+  stack. The exported `run-guarded-prolog` screens, reads, guards and
+  runs free text against a graph, returning `(values columns rows
+  truncated-p)` in JSON-shaped `:data` form or in-image `:raw` form;
+  see `docs/guarded-query.md`.
+
 - **A transaction reads its own claim writes** (#324): `claims-touching`
   and `claims-by-producer` overlay the open transaction's write set --
   the commit view validation already uses -- so retract-then-assert on
@@ -139,6 +148,16 @@ between releases; cutting a release renames it to the new version and dates it.
   one-relation read of a busy endpoint touches only that relation's rows.
 
 ### Fixed
+
+- **A goal's head resolved through one shared `*package*` binding**
+  (#322, second finding): `make-functor-symbol` now looks up an
+  already-registered functor first -- the head's own package, then
+  `graph-db`, where CL-inherited heads like `>` are registered -- and
+  interns only when neither hits, so a goal list spanning two packages
+  (the engine's globals and a schema's edge functors) compiles as one
+  query. `<-` definitions are unaffected: `add-clause` passes a new
+  `:define t` argument that skips both lookups and interns straight
+  into `*package*`, exactly as before.
 
 - **`def-claim-classes` derived its class names in `*package*`** (#323):
   a declaration read from another package minted a second

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,18 @@ between releases; cutting a release renames it to the new version and dates it.
 ### Added
 
 - **`graph-db/query`, a web-free subsystem for guarded queries** (#322):
-  the JSON pattern DSL and the free-text Prolog guard move out of
-  `graph-db/gui` into a subsystem depending only on `graph-db/core`, so
-  a consumer wanting a bounded query tool no longer pulls in a web
-  stack. The exported `run-guarded-prolog` screens, reads, guards and
-  runs free text against a graph, returning `(values columns rows
-  truncated-p)` in JSON-shaped `:data` form or in-image `:raw` form;
-  see `docs/guarded-query.md`.
+  the JSON pattern DSL moves out of the `graph-db` web system and the
+  free-text Prolog guard moves out of `graph-db/gui`, both into a
+  subsystem depending only on `graph-db/core`, so a consumer wanting a
+  bounded query tool no longer pulls in a web stack. The exported
+  `run-guarded-prolog` screens, reads, guards and runs free text
+  against a graph, returning `(values columns rows truncated-p)` in
+  JSON-shaped `:data` form or in-image `:raw` form; see
+  `docs/guarded-query.md`. The `/query` and `def-query` REST routes,
+  the DSL's only ndjson callers, now set the
+  `application/x-ndjson` content type themselves once their query has
+  produced its text. The GUI Prolog endpoint now reports `columns` for
+  a zero-row answer too, instead of `[]`.
 
 - **A transaction reads its own claim writes** (#324): `claims-touching`
   and `claims-by-producer` overlay the open transaction's write set --

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,8 +1,8 @@
 # CI: the full suite runs itself
 
 `.github/workflows/test.yml` runs the full test suite (main,
-concurrency, ACID, spacetime, geos, algorithms, gui; 12GiB heap
-per `tests/README.md`) on every push
+concurrency, ACID, spacetime, query, geos, algorithms, gui; 12GiB
+heap per `tests/README.md`) on every push
 to `experiment` or `master` and on pull requests.
 
 - **Runners are self-hosted** (personal-account runners are

--- a/docs/guarded-query.md
+++ b/docs/guarded-query.md
@@ -1,0 +1,144 @@
+# graph-db/query: running untrusted query text safely
+
+`graph-db/query` (GH #322) is a web-free ASDF subsystem,
+`:depends-on (:graph-db/core)` only, holding the two reviewed ways to
+run query text an operator did not write: the JSON pattern DSL
+(package `graph-db`, `query/dsl.lisp`, GH #44/#278) and the free-text
+Prolog guard (package `graph-db.query`, `query/guard.lisp`, GH #279).
+Both used to live inside `graph-db/gui`, so any consumer that only
+wanted a bounded query tool -- not a GUI, not ningle -- had to load a
+web stack to reach them. A tenant that hands a language model a query
+tool depends on `graph-db/core` and `graph-db/spacetime` and must not
+pull one in (kraison/cl-llm#14 unit 2); homing the guard here is what
+makes that possible.
+
+## Loading it
+
+```lisp
+(ql:quickload :graph-db/query)
+```
+
+Pulls in `graph-db/core` and nothing web-facing. The exported guard
+API lives in `graph-db.query`; the DSL's exports (`compile-pattern-query`,
+`run-query-goals`, `run-pattern-query`, `def-query`, and friends) stay
+in `graph-db` as before.
+
+## `run-guarded-prolog`
+
+```lisp
+(run-guarded-prolog text graph &key limit max-inferences timeout
+                                     (format :data))
+  => (values columns rows truncated-p)
+```
+
+Screens `text` character-by-character before the reader ever sees it,
+reads it into a per-call scratch package that uses nothing, walks and
+rebuilds the resulting forms out of canonical, whitelisted symbols, and
+runs the result through the DSL's own runner (`:effects nil`, one
+snapshot, the inference/time/row bounds) -- all before deleting the
+scratch package in an `unwind-protect`, on every exit path including a
+refusal.
+
+- **Columns** are the query's `?variables` in first-appearance order,
+  as camelCase wire strings without the `?` (`?min-age` becomes
+  `"minAge"`, via the DSL's `%query-var-field`) -- the same spelling
+  the GUI's wire format already used.
+- **Rows** are one list per solution, in solution order, shaped by
+  `format`:
+  - `:data` (the default): every cell through `%query-value->json` --
+    a node becomes its id string, everything else a string, a number,
+    `t`, or `nil`. `nil` covers both an unbound variable and an empty
+    slot; the two are not distinguished. Example:
+
+    ```lisp
+    (run-guarded-prolog
+     "(is-a ?i qt-item) (node-slot-value ?i label ?l)" graph)
+    => (values ("i" "l")
+               (("N1a2b3c..." "a") ("N4d5e6f..." "b") ("N789abc..." "c"))
+               nil)
+    ```
+  - `:raw`: the values Prolog actually bound, nodes included. For
+    in-image Lisp callers only -- nothing raw is meant to cross a wire.
+    Example:
+
+    ```lisp
+    (run-guarded-prolog "(is-a ?i qt-item)" graph :format :raw)
+    => (values ("i") ((#<vertex qt-item ...>) (#<vertex qt-item ...>)
+                       (#<vertex qt-item ...>))
+               nil)
+    ```
+
+**Budgets and truncation.** `limit` is clamped to
+`*query-default-limit*` (1000). `max-inferences` and `timeout` bind
+`*query-default-max-inferences*` and `*query-default-timeout*` for the
+call; left out, the specials' current values apply. The runner asks
+the DSL for one row past the clamped cap: `truncated-p` is `t` when
+that extra row shows up (more solutions exist than were returned) and
+`nil` when the result set exactly fills or falls under the cap.
+
+## The condition contract
+
+| what happened | signaled as | caller sees | logged |
+|---|---|---|---|
+| guard refusal (bad char, unregistered functor, qualified or string head, ...) | `prolog-guard-error` | `prolog-guard-error-reason`, names the token, client-safe | no |
+| engine's own reviewed conditions (`prolog-error` family, `query-param-error`) | passed through unchanged | the original condition and report | no |
+| ill-typed goal arguments | `prolog-ill-typed-error` | fixed text, "ill-typed query" | yes, "ill-typed query" label |
+| anything else -- an engine defect | `prolog-server-fault` | fixed text, "internal error" | yes, "UNEXPECTED SERVER FAULT" label |
+
+`prolog-ill-typed-error` and `prolog-server-fault` deliberately carry no
+detail: the conditions they stand in for can report engine internals --
+a store's keyword name, a generic-function name, an ANSI section
+reference -- to a client that is, on the free-text surface, otherwise
+unauthenticated. The detail goes to the log, never to the caller.
+
+## Head resolution (GH #322, second finding)
+
+A goal's head resolves by lookup before it interns anything: an
+already-registered functor in the head symbol's own package first,
+then in `graph-db`, where the engine's built-ins are registered under
+their literal name -- which is why a CL-inherited head like `>`, `atom`,
+or `write` (whose home package is always `common-lisp`, never
+`graph-db`) still finds the engine's functor. This is what lets one
+goal list name a global functor and a schema's own edge functor
+together, since each now resolves in its own home instead of a single
+shared `*package*` binding. Only `<-` (`add-clause`) skips both lookups
+and interns straight into `*package*`, via a `:define t` argument, so a
+schema-package clause defines its own functor rather than silently
+landing on an existing `graph-db` functor of the same name; the guard's
+rebuilt heads (`graph-db::is-a`, `schema::follows`, ...) each take the
+lookup path.
+
+## What the guard admits
+
+The whitelist, the exclusions, and the control-word list are derived
+from the live image, not hand-listed here -- see `query/guard.lisp`'s
+header and the block comments above `*prolog-excluded-predicates*`,
+`*prolog-goal-argument-control*`, and `*prolog-cost-unbounded-predicates*`
+for exactly what is admitted and why each exclusion exists.
+
+Two things a new caller reliably gets wrong first:
+
+- **Type and slot names are bare, never keyword-spelled.** Write
+  `(is-a ?x qt-item)`, not `(is-a ?x :qt-item)`. The character screen
+  refuses every `:` outright, before the reader runs -- a
+  keyword-spelled type name is a refusal, not a match.
+- **Package-qualified anything is refused for the same reason:** the
+  screen refuses `:` textually so that `READ` can never intern into
+  `graph-db` or a schema package from client text.
+
+## Callers
+
+The GUI's free-text Prolog workbench (`gui/prolog.lisp`, behind
+`START-GUI`'s `:allow-prolog` flag) is a caller: it calls
+`run-guarded-prolog` with the request's limit and `:data`, and wraps
+the result in its JSON envelope. The REST `/graph/:graph-name/query`
+route is a caller of the DSL side of this subsystem, running the JSON
+pattern DSL (`run-pattern-query`) rather than free-text Prolog -- it
+does not go through `run-guarded-prolog`.
+
+## Consumers outside this repo
+
+kraison/cl-llm's `cl-llm/agent/prolog` query tool re-homes onto
+`graph-db/query` (filed at landing); kraison/blackboard slice 1's
+`select` builds directly on `run-guarded-prolog` and
+`schema-type-names`.

--- a/docs/guarded-query.md
+++ b/docs/guarded-query.md
@@ -115,6 +115,27 @@ landing on an existing `graph-db` functor of the same name; the guard's
 rebuilt heads (`graph-db::is-a`, `schema::follows`, ...) each take the
 lookup path.
 
+This has a trade: with `:define t` the definition itself still lands
+in `*package*` as before, but a *call* whose head is a
+`common-lisp` symbol that collides with a `graph-db` global functor's
+literal name (`write`, `atom`, `not`, `>`, ...) resolves to the
+engine's functor rather than a same-named clause the user package
+defined -- the right choice, since those CL-inherited heads are
+exactly what the lookup exists to serve.
+
+## `schema-type-names`
+
+```lisp
+(schema-type-names graph parent)
+  => (name-symbol ...)
+```
+
+The vertex or edge class names (`parent` one of `:vertex` or `:edge`)
+registered in `graph`'s schema, sorted by name. Used to build the
+guard's own schema-name table (`%schema-name-table`) and, since #322,
+called qualified by `gui/api.lisp` for the same purpose the GUI's
+`/api/graphs/:name/types` route always served.
+
 ## What the guard admits
 
 The whitelist, the exclusions, and the control-word list are derived
@@ -122,6 +143,15 @@ from the live image, not hand-listed here -- see `query/guard.lisp`'s
 header and the block comments above `*prolog-excluded-predicates*`,
 `*prolog-goal-argument-control*`, and `*prolog-cost-unbounded-predicates*`
 for exactly what is admitted and why each exclusion exists.
+
+**Defence in depth, not the front line.** The GUI Prolog handler still
+has a `cost-unbounded-goal` arm (`prolog-cost-unbounded-error`), but it
+is normally unreachable through the guard: the whitelist already
+refuses an engine-homed cost-unbounded name by name before the goal
+ever runs, and a schema-homed name of the same spelling now runs the
+schema's own functor instead of the engine's excluded one. The arm
+exists for the case neither of those covers, not as the mechanism that
+enforces the exclusion.
 
 Two things a new caller reliably gets wrong first:
 

--- a/docs/guarded-query.md
+++ b/docs/guarded-query.md
@@ -5,12 +5,15 @@
 run query text an operator did not write: the JSON pattern DSL
 (package `graph-db`, `query/dsl.lisp`, GH #44/#278) and the free-text
 Prolog guard (package `graph-db.query`, `query/guard.lisp`, GH #279).
-Both used to live inside `graph-db/gui`, so any consumer that only
-wanted a bounded query tool -- not a GUI, not ningle -- had to load a
-web stack to reach them. A tenant that hands a language model a query
-tool depends on `graph-db/core` and `graph-db/spacetime` and must not
-pull one in (kraison/cl-llm#14 unit 2); homing the guard here is what
-makes that possible.
+Both used to sit above `graph-db/core`, never below it, but not in
+the same place: the DSL lived in the web system (`rest.lisp`, then
+`query-dsl.lisp`), kept out of core by one ningle line setting an
+ndjson content type; the guard lived inside `graph-db/gui`. Either
+way, any consumer that only wanted a bounded query tool -- not a GUI,
+not ningle -- had to load a web stack to reach them. A tenant that
+hands a language model a query tool depends on `graph-db/core` and
+`graph-db/spacetime` and must not pull one in (kraison/cl-llm#14 unit
+2); homing both here is what makes that possible.
 
 ## Loading it
 
@@ -71,10 +74,14 @@ refusal.
 **Budgets and truncation.** `limit` is clamped to
 `*query-default-limit*` (1000). `max-inferences` and `timeout` bind
 `*query-default-max-inferences*` and `*query-default-timeout*` for the
-call; left out, the specials' current values apply. The runner asks
-the DSL for one row past the clamped cap: `truncated-p` is `t` when
-that extra row shows up (more solutions exist than were returned) and
-`nil` when the result set exactly fills or falls under the cap.
+call; left out, the specials' current values apply. Below the cap,
+the runner asks the DSL for one row past it: `truncated-p` is `t`
+when that extra row shows up (more solutions exist than were
+returned) and `nil` when the result set exactly fills or falls under
+the cap. At the ceiling -- `limit` omitted or `>=
+*query-default-limit*` -- there is no room for the extra row
+(`%probe`), so an exactly-full page there reads as `truncated-p` `t`
+too; only a page short of 1000 rows is `nil` at the ceiling.
 
 ## The condition contract
 
@@ -140,5 +147,5 @@ does not go through `run-guarded-prolog`.
 
 kraison/cl-llm's `cl-llm/agent/prolog` query tool re-homes onto
 `graph-db/query` (filed at landing); kraison/blackboard slice 1's
-`select` builds directly on `run-guarded-prolog` and
-`schema-type-names`.
+`select` and slice 3's structure tier build directly on
+`run-guarded-prolog` and `schema-type-names`.

--- a/docs/spatiotemporal-substrate-programme.md
+++ b/docs/spatiotemporal-substrate-programme.md
@@ -59,7 +59,9 @@ tenant needs belongs in that tenant.
 spanning namespaces, not an optimisation), #102 (index-backed generator predicate — on
 the retrieval layer's path *and* gating any Datalog work), #104 and #105 (fixed in the
 engine, still open on the tracker), #45 (Prolog modernization; phases 0-1 complete and
-merged, remaining phases tracked as sub-issues #121–#124 plus #102).
+merged, remaining phases tracked as sub-issues #121–#124 plus #102). #322 (the query
+DSL and the free-text Prolog guard as a web-free `graph-db/query`, so a tenant like
+kraison/cl-llm can depend on the retrieval layer without a web stack) has landed.
 
 How much of #45 this programme actually needs is accounted for in §12.1 of the
 programme design — about half of phase 2, one bullet of phase 4, and nothing else until

--- a/docs/superpowers/plans/2026-09-03-guarded-query-subsystem.md
+++ b/docs/superpowers/plans/2026-09-03-guarded-query-subsystem.md
@@ -105,17 +105,17 @@ In `rest.lisp`, `call-rest-pattern-query`, immediately inside `(with-rest-graph 
                      (lack.response:response-headers ningle:*response*))))
 ```
 
-- [ ] **Step 4: Run the four REST tests by name**
+- [ ] **Step 4: Run the REST tests by name**
 
 ```bash
 W=$(pwd)/; sbcl --dynamic-space-size 4096 --non-interactive \
   --eval "(push #p\"$W\" asdf:*central-registry*)" \
   --eval '(ql:quickload :graph-db/test :silent t)' \
   --eval '(in-package :graph-db/test)' --eval '(log:config :error)' \
-  --eval '(let* ((d (make-temp-directory)) (graph-db::*system-directory* (namestring d)) (graph-db::*type-registry* nil)) (unwind-protect (fiveam:explain! (fiveam:run (quote (http-pattern-query-ndjson http-pattern-query-json-body http-def-query-friends def-query-returns-json-objects)))) (graph-db-test-scratch:cleanup-scratch-run)))'
+  --eval '(let* ((d (make-temp-directory)) (graph-db::*system-directory* (namestring d)) (graph-db::*type-registry* nil)) (unwind-protect (fiveam:explain! (fiveam:run (quote (http-pattern-query-ndjson http-pattern-query-json-body http-def-query-friends def-query-returns-json-objects def-query-ndjson-streams-one-object-per-line pattern-query-ndjson-format)))) (graph-db-test-scratch:cleanup-scratch-run)))'
 ```
 
-Expected: `Did N checks. Pass: N (100%)`. If `fiveam:run` does not accept a list, run the four names in four `run` calls. Also load `graph-db/gui` in a fresh subprocess and confirm it compiles (`(ql:quickload :graph-db/gui)` exits 0).
+Expected: `Did N checks. Pass: N (100%)`. If `fiveam:run` does not accept a list, run the six names in six `run` calls. Also load `graph-db/gui` in a fresh subprocess and confirm it compiles (`(ql:quickload :graph-db/gui)` exits 0).
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-09-03-guarded-query-subsystem.md
+++ b/docs/superpowers/plans/2026-09-03-guarded-query-subsystem.md
@@ -1,0 +1,589 @@
+# graph-db/query Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Home the JSON pattern DSL and the free-text Prolog guard in a web-free subsystem `graph-db/query`, export one runner that returns data, and make a goal's head resolve its functor in its own package.
+
+**Architecture:** `query-dsl.lisp` moves verbatim to `query/dsl.lisp` (package `graph-db`, exports unchanged) minus one ningle line that moves to the REST route. The guard pipeline moves from `gui/prolog.lisp` to `query/guard.lisp` in a new package `graph-db.query`, which exports `run-guarded-prolog` returning `(values columns rows truncated-p)`; the GUI handler becomes a thin caller. `compile-call` derives `NAME/ARITY` in the head symbol's package. A new `graph-db/query-test` suite covers the runner directly; the GUI and core suites are the regression net.
+
+**Tech Stack:** SBCL 2.6.6, ASDF, FiveAM, cl-json (already a core dependency), the existing `graph-db-test-scratch` fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md` (#322).
+
+## Global Constraints
+
+- Lisp: spaces only; hard 80-column limit; terse comments pointing at the spec section or issue.
+- **Moves are moves.** Bodies moved in Tasks 1 and 2 are byte-identical to their originals except where a task names an edit; `git diff --color-moved` on the commit must show the bulk as moved, not rewritten.
+- Nothing the guard admits or refuses changes (spec §10); the whitelist, exclusions and control words move untouched.
+- No new dependency on `graph-db/query` beyond `graph-db/core`. No web package (`ningle`, `lack`, `clack`, `hunchentoot`) is referenced from `query/`.
+- Suites run only in a subprocess from the worktree, with the worktree first on `asdf:*central-registry*`:
+  `sbcl --dynamic-space-size 4096 --non-interactive --eval '(push #p"<worktree>/" asdf:*central-registry*)' --eval '(ql:quickload :<system> :silent t)' --eval '(asdf:test-system :<system>)'`.
+  `asdf:test-system :graph-db/spacetime` and `:graph-db/query` (the non-test systems) are silent no-ops; always target the `-test` system, and read `Did N checks` from the output.
+- Local runs per task: `graph-db/gui-test` (about two minutes) and `graph-db/query-test`; the full `graph-db/test` suite and the rest run once, in CI on the single PR (Kevin: batch, limit pushes). Task 4 also runs the core `select` tests by name, listed there.
+- Commit trailers: `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>` and `Claude-Session: https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo`. No push until the branch is complete.
+
+---
+
+## File structure
+
+| file | after this plan |
+|---|---|
+| `query/dsl.lisp` | the DSL, moved from `query-dsl.lisp`; ndjson arm returns text only |
+| `query/package.lisp` | `graph-db.query` package and exports |
+| `query/guard.lisp` | the guard pipeline and `run-guarded-prolog`, moved from `gui/prolog.lisp`; `schema-type-names` from `gui/api.lisp` |
+| `gui/prolog.lisp` | flag, request-body helpers, envelope glue, handler |
+| `gui/api.lisp` | calls `graph-db.query:schema-type-names` |
+| `rest.lisp` | `/query` sets the ndjson content type itself |
+| `prologc.lisp` | `make-functor-symbol` homes the functor in the head's package |
+| `graph-db.asd` | systems `graph-db/query`, `graph-db/query-test`; `graph-db` depends on `graph-db/query` |
+| `tests/query/{package,suite,guard-tests}.lisp` | the new suite |
+| `.github/workflows/test.yml`, `docs/ci.md` | the new lane |
+| `docs/guarded-query.md`, `CHANGELOG.md`, two doc pointers | docs |
+
+---
+
+### Task 1: The `graph-db/query` system holding the DSL; the ndjson line moves to REST
+
+**Files:**
+- Create: `query/dsl.lisp` (git mv from `query-dsl.lisp`)
+- Modify: `graph-db.asd`, `rest.lisp`
+- Test: `tests/rest-http-tests.lisp` (existing `http-pattern-query-ndjson`, `http-pattern-query-json-body`, `http-def-query-friends`), `tests/rest-tests.lisp` (existing `def-query-returns-json-objects`)
+
+**Interfaces:**
+- Produces: system `graph-db/query` (`:depends-on (:graph-db/core)`, pathname `query/`, component `"dsl"`); `graph-db` depends on it and no longer lists `query-dsl`. `emit-query-results` with `:ndjson` returns the text and sets no header.
+
+- [ ] **Step 1: Move the file and rewire the systems**
+
+```bash
+mkdir -p query && git mv query-dsl.lisp query/dsl.lisp
+```
+
+In `graph-db.asd`, before `(defsystem graph-db`, add:
+
+```lisp
+;; The web-free query subsystem (GH #322): the JSON pattern DSL and,
+;; from Task 2 on, the free-text Prolog guard.  Depends on core only so
+;; a consumer that wants a bounded query tool never loads a web stack.
+(defsystem graph-db/query
+  :name "VivaceGraph guarded query"
+  :description "The JSON pattern DSL and the free-text Prolog guard,
+web-free.  docs/guarded-query.md; GH #322."
+  :maintainer "Kevin Raison"
+  :author "Kevin Raison <last name @ chatsubo dot net>"
+  :version "4.0.1"
+  :depends-on (:graph-db/core)
+  :pathname "query/"
+  :serial t
+  :components ((:file "dsl")))
+```
+
+In `(defsystem graph-db`: add `:graph-db/query` to `:depends-on` after `:graph-db/replication`; delete the `(:file "query-dsl")` component and the comment block above it that explains why it was not in core (it is now the subsystem's header, Step 2); leave `(:file "rest")`.
+
+- [ ] **Step 2: Edit the moved file's header and the ndjson arm**
+
+Replace the header paragraph beginning `;;;; Why this file sits in the :GRAPH-DB system` with:
+
+```lisp
+;;;; Home: the graph-db/query subsystem (GH #322), which depends on
+;;;; graph-db/core only.  The one web-bound line this file had -- the
+;;;; :NDJSON arm setting a content type on NINGLE:*RESPONSE* -- moved to
+;;;; rest.lisp's /query route, the only caller that asks for ndjson.
+```
+
+In `emit-query-results`, delete the `(setf (lack.response:response-headers ningle:*response*) ...)` form from the `:ndjson` arm and change the docstring's last sentence to `with :NDJSON returns each row as its own JSON line; the caller sets the content type.`
+
+- [ ] **Step 3: Set the header in the REST route**
+
+In `rest.lisp`, `call-rest-pattern-query`, immediately inside `(with-rest-graph (...)` and before `(handler-case (run-pattern-query dsl *graph*)`:
+
+```lisp
+      ;; The DSL renders ndjson; the wire header is HTTP's (GH #322).
+      (when (string-equal "ndjson"
+                          (princ-to-string (or (cdr (assoc :format dsl)) "")))
+        (setf (lack.response:response-headers ningle:*response*)
+              (list* :content-type "application/x-ndjson"
+                     (lack.response:response-headers ningle:*response*))))
+```
+
+- [ ] **Step 4: Run the four REST tests by name**
+
+```bash
+W=$(pwd)/; sbcl --dynamic-space-size 4096 --non-interactive \
+  --eval "(push #p\"$W\" asdf:*central-registry*)" \
+  --eval '(ql:quickload :graph-db/test :silent t)' \
+  --eval '(in-package :graph-db/test)' --eval '(log:config :error)' \
+  --eval '(let* ((d (make-temp-directory)) (graph-db::*system-directory* (namestring d)) (graph-db::*type-registry* nil)) (unwind-protect (fiveam:explain! (fiveam:run (quote (http-pattern-query-ndjson http-pattern-query-json-body http-def-query-friends def-query-returns-json-objects)))) (graph-db-test-scratch:cleanup-scratch-run)))'
+```
+
+Expected: `Did N checks. Pass: N (100%)`. If `fiveam:run` does not accept a list, run the four names in four `run` calls. Also load `graph-db/gui` in a fresh subprocess and confirm it compiles (`(ql:quickload :graph-db/gui)` exits 0).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A query graph-db.asd rest.lisp
+git commit -m "refactor(query): graph-db/query holds the DSL; REST sets the ndjson header (#322)"
+```
+
+`git show --color-moved --stat` must show `query-dsl.lisp => query/dsl.lisp` as a rename.
+
+---
+
+### Task 2: The guard moves to `query/guard.lisp` in package `graph-db.query`
+
+**Files:**
+- Create: `query/package.lisp`, `query/guard.lisp`
+- Modify: `gui/prolog.lisp`, `gui/api.lisp`, `gui/package.lisp` (if it imports anything moved), `graph-db.asd`
+- Test: `graph-db/gui-test` (existing; unchanged)
+
+**Interfaces:**
+- Produces: package `graph-db.query` exporting `prolog-guard-error prolog-guard-error-reason prolog-ill-typed-error prolog-server-fault *prolog-max-query-length* *prolog-max-depth* schema-type-names` and, internally for Task 3, the moved `%`-functions. `gui/prolog.lisp` keeps `*allow-prolog*`, `*prolog-internal-error-message*`, `%prolog-request-body`, `%prolog-field`, `%prolog-request-text`, `%run-guarded-prolog` (rewritten in Task 3) and `api-graph-prolog`.
+
+- [ ] **Step 1: Write the package**
+
+```lisp
+;;;; query/package.lisp -- the web-free guarded query subsystem (GH #322).
+
+(defpackage #:graph-db.query
+  (:use #:cl)
+  (:import-from #:graph-db
+                ;; the runner and its bounds (query/dsl.lisp)
+                #:run-query-goals #:*query-default-limit*
+                #:*query-default-max-inferences* #:*query-default-timeout*
+                #:query-param-error #:query-precondition-error
+                #:prolog-error #:prolog-resource-error
+                #:prolog-permission-error
+                ;; the registries the whitelist enumerates
+                #:*prolog-global-functors* #:*user-functors*
+                ;; schema lookups
+                #:schema #:schema-type-table #:node-type-name
+                #:lookup-node-type-by-name #:node-type-slots)
+  (:export
+   ;; the runner (spec SS4)
+   #:run-guarded-prolog
+   ;; conditions (spec SS3)
+   #:prolog-guard-error #:prolog-guard-error-reason
+   #:prolog-ill-typed-error #:prolog-server-fault
+   ;; the screen's limits
+   #:*prolog-max-query-length* #:*prolog-max-depth*
+   ;; schema names, shared with the GUI
+   #:schema-type-names))
+```
+
+Adjust the `:import-from` list to exactly the `graph-db` symbols the moved code references unqualified; the moved code was written in `graph-db.gui`, which uses only `cl`, so every engine reference in it is already package-qualified (`graph-db::...`) and needs no import — check with `grep -c 'graph-db::' query/guard.lisp` and keep the import list minimal (possibly empty). Keep the explicit `graph-db::` qualifications in the moved code rather than importing; that is what "moved verbatim" means.
+
+- [ ] **Step 2: Move the guard**
+
+Create `query/guard.lisp` with `(in-package #:graph-db.query)` and, in this order, the definitions from `gui/prolog.lisp` at these lines (numbers from the file at commit 4c9bc9f): the header comment `;;;; Free-text Prolog ...` through the interning-subtlety paragraph (lines 1–34), then `*prolog-max-query-length*` (48), `*prolog-max-depth*` (51), the three conditions (66–93), `%refuse` (95), `%term-label` (99), `%token-around` (111), `%skip-delimited` (123), `%scan-query-text` (134), `*prolog-readtable*` (186), `%refuse-reader-macro` (189), `%prolog-readtable` (193), `*prolog-scratch-counter*` (203), `%make-scratch-package` (205), `%read-query-forms` (218), `%split-functor-name` (238), `*prolog-excluded-predicates*` (254), `*prolog-goal-argument-control*` (269), `*prolog-cost-unbounded-predicates*` (279), `%excluded-predicate-p` (306), `%functor-whitelist` (311), `%control-word-table` (344), `%schema-name-table` (361), the `guard-ctx` struct (379), `%guard-context` (385), `%routes-to-engine-control-p` (396), `%cut-symbol-p` (418), `%guard-symbol` (425), `%guard-goal` (449), `%guard-term` (495), `%guard-query` (505), `%prolog-functor-names` (524), `%non-finite-p` (588), `%screen-non-finite` (601), `%read-guarded-forms` (612), `*no-applicable-method-type*` (637), `%ill-typed-condition-p` (651), `%run-guarded-query` (682), `%run-guarded-prolog` (718, renamed `%run-guarded-prolog-json` here; Task 3 replaces it).
+
+Also move `%schema-type-names` from `gui/api.lisp` (line 273) as `schema-type-names` (exported), and `%schema-package` (579) — keep it in `guard.lisp` for Task 4 to delete.
+
+Edit the moved header: change `;;;;   1. *ALLOW-PROLOG* -- the flag, checked in the handler` to note the flag stays in the GUI handler (`gui/prolog.lisp`), and add one line: `;;;; Home: graph-db/query (GH #322); the GUI handler is a caller.`
+
+Delete every moved definition from `gui/prolog.lisp`. What remains there: the file header (rewritten to three lines: free-text Prolog HTTP surface; the guard lives in `graph-db.query`; GH #279, #322), `*allow-prolog*`, `*prolog-internal-error-message*`, `%prolog-request-body`, `%prolog-field`, `%prolog-request-text`, `%run-guarded-prolog`, `api-graph-prolog`, and the capabilities/inventory handler if one lives here (check `def-gui-handler` occurrences: two). Qualify the references that now cross packages: `graph-db.query:prolog-guard-error`, `graph-db.query::%refuse` (used by `%prolog-request-text`), `graph-db.query:*prolog-max-query-length*`, `graph-db.query::%prolog-functor-names` (capabilities), `graph-db.query::%run-guarded-prolog-json`, `graph-db.query:prolog-ill-typed-error`, `graph-db.query:prolog-server-fault`.
+
+In `gui/api.lisp`, replace the definition of `%schema-type-names` with nothing and its three call sites with `graph-db.query:schema-type-names`.
+
+- [ ] **Step 3: Wire the system**
+
+`graph-db/query` components become `((:file "package") (:file "dsl") (:file "guard"))`. `graph-db/gui` needs no dependency change (it depends on `graph-db`, which depends on `graph-db/query`).
+
+- [ ] **Step 4: Run the GUI suite**
+
+`asdf:test-system :graph-db/gui-test` from the worktree. Expected: the same check count as before the move (record it from a run on `4c9bc9f` first: `Did N checks`), zero failures. A compile error naming a symbol is a missed qualification; a behaviour change is a moved body that was edited.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A query gui graph-db.asd
+git commit -m "refactor(query): the guard pipeline moves to graph-db.query (#322)"
+```
+
+---
+
+### Task 3: `run-guarded-prolog` returning data; the GUI calls it; the new suite
+
+**Files:**
+- Modify: `query/guard.lisp`, `gui/prolog.lisp`, `graph-db.asd`
+- Create: `tests/query/package.lisp`, `tests/query/suite.lisp`, `tests/query/guard-tests.lisp`
+- Test: `graph-db/query-test` (new), `graph-db/gui-test`
+
+**Interfaces:**
+- Produces: `(graph-db.query:run-guarded-prolog text graph &key limit max-inferences timeout (format :data))` → `(values columns rows truncated-p)` per spec §4. Internal `%guarded-rows` shared by both formats. `%run-guarded-prolog-json` deleted; the GUI's `%run-guarded-prolog` builds its envelope from the data.
+
+- [ ] **Step 1: Write the failing tests**
+
+```lisp
+;;;; tests/query/package.lisp
+(defpackage #:graph-db/query-test
+  (:use #:cl #:fiveam)
+  (:import-from #:graph-db #:def-vertex #:def-edge #:make-graph
+                #:close-graph #:with-transaction #:string-id)
+  (:export #:run-query-tests #:query-suite))
+```
+
+```lisp
+;;;; tests/query/suite.lisp -- runner + fixture for graph-db/query.
+(in-package #:graph-db/query-test)
+
+(def-suite query-suite
+  :description "The guarded query runner, called directly (GH #322).")
+
+(defun run-query-tests ()
+  "Run the suite; T when every check passed.  Invoked by
+(asdf:test-system :graph-db/query-test)."
+  (log:config :error)
+  (let* ((system-dir (graph-db-test-scratch:make-scratch-directory
+                      "graph-db-query-sys"))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'query-suite)))
+           (explain! results)
+           (results-status results))
+      (graph-db-test-scratch:cleanup-scratch-run))))
+
+;; A schema in a package that USES NOTHING: the case the head-resolution
+;; change (spec SS6) exists for.  Domain-neutral per repo policy #197.
+(defpackage #:graph-db/query-test.schema (:use))
+
+(defparameter *graph-name* :query-test-graph)
+
+(eval-when (:load-toplevel :execute)
+  (setf (gethash *graph-name* graph-db::*schema-node-metadata*) nil))
+
+(def-vertex graph-db/query-test.schema::qt-item ()
+  ((label :type string) (rank))
+  :query-test-graph)
+
+(def-edge graph-db/query-test.schema::qt-links ()
+  ()
+  :query-test-graph)
+
+(defmacro with-query-graph ((g) &body body)
+  `(let* ((dir (graph-db-test-scratch:make-scratch-directory "graph-db-query"))
+          (,g (make-graph *graph-name* (namestring dir)
+                          :buffer-pool-size 1000)))
+     (unwind-protect (let ((graph-db:*graph* ,g)) ,@body)
+       (ignore-errors (close-graph ,g)))))
+
+(defun seed (g)
+  "Three items and two links; returns the items in rank order."
+  (with-transaction ((graph-db::transaction-manager g))
+    (let ((a (graph-db/query-test.schema::make-qt-item
+              :graph g :label "a" :rank 1))
+          (b (graph-db/query-test.schema::make-qt-item
+              :graph g :label "b" :rank 2))
+          (c (graph-db/query-test.schema::make-qt-item
+              :graph g :label "c" :rank 3)))
+      (graph-db/query-test.schema::make-qt-links :graph g :from a :to b)
+      (graph-db/query-test.schema::make-qt-links :graph g :from b :to c)
+      (list a b c))))
+```
+
+Check `def-vertex`/`def-edge`'s exact constructor names and the edge constructor's `:from`/`:to` initargs against `tests/gui/suite.lisp`'s fixture before relying on them, and copy that fixture's spelling.
+
+```lisp
+;;;; tests/query/guard-tests.lisp
+(in-package #:graph-db/query-test)
+(in-suite query-suite)
+
+(defun q (g text &rest keys)
+  (apply #'graph-db.query:run-guarded-prolog text g keys))
+
+(test data-rows-are-json-shaped
+  (with-query-graph (g)
+    (seed g)
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i :qt-item) (node-slot-value ?i label ?l)")
+      (is (equal '("i" "l") columns))
+      (is (= 3 (length rows)))
+      (is (every (lambda (row) (and (stringp (first row))
+                                    (stringp (second row))))
+                 rows))
+      (is (equal '("a" "b" "c") (sort (mapcar #'second rows) #'string<)))
+      (is (null truncated)))))
+
+(test raw-rows-carry-nodes
+  (with-query-graph (g)
+    (seed g)
+    (let ((rows (nth-value 1 (q g "(is-a ?i :qt-item)" :format :raw))))
+      (is (every (lambda (row) (graph-db::node-p (first row))) rows)))))
+
+(test limit-clamps-and-flags-truncation
+  (with-query-graph (g)
+    (seed g)
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i :qt-item)" :limit 2)
+      (declare (ignore columns))
+      (is (= 2 (length rows)))
+      (is (eq t truncated)))
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i :qt-item)" :limit 3)
+      (declare (ignore columns))
+      (is (= 3 (length rows)))
+      (is (null truncated)))))
+
+(test each-screened-token-is-refused-and-its-absence-accepted
+  (with-query-graph (g)
+    (seed g)
+    (dolist (pair '(("(is-a ?i graph-db::qt-item)" . "(is-a ?i :qt-item)")
+                    ("(is-a ?i #.(quit))" . "(is-a ?i :qt-item)")
+                    ("(is-a ?i `x)" . "(is-a ?i :qt-item)")
+                    ("(is-a ?i ,x)" . "(is-a ?i :qt-item)")
+                    ("(is-a ?i :qt-item" . "(is-a ?i :qt-item)")))
+      (signals graph-db.query:prolog-guard-error (q g (car pair)))
+      (finishes (q g (cdr pair))))))
+
+(test unregistered-functor-and-string-head-refused
+  (with-query-graph (g)
+    (signals graph-db.query:prolog-guard-error (q g "(no-such-thing ?x)"))
+    (signals graph-db.query:prolog-guard-error (q g "(\"is-a\" ?x :qt-item)"))
+    (signals graph-db.query:prolog-guard-error (q g "(lisp ?x (quit))"))))
+
+(test an-inference-budget-breach-is-a-resource-error
+  (with-query-graph (g)
+    (seed g)
+    (signals graph-db:prolog-resource-error
+      (q g "(is-a ?i :qt-item) (is-a ?j :qt-item) (is-a ?k :qt-item)"
+         :max-inferences 2))))
+
+(test the-scratch-package-is-gone-afterwards
+  (with-query-graph (g)
+    (seed g)
+    (let ((before (length (list-all-packages))))
+      (q g "(is-a ?i :qt-item)")
+      (ignore-errors (q g "(is-a ?i #.(quit))"))
+      (is (= before (length (list-all-packages)))))))
+
+(test edge-and-global-functors-resolve-in-one-goal-list
+  "Spec SS6: the schema package uses nothing, so before the
+head-resolution change QT-LINKS/2 could not be found from GRAPH-DB's
+package nor IS-A/2 from the schema's."
+  (with-query-graph (g)
+    (destructuring-bind (a b c) (seed g)
+      (declare (ignore c))
+      (multiple-value-bind (columns rows)
+          (q g "(is-a ?x :qt-item) (qt-links ?x ?y)")
+        (is (equal '("x" "y") columns))
+        (is (= 2 (length rows)))
+        (is (member (list (string-id a) (string-id b)) rows
+                    :test #'equal))))))
+```
+
+The last test is expected to **fail** until Task 4; mark it `(test (edge-and-global-functors-resolve-in-one-goal-list :depends-on nil) ...)` is not needed — leave it failing and note the expected count in the ledger.
+
+```lisp
+;; graph-db.asd
+(defsystem graph-db/query-test
+  :name "VivaceGraph guarded-query test suite"
+  :depends-on (:graph-db/query :graph-db/test-scratch :fiveam)
+  :pathname "tests/query/"
+  :serial t
+  :components ((:file "package") (:file "suite") (:file "guard-tests"))
+  :perform (test-op (op c)
+             (unless (uiop:symbol-call :graph-db/query-test :run-query-tests)
+               (error "graph-db query tests failed."))))
+```
+
+and on `graph-db/query`: `:in-order-to ((test-op (test-op :graph-db/query-test)))`.
+
+- [ ] **Step 2: Run to verify failure**
+
+`asdf:test-system :graph-db/query-test`. Expected: `run-guarded-prolog` undefined.
+
+- [ ] **Step 3: Implement the runner**
+
+In `query/guard.lisp`, replace `%run-guarded-query` and `%run-guarded-prolog-json` with:
+
+```lisp
+(defun %clamp-cap (limit)
+  (if (and (integerp limit) (plusp limit))
+      (min limit graph-db::*query-default-limit*)
+      graph-db::*query-default-limit*))
+
+(defun %probe (cap)
+  "One past CAP tells truncated from exactly full; at the ceiling there
+is no room, so an exactly-full page reads as truncated (GH #278)."
+  (if (< cap graph-db::*query-default-limit*) (1+ cap) cap))
+
+(defun %run-guarded-goals (vars goals graph probe)
+  "The already-guarded query's rows, RAW, at most PROBE of them, with
+the GUI's three-way condition contract (GH #279)."
+  (handler-case
+      (let ((rows '()))
+        (graph-db::run-query-goals
+         vars goals graph :limit probe :format :raw
+         :callback (lambda (row) (push row rows)))
+        (nreverse rows))
+    (graph-db:prolog-error (c) (error c))
+    (graph-db:query-param-error (c) (error c))
+    (error (c)
+      (cond ((%ill-typed-condition-p c)
+             (log:error "query guard: ill-typed query (~S): ~A"
+                        (type-of c) c)
+             (error 'prolog-ill-typed-error))
+            (t
+             (log:error "query guard: UNEXPECTED SERVER FAULT (~S): ~A"
+                        (type-of c) c)
+             (error 'prolog-server-fault))))))
+
+(defun run-guarded-prolog (text graph &key limit max-inferences timeout
+                                            (format :data))
+  "Screen, read, guard and run TEXT against GRAPH; (VALUES COLUMNS ROWS
+TRUNCATED-P).  COLUMNS are the variables in first-appearance order as
+downcased wire strings; ROWS one list per solution, cells JSON-shaped
+under :DATA (a node is its id string; strings, numbers, T, NIL pass) or
+as bound under :RAW.  LIMIT is clamped to *QUERY-DEFAULT-LIMIT*;
+MAX-INFERENCES and TIMEOUT bind the DSL's budgets for this call.
+Refusals signal PROLOG-GUARD-ERROR; see the header for the rest of the
+condition contract (spec SS4, GH #322)."
+  (check-type format (member :data :raw))
+  (let* ((scratch (%make-scratch-package))
+         (cap (%clamp-cap limit))
+         (probe (%probe cap))
+         (graph-db::*query-default-max-inferences*
+           (or max-inferences graph-db::*query-default-max-inferences*))
+         (graph-db::*query-default-timeout*
+           (or timeout graph-db::*query-default-timeout*)))
+    (unwind-protect
+         (multiple-value-bind (vars goals)
+             (%read-guarded-forms text scratch (%guard-context graph scratch))
+           (let* ((rows (%run-guarded-goals vars goals graph probe))
+                  (n (length rows))
+                  (truncated (if (> probe cap) (> n cap) (>= n cap)))
+                  (shown (if (> n cap) (subseq rows 0 cap) rows)))
+             (values (mapcar #'graph-db::%query-var-field vars)
+                     (if (eq format :data)
+                         (mapcar (lambda (row)
+                                   (mapcar #'graph-db::%query-value->json row))
+                                 shown)
+                         shown)
+                     (and truncated t))))
+      (delete-package scratch))))
+```
+
+`run-query-goals` today renders through `emit-query-results` and has no `:raw`/`:callback` path. Add to `query/dsl.lisp`'s `run-query-goals` a `:format :raw` arm that requires a `callback` keyword and calls it per row instead of emitting — a small extension of the existing `run` closure (`(funcall run callback)`), with the docstring noting the new arm. `%query-value->json` and `%query-var-field` are internal to `graph-db`; reference them qualified as above.
+
+Then rewrite the GUI's `%run-guarded-prolog` in `gui/prolog.lisp`:
+
+```lisp
+(defun %run-guarded-prolog (text limit graph)
+  "The workbench envelope over GRAPH-DB.QUERY:RUN-GUARDED-PROLOG (GH
+#322).  The runner clamps and probes exactly as the DSL endpoint does,
+so the envelope's CAP/PROBE arithmetic is unchanged."
+  (let ((cap (%clamp-row-cap limit)))
+    (multiple-value-bind (columns rows)
+        (graph-db.query:run-guarded-prolog
+         text graph :limit (%query-probe-limit cap))
+      (%query-envelope
+       (graph-db::query-results->json-from-fields columns rows)
+       cap (%query-probe-limit cap)))))
+```
+
+`query-results->json` takes return VARS (symbols) and rows of raw values; add in `query/dsl.lisp` a sibling `query-results->json-from-fields (fields rows)` that takes field strings and already-converted cells and encodes the same array-of-objects shape (same `encode-json-alist` discipline as `query-results->json`, GH #279). Export it from `graph-db`. The envelope decodes that string as before, so the GUI's wire shape is unchanged.
+
+Wait: `run-guarded-prolog` is asked for `(%query-probe-limit cap)` rows and itself probes one past *that*; to keep the GUI's envelope arithmetic exact, pass `:limit cap` and let the runner's own truncation flag drive the envelope instead: change `%query-envelope`'s caller to hand it `truncated` directly. Simplest correct form:
+
+```lisp
+(defun %run-guarded-prolog (text limit graph)
+  (let ((cap (%clamp-row-cap limit)))
+    (multiple-value-bind (columns rows truncated)
+        (graph-db.query:run-guarded-prolog text graph :limit cap)
+      (%query-envelope-from-rows columns rows cap truncated))))
+```
+
+and split `%query-envelope` in `gui/api.lisp` into the existing string-taking entry (used by the builder endpoint) and `%query-envelope-from-rows (columns rows cap truncated)` that both call to build the JSON response object. Keep the response keys and order identical (`columns rows rowCount limit truncated`).
+
+- [ ] **Step 4: Run both suites**
+
+`graph-db/query-test`: everything passes except `edge-and-global-functors-resolve-in-one-goal-list` (expected until Task 4; record the failure text). `graph-db/gui-test`: same count as Task 2, zero failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A query gui tests/query graph-db.asd
+git commit -m "feat(query): run-guarded-prolog returns data; the GUI is a caller; query-test suite (#322)"
+```
+
+---
+
+### Task 4: Head resolution in the head's package
+
+**Files:**
+- Modify: `prologc.lisp` (`make-functor-symbol`, header comment), `query/guard.lisp` (drop `:package` and `%schema-package`)
+- Test: `tests/query/guard-tests.lisp` (the failing test from Task 3), core `tests/query-tests.lisp` select tests by name, `graph-db/gui-test`
+
+**Interfaces:**
+- Produces: `(make-functor-symbol symbol arity)` interns `NAME/ARITY` in `(symbol-package symbol)` when that is non-NIL, else in `*package*`.
+
+- [ ] **Step 1: Confirm the failing test fails for the right reason**
+
+Run `graph-db/query-test`; the failure text must be `unknown Prolog functor QT-LINKS/2` (or `IS-A/2`), not a fixture error.
+
+- [ ] **Step 2: Implement**
+
+```lisp
+(defun make-functor-symbol (symbol arity)
+  "The NAME/ARITY functor symbol for SYMBOL, interned where SYMBOL lives
+-- so a goal list whose canonical heads span the engine's package and a
+schema's resolves each in its home (GH #322).  An uninterned SYMBOL, or
+a string, falls back to *PACKAGE*, which is what every caller saw before."
+  (let ((*package* (or (and (symbolp symbol) (symbol-package symbol))
+                       *package*)))
+    (new-interned-symbol symbol '/ arity)))
+```
+
+Read `new-interned-symbol` (utilities.lisp:155) first: if it takes a package argument, pass it instead of rebinding `*package*`.
+
+In `query/guard.lisp`, `%run-guarded-goals` passes no `:package` (the default is `graph-db`, now irrelevant for guarded heads); delete `%schema-package`. Update the moved header's step 5 to say heads resolve in their own homes.
+
+- [ ] **Step 3: Run the suites**
+
+`graph-db/query-test`: all pass. `graph-db/gui-test`: unchanged count, zero failures. The core `select` tests by name, in a subprocess as in Task 1 step 4: `select-flat-is-a select-one-returns-single select-no-matches-is-nil select-edge-functor-pairs select-callback-streams-each-row select-count-returns-solution-count select-count-honors-limit-and-skip select-join-multiple-goals` plus the four REST tests. Expected: all pass. `graph-db/spacetime-test`: 650, unchanged (it uses `select` through the guard nowhere, but it is cheap).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prologc.lisp query/guard.lisp
+git commit -m "fix(prolog): a goal head resolves its functor in its own package (#322)"
+```
+
+---
+
+### Task 5: CI lane, docs, changelog
+
+**Files:**
+- Modify: `.github/workflows/test.yml`, `docs/ci.md`, `CHANGELOG.md`, `docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md`, `docs/spatiotemporal-substrate-programme.md`
+- Create: `docs/guarded-query.md`
+
+- [ ] **Step 1: CI lane**
+
+Copy the `spacetime suite` step in `.github/workflows/test.yml` as a new step `query suite` immediately after it, with `:graph-db/query-test` in both `quickload` and `test-system`. In `docs/ci.md`, add `query` to the list of suites in the first paragraph.
+
+- [ ] **Step 2: `docs/guarded-query.md`**
+
+Sections: what the subsystem is and why it is web-free (#322, one paragraph); loading it (`(ql:quickload :graph-db/query)`); `run-guarded-prolog` — signature, the `:data`/`:raw` shapes with one example each, budgets and truncation; the condition contract as a table (guard refusal / engine's own Prolog conditions / ill-typed / server fault, what the caller sees, what is logged); head resolution (spec §6, three sentences); what the guard admits, pointing at the whitelist rules in `guard.lisp`'s header rather than restating them; the GUI and REST as callers; consumers (cl-llm's query tool, blackboard) in one sentence.
+
+- [ ] **Step 3: CHANGELOG and pointers**
+
+`[Unreleased]` → Added: `graph-db/query` and `run-guarded-prolog` (two sentences, #322). Fixed: head resolution (#322, second finding). In the GUI design doc's Prolog section add one line: the guard pipeline lives in `graph-db/query` since #322. In the substrate programme doc's related issues, note #322 landed.
+
+- [ ] **Step 4: Full local check and commit**
+
+Run `graph-db/query-test` and `graph-db/gui-test` one last time. Commit:
+
+```bash
+git add .github docs CHANGELOG.md
+git commit -m "docs(query): guarded-query guide, CI lane, changelog (#322)"
+```
+
+Do not push. The PR, when Kevin says so, carries the five commits and one CI run.
+
+---
+
+## Self-review notes
+
+- **Spec coverage.** §2 → Tasks 1–2. §3 → Task 2 (package, exports). §4 → Task 3. §5 → Task 1. §6 → Task 4. §7 → Task 3 (suite) and Task 4 (the motivating test); CI → Task 5. §8 consumers → out of this repo; cl-llm re-homing is filed at landing. §9 → Task 5.
+- **Deviation recorded.** Spec §4 says `%schema-package` "stays for the DSL path only"; the DSL resolves its package inside `compile-pattern-query` and never called the guard's helper, so Task 4 deletes it. Spec §4's GUI paragraph is realised by `%query-envelope-from-rows` (Task 3) rather than re-encoding to a string and decoding it; the wire shape is the same and the GUI suite proves it.
+- **Type consistency.** `run-guarded-prolog text graph &key limit max-inferences timeout format` in Tasks 3–5 and the docs; `schema-type-names graph parent` in Tasks 2 and 5; `%run-guarded-goals vars goals graph probe` only inside Task 3.
+- **Placeholders.** None; the two "check before relying" notes (constructor spelling, `new-interned-symbol`'s arglist) name the file and line to read.

--- a/docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md
+++ b/docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md
@@ -18,7 +18,8 @@ not a v1 deliverable.
 - **Explorer** (the daily-use magnet): Bloom-style click-to-expand
   neighborhood exploration with a node inspector. Read-only.
 - **Fast follow, not v1**: the query workbench (Prolog `select` with
-  tabular results and result-to-canvas handoff).
+  tabular results and result-to-canvas handoff). The guard pipeline it
+  calls lives in `graph-db/query` since #322 (`docs/guarded-query.md`).
 - **Later versions, explicitly out**: uploads/exports, node editing,
   graph creation, free-form path opening, auth, search-by-slot,
   saved layouts/perspectives, style editors, multi-graph canvases,

--- a/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
+++ b/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
@@ -78,7 +78,7 @@ specials, `query-results->json`, `decode-dsl-json`.
   cap and reports `truncated-p` T when it arrives, the GUI's existing
   probe rule, now in one place.
 - **Columns** are the query's variables in first-appearance order, as
-  downcased wire strings without the `?` (`%query-var-field`).
+  camelCase wire strings without the `?` (`%query-var-field`).
 - **Rows** are lists, one per solution, in solution order.
   - `:data`: every cell through `%query-value->json`, so a node is its
     id string and every other value is a string, a number, `t` or NIL.

--- a/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
+++ b/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
@@ -153,7 +153,17 @@ Consequences, argued once here:
   `graph-db` or a package that uses it.
 - A functor defined with `<-` in a user package is called from that
   package by symbols read there; unchanged, now guaranteed by
-  `:define t` rather than incidentally by a shared `*package*`.
+  `:define t` rather than incidentally by a shared `*package*`. The
+  trade this brings: a *call* whose head is a `common-lisp` symbol
+  that collides with a `graph-db` global functor's literal name
+  (`write`, `atom`, `not`, `>`, ...) resolves to the engine's functor,
+  not a same-named clause the user package defined, because such a
+  head's home package is always `common-lisp`, never the user
+  package — the call-side lookup cannot tell the two apart by home.
+  This is the right trade: those are exactly the CL-inherited heads
+  the lookup exists to serve (§6 above), and a user package wanting
+  its own `write/1` still gets it by naming it something the engine
+  has not already claimed.
 - The guard's rebuilt heads — `graph-db::is-a`, `schema::follows` —
   each resolve in their own home (falling back to `graph-db` for a
   CL-inherited comparison or `write`/`atom`/etc.). The GUI's

--- a/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
+++ b/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
@@ -1,0 +1,194 @@
+# graph-db/query: the guarded query subsystem — design
+
+Issue: #322 (both findings). Status: approved in discussion 2026-09-03.
+
+## 1. Purpose
+
+The engine has two reviewed ways to run untrusted query text under its
+rails — the JSON pattern DSL (#44, #278) and the free-text Prolog guard
+(#279) — and both sit above `graph-db/core`: the DSL in the web system
+because of one ningle line, the guard inside the GUI. A consumer that
+wants to hand a language model a bounded query tool depends on core and
+`graph-db/spacetime` and must not pull a web stack (kraison/cl-llm#14
+unit 2, kraison/cl-llm#23); today it loads `graph-db/gui` and calls
+four internal symbols.
+
+This unit homes both in a web-free subsystem, exports one runner that
+returns data, and fixes the head-resolution defect that made the guard
+depend on a single package binding.
+
+## 2. Systems and files
+
+- New system **`graph-db/query`**, `:depends-on (:graph-db/core)`,
+  `:pathname "query/"`, components `("dsl" "guard")`, serial.
+  - `query/dsl.lisp` is `query-dsl.lisp` moved, minus the ndjson
+    header line (§5). Package `graph-db`, every export unchanged.
+  - `query/guard.lisp` is the guard pipeline moved out of
+    `gui/prolog.lisp`: the screen, the readtable and reader, the
+    functor whitelist and control-word table, the schema-name table,
+    the guard walk, the non-finite screen, the ill-typed classifier,
+    the guarded runner, and the schema-type-names helper from
+    `gui/api.lisp`. Package `graph-db.query` (§3).
+- `graph-db` (the web system) depends on `graph-db/query` and drops its
+  `query-dsl` component. `rest.lisp` is unchanged except §5.
+- `graph-db/gui` reaches the subsystem through `graph-db`.
+  `gui/prolog.lisp` keeps the flag, the request-body helpers, the
+  envelope and the handler, and calls `graph-db.query:run-guarded-prolog`.
+  `gui/api.lisp` calls `graph-db.query:schema-type-names`.
+- `graph-db/core` is untouched except §6.
+
+## 3. Package and exports
+
+`graph-db.query` uses `cl` and imports what it needs from `graph-db` by
+name. Exports:
+
+| symbol | what |
+|---|---|
+| `run-guarded-prolog` | §4 |
+| `prolog-guard-error`, `prolog-guard-error-reason` | a refusal, with the client-facing reason |
+| `prolog-ill-typed-error` | a shape client input is known to produce |
+| `prolog-server-fault` | anything else; the report is logged, never returned |
+| `*prolog-max-query-length*` (4096), `*prolog-max-depth*` (32) | the screen's limits, unchanged |
+| `schema-type-names` | `(graph parent)` → sorted class-name symbols for `:vertex` or `:edge` |
+
+The DSL's exports stay where they are, in `graph-db`:
+`compile-pattern-query`, `run-query-goals`, `run-pattern-query`,
+`def-query`, `query-param-error`, the three `*query-default-*`
+specials, `query-results->json`, `decode-dsl-json`.
+
+## 4. The exported runner
+
+```lisp
+(run-guarded-prolog text graph
+                    &key limit max-inferences timeout (format :data))
+  => (values columns rows truncated-p)
+```
+
+- **Pipeline**, unchanged in order and in what it admits: screen the
+  raw characters (`%scan-query-text`), read into a per-call scratch
+  package that uses nothing (`%read-query-forms`), screen non-finite
+  numbers, guard and rebuild the forms from canonical symbols
+  (`%guard-query`), run through `run-query-goals` with `:effects nil`,
+  one snapshot, the bounds. The scratch package is deleted in an
+  `unwind-protect` on every path.
+- **Budgets.** `max-inferences` and `timeout` bind
+  `*query-default-max-inferences*` and `*query-default-timeout*` for
+  the call; absent, the specials' values apply. `limit` is clamped to
+  `*query-default-limit*` (1000); the runner asks for one row past the
+  cap and reports `truncated-p` T when it arrives, the GUI's existing
+  probe rule, now in one place.
+- **Columns** are the query's variables in first-appearance order, as
+  downcased wire strings without the `?` (`%query-var-field`).
+- **Rows** are lists, one per solution, in solution order.
+  - `:data`: every cell through `%query-value->json`, so a node is its
+    id string and every other value is a string, a number, `t` or NIL.
+    NIL is an unbound variable or an empty slot; the two are not
+    distinguished, as today.
+  - `:raw`: the values Prolog bound, nodes included. For in-image Lisp
+    callers only; nothing raw crosses a wire.
+- **Conditions**, the GUI's contract moved verbatim: `prolog-guard-error`
+  for a refusal; the engine's own reviewed `prolog-error` family and
+  `query-param-error` pass through with their messages; a condition
+  shape client input is known to produce (`%ill-typed-condition-p`)
+  becomes `prolog-ill-typed-error`; any other `error` becomes
+  `prolog-server-fault`. The latter two are logged under distinct
+  labels with the original report; neither carries it.
+- **Package.** The runner no longer passes `:package` to
+  `run-query-goals` for head resolution — §6 makes the guard's
+  canonical heads self-resolving. `%schema-package` stays for the DSL
+  path only.
+
+The GUI's `%run-guarded-prolog` becomes: `run-guarded-prolog` with the
+request's limit and `:data`, the columns and rows encoded with
+`query-results->json`'s row shape, and that JSON handed to
+`%query-envelope` exactly as the runner's string was before. Its HTTP
+behaviour — status codes, the fixed fault text, the 403 flag — is
+unchanged, and the GUI suite is the proof.
+
+## 5. The ndjson line
+
+`emit-query-results`' `:ndjson` arm stops setting the content type; it
+returns the newline-delimited text. `run-pattern-query` is unchanged.
+The REST `/query` route, which is the only caller that asks for ndjson,
+sets `Content-Type: application/x-ndjson` on ningle's response when the
+decoded request's `format` is `ndjson`, before calling
+`run-pattern-query`. Same wire behaviour; the REST tests that check the
+header are the proof.
+
+## 6. Head resolution in core (#322, second finding)
+
+`compile-call` (`prologc.lisp`) derives the functor symbol `NAME/ARITY`
+through `make-functor-symbol`, which interns into `*package*`. A goal
+list whose canonical heads live in two packages — the engine's for
+global functors, a schema's for its edge functors — therefore cannot be
+compiled under one binding, which is why the GUI binds the schema
+package and a tenant whose schema package does not use `graph-db` had
+to bind `graph-db` and refuse edge-typed stores (kraison/cl-llm#14
+unit 2).
+
+Change: `make-functor-symbol` takes the package from its `symbol`
+argument when that is an interned symbol, and falls back to `*package*`
+otherwise (uninterned symbols, and the string heads the compiler macro
+path interns). `compile-call` passes the head through unchanged.
+
+Consequences, argued once here:
+
+- A head read at a REPL already lives in `*package*`, so REPL `select`
+  behaves exactly as before, including its known requirement to be in
+  `graph-db` or a package that uses it.
+- A functor defined with `<-` in a user package is called from that
+  package by symbols read there; unchanged.
+- The guard's rebuilt heads — `graph-db::is-a`, `schema::follows` —
+  each resolve in their own home. The GUI's `:package` binding becomes
+  redundant for the guard and is removed there; `run-query-goals` keeps
+  the keyword because `%dsl-resolve-type` and `%compile-match-pattern`
+  use it for type names.
+- `prolog-compiler-macro` still interns a string head into `graph-db`
+  by name; the guard refuses string heads before it, as today.
+
+## 7. Tests
+
+- New system `graph-db/query-test` (`tests/query/`), FiveAM, on-disk
+  graphs under the scratch parent, run by `asdf:test-system
+  :graph-db/query-test`:
+  - each screened token refused with the named reason, and the same
+    text minus the token accepted (non-vacuity);
+  - an unregistered functor, a package-qualified head, a string head
+    refused;
+  - `limit` clamped and `truncated-p` T with one row past the cap,
+    NIL at the cap;
+  - a `max-inferences` breach surfaces as `prolog-resource-error`;
+  - `:data` cells are strings, numbers, `t` or NIL and a node is its
+    id; `:raw` returns the node;
+  - the scratch package is gone after a refusal and after a success;
+  - **the motivating case**: a schema whose package does not use
+    `graph-db`, with a vertex type and an edge type, queried with a
+    global functor and the edge functor in one goal list, returns rows.
+    This test fails before §6 and passes after.
+- `graph-db/gui-test` and `graph-db/test` unchanged; they are the
+  regression net for the move and for §5.
+- CI (`.github/workflows/test.yml`) runs the new suite; `docs/ci.md`
+  lists it.
+
+## 8. Consumers
+
+- kraison/cl-llm `cl-llm/agent/prolog`: depend on `graph-db/query`
+  instead of `graph-db/gui`, call `run-guarded-prolog` with `:data`,
+  drop the JSON parse and the edge-typed-store refusal. Filed there
+  when this lands.
+- kraison/blackboard slice 1 and 3: `select` and the structure tier
+  build on the exported runner and `schema-type-names`.
+
+## 9. Docs
+
+`docs/guarded-query.md` (the exported API and the condition contract,
+with the head-resolution rule); CHANGELOG `[Unreleased]` — Added for the
+subsystem and runner, Fixed for §6; `docs/ci.md`; a pointer from
+`docs/superpowers/specs/2026-08-27-vg-gui-v1-design.md`'s Prolog
+section and from `docs/spatiotemporal-substrate-programme.md`'s related
+issues.
+
+## 10. Out of scope
+
+What the guard admits (the whitelist, the exclusions, the control
+words); the DSL's JSON schema; REST routes; the GUI's frontend.

--- a/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
+++ b/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
@@ -126,10 +126,22 @@ package and a tenant whose schema package does not use `graph-db` had
 to bind `graph-db` and refuse edge-typed stores (kraison/cl-llm#14
 unit 2).
 
-Change: `make-functor-symbol` takes the package from its `symbol`
-argument when that is an interned symbol, and falls back to `*package*`
-otherwise (uninterned symbols, and the string heads the compiler macro
-path interns). `compile-call` passes the head through unchanged.
+Change (revised after review: a rebind-`*package*` first attempt
+broke every built-in whose name collides with a `COMMON-LISP` symbol
+— `>`, `atom`, `write`, ... — since such a symbol's home package is
+always `COMMON-LISP`, never `graph-db`, so per-symbol-package
+rebinding can never find the engine's functor for them):
+`make-functor-symbol` resolves by LOOKUP before interning — an
+already-registered functor in the head symbol's own package, then in
+`graph-db` (where `def-global-prolog-functor` registers built-ins
+under their literal name, so the `>`/`atom`/`write` case is found
+there) — and only interns into `*package*` when neither lookup hits.
+Definitions keep the old rule exactly: `<-` (`add-clause`) passes
+`make-functor-symbol` a `:define t` argument that skips both lookups
+and interns straight into `*package*`, because a lookup there would
+let a schema-package clause silently land on an existing `graph-db`
+functor of the same name instead of defining its own. `compile-call`
+passes the head through unchanged.
 
 Consequences, argued once here:
 
@@ -137,12 +149,15 @@ Consequences, argued once here:
   behaves exactly as before, including its known requirement to be in
   `graph-db` or a package that uses it.
 - A functor defined with `<-` in a user package is called from that
-  package by symbols read there; unchanged.
+  package by symbols read there; unchanged, now guaranteed by
+  `:define t` rather than incidentally by a shared `*package*`.
 - The guard's rebuilt heads — `graph-db::is-a`, `schema::follows` —
-  each resolve in their own home. The GUI's `:package` binding becomes
-  redundant for the guard and is removed there; `run-query-goals` keeps
-  the keyword because `%dsl-resolve-type` and `%compile-match-pattern`
-  use it for type names.
+  each resolve in their own home (falling back to `graph-db` for a
+  CL-inherited comparison or `write`/`atom`/etc.). The GUI's
+  `:package` binding becomes redundant for the guard and is removed
+  there; `run-query-goals` keeps the keyword because
+  `%dsl-resolve-type` and `%compile-match-pattern` use it for type
+  names.
 - `prolog-compiler-macro` still interns a string head into `graph-db`
   by name; the guard refuses string heads before it, as today.
 

--- a/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
+++ b/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
@@ -109,11 +109,14 @@ unchanged, and the GUI suite is the proof.
 
 `emit-query-results`' `:ndjson` arm stops setting the content type; it
 returns the newline-delimited text. `run-pattern-query` is unchanged.
-The REST `/query` route, which is the only caller that asks for ndjson,
-sets `Content-Type: application/x-ndjson` on ningle's response when the
-decoded request's `format` is `ndjson`, before calling
-`run-pattern-query`. Same wire behaviour; the REST tests that check the
-header are the proof.
+Two callers ask for ndjson and both set
+`Content-Type: application/x-ndjson` on ningle's response themselves,
+through one shared helper (`%set-ndjson-content-type`), after their
+query has produced its text so an errored or refused query never gets
+an ndjson-labelled error body: the REST `/query` route (when the
+decoded request's `format` is `ndjson`) and `def-query`'s generated
+route (when the client's `?format=ndjson`). Same wire behaviour; the
+REST tests that check the header are the proof.
 
 ## 6. Head resolution in core (#322, second finding)
 

--- a/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
+++ b/docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md
@@ -39,8 +39,9 @@ depend on a single package binding.
 
 ## 3. Package and exports
 
-`graph-db.query` uses `cl` and imports what it needs from `graph-db` by
-name. Exports:
+`graph-db.query` uses `cl` and reaches `graph-db` through
+fully-qualified references (`graph-db::foo`); there is no
+`:import-from`. Exports:
 
 | symbol | what |
 |---|---|

--- a/globals.lisp
+++ b/globals.lisp
@@ -482,7 +482,7 @@ not match established segment dimension ~D"
 ;;; failed (GH #286): an unindexed slot, an unscoped spatial class, a wrong
 ;;; index arity.  Distinct from SIMPLE-ERROR / TYPE-ERROR so a server can
 ;;; answer 400 for these and 500 for an engine defect; QUERY-PARAM-ERROR
-;;; (query-dsl.lisp) is its DSL-level subclass.
+;;; (query/dsl.lisp) is its DSL-level subclass.
 
 (define-condition query-precondition-error (error)
   ((reason :initarg :reason :reader query-precondition-error-reason))

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -197,7 +197,9 @@ web-free.  docs/guarded-query.md; GH #322."
   :depends-on (:graph-db/core)
   :pathname "query/"
   :serial t
-  :components ((:file "dsl")))
+  :components ((:file "package")
+               (:file "dsl")
+               (:file "guard")))
 
 ;; FULL: replication + the HTTP API leaf (rest, clack/ningle).  graph-db/replication
 ;; (and transitively graph-db/core) has already compiled+loaded the engine + transport,

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -199,7 +199,24 @@ web-free.  docs/guarded-query.md; GH #322."
   :serial t
   :components ((:file "package")
                (:file "dsl")
-               (:file "guard")))
+               (:file "guard"))
+  :in-order-to ((test-op (test-op :graph-db/query-test))))
+
+(defsystem graph-db/query-test
+  :name "VivaceGraph guarded-query test suite"
+  :description "FiveAM tests driving GRAPH-DB.QUERY:RUN-GUARDED-PROLOG
+directly, web-free (GH #322)."
+  :maintainer "Kevin Raison"
+  :author "Kevin Raison <last name @ chatsubo dot net>"
+  :version "4.0.1"
+  :depends-on (:graph-db/query :graph-db/test-scratch :fiveam)
+  :pathname "tests/query/"
+  :serial t
+  :components ((:file "package") (:file "suite") (:file "guard-tests"))
+  :perform (test-op (op c)
+             (unless (uiop:symbol-call :graph-db/query-test
+                                       :run-query-tests)
+               (error "graph-db query tests failed."))))
 
 ;; FULL: replication + the HTTP API leaf (rest, clack/ningle).  graph-db/replication
 ;; (and transitively graph-db/core) has already compiled+loaded the engine + transport,

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -184,6 +184,21 @@
                ;; the master/slave packet primitives in transaction-streaming.
                (:file "peer-streaming")))
 
+;; The web-free query subsystem (GH #322): the JSON pattern DSL and,
+;; from Task 2 on, the free-text Prolog guard.  Depends on core only so
+;; a consumer that wants a bounded query tool never loads a web stack.
+(defsystem graph-db/query
+  :name "VivaceGraph guarded query"
+  :description "The JSON pattern DSL and the free-text Prolog guard,
+web-free.  docs/guarded-query.md; GH #322."
+  :maintainer "Kevin Raison"
+  :author "Kevin Raison <last name @ chatsubo dot net>"
+  :version "4.0.1"
+  :depends-on (:graph-db/core)
+  :pathname "query/"
+  :serial t
+  :components ((:file "dsl")))
+
 ;; FULL: replication + the HTTP API leaf (rest, clack/ningle).  graph-db/replication
 ;; (and transitively graph-db/core) has already compiled+loaded the engine + transport,
 ;; so rest needs no intra-file :depends-on -- the system-level dependency guarantees
@@ -195,6 +210,7 @@
   :author "Kevin Raison <last name @ chatsubo dot net>"
   :version "4.0.1"
   :depends-on (:graph-db/replication
+               :graph-db/query
                :hunchentoot
                :ningle
                :clack
@@ -207,18 +223,7 @@
                :usocket
                :trivial-shell)
   :serial t
-  ;; QUERY-DSL is the structured JSON query compiler+runner extracted from
-  ;; rest.lisp (GH #278): REST's /query route and the GUI workbench compile
-  ;; through the one implementation.  It needs the prolog compiler (SELECT,
-  ;; via prologc/prolog-functors), the schema type lookups
-  ;; (LOOKUP-NODE-TYPE-BY-NAME) and NODE-SLOT-VALUE (index) -- all already
-  ;; loaded by graph-db/core, which the system-level :depends-on guarantees,
-  ;; so no intra-file :depends-on is possible or needed here.  It is NOT in
-  ;; graph-db/core because EMIT-QUERY-RESULTS' :ndjson arm sets a header on
-  ;; NINGLE:*RESPONSE*, and core deliberately drops ningle/clack (the
-  ;; ECL/Android build).  :serial t puts it before "rest", which calls into it.
-  :components ((:file "query-dsl")
-               (:file "rest"))
+  :components ((:file "rest"))
   :in-order-to ((test-op (test-op :graph-db/test))))
 
 ;; OPTIONAL GUI cockpit backend (GH #269, design doc

--- a/gui/api.lisp
+++ b/gui/api.lisp
@@ -546,7 +546,7 @@ are domain identifiers a query author types, not protocol (GH #277)."
 ;;; ---------------------------------------------------------------------
 ;;; Query workbench (GH #278).  The body is the same structured DSL
 ;;; rest.lisp's /graph/:g/query route accepts, compiled and run by the
-;;; SHARED implementation in query-dsl.lisp -- read-only, snapshot-
+;;; SHARED implementation in query/dsl.lisp -- read-only, snapshot-
 ;;; isolated and capped, exactly as REST gets it.  Nothing here parses
 ;;; or reads user text into symbols beyond what that compiler does.
 ;;; ---------------------------------------------------------------------

--- a/gui/api.lisp
+++ b/gui/api.lisp
@@ -617,27 +617,40 @@ lose the spelling the DSL chose for each result variable."
                   (cons (car cell) (%json-value (cdr cell))))
                 row)))
 
-(defun %query-envelope (json-string cap probe)
+(defun %query-envelope-from-rows (columns rows cap truncated)
   "The workbench result envelope -- {columns, rows, rowCount, limit,
-truncated} -- for RUN-QUERY-GOALS' JSON-STRING, run under PROBE rows
-and answered under CAP.  Shared by the builder endpoint and the
-free-text Prolog one so one results table renders both (GH #278, #279)."
+truncated} -- built directly from already-JSON-shaped ROWS (one list
+of cells per COLUMNS, positional).  Shared by %QUERY-ENVELOPE and the
+free-text Prolog endpoint, so one results table renders both (GH #278,
+#279, #322)."
+  (%json-response
+   (list
+    (cons :columns (%arr columns))
+    (cons :rows (%arr (mapcar (lambda (row)
+                                (%query-row-json (mapcar #'cons columns row)))
+                              rows)))
+    (cons :row-count (length rows))
+    (cons :limit cap)
+    (cons :truncated (%bool truncated)))))
+
+(defun %query-envelope (json-string cap probe)
+  "The workbench result envelope for RUN-QUERY-GOALS' JSON-STRING, run
+under PROBE rows and answered under CAP.  Decodes the string, then
+shares %QUERY-ENVELOPE-FROM-ROWS' response building with the free-text
+Prolog endpoint (GH #278, #279, #322)."
   (let* ((rows (%decode-query-rows json-string))
          (n (length rows))
          ;; The probe row proves there was more; it is never shown.
          ;; Without room for it, >= is the best the runner's own clamp
          ;; allows.
          (truncated (if (> probe cap) (> n cap) (>= n cap)))
-         (shown (if (> n cap) (subseq rows 0 cap) rows)))
-    (%json-response
-     (list
-      ;; QUERY-ROW->ALIST builds every row in select order, so the
-      ;; first row names the columns.
-      (cons :columns (%arr (mapcar #'car (first shown))))
-      (cons :rows (%arr (mapcar #'%query-row-json shown)))
-      (cons :row-count (length shown))
-      (cons :limit cap)
-      (cons :truncated (%bool truncated))))))
+         (shown (if (> n cap) (subseq rows 0 cap) rows))
+         ;; QUERY-ROW->ALIST builds every row in select order, so the
+         ;; first row names the columns.
+         (columns (mapcar #'car (first shown))))
+    (%query-envelope-from-rows
+     columns (mapcar (lambda (row) (mapcar #'cdr row)) shown)
+     cap truncated)))
 
 ;; The whole query runs under WITH-GUI-GRAPH's read side, so a slow one
 ;; delays open/close for up to the DSL's *QUERY-DEFAULT-TIMEOUT*.  That

--- a/gui/api.lisp
+++ b/gui/api.lisp
@@ -270,16 +270,8 @@ close cannot unmap the store mid-read (GH #269)."
                       (format nil "Graph ~A is not open"
                               (param ,params :name)))))))
 
-(defun %schema-type-names (graph parent)
-  "Node-type names (class symbols) registered for PARENT (:vertex or
-:edge) in GRAPH's schema, sorted by name."
-  (let ((names '()))
-    (maphash (lambda (key meta)
-               (when (numberp key)
-                 (push (graph-db::node-type-name meta) names)))
-             (gethash parent (graph-db::schema-type-table
-                             (graph-db::schema graph))))
-    (sort names #'string< :key #'symbol-name)))
+;; SCHEMA-TYPE-NAMES moved to GRAPH-DB.QUERY (GH #322); called
+;; qualified below.
 
 (defun %wire-symbol (symbol)
   "SYMBOL as its wire spelling: the engine's own name, downcased kebab
@@ -345,7 +337,7 @@ count zero."
                                     (and meta
                                          (graph-db::node-type-slots
                                           meta)))))))))
-          (%schema-type-names graph parent)))
+          (graph-db.query:schema-type-names graph parent)))
 
 (defun %index-inventory (graph)
   "DEF-INDEX specs + spatial indexes registered for GRAPH."
@@ -418,11 +410,13 @@ count zero."
   (with-gui-graph (graph params)
     (%json-response
      (list (cons :vertex-types
-                 (%arr (mapcar #'%wire-symbol
-                               (%schema-type-names graph :vertex))))
+                 (%arr
+                  (mapcar #'%wire-symbol
+                          (graph-db.query:schema-type-names graph :vertex))))
            (cons :edge-types
-                 (%arr (mapcar #'%wire-symbol
-                               (%schema-type-names graph :edge))))))))
+                 (%arr
+                  (mapcar #'%wire-symbol
+                          (graph-db.query:schema-type-names graph :edge))))))))
 
 ;;; ---------------------------------------------------------------------
 ;;; Node sample, inspection, neighborhood

--- a/gui/prolog.lisp
+++ b/gui/prolog.lisp
@@ -78,54 +78,14 @@ is the package a goal head must canonicalize in."
     (or (and types (symbol-package (first types)))
         (find-package :graph-db))))
 
-(defun %run-guarded-query (vars goals graph limit)
-  "Run the already-guarded query and answer the shared envelope.
-
-Three outcomes, and the point of the split is that the third is never
-dressed up as the second: the DSL's own reviewed Prolog conditions keep
-their messages (they were written to be client-facing); a shape client
-input is known to produce becomes PROLOG-ILL-TYPED-ERROR (400);
-anything else is PROLOG-SERVER-FAULT (500).  Neither of the latter two
-carries the condition's own report to the client -- those name engine
-internals -- but they log under DISTINCT labels, so an operator can
-grep a genuine fault apart from a user's malformed goal (GH #279)."
-  (handler-case
-      (let* ((cap (%clamp-row-cap limit))
-             (probe (%query-probe-limit cap)))
-        (%query-envelope
-         (graph-db::run-query-goals
-          vars goals graph
-          ;; The schema's package, exactly as the JSON DSL runs:
-          ;; COMPILE-CALL canonicalizes each head there.
-          :package (%schema-package graph)
-          :limit probe)
-         cap probe))
-    ;; PROLOG-RESOURCE-ERROR and PROLOG-PERMISSION-ERROR are subtypes,
-    ;; so this one clause re-signals all three unchanged.
-    (graph-db:prolog-error (c) (error c))
-    (graph-db:query-param-error (c) (error c))
-    (error (c)
-      (cond ((graph-db.query::%ill-typed-condition-p c)
-             (log:error "GUI prolog: ill-typed query (~S): ~A"
-                        (type-of c) c)
-             (error 'graph-db.query:prolog-ill-typed-error))
-            (t
-             (log:error "GUI prolog: UNEXPECTED SERVER FAULT (~S): ~A"
-                        (type-of c) c)
-             (error 'graph-db.query:prolog-server-fault))))))
-
 (defun %run-guarded-prolog (text limit graph)
-  "Read, guard and run TEXT against GRAPH; answers the shared workbench
-envelope.  The scratch package dies in the UNWIND-PROTECT, on every
-path including a signal, so no request can leave symbols behind."
-  (let ((scratch (graph-db.query::%make-scratch-package)))
-    (unwind-protect
-         (multiple-value-bind (vars goals)
-             (graph-db.query::%read-guarded-forms
-              text scratch
-              (graph-db.query::%guard-context graph scratch))
-           (%run-guarded-query vars goals graph limit))
-      (delete-package scratch))))
+  "The workbench envelope over GRAPH-DB.QUERY:RUN-GUARDED-PROLOG (GH
+#322).  The runner clamps and probes exactly as the DSL endpoint does,
+so the envelope's CAP/TRUNCATED come straight from its own answer."
+  (let ((cap (%clamp-row-cap limit)))
+    (multiple-value-bind (columns rows truncated)
+        (graph-db.query:run-guarded-prolog text graph :limit cap)
+      (%query-envelope-from-rows columns rows cap truncated))))
 
 ;; The flag is checked FIRST -- before the graph is resolved -- so a GUI
 ;; started without :ALLOW-PROLOG answers identically whatever graph is

--- a/gui/prolog.lisp
+++ b/gui/prolog.lisp
@@ -69,15 +69,6 @@ asks for none."
                (length text) graph-db.query:*prolog-max-query-length*))
     text))
 
-(defun %schema-package (graph)
-  "The package GRAPH's schema symbols live in, or GRAPH-DB.  Edge
-functors are installed in their own type's package (GH #172), so this
-is the package a goal head must canonicalize in."
-  (let ((types (append (graph-db.query:schema-type-names graph :vertex)
-                        (graph-db.query:schema-type-names graph :edge))))
-    (or (and types (symbol-package (first types)))
-        (find-package :graph-db))))
-
 (defun %run-guarded-prolog (text limit graph)
   "The workbench envelope over GRAPH-DB.QUERY:RUN-GUARDED-PROLOG (GH
 #322).  The runner clamps and probes exactly as the DSL endpoint does,

--- a/gui/prolog.lisp
+++ b/gui/prolog.lisp
@@ -1,37 +1,6 @@
-;;;; Free-text Prolog, behind START-GUI's :ALLOW-PROLOG flag (GH #279).
-;;;;
-;;;; The builder (GH #278) reads no user text at all.  This surface
-;;;; does, so the whole risk of the workbench concentrates here and the
-;;;; guard -- not the editor -- is the deliverable.
-;;;;
-;;;; Order of operations, all of it before one character reaches the
-;;;; Prolog compiler:
-;;;;
-;;;;   1. *ALLOW-PROLOG*     -- the flag, checked in the handler before
-;;;;      the graph is even resolved.
-;;;;   2. %SCAN-QUERY-TEXT   -- a character screen that runs BEFORE the
-;;;;      reader: length, paren depth/balance, and an outright refusal
-;;;;      of #, `, , and the package marker.  Refusing ':' textually is
-;;;;      what makes package-qualified input safe -- READ would intern
-;;;;      GRAPH-DB::ANYTHING before any walker could object.
-;;;;   3. %READ-QUERY-FORMS  -- *READ-EVAL* NIL, a readtable with #, `
-;;;;      and , disabled, standard IO syntax otherwise, and *PACKAGE*
-;;;;      bound to a per-request scratch package that USES NOTHING.
-;;;;   4. %GUARD-QUERY       -- walks the form and rebuilds it out of
-;;;;      canonical symbols.  A symbol survives only as a registered
-;;;;      functor of that arity, a control construct, a schema type or
-;;;;      slot of THIS graph, a ?variable, or T/NIL.
-;;;;   5. RUN-QUERY-GOALS    -- query-dsl.lisp's own runner: :EFFECTS
-;;;;      NIL, one snapshot, the inference/time/row bounds.
-;;;;   6. DELETE-PACKAGE     -- in an UNWIND-PROTECT, so a hostile
-;;;;      query's symbols leave with the request that made them.
-;;;;
-;;;; The interning subtlety (issue text, utilities.lisp:155):
-;;;; MAKE-FUNCTOR-SYMBOL calls NEW-INTERNED-SYMBOL, so building
-;;;; NAME/ARITY from client input would itself intern the symbol it was
-;;;; asking about.  The whitelist therefore ENUMERATES the two live
-;;;; registries and compares NAMES AS STRINGS; nothing derived from the
-;;;; request is ever interned into GRAPH-DB or the schema package.
+;;;; Free-text Prolog HTTP surface, behind START-GUI's :ALLOW-PROLOG
+;;;; flag.  The guard (screen/read/whitelist) lives in GRAPH-DB.QUERY;
+;;;; the runner and its envelope stay here (GH #279, #322).
 
 (in-package #:graph-db.gui)
 
@@ -45,13 +14,6 @@ it from :ALLOW-PROLOG (default NIL) each time it actually starts a
 server; calling START-GUI against an already-running GUI changes
 nothing, this included.  Restart to change the flag.")
 
-(defparameter *prolog-max-query-length* 4096
-  "Longest free-text query accepted, in characters.")
-
-(defparameter *prolog-max-depth* 32
-  "Deepest parenthesis nesting accepted.  Bounds the reader's own
-recursion, so a nesting bomb is refused before READ sees it.")
-
 (defparameter *prolog-internal-error-message*
   "An internal error occurred while running the query."
   "The ONLY thing a server fault tells the client.  Fixed text, never
@@ -60,481 +22,8 @@ fault's report names engine internals just as an ill-typed goal's does.
 The detail goes to the log under an UNEXPECTED label (GH #279).")
 
 ;;; ---------------------------------------------------------------------
-;;; Refusals
-;;; ---------------------------------------------------------------------
-
-(define-condition prolog-guard-error (error)
-  ((reason :initarg :reason :reader prolog-guard-error-reason))
-  (:report (lambda (c s)
-             (format s "~A" (prolog-guard-error-reason c))))
-  (:documentation "A free-text query the guard refused.  Carries the
-client-facing reason, which names the offending token."))
-
-(define-condition prolog-ill-typed-error (error) ()
-  (:report (lambda (c s)
-             (declare (ignore c))
-             (format s "ill-typed query")))
-  (:documentation "A guarded query whose goals were given arguments a
-predicate cannot use -- the CLIENT's error, answered 400.  Deliberately
-CARRIES NO DETAIL: the conditions it stands in for report engine
-internals -- a store's keyword name, a generic-function name, an ANSI
-section reference -- and the client that provoked them is
-unauthenticated.  The detail is logged (GH #279)."))
-
-(define-condition prolog-server-fault (error) ()
-  (:report (lambda (c s)
-             (declare (ignore c))
-             (format s "internal error")))
-  (:documentation "A condition raised while running a guarded query
-that is NOT a shape client input is known to produce -- i.e. an engine
-defect, answered 500.  Separate from PROLOG-ILL-TYPED-ERROR so a
-genuine fault is never labelled the client's, in the response or in the
-log.  Carries no detail either: the leak rule does not relax because
-the fault is ours (GH #279)."))
-
-(defun %refuse (format-string &rest args)
-  (error 'prolog-guard-error
-         :reason (apply #'format nil format-string args)))
-
-(defun %term-label (x)
-  "X as the client wrote it.  A symbol prints bare and downcased -- ~S
-would spell out the request's scratch package, which is our bookkeeping
-and not something to explain in an error message."
-  (if (and x (symbolp x))
-      (string-downcase (symbol-name x))
-      (format nil "~S" x)))
-
-;;; ---------------------------------------------------------------------
-;;; Step 2: the pre-read character screen
-;;; ---------------------------------------------------------------------
-
-(defun %token-around (text pos)
-  "The whitespace/paren-delimited token of TEXT containing POS -- what
-to name in a refusal message."
-  (flet ((delim-p (ch)
-           (or (member ch '(#\( #\) #\" #\; #\')) (char<= ch #\Space))))
-    (let ((start pos) (end pos) (n (length text)))
-      (loop while (and (plusp start) (not (delim-p (char text (1- start)))))
-            do (decf start))
-      (loop while (and (< end n) (not (delim-p (char text end))))
-            do (incf end))
-      (subseq text start end))))
-
-(defun %skip-delimited (text start close what)
-  "Index just past the CLOSE that ends the region starting at START,
-honouring backslash escapes.  Refuses an unterminated region."
-  (let ((i start) (n (length text)))
-    (loop
-      (when (>= i n) (%refuse "unterminated ~A" what))
-      (let ((ch (char text i)))
-        (cond ((char= ch #\\) (incf i 2))
-              ((char= ch close) (return (1+ i)))
-              (t (incf i)))))))
-
-(defun %scan-query-text (text)
-  "Screen TEXT before the reader touches it (GH #279).
-
-Refuses, by name: the package marker (so no READ can intern into
-GRAPH-DB or a schema package), every # reader macro (#. above all),
-backquote and comma, unbalanced or over-deep parentheses, and an
-unterminated string or |...| name.  Inside a string or a |...| name
-none of those characters mean anything, so a literal \"#.(...)\" is
-data and passes -- the guard refuses reader syntax, not text."
-  (let ((depth 0) (i 0) (n (length text)))
-    (loop while (< i n) do
-      (let ((ch (char text i)))
-        (cond
-          ((char= ch #\\)
-           (when (> (+ i 2) n)
-             (%refuse "the query ends in a backslash escape"))
-           (incf i 2))
-          ((char= ch #\;)
-           (setq i (or (position #\Newline text :start i) n)))
-          ((char= ch #\") (setq i (%skip-delimited text (1+ i) #\" "string")))
-          ((char= ch #\|)
-           (setq i (%skip-delimited text (1+ i) #\| "|...| name")))
-          ((char= ch #\()
-           (incf depth)
-           (when (> depth *prolog-max-depth*)
-             (%refuse "nesting deeper than ~D parentheses is not ~
-permitted" *prolog-max-depth*))
-           (incf i))
-          ((char= ch #\))
-           (when (zerop depth)
-             (%refuse "unbalanced parentheses: a ')' closes nothing"))
-           (decf depth)
-           (incf i))
-          ((char= ch #\:)
-           (%refuse "package-qualified name ~S is not permitted: a ~
-query may name only this graph's schema and the registered Prolog ~
-functors" (%token-around text i)))
-          ((char= ch #\#)
-           (%refuse "reader macro ~S is not permitted; #. (read-time ~
-evaluation) least of all"
-                    (subseq text i (min n (+ i 2)))))
-          ((or (char= ch #\`) (char= ch #\,))
-           (%refuse "~S is not permitted in a query" (string ch)))
-          (t (incf i)))))
-    (unless (zerop depth)
-      (%refuse "unbalanced parentheses: ~D form~:P left open" depth))
-    t))
-
-;;; ---------------------------------------------------------------------
-;;; Step 3: the read
-;;; ---------------------------------------------------------------------
-
-(defvar *prolog-readtable* nil
-  "Lazily built readtable for free-text queries; see %PROLOG-READTABLE.")
-
-(defun %refuse-reader-macro (stream char)
-  (declare (ignore stream))
-  (%refuse "the ~S reader macro is not permitted" (string char)))
-
-(defun %prolog-readtable ()
-  "A copy of the standard readtable with #, ` and , disabled.  Second
-line of defence: %SCAN-QUERY-TEXT already refuses these characters, so
-this only fires if that screen is ever wrong."
-  (or *prolog-readtable*
-      (setq *prolog-readtable*
-            (let ((rt (copy-readtable nil)))
-              (dolist (ch '(#\# #\` #\,) rt)
-                (set-macro-character ch #'%refuse-reader-macro nil rt))))))
-
-(defvar *prolog-scratch-counter* 0)
-
-(defun %make-scratch-package ()
-  "A fresh empty package for one request's read.  :USE '() -- so a bare
-name the client types can intern nowhere but here, and DELETE-PACKAGE
-takes every one of them with it.  Retries on the (benign) name race
-between concurrent requests."
-  (loop repeat 64
-        for name = (format nil "GRAPH-DB.GUI.SCRATCH-~D"
-                           (incf *prolog-scratch-counter*))
-        for pkg = (and (not (find-package name))
-                       (ignore-errors (make-package name :use '())))
-        when pkg return pkg
-          finally (error "Cannot create a GUI Prolog scratch package.")))
-
-(defun %read-query-forms (text package)
-  "TEXT read into PACKAGE as a list of forms.  *READ-EVAL* NIL, the
-restricted readtable, standard IO syntax otherwise.  A string stream
-cannot block, and unbalanced input signals END-OF-FILE rather than
-hanging -- so this terminates for every input."
-  (with-standard-io-syntax
-    (let ((*read-eval* nil)
-          (*package* package)
-          (*readtable* (%prolog-readtable))
-          (*read-suppress* nil))
-      (with-input-from-string (in text)
-        ;; IN is its own EOF marker: no readable object can be EQ to it.
-        (loop for form = (read in nil in)
-              until (eq form in)
-              collect form)))))
-
-;;; ---------------------------------------------------------------------
-;;; Step 4: the whitelist, derived from the live image
-;;; ---------------------------------------------------------------------
-
-(defun %split-functor-name (symbol)
-  "SYMBOL named NAME/ARITY as (values name-string arity), else NIL.
-Splits at the LAST slash, so /=/2 reads as (\"/=\" . 2)."
-  (let* ((name (symbol-name symbol))
-         (slash (position #\/ name :from-end t)))
-    (when (and slash (plusp slash) (< (1+ slash) (length name)))
-      (let ((arity (ignore-errors (parse-integer name :start (1+ slash)))))
-        (when (and arity (>= arity 0))
-          (values (subseq name 0 slash) arity))))))
-
-;; ⚠ The three lists below are the ONLY hand-maintained part of the
-;; guard: the whitelist grows with the registries automatically, these
-;; do not.  PROLOG-FUNCTOR-INVENTORY-IS-PINNED (tests/gui/gui-tests.lisp)
-;; fails when a functor is added or removed anywhere, and its message
-;; says how to classify the new one.  Read it before editing any of them.
-
-(defparameter *prolog-excluded-predicates*
-  '("%COMMIT" "CALL" "CATCH" "FINDALL" "BAGOF" "SETOF" "MAP-QUERY"
-    "SELECT" "SHOW-PROLOG-VARS")
-  "Predicate names withheld from free text at EVERY arity, whatever the
-registries say.
-
-All but the first are the runtime meta-call family: each hands a term to
-%SOLVE, which builds a functor symbol from that term's head at run time
-(prolog-functors.lisp:229).  For a STRING head that is an INTERN of
-unvetted data -- graph content, reached through a variable -- into the
-live schema package, which is the one way a fully whitelisted query
-could still grow the image.  SELECT/2 and SHOW-PROLOG-VARS/2 are
-result-collection machinery and a REPL printer, neither a predicate.
-%COMMIT is an internal cut barrier taking compiler gensyms (GH #279).")
-
-(defparameter *prolog-goal-argument-control*
-  '("AND" "OR" "NOT" "ONCE" "IF" "FORALL")
-  "Control constructs whose arguments are GOALS.  Every such argument
-must be a parenthesised goal here, never a variable: a variable makes
-STATIC-GOAL-P (prologc.lisp:475) fail, the compiler macro declines, and
-the runtime functor behind it meta-calls whatever the variable holds --
-the %SOLVE path *PROLOG-EXCLUDED-PREDICATES* exists to close.  Demanding
-a static goal keeps all six on the compile-time path (GH #279).  Same
-tripwire as above: PROLOG-FUNCTOR-INVENTORY-IS-PINNED.")
-
-(defparameter *prolog-cost-unbounded-predicates*
-  (graph-db:cost-unbounded-predicate-names)   ; single source: GH #285
-  "Predicate names withheld because their worst-case cost is bounded
-neither by the graph nor by the length of the query.
-
-The query rails are enforced by %TICK (prologc.lisp:890), which runs at
-inference and goal boundaries -- NEVER inside a functor that is already
-running.  A predicate that can burn arbitrary time in one atomic Lisp
-call is therefore not preemptible by *QUERY-DEFAULT-TIMEOUT* or
-*QUERY-DEFAULT-MAX-INFERENCES*, and a watchdog is not an option here:
-interrupting a worker mid-call could unwind holding the GUI's rw lock
-or with an mmap operation in flight, which is worse than the hazard it
-would close.  Exclusion is the sound fix (GH #279).
-
-REGEX-MATCH/2 takes BOTH the pattern and the subject from the client,
-so a catastrophically backtracking pattern -- (a+)+$ against a run of
-a's -- costs ~2^n in a payload of a few dozen characters, well inside
-the 4096-character cap, and runs past the 30 s deadline unaborted.
-VALID-DATE-P/1 also runs a regex and STAYS: its pattern is a fixed,
-anchored, quantifier-free constant, so its cost is linear in a subject
-the length cap already bounds -- which is the line this category draws.
-
-Graph-bounded scans (IS-A/2, FIND-SLOT-RANGE/5, the spatial FIND-*
-family, whose window cover is capped at +SPATIAL-QUERY-MAX-CELLS+) are
-NOT in this category: their cost tracks the operator's own data, and
-the un-flagged structured builder already reaches all of it.")
-
-(defun %excluded-predicate-p (name)
-  "NAME is withheld from free text, for either reason."
-  (or (member name *prolog-excluded-predicates* :test #'string=)
-      (member name *prolog-cost-unbounded-predicates* :test #'string=)))
-
-(defun %functor-whitelist ()
-  "(name-string . arity) -> home package, ENUMERATED from the two live
-registries: *PROLOG-GLOBAL-FUNCTORS* (globals.lisp:420, which also
-carries the per-schema edge functors) and *USER-FUNCTORS*.
-
-Enumerated, never probed: MAKE-FUNCTOR-SYMBOL interns, so asking the
-registry whether a client's NAME/ARITY exists would create it.
-Uninterned keys are dropped -- SELECT registers a transient gensym
-functor per running query, which is nobody's predicate."
-  (let ((table (make-hash-table :test 'equal))
-        (engine (find-package :graph-db)))
-    (flet ((add (key)
-             (when (and (symbolp key) (symbol-package key))
-               (multiple-value-bind (name arity) (%split-functor-name key)
-                 ;; The exclusions name ENGINE predicates, so they only
-                 ;; apply to GRAPH-DB-homed keys.  A schema that happens
-                 ;; to declare an edge type called REGEX-MATCH (or CALL,
-                 ;; or SELECT) owns that name in its own package, and its
-                 ;; auto-installed NAME/2 and NAME/3 must not be silently
-                 ;; dropped -- the inventory tripwire watches the
-                 ;; registry, not the schema, so it would not catch it
-                 ;; (GH #279).
-                 (when (and name
-                            (not (and (eq (symbol-package key) engine)
-                                      (%excluded-predicate-p name))))
-                   (setf (gethash (cons name arity) table)
-                         (symbol-package key)))))))
-      (maphash (lambda (k v) (declare (ignore v)) (add k))
-               graph-db::*prolog-global-functors*)
-      (maphash (lambda (k v) (declare (ignore v)) (add k))
-               graph-db::*user-functors*))
-    table))
-
-(defun %control-word-table ()
-  "NAME-STRING -> canonical symbol for the Prolog control constructs,
-enumerated from the image: every GRAPH-DB symbol carrying a
-PROLOG-COMPILER-MACRO property, plus the two cut spellings COMPILE-BODY
-compares by EQ.  Derived from the image, not hand-listed, minus
-*PROLOG-EXCLUDED-PREDICATES*."
-  (let ((table (make-hash-table :test 'equal))
-        (pkg (find-package :graph-db)))
-    (do-symbols (s pkg)
-      (when (and (eq (symbol-package s) pkg)
-                 (get s 'graph-db::prolog-compiler-macro)
-                 (not (%excluded-predicate-p (symbol-name s))))
-        (setf (gethash (symbol-name s) table) s)))
-    (dolist (name '("!" "CUT") table)
-      (let ((s (find-symbol name pkg)))
-        (when s (setf (gethash name table) s))))))
-
-(defun %schema-name-table (graph)
-  "NAME-STRING -> canonical symbol for every vertex/edge type and every
-declared slot of GRAPH's schema.  Together with the functors and the
-?variables this is the complete set of symbols a query may name; the
-names are the engine's own kebab spelling, so what /types shows is what
-a query types (GH #277)."
-  (let ((table (make-hash-table :test 'equal)))
-    (dolist (parent '(:vertex :edge) table)
-      (dolist (type-name (%schema-type-names graph parent))
-        (setf (gethash (symbol-name type-name) table) type-name)
-        (let ((meta (graph-db::lookup-node-type-by-name
-                     (intern (symbol-name type-name) :keyword)
-                     parent :graph graph)))
-          (dolist (slot (and meta (graph-db::node-type-slots meta)))
-            (let ((s (if (consp slot) (first slot) slot)))
-              (when (symbolp s)
-                (setf (gethash (symbol-name s) table) s)))))))))
-
-(defstruct (guard-ctx (:conc-name gc-))
-  "One request's whitelist plus the scratch package its symbols came
-from.  VARS accumulates the query variables in reverse first-appearance
-order."
-  package functors control schema (vars '()))
-
-(defun %guard-context (graph package)
-  (make-guard-ctx :package package
-                  :functors (%functor-whitelist)
-                  :control (%control-word-table)
-                  :schema (%schema-name-table graph)))
-
-;;; The walk.  It does not merely validate: it REBUILDS the form out of
-;;; canonical symbols, so what reaches EVAL is made of the engine's own
-;;; symbols and the request's scratch variables -- never a symbol the
-;;; client's text interned.
-
-(defun %routes-to-engine-control-p (name)
-  "True when a goal head spelled NAME will be compiled by GRAPH-DB's own
-control macro, whatever package the head itself lives in.
-
-Ask the question the COMPILER asks, not the one the registry answers.
-PROLOG-COMPILER-MACRO (prologc.lisp:224) canonicalizes a foreign-package
-head BY NAME back into GRAPH-DB, so a head's HOME PACKAGE does not
-decide what compiles it -- its NAME does.  Scoping the exclusions to
-GRAPH-DB-homed registry keys therefore excluded by home while the
-compiler routed by name, and a schema-package CALL/2 (the GH #172
-runtime-schema shape) was admitted by the whitelist and then handed
-straight to the engine's CALL macro, re-opening %SOLVE-CALL -- the one
-path by which a fully whitelisted query can still intern a functor
-symbol from graph data.
-
-Only CALL and %COMMIT are both excluded and compiler-macro-backed, so
-this refuses exactly those two and leaves a schema's own FINDALL,
-SELECT or REGEX-MATCH working, which is what the home-scoping was for
-(GH #279)."
-  (let ((sym (find-symbol name (find-package :graph-db))))
-    (and sym (get sym 'graph-db::prolog-compiler-macro) t)))
-
-(defun %cut-symbol-p (x ctx)
-  "X is one of the two cut spellings -- the only bare symbol that is a
-goal on its own."
-  (and x (symbolp x)
-       (member (symbol-name x) '("!" "CUT") :test #'string=)
-       (gethash (symbol-name x) (gc-control ctx))))
-
-(defun %guard-symbol (sym ctx)
-  "SYM validated and translated, or a refusal naming it."
-  (let ((name (symbol-name sym))
-        (pkg (symbol-package sym)))
-    (cond
-      ((null pkg)
-       (%refuse "uninterned symbol ~A is not permitted" name))
-      ;; The scratch package uses nothing, so a symbol resolved
-      ;; anywhere else was package-qualified or inherited.
-      ((not (eq pkg (gc-package ctx)))
-       (%refuse "package-qualified symbol ~A::~A is not permitted"
-                (package-name pkg) name))
-      ((zerop (length name)) (%refuse "the empty symbol || is not a term"))
-      ((string= name "NIL") nil)
-      ((string= name "T") t)
-      ((char= (char name 0) #\?)
-       (pushnew sym (gc-vars ctx))
-       sym)
-      ((gethash name (gc-schema ctx)))
-      ((gethash name (gc-control ctx)))
-      (t
-       (%refuse "~A is not a Prolog functor, a schema name of this ~
-graph, or a ?variable" (string-downcase name))))))
-
-(defun %guard-goal (form ctx)
-  "FORM (a cons) validated and translated as a goal."
-  (let ((n (ignore-errors (list-length form))))
-    (unless n
-      (%refuse "a dotted or improper list is not a goal"))
-    (let ((head (first form))
-          (arity (1- n)))
-      (unless (and head (symbolp head))
-        ;; A string head is the sharp case: COMPILE-BODY hands it to
-        ;; PROLOG-COMPILER-MACRO, which INTERNS it into GRAPH-DB
-        ;; (prologc.lisp:225).  Symbols only.
-        (%refuse "a goal's head must be a symbol, not ~A"
-                 (%term-label head)))
-      (let ((name (symbol-name head))
-            (pkg (symbol-package head)))
-        (when (and pkg (not (eq pkg (gc-package ctx))))
-          (%refuse "package-qualified goal ~A::~A is not permitted"
-                   (package-name pkg) name))
-        ;; Routing, not home: an excluded name is refused however it got
-        ;; into the registry, because the compiler will route it to the
-        ;; engine's macro by name anyway (GH #279).
-        (when (and (%excluded-predicate-p name)
-                   (%routes-to-engine-control-p name))
-          (%refuse "~A/~D is not available in free text: a goal spelled ~
-~A is compiled by the engine's own control macro whatever package it ~
-comes from"
-                   (string-downcase name) arity (string-downcase name)))
-        (let* ((home (gethash (cons name arity) (gc-functors ctx)))
-               (canonical (or (gethash name (gc-control ctx))
-                              ;; Bounded: NAME came out of the registry
-                              ;; by string match, so this interns only
-                              ;; names the image already registered.
-                              (and home (intern name home)))))
-          (unless canonical
-            (%refuse "~A/~D is not a registered Prolog functor"
-                     (string-downcase name) arity))
-          (when (member name *prolog-goal-argument-control* :test #'string=)
-            (dolist (arg (rest form))
-              (unless (or (consp arg) (%cut-symbol-p arg ctx))
-                (%refuse "~A takes goals, not ~A: write the goal out ~
-in full -- a variable there would be meta-called at run time"
-                         (string-downcase name) (%term-label arg)))))
-          (cons canonical
-                (mapcar (lambda (arg) (%guard-term arg ctx))
-                        (rest form))))))))
-
-(defun %guard-term (x ctx)
-  "X validated and translated.  Every list is validated AS A GOAL:
-free-standing list data is not expressible here, which is what keeps an
-unvetted symbol or string out of head position at run time."
-  (cond ((null x) nil)
-        ((consp x) (%guard-goal x ctx))
-        ((symbolp x) (%guard-symbol x ctx))
-        ((or (numberp x) (stringp x) (characterp x)) x)
-        (t (%refuse "~A is not a permitted literal" (%term-label x)))))
-
-(defun %guard-query (forms ctx)
-  "FORMS validated and translated.  Returns (values vars goals): VARS
-in first-appearance order, which is the column order of the answer."
-  (unless forms (%refuse "the query is empty"))
-  (dolist (f forms)
-    (unless (or (consp f) (%cut-symbol-p f ctx))
-      (%refuse "~A is not a goal; a goal is a parenthesised form"
-               (%term-label f))))
-  (let ((goals (mapcar (lambda (f) (%guard-term f ctx)) forms)))
-    (let ((vars (reverse (gc-vars ctx))))
-      (unless vars
-        (%refuse "the query binds no ?variables, so it can return no ~
-columns"))
-      (values vars goals))))
-
-;;; ---------------------------------------------------------------------
 ;;; The endpoint
 ;;; ---------------------------------------------------------------------
-
-(defun %prolog-functor-names ()
-  "Every predicate a free-text query may name, in the wire's kebab
-spelling: the registered functors plus the control constructs.  Feeds
-the editor's overlay mode, which dims a head it does not know here."
-  (let ((names '()))
-    (maphash (lambda (key pkg)
-               (declare (ignore pkg))
-               (pushnew (string-downcase (car key)) names :test #'string=))
-             (%functor-whitelist))
-    (maphash (lambda (name sym)
-               (declare (ignore sym))
-               (pushnew (string-downcase name) names :test #'string=))
-             (%control-word-table))
-    (sort names #'string<)))
 
 ;; What this server offers the frontend.  Server-level, not per-graph:
 ;; the roster is a list of graphs and has nowhere to hang a server-wide
@@ -546,11 +35,15 @@ the editor's overlay mode, which dims a head it does not know here."
    (list (cons :allow-prolog (%bool *allow-prolog*))
          (cons :prolog
                (if *allow-prolog*
-                   (%obj (list (cons :max-query-length
-                                     *prolog-max-query-length*)
-                               (cons :max-depth *prolog-max-depth*)
-                               (cons :functors
-                                     (%arr (%prolog-functor-names)))))
+                   (%obj
+                    (list
+                     (cons :max-query-length
+                           graph-db.query:*prolog-max-query-length*)
+                     (cons :max-depth
+                           graph-db.query:*prolog-max-depth*)
+                     (cons :functors
+                           (%arr
+                            (graph-db.query::%prolog-functor-names)))))
                    (%maybe nil))))))
 
 (defun %prolog-request-body ()
@@ -570,114 +63,20 @@ asks for none."
   "The \"query\" string of a decoded request BODY, or a refusal."
   (let ((text (%prolog-field body "query")))
     (unless (stringp text)
-      (%refuse "the request needs a \"query\" string"))
-    (when (> (length text) *prolog-max-query-length*)
-      (%refuse "query is ~D characters; the limit is ~D"
-               (length text) *prolog-max-query-length*))
+      (graph-db.query::%refuse "the request needs a \"query\" string"))
+    (when (> (length text) graph-db.query:*prolog-max-query-length*)
+      (graph-db.query::%refuse "query is ~D characters; the limit is ~D"
+               (length text) graph-db.query:*prolog-max-query-length*))
     text))
 
 (defun %schema-package (graph)
   "The package GRAPH's schema symbols live in, or GRAPH-DB.  Edge
 functors are installed in their own type's package (GH #172), so this
 is the package a goal head must canonicalize in."
-  (let ((types (append (%schema-type-names graph :vertex)
-                       (%schema-type-names graph :edge))))
+  (let ((types (append (graph-db.query:schema-type-names graph :vertex)
+                        (graph-db.query:schema-type-names graph :edge))))
     (or (and types (symbol-package (first types)))
         (find-package :graph-db))))
-
-(defun %non-finite-p (x)
-  "True for a float that is not a finite number.  A comparison that
-itself signals counts too: this feeds a refusal screen (GH #309)."
-  (and (floatp x)
-       (handler-case
-           (let ((most (etypecase x
-                         (single-float most-positive-single-float)
-                         (double-float most-positive-double-float)
-                         (short-float most-positive-short-float)
-                         (long-float most-positive-long-float))))
-             (or (/= x x) (> x most) (< x (- most))))
-         (arithmetic-error () t))))
-
-(defun %screen-non-finite (form)
-  "Refuse FORM if any float in it is non-finite.  Not every reader
-rejects an overflowing literal: ECL reads 1e999999 as infinity, which
-would sail past the read guard and 500 at JSON encoding (GH #309)."
-  (cond ((consp form)
-         (%screen-non-finite (car form))
-         (%screen-non-finite (cdr form)))
-        ((%non-finite-p form)
-         (%refuse "the query could not be read: check the quoting and ~
-the numeric literals"))))
-
-(defun %read-guarded-forms (text scratch ctx)
-  "TEXT screened, read into SCRATCH, and guarded through CTX -- steps 2,
-3 and 4 in order.  The screen runs FIRST and on the raw characters:
-once READ has resolved a package-qualified name the interning it was
-meant to prevent has already happened.  Every way READ can fail is a
-refusal, so a malformed query is a 400 and never a 500."
-  (%scan-query-text text)
-  (let ((forms (handler-case (%read-query-forms text scratch)
-                 (prolog-guard-error (c) (error c))
-                 (end-of-file ()
-                   (%refuse "the query ends mid-form: unbalanced ~
-parentheses or an unterminated string"))
-                 ;; A reader condition's report is raw implementation
-                 ;; text (SBCL spells out its internal reader-error
-                 ;; classes), so it is logged, not echoed.  1/0 and (on
-                 ;; SBCL) 1e999999 land here; a reader that instead
-                 ;; produces infinity is caught by %SCREEN-NON-FINITE
-                 ;; below (GH #309).
-                 (error (c)
-                   (log:error "GUI prolog: unreadable query: ~A" c)
-                   (%refuse "the query could not be read: check the ~
-quoting and the numeric literals")))))
-    (%screen-non-finite forms)
-    (%guard-query forms ctx)))
-
-(defvar *no-applicable-method-type*
-  (or #+sbcl (find-symbol "NO-APPLICABLE-METHOD-ERROR" "SB-PCL")
-      #+ccl (find-symbol "NO-APPLICABLE-METHOD-EXISTS" "CCL")
-      nil)
-  "The implementation's condition class for a generic function called
-with arguments no method matches, or NIL where it has none.  ANSI
-defines the NO-APPLICABLE-METHOD generic but no condition class, so
-this is looked up by name once at load.  Belt-and-suspenders since GH
-#309: the three whitelisted read generics define their own
-NO-APPLICABLE-METHOD methods signalling QUERY-PRECONDITION-ERROR, which
-%ILL-TYPED-CONDITION-P admits on every implementation -- necessary
-because ECL has no distinct class here (it signals a bare SIMPLE-ERROR,
-which is deliberately a 500).")
-
-(defun %ill-typed-condition-p (c)
-  "True when C is a shape that CLIENT INPUT is known to produce, as
-opposed to an engine defect.  The two were MEASURED against the
-whitelisted read functors, not assumed (GH #279):
-
-  NO-APPLICABLE-METHOD -- an unbound Prolog variable reaching a generic
-    that dispatches on node classes: (outgoing-edges ?a ?b),
-    (incoming-edges ?a ?b), (invoke-view ?a ?b ?c ?d).
-
-  QUERY-PRECONDITION-ERROR -- how the query layer reports a failed
-    precondition it checked on purpose: \"No secondary index on ?2.?3
-    in :G\" for (find-by-slot ?a ?b ?c ?d), and the not-spatially-indexed
-    report from %RESOLVE-SPATIAL-SCOPE for (find-nearest ?n some-type
-    0 0 5).  Both were SIMPLE-ERRORs before GH #286.
-
-TYPE-ERROR and UNBOUND-VARIABLE are deliberately NOT here, though they
-are the obvious guesses.  No client input produced either: the read
-functors guard with NUMBERP / NODE-P and simply fail instead of
-signalling.  A TYPE-ERROR is instead the classic shape of a real defect
--- a NIL where a struct was expected -- so admitting it would relabel
-exactly the fault this split exists to surface.
-
-Since GH #286 the engine signals those preconditions as
-QUERY-PRECONDITION-ERROR, so that class is what is admitted here; a
-plain SIMPLE-ERROR -- an internal (error \"...\") or a failed ASSERT --
-is a defect again and answers 500, which closes the residual the first
-cut recorded."
-  (or (typep c 'graph-db:query-precondition-error)
-      (and *no-applicable-method-type*
-           (typep c *no-applicable-method-type*))))
 
 (defun %run-guarded-query (vars goals graph limit)
   "Run the already-guarded query and answer the shared envelope.
@@ -706,24 +105,25 @@ grep a genuine fault apart from a user's malformed goal (GH #279)."
     (graph-db:prolog-error (c) (error c))
     (graph-db:query-param-error (c) (error c))
     (error (c)
-      (cond ((%ill-typed-condition-p c)
+      (cond ((graph-db.query::%ill-typed-condition-p c)
              (log:error "GUI prolog: ill-typed query (~S): ~A"
                         (type-of c) c)
-             (error 'prolog-ill-typed-error))
+             (error 'graph-db.query:prolog-ill-typed-error))
             (t
              (log:error "GUI prolog: UNEXPECTED SERVER FAULT (~S): ~A"
                         (type-of c) c)
-             (error 'prolog-server-fault))))))
+             (error 'graph-db.query:prolog-server-fault))))))
 
 (defun %run-guarded-prolog (text limit graph)
   "Read, guard and run TEXT against GRAPH; answers the shared workbench
 envelope.  The scratch package dies in the UNWIND-PROTECT, on every
 path including a signal, so no request can leave symbols behind."
-  (let ((scratch (%make-scratch-package)))
+  (let ((scratch (graph-db.query::%make-scratch-package)))
     (unwind-protect
          (multiple-value-bind (vars goals)
-             (%read-guarded-forms text scratch
-                                  (%guard-context graph scratch))
+             (graph-db.query::%read-guarded-forms
+              text scratch
+              (graph-db.query::%guard-context graph scratch))
            (%run-guarded-query vars goals graph limit))
       (delete-package scratch))))
 
@@ -749,9 +149,9 @@ server; start the GUI with :ALLOW-PROLOG T to enable it"))
                  (%run-guarded-prolog (%prolog-request-text body)
                                       (%prolog-field body "limit")
                                       graph)
-               (prolog-guard-error (c)
+               (graph-db.query:prolog-guard-error (c)
                  (gui-error 400 "refused-query"
-                            (prolog-guard-error-reason c)))
+                            (graph-db.query:prolog-guard-error-reason c)))
                ;; Same mapping unit B's endpoint uses for the same
                ;; conditions.  The two resource/permission subtypes must
                ;; precede PROLOG-ERROR: HANDLER-CASE takes the first
@@ -778,13 +178,13 @@ server; start the GUI with :ALLOW-PROLOG T to enable it"))
                  (declare (ignore c))
                  (gui-error 400 "bad-query"
                             "Not a well-formed Prolog goal sequence"))
-               (prolog-ill-typed-error (c)
+               (graph-db.query:prolog-ill-typed-error (c)
                  (declare (ignore c))
                  (gui-error 400 "ill-typed-query"
                             (format nil "A goal was given arguments ~
 its predicate cannot use.  Check that each goal's arguments are bound ~
 the way that predicate needs.")))
-               (prolog-server-fault (c)
+               (graph-db.query:prolog-server-fault (c)
                  (declare (ignore c))
                  (gui-error 500 "internal-error"
                             *prolog-internal-error-message*))

--- a/gui/prolog.lisp
+++ b/gui/prolog.lisp
@@ -1,6 +1,6 @@
 ;;;; Free-text Prolog HTTP surface, behind START-GUI's :ALLOW-PROLOG
-;;;; flag.  The guard (screen/read/whitelist) lives in GRAPH-DB.QUERY;
-;;;; the runner and its envelope stay here (GH #279, #322).
+;;;; flag.  The guard and the runner live in GRAPH-DB.QUERY; only the
+;;;; flag, the body helpers and the envelope stay here (GH #279, #322).
 
 (in-package #:graph-db.gui)
 
@@ -66,7 +66,8 @@ asks for none."
       (graph-db.query::%refuse "the request needs a \"query\" string"))
     (when (> (length text) graph-db.query:*prolog-max-query-length*)
       (graph-db.query::%refuse "query is ~D characters; the limit is ~D"
-               (length text) graph-db.query:*prolog-max-query-length*))
+                               (length text)
+                               graph-db.query:*prolog-max-query-length*))
     text))
 
 (defun %run-guarded-prolog (text limit graph)

--- a/profiling/modules/prolog.lisp
+++ b/profiling/modules/prolog.lisp
@@ -20,7 +20,9 @@
              
              ;; 2. Prolog functor creation and query compilation
              (dotimes (i (floor query-count 10))
-               (let ((f (graph-db::make-functor :name (graph-db::make-functor-symbol (format nil "prof-pred-~D" i) 1))))
+               (let* ((name (graph-db::make-functor-symbol
+                             (format nil "prof-pred-~D" i) 1 :define t))
+                      (f (graph-db::make-functor :name name)))
                  (graph-db::prolog-compile f)))))
       (graph-db:close-graph graph)
       (ignore-errors (uiop:delete-directory-tree temp-dir :validate t :if-does-not-exist :ignore)))))

--- a/profiling/modules/real_world.lisp
+++ b/profiling/modules/real_world.lisp
@@ -499,7 +499,8 @@ application-representative."
                   (graph-db::deref-exp 'graph-db::?x)
                   (let ((f (graph-db::make-functor
                             :name (graph-db::make-functor-symbol
-                                   (format nil "prof-pred-~D" (mod i 50)) 1))))
+                                   (format nil "prof-pred-~D" (mod i 50))
+                                   1 :define t))))
                     (graph-db::prolog-compile f)))))))
     (make-realworld-workload-result
      :name "Workload 4: Prolog Engine (synthetic)"

--- a/prologc.lisp
+++ b/prologc.lisp
@@ -794,7 +794,7 @@ in *PACKAGE*, never the lookup-first read path (GH #322)."
          ;; New functor per invocation (GH #322): DEFINE T so this
          ;; never resolves onto an existing functor of the same name.
          (*functor* (make-functor-symbol top-level-query 0
-                                          :define t)))
+                                         :define t)))
     `(let* ((*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*functor* ',*functor*)
@@ -833,7 +833,7 @@ in *PACKAGE*, never the lookup-first read path (GH #322)."
   (let* ((goals (replace-?-vars goals)))
     `(let* ((top-level-query (prolog-gensym "PROVE"))
             (*functor* (make-functor-symbol top-level-query 0
-                                             :define t))
+                                            :define t))
             (*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*select-list* nil)
@@ -1064,7 +1064,7 @@ SELECT-FIRST for common shorthands."
             ;; New functor per invocation (GH #322): DEFINE T so
             ;; this never resolves onto an existing functor.
             (*functor* (make-functor-symbol top-level-query 0
-                                             :define t))
+                                            :define t))
             (*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*select-list* nil)
@@ -1166,7 +1166,7 @@ goals like (trigger ...) or (retract ...)."
   (let* ((goals (replace-?-vars goals)))
     `(let* ((top-level-query (prolog-gensym "PROVE"))
             (*functor* (make-functor-symbol top-level-query 0
-                                             :define t))
+                                            :define t))
             (*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*select-list* nil)

--- a/prologc.lisp
+++ b/prologc.lisp
@@ -197,23 +197,31 @@ read-only: no symbol is created or registered by asking (GH #322)."
   (or (get-functor-fn symbol)
       (nth-value 1 (gethash symbol *prolog-global-functors*))))
 
-(defun make-functor-symbol (symbol arity)
-  "The NAME/ARITY functor symbol for SYMBOL.  Resolved by LOOKUP
-before interning: an already-registered functor in SYMBOL's own
-package, then in GRAPH-DB -- so a goal list whose canonical heads
-span the engine's package and a schema's resolves each in its home,
-and a head inherited from COMMON-LISP (>, atom, write) still finds
-the engine's functor.  Otherwise interned in *PACKAGE*, exactly as
-before: that is the definition path (<-) and every caller that
-predates this rule (GH #322)."
+(defun make-functor-symbol (symbol arity &key define)
+  "The NAME/ARITY functor symbol for SYMBOL.  DEFINE (true only from
+the definition path -- <- via ADD-CLAUSE, and any other site minting
+a symbol for a NEW functor) skips lookup and interns NAME straight
+into *PACKAGE*, the rule those callers already depended on -- a
+schema-package clause must not silently land on, or collide with, an
+existing GRAPH-DB functor of the same name.  Otherwise resolved by
+LOOKUP first: an already-registered functor in SYMBOL's own package,
+then in GRAPH-DB -- so a goal list whose canonical heads span the
+engine's package and a schema's resolves each in its home, and a head
+inherited from COMMON-LISP (>, atom, write) still finds the engine's
+functor.  A string SYMBOL never probes a package -- like DEFINE, it
+interns exactly as before this rule existed.  NAME is built with the
+same \"~{~a~}\" FORMAT NEW-INTERNED-SYMBOL uses (utilities.lisp:155,
+which is nothing but INTERN of that string), so every path spells the
+identical symbol (GH #322)."
   (let ((name (format nil "~{~a~}" (list symbol '/ arity))))
     (flet ((hit (pkg)
              (and pkg
                   (let ((s (find-symbol name pkg)))
                     (and s (%registered-functor-p s) s)))))
-      (or (and (symbolp symbol) (hit (symbol-package symbol)))
-          (hit (find-package :graph-db))
-          (new-interned-symbol symbol '/ arity)))))
+      (or (and (not define) (symbolp symbol)
+               (or (hit (symbol-package symbol))
+                   (hit (find-package :graph-db))))
+          (intern name)))))
 
 (defun make-= (x y) `(= ,x ,y))
 
@@ -649,12 +657,14 @@ inline, composing with cut and the control constructs.  When Goal is a variable
     body))
 
 (defun add-clause (clause)
-  "add a user-defined functor"
+  "add a user-defined functor.  :DEFINE T -- a clause always interns
+in *PACKAGE*, never the lookup-first read path (GH #322)."
   (let* ((functor-name (first (clause-head clause))))
     (when *prolog-trace* (format t "TRACE:  Adding clause ~A~%" clause))
     (assert (and (atom functor-name) (not (variable-p functor-name))))
     (let* ((arity (relation-arity (clause-head clause)))
-           (functor (make-functor-symbol functor-name arity)))
+           (functor (make-functor-symbol functor-name arity
+                                         :define t)))
       (if (gethash functor *prolog-global-functors*)
           (error 'prolog-error
                  :reason

--- a/prologc.lisp
+++ b/prologc.lisp
@@ -194,6 +194,8 @@ present, so an error from the continuation after Goal succeeds is not caught.")
   "True when SYMBOL is a live functor -- a user clause (GET-FUNCTOR-FN)
 or a global primitive (*PROLOG-GLOBAL-FUNCTORS*).  Both lookups are
 read-only: no symbol is created or registered by asking (GH #322)."
+  ;; GET-FUNCTOR-FN (compiled fn), not LOOKUP-FUNCTOR (struct): an
+  ;; uncompiled registered functor falls through to the old rule.
   (or (get-functor-fn symbol)
       (nth-value 1 (gethash symbol *prolog-global-functors*))))
 
@@ -789,7 +791,10 @@ in *PACKAGE*, never the lookup-first read path (GH #322)."
   (let* ((goals (replace-?-vars goals))
          (vars (delete '? (variables-in goals)))
          (top-level-query (prolog-gensym "PROVE"))
-         (*functor* (make-functor-symbol top-level-query 0)))
+         ;; New functor per invocation (GH #322): DEFINE T so this
+         ;; never resolves onto an existing functor of the same name.
+         (*functor* (make-functor-symbol top-level-query 0
+                                          :define t)))
     `(let* ((*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*functor* ',*functor*)
@@ -827,7 +832,8 @@ in *PACKAGE*, never the lookup-first read path (GH #322)."
   ((:entity Spot) (:species Dog)))"
   (let* ((goals (replace-?-vars goals)))
     `(let* ((top-level-query (prolog-gensym "PROVE"))
-            (*functor* (make-functor-symbol top-level-query 0))
+            (*functor* (make-functor-symbol top-level-query 0
+                                             :define t))
             (*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*select-list* nil)
@@ -1055,7 +1061,10 @@ SELECT-FIRST for common shorthands."
   (let* ((goals (replace-?-vars goals))
          (options (plist-alist options)))
     `(let* ((top-level-query (prolog-gensym "PROVE"))
-            (*functor* (make-functor-symbol top-level-query 0))
+            ;; New functor per invocation (GH #322): DEFINE T so
+            ;; this never resolves onto an existing functor.
+            (*functor* (make-functor-symbol top-level-query 0
+                                             :define t))
             (*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*select-list* nil)
@@ -1156,7 +1165,8 @@ goals like (trigger ...) or (retract ...)."
   ((:entity Spot)(:species Dog)))"
   (let* ((goals (replace-?-vars goals)))
     `(let* ((top-level-query (prolog-gensym "PROVE"))
-            (*functor* (make-functor-symbol top-level-query 0))
+            (*functor* (make-functor-symbol top-level-query 0
+                                             :define t))
             (*trail* (make-array 200 :fill-pointer 0 :adjustable t))
             (*var-counter* 0)
             (*select-list* nil)

--- a/prologc.lisp
+++ b/prologc.lisp
@@ -190,8 +190,30 @@ present, so an error from the continuation after Goal succeeds is not caught.")
   (loop for i from 1 to arity
         collect (new-interned-symbol '?arg i)))
 
+(defun %registered-functor-p (symbol)
+  "True when SYMBOL is a live functor -- a user clause (GET-FUNCTOR-FN)
+or a global primitive (*PROLOG-GLOBAL-FUNCTORS*).  Both lookups are
+read-only: no symbol is created or registered by asking (GH #322)."
+  (or (get-functor-fn symbol)
+      (nth-value 1 (gethash symbol *prolog-global-functors*))))
+
 (defun make-functor-symbol (symbol arity)
-  (new-interned-symbol symbol '/ arity))
+  "The NAME/ARITY functor symbol for SYMBOL.  Resolved by LOOKUP
+before interning: an already-registered functor in SYMBOL's own
+package, then in GRAPH-DB -- so a goal list whose canonical heads
+span the engine's package and a schema's resolves each in its home,
+and a head inherited from COMMON-LISP (>, atom, write) still finds
+the engine's functor.  Otherwise interned in *PACKAGE*, exactly as
+before: that is the definition path (<-) and every caller that
+predates this rule (GH #322)."
+  (let ((name (format nil "~{~a~}" (list symbol '/ arity))))
+    (flet ((hit (pkg)
+             (and pkg
+                  (let ((s (find-symbol name pkg)))
+                    (and s (%registered-functor-p s) s)))))
+      (or (and (symbolp symbol) (hit (symbol-package symbol)))
+          (hit (find-package :graph-db))
+          (new-interned-symbol symbol '/ arity)))))
 
 (defun make-= (x y) `(= ,x ,y))
 
@@ -219,8 +241,11 @@ present, so an error from the continuation after Goal succeeds is not caught.")
   ;; user package (e.g. GRAPH-DB/TEST::ONCE) is a *different* symbol from the
   ;; GRAPH-DB symbol the macro is defined on.  CL-inherited heads (=, and, or,
   ;; not, if) are the same symbol everywhere and hit directly; for the rest we
-  ;; fall back to the same-named symbol interned in GRAPH-DB -- mirroring how
-  ;; MAKE-FUNCTOR-SYMBOL canonicalizes runtime predicate names by string.
+  ;; fall back to the same-named symbol interned in GRAPH-DB, by NAME.
+  ;; Unrelated to MAKE-FUNCTOR-SYMBOL's routing, which since GH #322
+  ;; looks up a registered functor in the head's OWN package before
+  ;; falling back to GRAPH-DB -- a different question, asked by LOOKUP
+  ;; rather than NAME alone.
   (flet ((canonical (sym)
            (let ((c (find-symbol (symbol-name sym) :graph-db)))
              (and c (not (eq c sym)) (get c 'prolog-compiler-macro)))))

--- a/query/dsl.lisp
+++ b/query/dsl.lisp
@@ -307,11 +307,15 @@ This is THE runner: every client-supplied query -- the JSON pattern DSL and
 the GUI's free-text Prolog alike -- reaches SELECT through here, so the rails
 are stated once.  Read-only (:EFFECTS NIL), snapshot-isolated, bounded by
 *QUERY-DEFAULT-MAX-INFERENCES* / *QUERY-DEFAULT-TIMEOUT*, and LIMIT capped at
-*QUERY-DEFAULT-LIMIT*.  PACKAGE is bound around the EVAL because COMPILE-CALL
-canonicalizes each goal head through MAKE-FUNCTOR-SYMBOL, which interns
-NAME/ARITY in *PACKAGE*: it must be the schema's package for an edge functor
-to resolve.  Callers built from untrusted text must whitelist every symbol
-BEFORE calling (see gui/prolog.lisp, GH #279).  Returns the result string
+*QUERY-DEFAULT-LIMIT*.  PACKAGE no longer routes functor resolution: since
+GH #322, MAKE-FUNCTOR-SYMBOL resolves each goal head in its own home
+package (falling back to GRAPH-DB), so a goal list spanning the engine
+and a schema resolves correctly regardless of *PACKAGE*.  PACKAGE stays
+advisory -- it is what COMPILE-PATTERN-QUERY resolved the DSL's own
+match/where types against, and is still bound around the EVAL, but
+nothing here depends on it for a goal head to be found any more.
+Callers built from untrusted text must whitelist every symbol BEFORE
+calling (see gui/prolog.lisp, GH #279).  Returns the result string
 under :JSON/:NDJSON.
 
 :RAW is a fourth arm (GH #322): CALLBACK (required) receives each raw

--- a/query/dsl.lisp
+++ b/query/dsl.lisp
@@ -300,7 +300,7 @@ QUERY-PARAM-ERROR on malformed input."
 
 (defun run-query-goals (vars goals graph
                         &key (package (find-package :graph-db))
-                             limit skip (format :json))
+                             limit skip (format :json) callback)
   "Run the already-compiled query GOALS against GRAPH, collecting VARS.
 
 This is THE runner: every client-supplied query -- the JSON pattern DSL and
@@ -311,26 +311,37 @@ are stated once.  Read-only (:EFFECTS NIL), snapshot-isolated, bounded by
 canonicalizes each goal head through MAKE-FUNCTOR-SYMBOL, which interns
 NAME/ARITY in *PACKAGE*: it must be the schema's package for an edge functor
 to resolve.  Callers built from untrusted text must whitelist every symbol
-BEFORE calling (see gui/prolog.lisp, GH #279).  Returns the result string."
+BEFORE calling (see gui/prolog.lisp, GH #279).  Returns the result string
+under :JSON/:NDJSON.
+
+:RAW is a fourth arm (GH #322): CALLBACK (required) receives each raw
+row -- no JSON rendering -- and the function returns NIL, for a caller
+that wants the bound values themselves (graph-db.query:run-guarded-
+prolog's :DATA format still converts them; :RAW does not)."
+  (when (and (eq format :raw) (not callback))
+    (error "RUN-QUERY-GOALS :FORMAT :RAW requires :CALLBACK."))
   ;; The eval'd SELECT / node-slot-value goals key off *GRAPH*.
   (let* ((*graph* graph)
          (*package* package)
          (cap (if (and (integerp limit) (plusp limit))
                   (min limit *query-default-limit*)
-                  *query-default-limit*)))
-    (emit-query-results
-     vars format
-     (lambda (cb)
-       ;; the select form is EVAL'd (null lexenv), so pass the callback through
-       ;; a special the form references rather than a lexical.
-       (let ((*pattern-query-callback* cb))
-         (eval `(select (:effects nil :snapshot t
-                         :limit ,cap
-                         :skip ,(when (integerp skip) skip)
-                         :max-inferences ,*query-default-max-inferences*
-                         :timeout ,*query-default-timeout*
-                         :callback *pattern-query-callback*)
-                        ,vars ,@goals)))))))
+                  *query-default-limit*))
+         (run (lambda (cb)
+                ;; the select form is EVAL'd (null lexenv), so pass the
+                ;; callback through a special the form references
+                ;; rather than a lexical.
+                (let ((*pattern-query-callback* cb))
+                  (eval `(select (:effects nil :snapshot t
+                                  :limit ,cap
+                                  :skip ,(when (integerp skip) skip)
+                                  :max-inferences
+                                  ,*query-default-max-inferences*
+                                  :timeout ,*query-default-timeout*
+                                  :callback *pattern-query-callback*)
+                                 ,vars ,@goals))))))
+    (if (eq format :raw)
+        (progn (funcall run callback) nil)
+        (emit-query-results vars format run))))
 
 (defun %dsl-ndjson-p (dsl)
   "T when the decoded JSON pattern query DSL asks for \"format\":\"ndjson\"."

--- a/query/dsl.lisp
+++ b/query/dsl.lisp
@@ -332,6 +332,10 @@ BEFORE calling (see gui/prolog.lisp, GH #279).  Returns the result string."
                          :callback *pattern-query-callback*)
                         ,vars ,@goals)))))))
 
+(defun %dsl-ndjson-p (dsl)
+  "T when the decoded JSON pattern query DSL asks for \"format\":\"ndjson\"."
+  (string-equal "ndjson" (princ-to-string (or (cdr (assoc :format dsl)) ""))))
+
 (defun run-pattern-query (dsl graph)
   "Compile and run a decoded JSON pattern query DSL against GRAPH, returning the
 result string.  Read-only, snapshot-isolated, and bounded; the client :limit is
@@ -341,8 +345,4 @@ as newline-delimited JSON instead of an array."
       (compile-pattern-query dsl graph)
     (run-query-goals vars goals graph
                      :package pkg :limit limit :skip skip
-                     :format (if (string-equal
-                                  "ndjson"
-                                  (princ-to-string
-                                   (or (cdr (assoc :format dsl)) "")))
-                                 :ndjson :json))))
+                     :format (if (%dsl-ndjson-p dsl) :ndjson :json))))

--- a/query/dsl.lisp
+++ b/query/dsl.lisp
@@ -8,12 +8,10 @@
 ;;;; routes).  Moved verbatim: bodies here are byte-identical to the
 ;;;; rest.lisp originals, including their pre-80-column line widths.
 ;;;;
-;;;; Why this file sits in the :GRAPH-DB system and not in
-;;;; :GRAPH-DB/CORE: EMIT-QUERY-RESULTS' :NDJSON arm sets the content
-;;;; type on NINGLE:*RESPONSE*, and core deliberately drops
-;;;; ningle/clack/hunchentoot (it is the ECL/Android build).  Hoisting
-;;;; the rest of the DSL below that one line would have meant editing
-;;;; it, which the extraction ruled out.
+;;;; Home: the graph-db/query subsystem (GH #322), which depends on
+;;;; graph-db/core only.  The one web-bound line this file had -- the
+;;;; :NDJSON arm setting a content type on NINGLE:*RESPONSE* -- moved to
+;;;; rest.lisp's /query route, the only caller that asks for ndjson.
 
 (in-package :graph-db)
 
@@ -104,17 +102,14 @@ second, unrelated change to the wire."
   "Render a query's results.  RUN is a function of one argument -- a per-row
 callback -- that runs the query, invoking the callback for each result row as it
 is produced (via SELECT :callback, so no intermediate result list is built).
-With FORMAT :JSON returns a JSON array; with :NDJSON streams each row as its own
-JSON line and sets the application/x-ndjson content type."
+With FORMAT :JSON returns a JSON array; with :NDJSON returns each row as its own
+JSON line; the caller sets the content type."
   (ecase format
     (:json
      (let ((rows '()))
        (funcall run (lambda (row) (push row rows)))
        (query-results->json return-vars (nreverse rows))))
     (:ndjson
-     (setf (lack.response:response-headers ningle:*response*)
-           (list* :content-type "application/x-ndjson"
-                  (lack.response:response-headers ningle:*response*)))
      (with-output-to-string (out)
        (funcall run
                 (lambda (row)

--- a/query/dsl.lisp
+++ b/query/dsl.lisp
@@ -11,7 +11,8 @@
 ;;;; Home: the graph-db/query subsystem (GH #322), which depends on
 ;;;; graph-db/core only.  The one web-bound line this file had -- the
 ;;;; :NDJSON arm setting a content type on NINGLE:*RESPONSE* -- moved to
-;;;; rest.lisp's /query route, the only caller that asks for ndjson.
+;;;; rest.lisp's %SET-NDJSON-CONTENT-TYPE, called by both the /query
+;;;; route and DEF-QUERY when they ask for ndjson.
 
 (in-package :graph-db)
 

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -21,7 +21,7 @@
 ;;;;      canonical symbols.  A symbol survives only as a registered
 ;;;;      functor of that arity, a control construct, a schema type or
 ;;;;      slot of THIS graph, a ?variable, or T/NIL.
-;;;;   5. RUN-QUERY-GOALS    -- query-dsl.lisp's own runner: :EFFECTS
+;;;;   5. RUN-QUERY-GOALS    -- query/dsl.lisp's own runner: :EFFECTS
 ;;;;      NIL, one snapshot, the inference/time/row bounds.  Reached
 ;;;;      through %RUN-GUARDED-GOALS in this file.  Goal heads resolve
 ;;;;      each in its own package now, not one shared :PACKAGE
@@ -32,11 +32,13 @@
 ;;;;      only step 1's flag check stays in gui/prolog.lisp.
 ;;;;
 ;;;; The interning subtlety (issue text, utilities.lisp:155):
-;;;; MAKE-FUNCTOR-SYMBOL calls NEW-INTERNED-SYMBOL, so building
-;;;; NAME/ARITY from client input would itself intern the symbol it was
-;;;; asking about.  The whitelist therefore ENUMERATES the two live
-;;;; registries and compares NAMES AS STRINGS; nothing derived from the
-;;;; request is ever interned into GRAPH-DB or the schema package.
+;;;; MAKE-FUNCTOR-SYMBOL now looks up an existing functor before
+;;;; interning (GH #322), but a miss still falls through to INTERN --
+;;;; so probing it with a client's own NAME/ARITY would create exactly
+;;;; the symbol it was asking about.  The whitelist therefore ENUMERATES
+;;;; the two live registries and compares NAMES AS STRINGS; nothing
+;;;; derived from the request is ever interned into GRAPH-DB or the
+;;;; schema package.
 ;;;;
 ;;;; Home: graph-db/query (GH #322) -- steps 2 through 6, including
 ;;;; RUN-GUARDED-PROLOG.  Only step 1's flag and the HTTP envelope

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -1,0 +1,623 @@
+;;;; Free-text Prolog, behind START-GUI's :ALLOW-PROLOG flag (GH #279).
+;;;;
+;;;; The builder (GH #278) reads no user text at all.  This surface
+;;;; does, so the whole risk of the workbench concentrates here and the
+;;;; guard -- not the editor -- is the deliverable.
+;;;;
+;;;; Order of operations, all of it before one character reaches the
+;;;; Prolog compiler:
+;;;;
+;;;;   1. *ALLOW-PROLOG*     -- the flag, stays in the GUI handler
+;;;;      (gui/prolog.lisp), checked before the graph is resolved.
+;;;;   2. %SCAN-QUERY-TEXT   -- a character screen that runs BEFORE the
+;;;;      reader: length, paren depth/balance, and an outright refusal
+;;;;      of #, `, , and the package marker.  Refusing ':' textually is
+;;;;      what makes package-qualified input safe -- READ would intern
+;;;;      GRAPH-DB::ANYTHING before any walker could object.
+;;;;   3. %READ-QUERY-FORMS  -- *READ-EVAL* NIL, a readtable with #, `
+;;;;      and , disabled, standard IO syntax otherwise, and *PACKAGE*
+;;;;      bound to a per-request scratch package that USES NOTHING.
+;;;;   4. %GUARD-QUERY       -- walks the form and rebuilds it out of
+;;;;      canonical symbols.  A symbol survives only as a registered
+;;;;      functor of that arity, a control construct, a schema type or
+;;;;      slot of THIS graph, a ?variable, or T/NIL.
+;;;;   5. RUN-QUERY-GOALS    -- query-dsl.lisp's own runner: :EFFECTS
+;;;;      NIL, one snapshot, the inference/time/row bounds.  Reached
+;;;;      through %RUN-GUARDED-QUERY, which stays in gui/prolog.lisp.
+;;;;   6. DELETE-PACKAGE     -- in an UNWIND-PROTECT, so a hostile
+;;;;      query's symbols leave with the request that made them.
+;;;;      %RUN-GUARDED-PROLOG, which does this, also stays there.
+;;;;
+;;;; The interning subtlety (issue text, utilities.lisp:155):
+;;;; MAKE-FUNCTOR-SYMBOL calls NEW-INTERNED-SYMBOL, so building
+;;;; NAME/ARITY from client input would itself intern the symbol it was
+;;;; asking about.  The whitelist therefore ENUMERATES the two live
+;;;; registries and compares NAMES AS STRINGS; nothing derived from the
+;;;; request is ever interned into GRAPH-DB or the schema package.
+;;;;
+;;;; Home: graph-db/query (GH #322) -- the guard (steps 2-4).  The
+;;;; GUI runner and its envelope (steps 1, 5, 6) stay in
+;;;; gui/prolog.lisp, which calls this file's internals qualified.
+
+(in-package #:graph-db.query)
+
+(defparameter *prolog-max-query-length* 4096
+  "Longest free-text query accepted, in characters.")
+
+(defparameter *prolog-max-depth* 32
+  "Deepest parenthesis nesting accepted.  Bounds the reader's own
+recursion, so a nesting bomb is refused before READ sees it.")
+
+(define-condition prolog-guard-error (error)
+  ((reason :initarg :reason :reader prolog-guard-error-reason))
+  (:report (lambda (c s)
+             (format s "~A" (prolog-guard-error-reason c))))
+  (:documentation "A free-text query the guard refused.  Carries the
+client-facing reason, which names the offending token."))
+
+(define-condition prolog-ill-typed-error (error) ()
+  (:report (lambda (c s)
+             (declare (ignore c))
+             (format s "ill-typed query")))
+  (:documentation "A guarded query whose goals were given arguments a
+predicate cannot use -- the CLIENT's error, answered 400.  Deliberately
+CARRIES NO DETAIL: the conditions it stands in for report engine
+internals -- a store's keyword name, a generic-function name, an ANSI
+section reference -- and the client that provoked them is
+unauthenticated.  The detail is logged (GH #279)."))
+
+(define-condition prolog-server-fault (error) ()
+  (:report (lambda (c s)
+             (declare (ignore c))
+             (format s "internal error")))
+  (:documentation "A condition raised while running a guarded query
+that is NOT a shape client input is known to produce -- i.e. an engine
+defect, answered 500.  Separate from PROLOG-ILL-TYPED-ERROR so a
+genuine fault is never labelled the client's, in the response or in the
+log.  Carries no detail either: the leak rule does not relax because
+the fault is ours (GH #279)."))
+
+(defun %refuse (format-string &rest args)
+  (error 'prolog-guard-error
+         :reason (apply #'format nil format-string args)))
+
+(defun %term-label (x)
+  "X as the client wrote it.  A symbol prints bare and downcased -- ~S
+would spell out the request's scratch package, which is our bookkeeping
+and not something to explain in an error message."
+  (if (and x (symbolp x))
+      (string-downcase (symbol-name x))
+      (format nil "~S" x)))
+
+;;; ---------------------------------------------------------------------
+;;; Step 2: the pre-read character screen
+;;; ---------------------------------------------------------------------
+
+(defun %token-around (text pos)
+  "The whitespace/paren-delimited token of TEXT containing POS -- what
+to name in a refusal message."
+  (flet ((delim-p (ch)
+           (or (member ch '(#\( #\) #\" #\; #\')) (char<= ch #\Space))))
+    (let ((start pos) (end pos) (n (length text)))
+      (loop while (and (plusp start) (not (delim-p (char text (1- start)))))
+            do (decf start))
+      (loop while (and (< end n) (not (delim-p (char text end))))
+            do (incf end))
+      (subseq text start end))))
+
+(defun %skip-delimited (text start close what)
+  "Index just past the CLOSE that ends the region starting at START,
+honouring backslash escapes.  Refuses an unterminated region."
+  (let ((i start) (n (length text)))
+    (loop
+      (when (>= i n) (%refuse "unterminated ~A" what))
+      (let ((ch (char text i)))
+        (cond ((char= ch #\\) (incf i 2))
+              ((char= ch close) (return (1+ i)))
+              (t (incf i)))))))
+
+(defun %scan-query-text (text)
+  "Screen TEXT before the reader touches it (GH #279).
+
+Refuses, by name: the package marker (so no READ can intern into
+GRAPH-DB or a schema package), every # reader macro (#. above all),
+backquote and comma, unbalanced or over-deep parentheses, and an
+unterminated string or |...| name.  Inside a string or a |...| name
+none of those characters mean anything, so a literal \"#.(...)\" is
+data and passes -- the guard refuses reader syntax, not text."
+  (let ((depth 0) (i 0) (n (length text)))
+    (loop while (< i n) do
+      (let ((ch (char text i)))
+        (cond
+          ((char= ch #\\)
+           (when (> (+ i 2) n)
+             (%refuse "the query ends in a backslash escape"))
+           (incf i 2))
+          ((char= ch #\;)
+           (setq i (or (position #\Newline text :start i) n)))
+          ((char= ch #\") (setq i (%skip-delimited text (1+ i) #\" "string")))
+          ((char= ch #\|)
+           (setq i (%skip-delimited text (1+ i) #\| "|...| name")))
+          ((char= ch #\()
+           (incf depth)
+           (when (> depth *prolog-max-depth*)
+             (%refuse "nesting deeper than ~D parentheses is not ~
+permitted" *prolog-max-depth*))
+           (incf i))
+          ((char= ch #\))
+           (when (zerop depth)
+             (%refuse "unbalanced parentheses: a ')' closes nothing"))
+           (decf depth)
+           (incf i))
+          ((char= ch #\:)
+           (%refuse "package-qualified name ~S is not permitted: a ~
+query may name only this graph's schema and the registered Prolog ~
+functors" (%token-around text i)))
+          ((char= ch #\#)
+           (%refuse "reader macro ~S is not permitted; #. (read-time ~
+evaluation) least of all"
+                    (subseq text i (min n (+ i 2)))))
+          ((or (char= ch #\`) (char= ch #\,))
+           (%refuse "~S is not permitted in a query" (string ch)))
+          (t (incf i)))))
+    (unless (zerop depth)
+      (%refuse "unbalanced parentheses: ~D form~:P left open" depth))
+    t))
+
+;;; ---------------------------------------------------------------------
+;;; Step 3: the read
+;;; ---------------------------------------------------------------------
+
+(defvar *prolog-readtable* nil
+  "Lazily built readtable for free-text queries; see %PROLOG-READTABLE.")
+
+(defun %refuse-reader-macro (stream char)
+  (declare (ignore stream))
+  (%refuse "the ~S reader macro is not permitted" (string char)))
+
+(defun %prolog-readtable ()
+  "A copy of the standard readtable with #, ` and , disabled.  Second
+line of defence: %SCAN-QUERY-TEXT already refuses these characters, so
+this only fires if that screen is ever wrong."
+  (or *prolog-readtable*
+      (setq *prolog-readtable*
+            (let ((rt (copy-readtable nil)))
+              (dolist (ch '(#\# #\` #\,) rt)
+                (set-macro-character ch #'%refuse-reader-macro nil rt))))))
+
+(defvar *prolog-scratch-counter* 0)
+
+(defun %make-scratch-package ()
+  "A fresh empty package for one request's read.  :USE '() -- so a bare
+name the client types can intern nowhere but here, and DELETE-PACKAGE
+takes every one of them with it.  Retries on the (benign) name race
+between concurrent requests."
+  (loop repeat 64
+        for name = (format nil "GRAPH-DB.GUI.SCRATCH-~D"
+                           (incf *prolog-scratch-counter*))
+        for pkg = (and (not (find-package name))
+                       (ignore-errors (make-package name :use '())))
+        when pkg return pkg
+          finally (error "Cannot create a GUI Prolog scratch package.")))
+
+(defun %read-query-forms (text package)
+  "TEXT read into PACKAGE as a list of forms.  *READ-EVAL* NIL, the
+restricted readtable, standard IO syntax otherwise.  A string stream
+cannot block, and unbalanced input signals END-OF-FILE rather than
+hanging -- so this terminates for every input."
+  (with-standard-io-syntax
+    (let ((*read-eval* nil)
+          (*package* package)
+          (*readtable* (%prolog-readtable))
+          (*read-suppress* nil))
+      (with-input-from-string (in text)
+        ;; IN is its own EOF marker: no readable object can be EQ to it.
+        (loop for form = (read in nil in)
+              until (eq form in)
+              collect form)))))
+
+;;; ---------------------------------------------------------------------
+;;; Step 4: the whitelist, derived from the live image
+;;; ---------------------------------------------------------------------
+
+(defun %split-functor-name (symbol)
+  "SYMBOL named NAME/ARITY as (values name-string arity), else NIL.
+Splits at the LAST slash, so /=/2 reads as (\"/=\" . 2)."
+  (let* ((name (symbol-name symbol))
+         (slash (position #\/ name :from-end t)))
+    (when (and slash (plusp slash) (< (1+ slash) (length name)))
+      (let ((arity (ignore-errors (parse-integer name :start (1+ slash)))))
+        (when (and arity (>= arity 0))
+          (values (subseq name 0 slash) arity))))))
+
+;; ⚠ The three lists below are the ONLY hand-maintained part of the
+;; guard: the whitelist grows with the registries automatically, these
+;; do not.  PROLOG-FUNCTOR-INVENTORY-IS-PINNED (tests/gui/gui-tests.lisp)
+;; fails when a functor is added or removed anywhere, and its message
+;; says how to classify the new one.  Read it before editing any of them.
+
+(defparameter *prolog-excluded-predicates*
+  '("%COMMIT" "CALL" "CATCH" "FINDALL" "BAGOF" "SETOF" "MAP-QUERY"
+    "SELECT" "SHOW-PROLOG-VARS")
+  "Predicate names withheld from free text at EVERY arity, whatever the
+registries say.
+
+All but the first are the runtime meta-call family: each hands a term to
+%SOLVE, which builds a functor symbol from that term's head at run time
+(prolog-functors.lisp:229).  For a STRING head that is an INTERN of
+unvetted data -- graph content, reached through a variable -- into the
+live schema package, which is the one way a fully whitelisted query
+could still grow the image.  SELECT/2 and SHOW-PROLOG-VARS/2 are
+result-collection machinery and a REPL printer, neither a predicate.
+%COMMIT is an internal cut barrier taking compiler gensyms (GH #279).")
+
+(defparameter *prolog-goal-argument-control*
+  '("AND" "OR" "NOT" "ONCE" "IF" "FORALL")
+  "Control constructs whose arguments are GOALS.  Every such argument
+must be a parenthesised goal here, never a variable: a variable makes
+STATIC-GOAL-P (prologc.lisp:475) fail, the compiler macro declines, and
+the runtime functor behind it meta-calls whatever the variable holds --
+the %SOLVE path *PROLOG-EXCLUDED-PREDICATES* exists to close.  Demanding
+a static goal keeps all six on the compile-time path (GH #279).  Same
+tripwire as above: PROLOG-FUNCTOR-INVENTORY-IS-PINNED.")
+
+(defparameter *prolog-cost-unbounded-predicates*
+  (graph-db:cost-unbounded-predicate-names)   ; single source: GH #285
+  "Predicate names withheld because their worst-case cost is bounded
+neither by the graph nor by the length of the query.
+
+The query rails are enforced by %TICK (prologc.lisp:890), which runs at
+inference and goal boundaries -- NEVER inside a functor that is already
+running.  A predicate that can burn arbitrary time in one atomic Lisp
+call is therefore not preemptible by *QUERY-DEFAULT-TIMEOUT* or
+*QUERY-DEFAULT-MAX-INFERENCES*, and a watchdog is not an option here:
+interrupting a worker mid-call could unwind holding the GUI's rw lock
+or with an mmap operation in flight, which is worse than the hazard it
+would close.  Exclusion is the sound fix (GH #279).
+
+REGEX-MATCH/2 takes BOTH the pattern and the subject from the client,
+so a catastrophically backtracking pattern -- (a+)+$ against a run of
+a's -- costs ~2^n in a payload of a few dozen characters, well inside
+the 4096-character cap, and runs past the 30 s deadline unaborted.
+VALID-DATE-P/1 also runs a regex and STAYS: its pattern is a fixed,
+anchored, quantifier-free constant, so its cost is linear in a subject
+the length cap already bounds -- which is the line this category draws.
+
+Graph-bounded scans (IS-A/2, FIND-SLOT-RANGE/5, the spatial FIND-*
+family, whose window cover is capped at +SPATIAL-QUERY-MAX-CELLS+) are
+NOT in this category: their cost tracks the operator's own data, and
+the un-flagged structured builder already reaches all of it.")
+
+(defun %excluded-predicate-p (name)
+  "NAME is withheld from free text, for either reason."
+  (or (member name *prolog-excluded-predicates* :test #'string=)
+      (member name *prolog-cost-unbounded-predicates* :test #'string=)))
+
+(defun %functor-whitelist ()
+  "(name-string . arity) -> home package, ENUMERATED from the two live
+registries: *PROLOG-GLOBAL-FUNCTORS* (globals.lisp:420, which also
+carries the per-schema edge functors) and *USER-FUNCTORS*.
+
+Enumerated, never probed: MAKE-FUNCTOR-SYMBOL interns, so asking the
+registry whether a client's NAME/ARITY exists would create it.
+Uninterned keys are dropped -- SELECT registers a transient gensym
+functor per running query, which is nobody's predicate."
+  (let ((table (make-hash-table :test 'equal))
+        (engine (find-package :graph-db)))
+    (flet ((add (key)
+             (when (and (symbolp key) (symbol-package key))
+               (multiple-value-bind (name arity) (%split-functor-name key)
+                 ;; The exclusions name ENGINE predicates, so they only
+                 ;; apply to GRAPH-DB-homed keys.  A schema that happens
+                 ;; to declare an edge type called REGEX-MATCH (or CALL,
+                 ;; or SELECT) owns that name in its own package, and its
+                 ;; auto-installed NAME/2 and NAME/3 must not be silently
+                 ;; dropped -- the inventory tripwire watches the
+                 ;; registry, not the schema, so it would not catch it
+                 ;; (GH #279).
+                 (when (and name
+                            (not (and (eq (symbol-package key) engine)
+                                      (%excluded-predicate-p name))))
+                   (setf (gethash (cons name arity) table)
+                         (symbol-package key)))))))
+      (maphash (lambda (k v) (declare (ignore v)) (add k))
+               graph-db::*prolog-global-functors*)
+      (maphash (lambda (k v) (declare (ignore v)) (add k))
+               graph-db::*user-functors*))
+    table))
+
+(defun %control-word-table ()
+  "NAME-STRING -> canonical symbol for the Prolog control constructs,
+enumerated from the image: every GRAPH-DB symbol carrying a
+PROLOG-COMPILER-MACRO property, plus the two cut spellings COMPILE-BODY
+compares by EQ.  Derived from the image, not hand-listed, minus
+*PROLOG-EXCLUDED-PREDICATES*."
+  (let ((table (make-hash-table :test 'equal))
+        (pkg (find-package :graph-db)))
+    (do-symbols (s pkg)
+      (when (and (eq (symbol-package s) pkg)
+                 (get s 'graph-db::prolog-compiler-macro)
+                 (not (%excluded-predicate-p (symbol-name s))))
+        (setf (gethash (symbol-name s) table) s)))
+    (dolist (name '("!" "CUT") table)
+      (let ((s (find-symbol name pkg)))
+        (when s (setf (gethash name table) s))))))
+
+(defun schema-type-names (graph parent)
+  "Node-type names (class symbols) registered for PARENT (:vertex or
+:edge) in GRAPH's schema, sorted by name."
+  (let ((names '()))
+    (maphash (lambda (key meta)
+               (when (numberp key)
+                 (push (graph-db::node-type-name meta) names)))
+             (gethash parent (graph-db::schema-type-table
+                             (graph-db::schema graph))))
+    (sort names #'string< :key #'symbol-name)))
+
+(defun %schema-name-table (graph)
+  "NAME-STRING -> canonical symbol for every vertex/edge type and every
+declared slot of GRAPH's schema.  Together with the functors and the
+?variables this is the complete set of symbols a query may name; the
+names are the engine's own kebab spelling, so what /types shows is what
+a query types (GH #277)."
+  (let ((table (make-hash-table :test 'equal)))
+    (dolist (parent '(:vertex :edge) table)
+      (dolist (type-name (schema-type-names graph parent))
+        (setf (gethash (symbol-name type-name) table) type-name)
+        (let ((meta (graph-db::lookup-node-type-by-name
+                     (intern (symbol-name type-name) :keyword)
+                     parent :graph graph)))
+          (dolist (slot (and meta (graph-db::node-type-slots meta)))
+            (let ((s (if (consp slot) (first slot) slot)))
+              (when (symbolp s)
+                (setf (gethash (symbol-name s) table) s)))))))))
+
+(defstruct (guard-ctx (:conc-name gc-))
+  "One request's whitelist plus the scratch package its symbols came
+from.  VARS accumulates the query variables in reverse first-appearance
+order."
+  package functors control schema (vars '()))
+
+(defun %guard-context (graph package)
+  (make-guard-ctx :package package
+                  :functors (%functor-whitelist)
+                  :control (%control-word-table)
+                  :schema (%schema-name-table graph)))
+
+;;; The walk.  It does not merely validate: it REBUILDS the form out of
+;;; canonical symbols, so what reaches EVAL is made of the engine's own
+;;; symbols and the request's scratch variables -- never a symbol the
+;;; client's text interned.
+
+(defun %routes-to-engine-control-p (name)
+  "True when a goal head spelled NAME will be compiled by GRAPH-DB's own
+control macro, whatever package the head itself lives in.
+
+Ask the question the COMPILER asks, not the one the registry answers.
+PROLOG-COMPILER-MACRO (prologc.lisp:224) canonicalizes a foreign-package
+head BY NAME back into GRAPH-DB, so a head's HOME PACKAGE does not
+decide what compiles it -- its NAME does.  Scoping the exclusions to
+GRAPH-DB-homed registry keys therefore excluded by home while the
+compiler routed by name, and a schema-package CALL/2 (the GH #172
+runtime-schema shape) was admitted by the whitelist and then handed
+straight to the engine's CALL macro, re-opening %SOLVE-CALL -- the one
+path by which a fully whitelisted query can still intern a functor
+symbol from graph data.
+
+Only CALL and %COMMIT are both excluded and compiler-macro-backed, so
+this refuses exactly those two and leaves a schema's own FINDALL,
+SELECT or REGEX-MATCH working, which is what the home-scoping was for
+(GH #279)."
+  (let ((sym (find-symbol name (find-package :graph-db))))
+    (and sym (get sym 'graph-db::prolog-compiler-macro) t)))
+
+(defun %cut-symbol-p (x ctx)
+  "X is one of the two cut spellings -- the only bare symbol that is a
+goal on its own."
+  (and x (symbolp x)
+       (member (symbol-name x) '("!" "CUT") :test #'string=)
+       (gethash (symbol-name x) (gc-control ctx))))
+
+(defun %guard-symbol (sym ctx)
+  "SYM validated and translated, or a refusal naming it."
+  (let ((name (symbol-name sym))
+        (pkg (symbol-package sym)))
+    (cond
+      ((null pkg)
+       (%refuse "uninterned symbol ~A is not permitted" name))
+      ;; The scratch package uses nothing, so a symbol resolved
+      ;; anywhere else was package-qualified or inherited.
+      ((not (eq pkg (gc-package ctx)))
+       (%refuse "package-qualified symbol ~A::~A is not permitted"
+                (package-name pkg) name))
+      ((zerop (length name)) (%refuse "the empty symbol || is not a term"))
+      ((string= name "NIL") nil)
+      ((string= name "T") t)
+      ((char= (char name 0) #\?)
+       (pushnew sym (gc-vars ctx))
+       sym)
+      ((gethash name (gc-schema ctx)))
+      ((gethash name (gc-control ctx)))
+      (t
+       (%refuse "~A is not a Prolog functor, a schema name of this ~
+graph, or a ?variable" (string-downcase name))))))
+
+(defun %guard-goal (form ctx)
+  "FORM (a cons) validated and translated as a goal."
+  (let ((n (ignore-errors (list-length form))))
+    (unless n
+      (%refuse "a dotted or improper list is not a goal"))
+    (let ((head (first form))
+          (arity (1- n)))
+      (unless (and head (symbolp head))
+        ;; A string head is the sharp case: COMPILE-BODY hands it to
+        ;; PROLOG-COMPILER-MACRO, which INTERNS it into GRAPH-DB
+        ;; (prologc.lisp:225).  Symbols only.
+        (%refuse "a goal's head must be a symbol, not ~A"
+                 (%term-label head)))
+      (let ((name (symbol-name head))
+            (pkg (symbol-package head)))
+        (when (and pkg (not (eq pkg (gc-package ctx))))
+          (%refuse "package-qualified goal ~A::~A is not permitted"
+                   (package-name pkg) name))
+        ;; Routing, not home: an excluded name is refused however it got
+        ;; into the registry, because the compiler will route it to the
+        ;; engine's macro by name anyway (GH #279).
+        (when (and (%excluded-predicate-p name)
+                   (%routes-to-engine-control-p name))
+          (%refuse "~A/~D is not available in free text: a goal spelled ~
+~A is compiled by the engine's own control macro whatever package it ~
+comes from"
+                   (string-downcase name) arity (string-downcase name)))
+        (let* ((home (gethash (cons name arity) (gc-functors ctx)))
+               (canonical (or (gethash name (gc-control ctx))
+                              ;; Bounded: NAME came out of the registry
+                              ;; by string match, so this interns only
+                              ;; names the image already registered.
+                              (and home (intern name home)))))
+          (unless canonical
+            (%refuse "~A/~D is not a registered Prolog functor"
+                     (string-downcase name) arity))
+          (when (member name *prolog-goal-argument-control* :test #'string=)
+            (dolist (arg (rest form))
+              (unless (or (consp arg) (%cut-symbol-p arg ctx))
+                (%refuse "~A takes goals, not ~A: write the goal out ~
+in full -- a variable there would be meta-called at run time"
+                         (string-downcase name) (%term-label arg)))))
+          (cons canonical
+                (mapcar (lambda (arg) (%guard-term arg ctx))
+                        (rest form))))))))
+
+(defun %guard-term (x ctx)
+  "X validated and translated.  Every list is validated AS A GOAL:
+free-standing list data is not expressible here, which is what keeps an
+unvetted symbol or string out of head position at run time."
+  (cond ((null x) nil)
+        ((consp x) (%guard-goal x ctx))
+        ((symbolp x) (%guard-symbol x ctx))
+        ((or (numberp x) (stringp x) (characterp x)) x)
+        (t (%refuse "~A is not a permitted literal" (%term-label x)))))
+
+(defun %guard-query (forms ctx)
+  "FORMS validated and translated.  Returns (values vars goals): VARS
+in first-appearance order, which is the column order of the answer."
+  (unless forms (%refuse "the query is empty"))
+  (dolist (f forms)
+    (unless (or (consp f) (%cut-symbol-p f ctx))
+      (%refuse "~A is not a goal; a goal is a parenthesised form"
+               (%term-label f))))
+  (let ((goals (mapcar (lambda (f) (%guard-term f ctx)) forms)))
+    (let ((vars (reverse (gc-vars ctx))))
+      (unless vars
+        (%refuse "the query binds no ?variables, so it can return no ~
+columns"))
+      (values vars goals))))
+
+(defun %prolog-functor-names ()
+  "Every predicate a free-text query may name, in the wire's kebab
+spelling: the registered functors plus the control constructs.  Feeds
+the editor's overlay mode, which dims a head it does not know here."
+  (let ((names '()))
+    (maphash (lambda (key pkg)
+               (declare (ignore pkg))
+               (pushnew (string-downcase (car key)) names :test #'string=))
+             (%functor-whitelist))
+    (maphash (lambda (name sym)
+               (declare (ignore sym))
+               (pushnew (string-downcase name) names :test #'string=))
+             (%control-word-table))
+    (sort names #'string<)))
+
+(defun %non-finite-p (x)
+  "True for a float that is not a finite number.  A comparison that
+itself signals counts too: this feeds a refusal screen (GH #309)."
+  (and (floatp x)
+       (handler-case
+           (let ((most (etypecase x
+                         (single-float most-positive-single-float)
+                         (double-float most-positive-double-float)
+                         (short-float most-positive-short-float)
+                         (long-float most-positive-long-float))))
+             (or (/= x x) (> x most) (< x (- most))))
+         (arithmetic-error () t))))
+
+(defun %screen-non-finite (form)
+  "Refuse FORM if any float in it is non-finite.  Not every reader
+rejects an overflowing literal: ECL reads 1e999999 as infinity, which
+would sail past the read guard and 500 at JSON encoding (GH #309)."
+  (cond ((consp form)
+         (%screen-non-finite (car form))
+         (%screen-non-finite (cdr form)))
+        ((%non-finite-p form)
+         (%refuse "the query could not be read: check the quoting and ~
+the numeric literals"))))
+
+(defun %read-guarded-forms (text scratch ctx)
+  "TEXT screened, read into SCRATCH, and guarded through CTX -- steps 2,
+3 and 4 in order.  The screen runs FIRST and on the raw characters:
+once READ has resolved a package-qualified name the interning it was
+meant to prevent has already happened.  Every way READ can fail is a
+refusal, so a malformed query is a 400 and never a 500."
+  (%scan-query-text text)
+  (let ((forms (handler-case (%read-query-forms text scratch)
+                 (prolog-guard-error (c) (error c))
+                 (end-of-file ()
+                   (%refuse "the query ends mid-form: unbalanced ~
+parentheses or an unterminated string"))
+                 ;; A reader condition's report is raw implementation
+                 ;; text (SBCL spells out its internal reader-error
+                 ;; classes), so it is logged, not echoed.  1/0 and (on
+                 ;; SBCL) 1e999999 land here; a reader that instead
+                 ;; produces infinity is caught by %SCREEN-NON-FINITE
+                 ;; below (GH #309).
+                 (error (c)
+                   (log:error "GUI prolog: unreadable query: ~A" c)
+                   (%refuse "the query could not be read: check the ~
+quoting and the numeric literals")))))
+    (%screen-non-finite forms)
+    (%guard-query forms ctx)))
+
+(defvar *no-applicable-method-type*
+  (or #+sbcl (find-symbol "NO-APPLICABLE-METHOD-ERROR" "SB-PCL")
+      #+ccl (find-symbol "NO-APPLICABLE-METHOD-EXISTS" "CCL")
+      nil)
+  "The implementation's condition class for a generic function called
+with arguments no method matches, or NIL where it has none.  ANSI
+defines the NO-APPLICABLE-METHOD generic but no condition class, so
+this is looked up by name once at load.  Belt-and-suspenders since GH
+#309: the three whitelisted read generics define their own
+NO-APPLICABLE-METHOD methods signalling QUERY-PRECONDITION-ERROR, which
+%ILL-TYPED-CONDITION-P admits on every implementation -- necessary
+because ECL has no distinct class here (it signals a bare SIMPLE-ERROR,
+which is deliberately a 500).")
+
+(defun %ill-typed-condition-p (c)
+  "True when C is a shape that CLIENT INPUT is known to produce, as
+opposed to an engine defect.  The two were MEASURED against the
+whitelisted read functors, not assumed (GH #279):
+
+  NO-APPLICABLE-METHOD -- an unbound Prolog variable reaching a generic
+    that dispatches on node classes: (outgoing-edges ?a ?b),
+    (incoming-edges ?a ?b), (invoke-view ?a ?b ?c ?d).
+
+  QUERY-PRECONDITION-ERROR -- how the query layer reports a failed
+    precondition it checked on purpose: \"No secondary index on ?2.?3
+    in :G\" for (find-by-slot ?a ?b ?c ?d), and the not-spatially-indexed
+    report from %RESOLVE-SPATIAL-SCOPE for (find-nearest ?n some-type
+    0 0 5).  Both were SIMPLE-ERRORs before GH #286.
+
+TYPE-ERROR and UNBOUND-VARIABLE are deliberately NOT here, though they
+are the obvious guesses.  No client input produced either: the read
+functors guard with NUMBERP / NODE-P and simply fail instead of
+signalling.  A TYPE-ERROR is instead the classic shape of a real defect
+-- a NIL where a struct was expected -- so admitting it would relabel
+exactly the fault this split exists to surface.
+
+Since GH #286 the engine signals those preconditions as
+QUERY-PRECONDITION-ERROR, so that class is what is admitted here; a
+plain SIMPLE-ERROR -- an internal (error \"...\") or a failed ASSERT --
+is a defect again and answers 500, which closes the residual the first
+cut recorded."
+  (or (typep c 'graph-db:query-precondition-error)
+      (and *no-applicable-method-type*
+           (typep c *no-applicable-method-type*))))

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -666,7 +666,7 @@ passed -- each head resolves in its own package (GH #322)."
                                             (format :data))
   "Screen, read, guard and run TEXT against GRAPH; (VALUES COLUMNS ROWS
 TRUNCATED-P).  COLUMNS are the variables in first-appearance order as
-downcased wire strings; ROWS one list per solution, cells JSON-shaped
+camelCase wire spelling; ROWS one list per solution, cells JSON-shaped
 under :DATA (a node is its id string; strings, numbers, T, NIL pass) or
 as bound under :RAW.  LIMIT is clamped to *QUERY-DEFAULT-LIMIT*;
 MAX-INFERENCES and TIMEOUT bind the DSL's budgets for this call.

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -28,7 +28,8 @@
 ;;;;      (GH #322).
 ;;;;   6. DELETE-PACKAGE     -- in an UNWIND-PROTECT, so a hostile
 ;;;;      query's symbols leave with the request that made them.
-;;;;      %RUN-GUARDED-PROLOG, which does this, also stays there.
+;;;;      RUN-GUARDED-PROLOG, which does this, is also in this file;
+;;;;      only step 1's flag check stays in gui/prolog.lisp.
 ;;;;
 ;;;; The interning subtlety (issue text, utilities.lisp:155):
 ;;;; MAKE-FUNCTOR-SYMBOL calls NEW-INTERNED-SYMBOL, so building

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -38,9 +38,10 @@
 ;;;; registries and compares NAMES AS STRINGS; nothing derived from the
 ;;;; request is ever interned into GRAPH-DB or the schema package.
 ;;;;
-;;;; Home: graph-db/query (GH #322) -- the guard (steps 2-4).  The
-;;;; GUI runner and its envelope (steps 1, 5, 6) stay in
-;;;; gui/prolog.lisp, which calls this file's internals qualified.
+;;;; Home: graph-db/query (GH #322) -- steps 2 through 6, including
+;;;; RUN-GUARDED-PROLOG.  Only step 1's flag and the HTTP envelope
+;;;; around a call into this file stay in gui/prolog.lisp, which
+;;;; calls this file's exports qualified.
 
 (in-package #:graph-db.query)
 

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -23,7 +23,9 @@
 ;;;;      slot of THIS graph, a ?variable, or T/NIL.
 ;;;;   5. RUN-QUERY-GOALS    -- query-dsl.lisp's own runner: :EFFECTS
 ;;;;      NIL, one snapshot, the inference/time/row bounds.  Reached
-;;;;      through %RUN-GUARDED-QUERY, which stays in gui/prolog.lisp.
+;;;;      through %RUN-GUARDED-GOALS in this file.  Goal heads resolve
+;;;;      each in its own package now, not one shared :PACKAGE
+;;;;      (GH #322).
 ;;;;   6. DELETE-PACKAGE     -- in an UNWIND-PROTECT, so a hostile
 ;;;;      query's symbols leave with the request that made them.
 ;;;;      %RUN-GUARDED-PROLOG, which does this, also stays there.
@@ -636,35 +638,14 @@ cut recorded."
 is no room, so an exactly-full page reads as truncated (GH #278)."
   (if (< cap graph-db::*query-default-limit*) (1+ cap) cap))
 
-(defun %guarded-run-package (graph)
-  "The package a guarded goal list's heads canonicalize in.
-
-Single-package resolution: COMPILE-CALL interns NAME/ARITY in
-*PACKAGE*, so one binding must cover every head in the goal list.
-GRAPH's schema package (edge functors are installed there, GH #172) is
-used when it :USES GRAPH-DB -- then a GRAPH-DB global head still
-resolves, by inheritance, alongside the schema's own edge functors,
-exactly as the GUI's former %SCHEMA-PACKAGE ran.  A schema declared
-:USE NOTHING (spec SS6) cannot inherit, so GRAPH-DB is used instead:
-its own globals resolve, an edge functor from that schema does not --
-the gap Task 4's head resolution closes (GH #279, #322)."
-  (let* ((types (append (schema-type-names graph :vertex)
-                        (schema-type-names graph :edge)))
-         (schema-pkg (and types (symbol-package (first types)))))
-    (if (and schema-pkg
-             (member (find-package :graph-db)
-                     (package-use-list schema-pkg)))
-        schema-pkg
-        (find-package :graph-db))))
-
 (defun %run-guarded-goals (vars goals graph probe)
   "The already-guarded query's rows, RAW, at most PROBE of them, with
-the GUI's three-way condition contract (GH #279)."
+the GUI's three-way condition contract (GH #279).  No :PACKAGE is
+passed -- each head resolves in its own package (GH #322)."
   (handler-case
       (let ((rows '()))
         (graph-db::run-query-goals
          vars goals graph :limit probe :format :raw
-         :package (%guarded-run-package graph)
          :callback (lambda (row) (push row rows)))
         (nreverse rows))
     (graph-db:prolog-error (c) (error c))

--- a/query/guard.lisp
+++ b/query/guard.lisp
@@ -621,3 +621,94 @@ cut recorded."
   (or (typep c 'graph-db:query-precondition-error)
       (and *no-applicable-method-type*
            (typep c *no-applicable-method-type*))))
+
+;;; ---------------------------------------------------------------------
+;;; Step 5-6: the runner, exported (spec SS4, GH #322)
+;;; ---------------------------------------------------------------------
+
+(defun %clamp-cap (limit)
+  (if (and (integerp limit) (plusp limit))
+      (min limit graph-db::*query-default-limit*)
+      graph-db::*query-default-limit*))
+
+(defun %probe (cap)
+  "One past CAP tells truncated from exactly full; at the ceiling there
+is no room, so an exactly-full page reads as truncated (GH #278)."
+  (if (< cap graph-db::*query-default-limit*) (1+ cap) cap))
+
+(defun %guarded-run-package (graph)
+  "The package a guarded goal list's heads canonicalize in.
+
+Single-package resolution: COMPILE-CALL interns NAME/ARITY in
+*PACKAGE*, so one binding must cover every head in the goal list.
+GRAPH's schema package (edge functors are installed there, GH #172) is
+used when it :USES GRAPH-DB -- then a GRAPH-DB global head still
+resolves, by inheritance, alongside the schema's own edge functors,
+exactly as the GUI's former %SCHEMA-PACKAGE ran.  A schema declared
+:USE NOTHING (spec SS6) cannot inherit, so GRAPH-DB is used instead:
+its own globals resolve, an edge functor from that schema does not --
+the gap Task 4's head resolution closes (GH #279, #322)."
+  (let* ((types (append (schema-type-names graph :vertex)
+                        (schema-type-names graph :edge)))
+         (schema-pkg (and types (symbol-package (first types)))))
+    (if (and schema-pkg
+             (member (find-package :graph-db)
+                     (package-use-list schema-pkg)))
+        schema-pkg
+        (find-package :graph-db))))
+
+(defun %run-guarded-goals (vars goals graph probe)
+  "The already-guarded query's rows, RAW, at most PROBE of them, with
+the GUI's three-way condition contract (GH #279)."
+  (handler-case
+      (let ((rows '()))
+        (graph-db::run-query-goals
+         vars goals graph :limit probe :format :raw
+         :package (%guarded-run-package graph)
+         :callback (lambda (row) (push row rows)))
+        (nreverse rows))
+    (graph-db:prolog-error (c) (error c))
+    (graph-db:query-param-error (c) (error c))
+    (error (c)
+      (cond ((%ill-typed-condition-p c)
+             (log:error "query guard: ill-typed query (~S): ~A"
+                        (type-of c) c)
+             (error 'prolog-ill-typed-error))
+            (t
+             (log:error "query guard: UNEXPECTED SERVER FAULT (~S): ~A"
+                        (type-of c) c)
+             (error 'prolog-server-fault))))))
+
+(defun run-guarded-prolog (text graph &key limit max-inferences timeout
+                                            (format :data))
+  "Screen, read, guard and run TEXT against GRAPH; (VALUES COLUMNS ROWS
+TRUNCATED-P).  COLUMNS are the variables in first-appearance order as
+downcased wire strings; ROWS one list per solution, cells JSON-shaped
+under :DATA (a node is its id string; strings, numbers, T, NIL pass) or
+as bound under :RAW.  LIMIT is clamped to *QUERY-DEFAULT-LIMIT*;
+MAX-INFERENCES and TIMEOUT bind the DSL's budgets for this call.
+Refusals signal PROLOG-GUARD-ERROR; see the header for the rest of the
+condition contract (spec SS4, GH #322)."
+  (check-type format (member :data :raw))
+  (let* ((scratch (%make-scratch-package))
+         (cap (%clamp-cap limit))
+         (probe (%probe cap))
+         (graph-db::*query-default-max-inferences*
+           (or max-inferences graph-db::*query-default-max-inferences*))
+         (graph-db::*query-default-timeout*
+           (or timeout graph-db::*query-default-timeout*)))
+    (unwind-protect
+         (multiple-value-bind (vars goals)
+             (%read-guarded-forms text scratch (%guard-context graph scratch))
+           (let* ((rows (%run-guarded-goals vars goals graph probe))
+                  (n (length rows))
+                  (truncated (if (> probe cap) (> n cap) (>= n cap)))
+                  (shown (if (> n cap) (subseq rows 0 cap) rows)))
+             (values (mapcar #'graph-db::%query-var-field vars)
+                     (if (eq format :data)
+                         (mapcar (lambda (row)
+                                   (mapcar #'graph-db::%query-value->json row))
+                                 shown)
+                         shown)
+                     (and truncated t))))
+      (delete-package scratch))))

--- a/query/package.lisp
+++ b/query/package.lisp
@@ -1,0 +1,12 @@
+;;;; query/package.lisp -- the web-free guarded query subsystem (GH #322).
+
+(defpackage #:graph-db.query
+  (:use #:cl)
+  (:export
+   ;; conditions (spec SS3)
+   #:prolog-guard-error #:prolog-guard-error-reason
+   #:prolog-ill-typed-error #:prolog-server-fault
+   ;; the screen's limits
+   #:*prolog-max-query-length* #:*prolog-max-depth*
+   ;; schema names, shared with the GUI
+   #:schema-type-names))

--- a/query/package.lisp
+++ b/query/package.lisp
@@ -9,4 +9,6 @@
    ;; the screen's limits
    #:*prolog-max-query-length* #:*prolog-max-depth*
    ;; schema names, shared with the GUI
-   #:schema-type-names))
+   #:schema-type-names
+   ;; the runner (spec SS4, GH #322)
+   #:run-guarded-prolog))

--- a/rest.lisp
+++ b/rest.lisp
@@ -426,8 +426,7 @@ A malformed query or a resource-bound breach is a 400, a forbidden effect a 403.
   (with-rest-auth ((get-param params "username") (get-param params "password"))
     (with-rest-graph ((get-param params :graph-name))
       ;; The DSL renders ndjson; the wire header is HTTP's (GH #322).
-      (when (string-equal "ndjson"
-                          (princ-to-string (or (cdr (assoc :format dsl)) "")))
+      (when (%dsl-ndjson-p dsl)
         (setf (lack.response:response-headers ningle:*response*)
               (list* :content-type "application/x-ndjson"
                      (lack.response:response-headers ningle:*response*))))

--- a/rest.lisp
+++ b/rest.lisp
@@ -81,6 +81,14 @@ request alist REQ-PARAMS, coercing each value to its declared type."
       :ndjson
       :json))
 
+(defun %set-ndjson-content-type ()
+  "Mark NINGLE:*RESPONSE* as newline-delimited JSON (GH #322).  Both
+/query and DEF-QUERY's route call this once their query has produced
+its text, so an error body is never labelled ndjson."
+  (setf (lack.response:response-headers ningle:*response*)
+        (list* :content-type "application/x-ndjson"
+               (lack.response:response-headers ningle:*response*))))
+
 (defun register-query (name fn)
   "Register query handler FN under NAME (both its symbol name and camelCase)."
   (setf (gethash (string name) *rest-queries*) fn)
@@ -348,11 +356,16 @@ the declared parameters."
     `(register-query ',name
        (lambda (req-params)
          (handler-case
-             (let ((*query-params* (coerce-query-params ',params req-params)))
-               ;; stream rows through the callback; :json buffers an array,
-               ;; :ndjson writes one JSON object per line
-               (emit-query-results ',return (query-format req-params)
-                                   (lambda (,cb) ,run-form)))
+             (let* ((*query-params* (coerce-query-params ',params req-params))
+                    (fmt (query-format req-params))
+                    ;; stream rows through the callback; :json buffers an
+                    ;; array, :ndjson writes one JSON object per line
+                    (result (emit-query-results ',return fmt
+                                                (lambda (,cb) ,run-form))))
+               ;; Set once the query has produced its text (GH #322), so
+               ;; an error body is never labelled ndjson.
+               (when (eq fmt :ndjson) (%set-ndjson-content-type))
+               result)
            ;; QUERY-PARAM-ERROR is a subclass, so one clause covers the
            ;; DSL's own refusals and the engine's typed preconditions --
            ;; an unindexed slot, an unscoped spatial class (GH #286).
@@ -426,11 +439,12 @@ A malformed query or a resource-bound breach is a 400, a forbidden effect a 403.
   (with-rest-auth ((get-param params "username") (get-param params "password"))
     (with-rest-graph ((get-param params :graph-name))
       ;; The DSL renders ndjson; the wire header is HTTP's (GH #322).
-      (when (%dsl-ndjson-p dsl)
-        (setf (lack.response:response-headers ningle:*response*)
-              (list* :content-type "application/x-ndjson"
-                     (lack.response:response-headers ningle:*response*))))
-      (handler-case (run-pattern-query dsl *graph*)
+      ;; Set only once the query has produced its text, so a refused
+      ;; or errored query never gets an ndjson-labelled error body.
+      (handler-case
+          (let ((result (run-pattern-query dsl *graph*)))
+            (when (%dsl-ndjson-p dsl) (%set-ndjson-content-type))
+            result)
         ;; Includes QUERY-PARAM-ERROR, its subclass (GH #286).
         (query-precondition-error (c)
           (setf (lack.response:response-status ningle:*response*) 400)

--- a/rest.lisp
+++ b/rest.lisp
@@ -419,7 +419,7 @@ handlers turn ERROR-STRING into their :error JSON (GH #190)."
 ;;; ---------------------------------------------------------------------------
 ;;; Ad-hoc JSON pattern queries (#44, tier 2): the HTTP wrappers only.  The DSL
 ;;; itself -- COMPILE-PATTERN-QUERY / RUN-PATTERN-QUERY / EMIT-QUERY-RESULTS and
-;;; the shape it accepts -- moved to query-dsl.lisp, which the GUI workbench
+;;; the shape it accepts -- moved to query/dsl.lisp, which the GUI workbench
 ;;; compiles through as well (GH #278).
 ;;; ---------------------------------------------------------------------------
 

--- a/rest.lisp
+++ b/rest.lisp
@@ -425,6 +425,12 @@ bogus field per request (GH #284)."
 A malformed query or a resource-bound breach is a 400, a forbidden effect a 403."
   (with-rest-auth ((get-param params "username") (get-param params "password"))
     (with-rest-graph ((get-param params :graph-name))
+      ;; The DSL renders ndjson; the wire header is HTTP's (GH #322).
+      (when (string-equal "ndjson"
+                          (princ-to-string (or (cdr (assoc :format dsl)) "")))
+        (setf (lack.response:response-headers ningle:*response*)
+              (list* :content-type "application/x-ndjson"
+                     (lack.response:response-headers ningle:*response*))))
       (handler-case (run-pattern-query dsl *graph*)
         ;; Includes QUERY-PARAM-ERROR, its subclass (GH #286).
         (query-precondition-error (c)

--- a/tests/gui/gui-tests.lisp
+++ b/tests/gui/gui-tests.lisp
@@ -1794,9 +1794,20 @@ shape of GH #172, where DEF-EDGE installs NAME/2 and NAME/3 into
 nothing, so a symbol interned here is genuinely foreign, exactly as a
 real operator schema's would be.")
 
+(defvar *foreign-schema-functor-fired-p* nil
+  "Set by WITH-FOREIGN-SCHEMA-FUNCTOR's stub when the schema-homed
+functor actually runs.  A plain global, mutated with SETF rather than
+bound with LET: the GUI server answers on its own worker thread, which
+does not see a dynamic binding made on the test's thread (GH #322,
+review round 2).")
+
 (defmacro with-foreign-schema-functor ((name arity) &body body)
   "Register NAME/ARITY in *PROLOG-GLOBAL-FUNCTORS* homed in
-*FOREIGN-SCHEMA-PACKAGE*, run BODY, then remove it.
+*FOREIGN-SCHEMA-PACKAGE*, run BODY, then remove it.  Resets
+*FOREIGN-SCHEMA-FUNCTOR-FIRED-P* to NIL first; the stub sets it T when
+called (it never calls its continuation, so the goal still fails) --
+direct proof, inside BODY, of whether resolution reached the schema's
+own functor rather than GRAPH-DB's.
 
 Registered and removed inside one test, so
 PROLOG-FUNCTOR-INVENTORY-IS-PINNED -- which pins the registry's key set
@@ -1804,10 +1815,14 @@ PROLOG-FUNCTOR-INVENTORY-IS-PINNED -- which pins the registry's key set
   (let ((key (gensym "KEY")))
     `(let ((,key (intern (format nil "~A/~D" (string-upcase ,name) ,arity)
                          *foreign-schema-package*)))
+       (setf *foreign-schema-functor-fired-p* nil)
        (unwind-protect
             (progn
               (setf (gethash ,key graph-db::*prolog-global-functors*)
-                    (lambda (&rest args) (declare (ignore args)) nil))
+                    (lambda (&rest args)
+                      (declare (ignore args))
+                      (setf *foreign-schema-functor-fired-p* t)
+                      nil))
               ,@body)
          (remhash ,key graph-db::*prolog-global-functors*)))))
 
@@ -1829,22 +1844,29 @@ now asks the same question the compiler will (GH #279)."
         ;; The data-driven shape the exclusion exists for, refused too.
         (is-true
          (refused-p "(is-a ?p gui-person) (node-slot-value ?p name ?g)
-                     (call ?g ?x)")))
+                     (call ?g ?x)"))
+        ;; Refused before the engine ever calls it -- the schema's own
+        ;; CALL/2 never ran, direct proof this is a routing refusal.
+        (is-false *foreign-schema-functor-fired-p*
+                  "the excluded name still reached the schema's own ~
+functor"))
       ;; ...and the home-scoping stays intact at THIS layer: a schema
       ;; that owns the name is admitted past the whitelist, and (GH
       ;; #322) now resolves in ITS OWN package -- the schema's stub
       ;; runs, not the engine's REGEX-MATCH/2, so the ReDoS the
       ;; exclusion category exists for never reaches the engine's real
-      ;; implementation.  The stub ignores its args and never calls
-      ;; its continuation, so the query succeeds with zero rows; that
-      ;; (not a refusal) is the proof the schema's own functor ran.
+      ;; implementation.  *FOREIGN-SCHEMA-FUNCTOR-FIRED-P* is the
+      ;; direct proof of which functor ran.
       (with-foreign-schema-functor ("REGEX-MATCH" 2)
-        (multiple-value-bind (json status)
-            (run-prolog "(is-a ?p gui-person) (regex-match \"a\" \"b\")")
+        (let ((status (nth-value
+                       1 (run-prolog
+                          "(is-a ?p gui-person) (regex-match \"a\" \"b\")"))))
           (is (= 200 status))
-          (is (= 0 (jref json :row-count)))
-          (is-false (jref json :error)
-                    "a successful query must not carry an :error")))
+          ;; Direct proof, not just the shape of a non-refusal: the
+          ;; schema's own stub is what actually ran, not a refusal and
+          ;; not the engine's REGEX-MATCH/2.
+          (is-true *foreign-schema-functor-fired-p*
+                   "the schema's own functor never ran")))
       ;; Without that registration the engine's own one is still out.
       (is-true (refused-p "(regex-match \"a\" \"b\")"))
       ;; ...and the fixture's real edge functor is untouched.

--- a/tests/gui/gui-tests.lisp
+++ b/tests/gui/gui-tests.lisp
@@ -1031,7 +1031,9 @@ be refused -- the screen refuses syntax, not text (GH #279)."
                        (node-slot-value ?p name \"#.(cl:print 1)\")")
         (is (= 200 status))
         (is (= 0 (jref json :row-count))
-            "the literal matched something; it should match nothing"))
+            "the literal matched something; it should match nothing")
+        ;; A zero-row answer still names its columns (#322), not [].
+        (is (equal '("p") (jref json :columns))))
       ;; ...and one that DOES match, so the literal really is compared.
       (multiple-value-bind (json status)
           (run-prolog "(is-a ?p gui-person)

--- a/tests/gui/gui-tests.lisp
+++ b/tests/gui/gui-tests.lisp
@@ -1831,24 +1831,20 @@ now asks the same question the compiler will (GH #279)."
          (refused-p "(is-a ?p gui-person) (node-slot-value ?p name ?g)
                      (call ?g ?x)")))
       ;; ...and the home-scoping stays intact at THIS layer: a schema
-      ;; that owns the name is admitted past the whitelist.  Since GH
-      ;; #285 the ENGINE then refuses it under the runner's resource
-      ;; bounds -- the compiler canonicalizes the head back into
-      ;; GRAPH-DB, so the admitted goal would EXECUTE the engine's
-      ;; regex-match/2, the very ReDoS the category exists for.  The
-      ;; proof of layering is the refusal's origin: the engine's
-      ;; cost-unbounded report, not the whitelist's routing message.
+      ;; that owns the name is admitted past the whitelist, and (GH
+      ;; #322) now resolves in ITS OWN package -- the schema's stub
+      ;; runs, not the engine's REGEX-MATCH/2, so the ReDoS the
+      ;; exclusion category exists for never reaches the engine's real
+      ;; implementation.  The stub ignores its args and never calls
+      ;; its continuation, so the query succeeds with zero rows; that
+      ;; (not a refusal) is the proof the schema's own functor ran.
       (with-foreign-schema-functor ("REGEX-MATCH" 2)
-        (multiple-value-bind (ok message)
-            (refused-p "(is-a ?p gui-person) (regex-match \"a\" \"b\")"
-                       :code "cost-unbounded-goal")
-          (is-true ok "the engine rails admitted an unboundable goal")
-          (is-true (search "cost-unbounded" message)
-                   "refused at the wrong layer -- expected the engine's ~
-#285 report, got: ~A" message)
-          (is (null (search "control macro" message))
-              "the whitelist refused it; home-scoping was undone: ~A"
-              message)))
+        (multiple-value-bind (json status)
+            (run-prolog "(is-a ?p gui-person) (regex-match \"a\" \"b\")")
+          (is (= 200 status))
+          (is (= 0 (jref json :row-count)))
+          (is-false (jref json :error)
+                    "a successful query must not carry an :error")))
       ;; Without that registration the engine's own one is still out.
       (is-true (refused-p "(regex-match \"a\" \"b\")"))
       ;; ...and the fixture's real edge functor is untouched.

--- a/tests/prolog-functor-tests.lisp
+++ b/tests/prolog-functor-tests.lisp
@@ -351,23 +351,40 @@ with :allow-cost-unbounded t, the goal runs as before."
 ;;; Head resolution (#322, second finding): a functor DEFINED with <- in
 ;;; a package that does not use GRAPH-DB still lands on that package's
 ;;; own NAME/ARITY symbol, via the :DEFINE T argument ADD-CLAUSE passes
-;;; MAKE-FUNCTOR-SYMBOL -- not on an existing GRAPH-DB functor.
+;;; MAKE-FUNCTOR-SYMBOL -- not on an existing GRAPH-DB functor.  The head
+;;; is =/2, a name GRAPH-DB already registers globally (see
+;;; PROLOG-FUNCTORS.LISP's DEF-GLOBAL-PROLOG-FUNCTOR =/2), so the
+;;; collision the fix must avoid is actually exercised.
 ;;; ---------------------------------------------------------------------------
 
 (defpackage #:graph-db/test.define-probe (:use #:cl))
 
 (test define-in-a-package-that-does-not-use-graph-db
   "<- in a package that does not use GRAPH-DB defines its own NAME/ARITY
-symbol there, not a same-named GRAPH-DB functor (#322)."
-  (let ((pkg (find-package "GRAPH-DB/TEST.DEFINE-PROBE")))
-    ;; GRAPH-DB::<- itself must be qualified to be called at all from
-    ;; a package that uses nothing; only the clause body (head, ?x)
-    ;; reads into PKG, which is the case this test exists for.
-    (let ((*package* pkg))
-      (eval (read-from-string "(graph-db::<- (probe-322-fact ?x) (= ?x 1))")))
-    (let ((own (find-symbol "PROBE-322-FACT/1" pkg)))
-      (is-true own "the clause's functor symbol is not in its own package")
-      (is-true (graph-db::lookup-functor own)
-               "the clause did not register under its own package's symbol"))
-    (is (null (find-symbol "PROBE-322-FACT/1" (find-package :graph-db)))
-        "GRAPH-DB must not have interned a symbol for this functor")))
+symbol there, even though =/2 already names a GRAPH-DB global functor:
+the clause lands on the probe package's own =/2, and GRAPH-DB::=/2
+gains no user clause and stays the registered global (#322)."
+  (let ((pkg (find-package "GRAPH-DB/TEST.DEFINE-PROBE"))
+        (own nil))
+    (unwind-protect
+        (progn
+          ;; GRAPH-DB::<- itself must be qualified to be called at all
+          ;; from a package that uses nothing; only the clause body
+          ;; (head, ?x) reads into PKG, which is the case this test
+          ;; exists for.
+          (let ((*package* pkg))
+            (eval (read-from-string "(graph-db::<- (= ?x ?x))")))
+          (setq own (find-symbol "=/2" pkg))
+          (is-true own "the clause's functor symbol is not in its own package")
+          (is-true (not (eq own 'graph-db::=/2))
+                   "the probe's =/2 must not be GRAPH-DB's own symbol")
+          (is-true (graph-db::lookup-functor own)
+                   "the clause did not register under its own package's symbol")
+          (is (null (graph-db::lookup-functor 'graph-db::=/2))
+              "GRAPH-DB::=/2 must not have picked up a user clause")
+          (is-true (nth-value 1 (gethash 'graph-db::=/2
+                                          graph-db::*prolog-global-functors*))
+                   "GRAPH-DB::=/2 must remain the registered global functor"))
+      (when (and own (graph-db::lookup-functor own))
+        (graph-db::delete-functor (graph-db::lookup-functor own)))
+      (when pkg (delete-package pkg)))))

--- a/tests/prolog-functor-tests.lisp
+++ b/tests/prolog-functor-tests.lisp
@@ -346,3 +346,28 @@ with :allow-cost-unbounded t, the goal runs as before."
                (quote graph-db::regex-match) 2)))
     (is (member "REGEX-MATCH" (graph-db:cost-unbounded-predicate-names)
                 :test #'string=))))
+
+;;; ---------------------------------------------------------------------------
+;;; Head resolution (#322, second finding): a functor DEFINED with <- in
+;;; a package that does not use GRAPH-DB still lands on that package's
+;;; own NAME/ARITY symbol, via the :DEFINE T argument ADD-CLAUSE passes
+;;; MAKE-FUNCTOR-SYMBOL -- not on an existing GRAPH-DB functor.
+;;; ---------------------------------------------------------------------------
+
+(defpackage #:graph-db/test.define-probe (:use #:cl))
+
+(test define-in-a-package-that-does-not-use-graph-db
+  "<- in a package that does not use GRAPH-DB defines its own NAME/ARITY
+symbol there, not a same-named GRAPH-DB functor (#322)."
+  (let ((pkg (find-package "GRAPH-DB/TEST.DEFINE-PROBE")))
+    ;; GRAPH-DB::<- itself must be qualified to be called at all from
+    ;; a package that uses nothing; only the clause body (head, ?x)
+    ;; reads into PKG, which is the case this test exists for.
+    (let ((*package* pkg))
+      (eval (read-from-string "(graph-db::<- (probe-322-fact ?x) (= ?x 1))")))
+    (let ((own (find-symbol "PROBE-322-FACT/1" pkg)))
+      (is-true own "the clause's functor symbol is not in its own package")
+      (is-true (graph-db::lookup-functor own)
+               "the clause did not register under its own package's symbol"))
+    (is (null (find-symbol "PROBE-322-FACT/1" (find-package :graph-db)))
+        "GRAPH-DB must not have interned a symbol for this functor")))

--- a/tests/query/guard-tests.lisp
+++ b/tests/query/guard-tests.lisp
@@ -1,0 +1,92 @@
+;;;; tests/query/guard-tests.lisp -- RUN-GUARDED-PROLOG (GH #322).
+;;;;
+;;;; Type/slot names are bare, never keyword-spelled ("qt-item", not
+;;;; ":qt-item"): %SCAN-QUERY-TEXT refuses any ':' outright (query/
+;;;; guard.lisp), the same rule tests/gui/gui-tests.lisp's Prolog
+;;;; tests already rely on.
+
+(in-package #:graph-db/query-test)
+(in-suite query-suite)
+
+(defun q (g text &rest keys)
+  (apply #'graph-db.query:run-guarded-prolog text g keys))
+
+(test data-rows-are-json-shaped
+  (with-query-graph (g)
+    (seed g)
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i qt-item) (node-slot-value ?i label ?l)")
+      (is (equal '("i" "l") columns))
+      (is (= 3 (length rows)))
+      (is (every (lambda (row) (and (stringp (first row))
+                                    (stringp (second row))))
+                 rows))
+      (is (equal '("a" "b" "c") (sort (mapcar #'second rows) #'string<)))
+      (is (null truncated)))))
+
+(test raw-rows-carry-nodes
+  (with-query-graph (g)
+    (seed g)
+    (let ((rows (nth-value 1 (q g "(is-a ?i qt-item)" :format :raw))))
+      (is (every (lambda (row) (graph-db::node-p (first row))) rows)))))
+
+(test limit-clamps-and-flags-truncation
+  (with-query-graph (g)
+    (seed g)
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i qt-item)" :limit 2)
+      (declare (ignore columns))
+      (is (= 2 (length rows)))
+      (is (eq t truncated)))
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i qt-item)" :limit 3)
+      (declare (ignore columns))
+      (is (= 3 (length rows)))
+      (is (null truncated)))))
+
+(test each-screened-token-is-refused-and-its-absence-accepted
+  (with-query-graph (g)
+    (seed g)
+    (dolist (pair '(("(is-a ?i graph-db::qt-item)" . "(is-a ?i qt-item)")
+                    ("(is-a ?i #.(quit))" . "(is-a ?i qt-item)")
+                    ("(is-a ?i `x)" . "(is-a ?i qt-item)")
+                    ("(is-a ?i ,x)" . "(is-a ?i qt-item)")
+                    ("(is-a ?i qt-item" . "(is-a ?i qt-item)")))
+      (signals graph-db.query:prolog-guard-error (q g (car pair)))
+      (finishes (q g (cdr pair))))))
+
+(test unregistered-functor-and-string-head-refused
+  (with-query-graph (g)
+    (signals graph-db.query:prolog-guard-error (q g "(no-such-thing ?x)"))
+    (signals graph-db.query:prolog-guard-error
+      (q g "(\"is-a\" ?x qt-item)"))
+    (signals graph-db.query:prolog-guard-error (q g "(lisp ?x (quit))"))))
+
+(test an-inference-budget-breach-is-a-resource-error
+  (with-query-graph (g)
+    (seed g)
+    (signals graph-db:prolog-resource-error
+      (q g "(is-a ?i qt-item) (is-a ?j qt-item) (is-a ?k qt-item)"
+         :max-inferences 2))))
+
+(test the-scratch-package-is-gone-afterwards
+  (with-query-graph (g)
+    (seed g)
+    (let ((before (length (list-all-packages))))
+      (q g "(is-a ?i qt-item)")
+      (ignore-errors (q g "(is-a ?i #.(quit))"))
+      (is (= before (length (list-all-packages)))))))
+
+(test edge-and-global-functors-resolve-in-one-goal-list
+  "Spec SS6: the schema package uses nothing, so before the
+head-resolution change QT-LINKS/2 could not be found from GRAPH-DB's
+package nor IS-A/2 from the schema's."
+  (with-query-graph (g)
+    (destructuring-bind (a b c) (seed g)
+      (declare (ignore c))
+      (multiple-value-bind (columns rows)
+          (q g "(is-a ?x qt-item) (qt-links ?x ?y)")
+        (is (equal '("x" "y") columns))
+        (is (= 2 (length rows)))
+        (is (member (list (string-id a) (string-id b)) rows
+                    :test #'equal))))))

--- a/tests/query/guard-tests.lisp
+++ b/tests/query/guard-tests.lisp
@@ -15,13 +15,16 @@
   (with-query-graph (g)
     (seed g)
     (multiple-value-bind (columns rows truncated)
-        (q g "(is-a ?i qt-item) (node-slot-value ?i label ?l)")
-      (is (equal '("i" "l") columns))
+        (q g "(is-a ?i qt-item) (node-slot-value ?i label ?l)
+              (node-slot-value ?i rank ?r)")
+      (is (equal '("i" "l" "r") columns))
       (is (= 3 (length rows)))
       (is (every (lambda (row) (and (stringp (first row))
-                                    (stringp (second row))))
+                                    (stringp (second row))
+                                    (integerp (third row))))
                  rows))
       (is (equal '("a" "b" "c") (sort (mapcar #'second rows) #'string<)))
+      (is (equal '(1 2 3) (sort (mapcar #'third rows) #'<)))
       (is (null truncated)))))
 
 (test raw-rows-carry-nodes
@@ -40,6 +43,18 @@
       (is (eq t truncated)))
     (multiple-value-bind (columns rows truncated)
         (q g "(is-a ?i qt-item)" :limit 3)
+      (declare (ignore columns))
+      (is (= 3 (length rows)))
+      (is (null truncated)))
+    ;; :LIMIT 5000 clamps to the 1000 ceiling (%CLAMP-CAP), where
+    ;; %PROBE leaves no room for an extra row: TRUNCATED-P is NIL
+    ;; here because 3 rows is short of the 1000 cap -- (>= 3 1000) is
+    ;; NIL, not because being at the ceiling makes it NIL.  The other
+    ;; ceiling case, an EXACTLY-full 1000-row page reading TRUNCATED-P
+    ;; T, needs 1000 rows to seed and is documented (docs/guarded-
+    ;; query.md), not exercised here.
+    (multiple-value-bind (columns rows truncated)
+        (q g "(is-a ?i qt-item)" :limit 5000)
       (declare (ignore columns))
       (is (= 3 (length rows)))
       (is (null truncated)))))
@@ -69,13 +84,35 @@
       (q g "(is-a ?i qt-item) (is-a ?j qt-item) (is-a ?k qt-item)"
          :max-inferences 2))))
 
+(defun %scratch-package-names ()
+  "Names of every live scratch package RUN-GUARDED-PROLOG could have
+left behind, so a count check alone can't miss a leak masked by some
+unrelated package disappearing in the same window."
+  (remove-if-not (lambda (name)
+                    (and (>= (length name) 21)
+                         (string= name "GRAPH-DB.GUI.SCRATCH-"
+                                  :end1 21)))
+                  (mapcar #'package-name (list-all-packages))))
+
 (test the-scratch-package-is-gone-afterwards
   (with-query-graph (g)
     (seed g)
     (let ((before (length (list-all-packages))))
       (q g "(is-a ?i qt-item)")
       (ignore-errors (q g "(is-a ?i #.(quit))"))
-      (is (= before (length (list-all-packages)))))))
+      (is (= before (length (list-all-packages))))
+      (is (null (%scratch-package-names))
+          "a scratch package survived: ~S" (%scratch-package-names)))))
+
+(test hyphenated-variable-becomes-a-camelcase-column
+  "A ?hyphenated-name variable's column is its camelCase wire spelling
+(%QUERY-VAR-FIELD), same rule the DSL uses (GH #322)."
+  (with-query-graph (g)
+    (seed g)
+    (multiple-value-bind (columns rows)
+        (q g "(is-a ?i qt-item) (node-slot-value ?i label ?item-label)")
+      (declare (ignore rows))
+      (is (equal '("i" "itemLabel") columns)))))
 
 (test edge-and-global-functors-resolve-in-one-goal-list
   "Spec SS6: the schema package uses nothing, so before the

--- a/tests/query/package.lisp
+++ b/tests/query/package.lisp
@@ -1,0 +1,7 @@
+;;;; tests/query/package.lisp -- graph-db/query-test (GH #322).
+
+(defpackage #:graph-db/query-test
+  (:use #:cl #:fiveam)
+  (:import-from #:graph-db #:def-vertex #:def-edge #:make-graph
+                #:close-graph #:with-transaction #:string-id)
+  (:export #:run-query-tests #:query-suite))

--- a/tests/query/suite.lisp
+++ b/tests/query/suite.lisp
@@ -1,0 +1,59 @@
+;;;; tests/query/suite.lisp -- runner + fixture for graph-db/query
+;;;; (GH #322).
+
+(in-package #:graph-db/query-test)
+
+(def-suite query-suite
+  :description "The guarded query runner, called directly (GH #322).")
+
+(defun run-query-tests ()
+  "Run the suite; T when every check passed.  Invoked by
+(asdf:test-system :graph-db/query-test)."
+  (log:config :error)
+  (let* ((system-dir (graph-db-test-scratch:make-scratch-directory
+                      "graph-db-query-sys"))
+         (graph-db::*system-directory* (namestring system-dir))
+         (graph-db::*type-registry* nil))
+    (unwind-protect
+         (let ((results (run 'query-suite)))
+           (explain! results)
+           (results-status results))
+      (graph-db-test-scratch:cleanup-scratch-run))))
+
+;; A schema in a package that USES NOTHING: the case the head-resolution
+;; change (spec SS6) exists for.  Domain-neutral per repo policy #197.
+(defpackage #:graph-db/query-test.schema (:use))
+
+(defparameter *graph-name* :query-test-graph)
+
+(eval-when (:load-toplevel :execute)
+  (setf (gethash *graph-name* graph-db::*schema-node-metadata*) nil))
+
+(def-vertex graph-db/query-test.schema::qt-item ()
+  ((label :type string) (rank))
+  :query-test-graph)
+
+(def-edge graph-db/query-test.schema::qt-links ()
+  ()
+  :query-test-graph)
+
+(defmacro with-query-graph ((g) &body body)
+  `(let* ((dir (graph-db-test-scratch:make-scratch-directory
+               "graph-db-query"))
+          (,g (make-graph *graph-name* (namestring dir)
+                          :buffer-pool-size 1000)))
+     (unwind-protect (let ((graph-db:*graph* ,g)) ,@body)
+       (ignore-errors (close-graph ,g)))))
+
+(defun seed (g)
+  "Three items and two links; returns the items in rank order."
+  (with-transaction ((graph-db::transaction-manager g))
+    (let ((a (graph-db/query-test.schema::make-qt-item
+              :graph g :label "a" :rank 1))
+          (b (graph-db/query-test.schema::make-qt-item
+              :graph g :label "b" :rank 2))
+          (c (graph-db/query-test.schema::make-qt-item
+              :graph g :label "c" :rank 3)))
+      (graph-db/query-test.schema::make-qt-links :graph g :from a :to b)
+      (graph-db/query-test.schema::make-qt-links :graph g :from b :to c)
+      (list a b c))))


### PR DESCRIPTION
## Summary

Closes #322, both findings. Spec: `docs/superpowers/specs/2026-09-03-guarded-query-subsystem-design.md`; plan beside it. Guide: `docs/guarded-query.md`.

- **`graph-db/query`**, a new ASDF subsystem depending on `graph-db/core` only. `query/dsl.lisp` is `query-dsl.lisp` moved (package `graph-db`, exports unchanged); `query/guard.lisp` is the free-text Prolog guard moved out of the GUI, byte-identical bodies except the enumerated edits. Package `graph-db.query` exports **`run-guarded-prolog`** (`text graph &key limit max-inferences timeout (format :data)` → `(values columns rows truncated-p)`), the three guard conditions, the two screen limits and `schema-type-names`.
- The GUI's Prolog handler is a thin caller; its envelope and 403 flag stay. The REST `/query` and `def-query` routes set the ndjson content type themselves through one helper (the one ningle line that kept the DSL out of core).
- **Second finding.** `make-functor-symbol` resolves a goal head's functor by lookup — the head's own package, then `graph-db`, registered functors only — before the old `*package*` interning, with `:define t` at every functor-minting site so `<-`, `?-` and `select` keep the old rule. A guarded goal list mixing global and schema-edge functors now compiles from a schema package that uses nothing; a CL-inherited head (`>`, `atom`, `write`) still finds the engine's functor. The trade for CL-name collisions is stated in spec §6 and the guide.
- New suite `graph-db/query-test` (33 checks) with a CI lane; the GUI suite pins the wire shape (one added assertion: a zero-row Prolog answer now names its columns).

Not in this PR: #328 (one home for the row-cap/probe rule, filed from the final review). Consumers re-home afterwards: kraison/cl-llm's query tool (issue to be filed at landing), kraison/blackboard slices 1 and 3.

## Test plan

Foreground, from the branch worktree: query-test 33/0; gui-test 635/0 (baseline 634 + 1); REST + def-query ndjson tests by name 14/0; core `select` tests by name; the `:define` rule test proven non-vacuous by ablation; spacetime-test 650/0. Full suite: CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo
