### PR TITLE
rules: the claim refusals honour :allow-cost-unbounded (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,16 @@ between releases; cutting a release renames it to the new version and dates it.
 
 ### Fixed
 
+- **`graph-db/rules`' refusals now honour `:allow-cost-unbounded`**
+  (#334, follow-up to #330): `claim/7`'s family walk and
+  `claim-producer/2`'s neither-bound case refuse from their own bodies,
+  per goal rather than per functor, and could not see the option until
+  `select` began binding `*allow-cost-unbounded*`. Both now read it, so
+  a caller who accepts the cost gets the walk under a budget instead of
+  a refusal whose own report told them to pass an option that did
+  nothing. For `claim-producer/2` the option buys the empty answer, not
+  a walk -- that goal has none to buy.
+
 - **`:allow-cost-unbounded` reached nothing at run time** (#334):
   `select` read the option as a literal at macroexpansion and handed it
   straight to the static refusal, so no running code could see it.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -177,12 +177,17 @@ too -- an unrouted goal there is **always** a refusal, exactly as spec
 §4 says. Otherwise the walk is reachable only from an in-image
 `select` with neither `:max-inferences` nor `:timeout`.
 
-That refusal is unconditional: `:allow-cost-unbounded t` does not
-reach it. The option is threaded as a literal at query-compile time
-and no special variable carries it into a functor body
-(kraison/vivace-graph#334). A caller who knows the walk is affordable
-drops the budget, or binds a namespace and its key together so the
-goal routes.
+A caller who knows the walk is affordable says so with
+`:allow-cost-unbounded t`, and gets it under a budget
+(kraison/vivace-graph#334): `select` binds `*allow-cost-unbounded*` for
+the query's dynamic extent, and the refusal here reads the same value
+`%refuse-cost-unbounded`'s static one does. Binding a namespace and its
+key together, so the goal routes, remains the cheaper answer.
+
+The option reaches `claim-producer/2`'s neither-bound refusal too, but
+there it buys silence rather than a walk: that goal has no index to
+generate from and nothing to fall back to, so opting out of the refusal
+leaves the empty answer an unbudgeted query already gets.
 
 `claim/7` is deliberately **not** `declare-functor-cost-unbounded`'d.
 That classifies a whole functor, and `%excluded-predicate-p` would

--- a/rules/facts.lisp
+++ b/rules/facts.lisp
@@ -101,11 +101,12 @@ asked in; see %NAMESPACE-VALUE."
   "Every claim of FAMILY in GRAPH -- CLAIM/7's fallback, the COND's last
 clause, not a nothing-bound special case.  Refused as cost-unbounded
 when a resource bound is in effect, since %TICK cannot preempt inside a
-family walk (GH #285).  The refusal is unconditional:
-:ALLOW-COST-UNBOUNDED is threaded through SELECT at query-compile time
-and no special variable carries it into a functor body, so it cannot
-reach here."
-  (when (or *inference-budget* *query-deadline*)
+family walk (GH #285) -- unless the caller accepted that with
+:ALLOW-COST-UNBOUNDED, which SELECT now carries into a functor body
+(GH #334).  Same test as %REFUSE-COST-UNBOUNDED's, so the static
+refusal and this one answer to one value."
+  (when (and (not *allow-cost-unbounded*)
+             (or *inference-budget* *query-deadline*))
     (error 'prolog-cost-unbounded-error :functor 'claim/7))
   ;; :INCLUDE-SUBCLASSES-P defaults to T, so the parent covers unary and
   ;; binary.  :COLLECT-P is what materialises node bytes before a node
@@ -248,8 +249,9 @@ instead: every claim ?P wrote, across every family this graph indexes --
 write that goal BEFORE the CLAIM/7 goal it feeds, or ?C is bound by then
 and this filters.  With neither bound there is no index to generate from
 and no walk to fall back to, so the goal is refused as cost-unbounded
-under a resource bound and answers nothing without one (spec §4,
-docs/rules.md)."
+under a resource bound and answers nothing without one -- or with
+:ALLOW-COST-UNBOUNDED, which buys that same silence rather than a walk,
+there being none to buy (spec §4, GH #334, docs/rules.md)."
   (let ((c (%claim-arg ?c))
         (c-arg (%prolog-index-bound ?c))
         (p (%prolog-index-bound ?p)))
@@ -265,6 +267,7 @@ docs/rules.md)."
           ;; than silence.  A bound ?P that names no producer still
           ;; answers empty, as an unresolvable namespace does.
           ((and (null c-arg) (null p)
+                (not *allow-cost-unbounded*)
                 (or *inference-budget* *query-deadline*))
            (error 'prolog-cost-unbounded-error
                   :functor 'claim-producer/2)))))

--- a/tests/rules/facts-tests.lisp
+++ b/tests/rules/facts-tests.lisp
@@ -86,6 +86,30 @@
         (claim ?c rt-claim ?a ?b ?r ?d ?e)))
     (is (= 4 (select-count (?c) (claim ?c rt-claim ?a ?b ?r ?d ?e))))))
 
+(test allow-cost-unbounded-accepts-an-unrouted-goal
+  "GH #334: the escape hatch reaches a run-time refusal now that SELECT
+binds *ALLOW-COST-UNBOUNDED*.  A caller who says the walk is affordable
+gets the walk under a budget, the same answer an unbudgeted query gives."
+  (with-rules-graph (g)
+    (seed g)
+    (is (= 4 (length (select (:max-inferences 1000
+                              :allow-cost-unbounded t)
+                             (?c)
+                             (claim ?c rt-claim ?a ?b ?r ?d ?e)))))
+    ;; The shapes that route nowhere for want of an index prefix, not
+    ;; for want of bindings, take the hatch too.
+    ;; Three: h1 runs web, h1 runs db, h2 runs web.  The unary
+    ;; "reachable" claim on h2 is filtered out by the bound relation.
+    (is (= 3 (length (select (:max-inferences 1000
+                              :allow-cost-unbounded t)
+                             (?c)
+                             (claim ?c rt-claim "host" ?k "runs" ?a ?b)))))
+    ;; Control: without the option the same goals still refuse, so the
+    ;; option is what changed the answer, not the budget.
+    (signals graph-db::prolog-cost-unbounded-error
+      (select (:max-inferences 1000) (?c)
+        (claim ?c rt-claim ?a ?b ?r ?d ?e)))))
+
 ;; The refusal is a property of the goal's shape, not of the
 ;; nothing-bound shape alone.  The namespace is the leading slot of both
 ;; endpoint indexes and an index is usable only from a prefix, so
@@ -241,6 +265,18 @@
 ;; that answers zero rows in silence is the one thing CLAIM/7 already
 ;; refuses to be.  Under a bound it refuses the same way; with no bound
 ;; there is no producer walk to offer, so it still just fails.
+(test allow-cost-unbounded-quiets-the-producer-refusal
+  "GH #334: with neither argument bound CLAIM-PRODUCER/2 has no route, so
+the escape hatch cannot buy a walk -- it buys the silence an unbudgeted
+query already gets, rather than a refusal the caller opted out of."
+  (with-rules-graph (g)
+    (seed g)
+    (is (null (select (:max-inferences 1000 :allow-cost-unbounded t)
+                      (?c ?p) (claim-producer ?c ?p))))
+    ;; Control: without the option, still a refusal.
+    (signals graph-db::prolog-cost-unbounded-error
+      (select (:max-inferences 1000) (?c ?p) (claim-producer ?c ?p)))))
+
 (test claim-producer-with-neither-argument-bound
   (with-rules-graph (g)
     (seed g)


### PR DESCRIPTION
The follow-up #337 named: the mechanism landed there, and these are its only
intended consumers. One commit on top of the #337 merge.

## What

`claim/7`'s family walk and `claim-producer/2`'s neither-bound case refuse
from their own bodies — **per goal, not per functor** — which is why neither
is `declare-functor-cost-unbounded`'d (that would withhold `claim` from free
text entirely and break the guarded surface S1 exists to provide). Until
`select` began binding `*allow-cost-unbounded*` in #337, a run-time refusal
could not see the option, while `prolog-cost-unbounded-error`'s own report
told the caller to pass it.

Both now read it, with the same test `%refuse-cost-unbounded` uses, so the
static refusal and these answer to one value.

## The two refusals are not the same kind, and behave differently

Worth a reviewer's eye, because it is a judgement rather than mechanical
wiring:

- **`claim/7`** — a genuine cost refusal. The walk is affordable if the
  caller says so, and the option now buys it: an unrouted goal under a
  budget returns the same rows an unbudgeted query would.
- **`claim-producer/2` with neither argument bound** — not a cost problem at
  all. There is no index to generate from and no walk to fall back to. The
  option therefore buys **silence**, not a walk: the empty answer an
  unbudgeted query already gives, rather than a refusal the caller
  explicitly opted out of. That is consistent with what the option means
  everywhere else ("behave as if unbounded"), and it is documented in the
  docstring and `docs/rules.md` rather than left for someone to discover.

## Tests

`graph-db/rules-test` — **67/67**, up from S1's 62.

Both new tests were red first, and the failure was the bug quoted back:

    Goal claim/7 is cost-unbounded ... Run without resource bounds, or pass
    :ALLOW-COST-UNBOUNDED T to accept the risk (GH #285).

— raised by a query that had passed exactly that. Each new test carries a
control asserting the same goal still refuses **without** the option, so the
option is what changed the answer and not the budget.

Only `rules/` changed, so `graph-db/rules-test` is the covering suite; the
base is the CI-green #337 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo