### PR TITLE
Two engine findings from the rules S1 review (#334, #335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,19 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **`:allow-cost-unbounded` reached nothing at run time** (#334):
+  `select` read the option as a literal at macroexpansion and handed it
+  straight to the static refusal, so no running code could see it.
+  `declare-functor-cost-unbounded` classifies a whole functor, but a
+  functor can be cheap or unbounded *per goal* -- cheap with an argument
+  bound to an indexed value, unbounded with nothing bound -- and such a
+  functor must refuse from its own body, where the caller's escape hatch
+  was invisible; the condition's own report told the caller to pass an
+  option that could not work. `select` now binds the exported
+  `*allow-cost-unbounded*` for the query's dynamic extent, and
+  `%refuse-cost-unbounded` reads it, so the static refusal and a
+  functor's run-time one answer to one value.
+
 - **`claim-identity-key`'s refusal could not be printed** (#335): the
   signal site passed `:name`, an initarg `unknown-claim-family` does not
   define, so SBCL accepted it silently and left `parent` unbound. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **`claim-identity-key`'s refusal could not be printed** (#335): the
+  signal site passed `:name`, an initarg `unknown-claim-family` does not
+  define, so SBCL accepted it silently and left `parent` unbound. The
+  condition was of the right type -- `handler-case` and `typep` both
+  worked -- and only *reporting* it signalled `unbound-slot`, inside
+  whichever handler formatted it. It now passes `:parent`, and a test
+  asserts the report rather than only the type; that branch had no test,
+  which is how a wrong initarg survived.
+
 - **A goal's head resolved through one shared `*package*` binding**
   (#322, second finding): `make-functor-symbol` now looks up an
   already-registered functor first -- the head's own package, then

--- a/package.lisp
+++ b/package.lisp
@@ -509,6 +509,7 @@
            #:cost-unbounded-predicate-names #:prolog-cost-unbounded-error
            #:prolog-permission-error
            #:*inference-budget*
+           #:*allow-cost-unbounded*
            #:*default-inference-budget*
            #:*default-query-timeout*
            #:*allowed-effects*

--- a/prologc.lisp
+++ b/prologc.lisp
@@ -920,6 +920,12 @@ for the current query, or nil for unlimited.")
   "Inference budget applied to queries that don't specify :MAX-INFERENCES.")
 (defvar *default-query-timeout* nil
   "Default query timeout in seconds for queries that don't specify :TIMEOUT.")
+(defvar *allow-cost-unbounded* nil
+  "True while a query whose :ALLOW-COST-UNBOUNDED option was set is running.
+Read it in a functor that is unbounded per GOAL rather than per functor --
+cheap with an argument bound to an indexed value, unbounded with nothing
+bound -- so its own run-time refusal honours the same escape hatch
+DECLARE-FUNCTOR-COST-UNBOUNDED's static one does (GH #334).")
 
 (defun %deadline (seconds)
   "Translate a timeout in SECONDS into an INTERNAL-REAL-TIME deadline (or nil)."
@@ -989,10 +995,12 @@ compile-time path (GH #285, #279)."
       (mapc #'walk goals))
     acc))
 
-(defun %refuse-cost-unbounded (functors allow-p)
+(defun %refuse-cost-unbounded (functors)
   "Signal for the first cost-unbounded functor in FUNCTORS when a
-resource bound is in effect and ALLOW-P is false (GH #285)."
-  (when (and (not allow-p)
+resource bound is in effect and the query did not opt out (GH #285).
+Reads *ALLOW-COST-UNBOUNDED*, which SELECT binds, so this static refusal
+and a functor's own run-time one answer to one value (GH #334)."
+  (when (and (not *allow-cost-unbounded*)
              (or *inference-budget* *query-deadline*))
     (dolist (f functors)
       (when (functor-cost-unbounded-p f)
@@ -1083,6 +1091,8 @@ SELECT-FIRST for common shorthands."
             (*allowed-effects* ,(if (assoc :effects options)
                                     `',(cdr (assoc :effects options))
                                     '*default-allowed-effects*))
+            (*allow-cost-unbounded* ,(cdr (assoc :allow-cost-unbounded
+                                                 options)))
             (*select-count-only* ,(cdr (assoc :count options)))
             (*select-callback* ,(cdr (assoc :callback options)))
             (*seen-table* (make-hash-table)) ;; For unique values
@@ -1090,9 +1100,7 @@ SELECT-FIRST for common shorthands."
        ;; A resource-bounded query must not carry a goal the rails
        ;; cannot bound (GH #285).  Static over the goal list; checked
        ;; at runtime because the budgets default from runtime globals.
-       (%refuse-cost-unbounded ',(%static-goal-functors goals)
-                               ,(cdr (assoc :allow-cost-unbounded
-                                            options)))
+       (%refuse-cost-unbounded ',(%static-goal-functors goals))
        (unwind-protect
             (let ((func
                    (lambda (cont)

--- a/spacetime/claim-query.lisp
+++ b/spacetime/claim-query.lisp
@@ -38,8 +38,10 @@ regeneration, which node ids do not (GH #303).  Fields join on |, with
                                 (typep claim (claim-family-parent f)))
                               (alexandria:hash-table-values
                                *claim-families*))
+                     ;; :PARENT is the condition's only initarg; :NAME left
+                     ;; it unbound, so the report signalled (GH #335).
                      (error 'unknown-claim-family
-                            :name (class-name (class-of claim)))))
+                            :parent (class-name (class-of claim)))))
          (binary-p (typep claim (claim-family-binary family)))
          (fields
            (append

--- a/tests/prolog-functor-tests.lisp
+++ b/tests/prolog-functor-tests.lisp
@@ -347,6 +347,30 @@ with :allow-cost-unbounded t, the goal runs as before."
     (is (member "REGEX-MATCH" (graph-db:cost-unbounded-predicate-names)
                 :test #'string=))))
 
+(test allow-cost-unbounded-reaches-a-running-goal
+  "GH #334: DECLARE-FUNCTOR-COST-UNBOUNDED classifies a whole functor, but
+a functor can be cheap or unbounded per GOAL -- cheap when an argument is
+bound to an indexed value, unbounded when nothing is.  Such a functor must
+refuse from its own body, and can only honour the caller's escape hatch if
+the option reaches it at run time; :ALLOW-COST-UNBOUNDED was read as a
+literal at macroexpansion and reached nothing."
+  (with-test-graph (g)
+    (declare (ignorable g))
+    (is (equal '(:allowed)
+               (select (:flat t :max-inferences 1000
+                        :allow-cost-unbounded t)
+                       (?a)
+                       (lisp ?a (if graph-db:*allow-cost-unbounded*
+                                    :allowed :refused)))))
+    (is (equal '(:refused)
+               (select (:flat t :max-inferences 1000)
+                       (?a)
+                       (lisp ?a (if graph-db:*allow-cost-unbounded*
+                                    :allowed :refused)))))
+    ;; NIL outside a query, so a functor body cannot read a stale value
+    ;; left by the last one.
+    (is (null graph-db:*allow-cost-unbounded*))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Head resolution (#322, second finding): a functor DEFINED with <- in
 ;;; a package that does not use GRAPH-DB still lands on that package's

--- a/tests/spacetime/claim-identity-tests.lisp
+++ b/tests/spacetime/claim-identity-tests.lisp
@@ -270,3 +270,18 @@ package -- proved by the keyword not existing afterwards."
   (is (eq :never-seen-before-ns
           (nth-value 1 (split-claim-identity-key
                         "a|:never-seen-before-ns|c|d")))))
+
+(test claim-identity-key-refusal-is-printable
+  "GH #335: a value matching no registered family is refused with
+UNKNOWN-CLAIM-FAMILY, and the refusal must REPORT.  A signal site passing
+an initarg the condition does not define leaves PARENT unbound, which SBCL
+accepts silently -- so the type is right and only printing fails, inside
+whichever handler formats it."
+  (let* ((c (handler-case (claim-identity-key 42)
+              (unknown-claim-family (e) e)))
+         (report (handler-case (princ-to-string c)
+                   (error (e) (format nil "report signalled ~A"
+                                      (type-of e))))))
+    (is (typep c 'unknown-claim-family))
+    (is (search "names no claim family" report))
+    (is (search "FIXNUM" report))))


### PR DESCRIPTION
Both were found while building `graph-db/rules` S1 (#330) and filed rather
than folded into that slice, per the design's §13. Two independent fixes,
disjoint files, one commit each. Closes #334. Closes #335.

They share a branch because the self-hosted runner is serial and this is one
CI run instead of two; say the word and I'll split them.

## `#335` — `claim-identity-key`'s refusal could not be printed

`spacetime/claim-query.lisp` signalled `unknown-claim-family` with `:name`,
an initarg the condition does not define (it has only `:parent`).

Verified in a REPL rather than reasoned about: **SBCL accepts the undefined
initarg silently.** So the condition was of the right type and every
`handler-case`, `typep` and the guard's own classifier all worked — only
*reporting* it signalled `unbound-slot`, from the report function reading the
unbound `parent`. That is why nothing caught it: the failure moves to whoever
formats the condition. With #330 merged, `query/guard.lisp`'s ill-typed
branch logs it, so this would have raised inside the guard's own handler
rather than returning the intended 400.

Now passes `:parent`. The test asserts the **report**, not only the type —
asserting the type passes on the broken code, which is how a wrong initarg
survived in a branch that had no test at all.

## `#334` — `:allow-cost-unbounded` reached nothing at run time

`select` read the option as a literal at macroexpansion and handed it
straight to `%refuse-cost-unbounded`, so no running code could observe it.

`declare-functor-cost-unbounded` classifies a *whole functor*, but a functor
can be cheap or unbounded **per goal** — cheap with an argument bound to an
indexed value, unbounded with nothing bound. Such a functor has to refuse
from its own body, and there the caller's escape hatch was invisible, while
`prolog-cost-unbounded-error`'s own report told them to pass it.

`select` now binds the exported `*allow-cost-unbounded*` for the query's
dynamic extent, beside the budgets a functor already reads, and
`%refuse-cost-unbounded` reads it instead of taking it as an argument — one
value behind both the static refusal and a functor's run-time one.

`graph-db/rules`' `claim/7` and `claim-producer/2` are the first per-goal
refusals. Wiring them to consult this is a three-line follow-up that needs
#336 merged first; until then their refusals still ignore the option, which
is why this PR does not close that loop.

## Suites

Each in its own foreground subprocess, at the tip:

    graph-db/test (main)        Did 5361 checks  Pass 5351  Skip 10  Fail 0
    graph-db/spacetime-test     Did 653 checks   Pass 653   Fail 0
    graph-db/query-test         Did 33 checks    Pass 33    Fail 0
    graph-db/algorithms-test    Did 151 checks   Pass 151   Fail 0
    graph-db/gui-test           Did 635 checks   Pass 635   Fail 0

The 10 skips are the GEOS lane on a host without `libgeos_c`. The main suite
is the one that matters for `#334`: `prologc.lisp`'s `select` is what every
other suite runs through.

## Note for review

`CHANGELOG.md` will conflict with #336 — both add entries under
`[Unreleased]`, so whichever merges second needs a trivial textual fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo