### PR TITLE
ci: one live run per ref, so a superseded run stops blocking the queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,16 @@ on:
     branches: [experiment, master]
   workflow_dispatch:
 
+# One live run per ref (docs/ci.md).  The runner is serial, so a
+# superseded run costs the next one its whole queue wait: a fixup
+# pushed to a PR used to sit behind the run it replaced, and two merges
+# landing close together queued two experiment runs when the second
+# already covers the first.  Groups are per-ref, so a PR can cancel
+# only its own earlier run, never experiment's and never another PR's.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   full-suite:
     runs-on: [self-hosted, Linux]

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -15,6 +15,19 @@ to `experiment` or `master` and on pull requests.
   on every change.  Local runs are the affected subsystem's suite;
   the push gets the full matrix; `experiment -> master` promotion
   waits for the green check.
+- **One live run per ref**: the workflow sets `concurrency` with
+  `cancel-in-progress`, keyed on the ref.  The runner is serial, so a
+  superseded run does not just waste 40 minutes of its own -- it costs
+  whatever is behind it that whole wait.  A fixup pushed to a PR now
+  cancels that PR's earlier run instead of queueing behind it, and two
+  merges landing close together leave one `experiment` run, the later
+  one, which contains both.  Groups are per-ref, so a PR can cancel
+  only its own earlier run.
+  The cost: when merges land together, the earlier commit never gets a
+  run of its own, so a red head does not say which merge broke it.
+  Promotion is unaffected -- it gates on the head, which always runs.
+  Re-run a cancelled commit with `gh run rerun <id>` if you need to
+  bisect.
 - The runner neutralises quicklisp `local-projects` and pins the
   source registry to the workspace checkout plus
   `cl-temporal-extent` refreshed to master head each run (in


### PR DESCRIPTION
Adds a `concurrency` block to `.github/workflows/test.yml`, keyed on the ref,
with `cancel-in-progress`.

## Why

The runner is serial. A superseded run therefore does not merely waste its
own ~40 minutes — it costs whatever is behind it that whole wait. Twice in
one session:

- a fixup pushed to a PR queued behind the run it replaced;
- #336 and #337 merging close together left two `experiment` runs queued,
  when the later one already contained both.

Both were cancelled by hand. Doing it by hand is not a mechanism: it only
works when someone happens to look at `gh run list`.

## What it does, and does not do

Groups are per-ref, so a PR cancels **only its own** earlier run — never
`experiment`'s, never another PR's.

The cost is recorded in `docs/ci.md` rather than left to be discovered: when
two merges land close together the earlier commit never gets a run of its
own, so a red head does not say which merge broke it. Promotion is
unaffected — it gates on the head, and the head always runs. `gh run rerun
<id>` re-tests a cancelled commit when a bisect needs it.

If you would rather keep every `experiment` commit individually tested, the
conservative variant is to scope the block to pull requests only; that keeps
most of the benefit, since PR fixups are the common case.

## Validation

`yaml.safe_load` parses the workflow, `concurrency` reads back as expected,
and both jobs still resolve.

Worth saying plainly: **the suite cannot validate this change.** A green
matrix tells you nothing about whether `concurrency` works — that shows up
only in the behaviour of the *next* superseded run. So this PR's own CI run
is close to pure cost, and cancelling it loses nothing but the check mark.
Nothing outside the workflow file and `docs/ci.md` changed; no Lisp is
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo
