### PR TITLE
ci: pull requests run the main suite's fast tier (#340)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,18 @@ jobs:
               https://github.com/kraison/cl-temporal-extent $d
           fi
           echo "cl-temporal-extent @ $(git -C $d rev-parse --short HEAD)"
-      - name: full suite (12GiB heap per tests/README.md)
+      # Full on a push, fast tier on a pull request (docs/ci.md, GH #340):
+      # three suites are 71% of this step's wall time for 8% of its checks.
+      # The other lanes below run either way -- together they are ~4
+      # minutes, so there is nothing to tier there.
+      - name: main suite (12GiB heap per tests/README.md)
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SYSTEM=graph-db/fast-test
+          else
+            SYSTEM=graph-db
+          fi
+          echo "main suite: asdf:test-system :$SYSTEM"
           sbcl --dynamic-space-size 12288 --non-interactive \
             --load "$HOME/quicklisp/setup.lisp" \
             --eval '(setf ql:*local-project-directories* nil)' \
@@ -57,7 +67,7 @@ jobs:
                                                    (user-homedir-pathname)))
                             :ignore-inherited-configuration))' \
             --eval '(ql:quickload :graph-db/test :silent t)' \
-            --eval '(asdf:test-system :graph-db)'
+            --eval "(asdf:test-system :$SYSTEM)"
       - name: concurrency suite
         run: |
           sbcl --dynamic-space-size 12288 --non-interactive \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,21 @@ between releases; cutting a release renames it to the new version and dates it.
   index every claim family now declares (`claim-subject-relation`), so a
   one-relation read of a busy endpoint touches only that relation's rows.
 
+### Changed
+
+- **Pull requests run the main suite's fast tier** (#340): timing all
+  143 children of `graph-db-suite` found three of them -- the
+  `system-restore`, `detach` and `type-id-width` suites, which build
+  real on-disk stores -- are 71% of its wall clock for 8% of its
+  checks. A pull request now runs `graph-db/fast-test`, the same suite
+  minus those three (~10 minutes, 92% of the checks); a push to
+  `experiment` still runs `graph-db` in full and remains the gate
+  promotion waits on. The list is `*slow-suites*` in
+  `tests/suite.lisp`, next to the suites rather than in the workflow,
+  and `run-tests` refuses a name that is not a child of
+  `graph-db-suite` so a rename cannot silently exclude nothing.
+  `docs/ci.md` has the numbers and the trade.
+
 ### Fixed
 
 - **`graph-db/rules`' refusals now honour `:allow-cost-unbounded`**

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,9 +1,36 @@
 # CI: the full suite runs itself
 
-`.github/workflows/test.yml` runs the full test suite (main,
-concurrency, ACID, spacetime, query, rules, geos, algorithms, gui;
-12GiB heap per `tests/README.md`) on every push
-to `experiment` or `master` and on pull requests.
+`.github/workflows/test.yml` runs the test suite (main, concurrency,
+ACID, spacetime, query, rules, geos, algorithms, gui; 12GiB heap per
+`tests/README.md`) on every push to `experiment` or `master` and on
+pull requests.  A push runs all of it; a pull request runs the main
+suite's fast tier and every other lane in full (see below).
+
+- **The main suite is tiered** (GH #340).  Timing all 143 children of
+  `graph-db-suite` on 2026-09-04 found three of them are **71% of the
+  wall clock for 8% of the checks** -- `system-restore-suite` (706s),
+  `detach-suite` (677s) and `type-id-width-suite` (174s), which build
+  and tear down real on-disk stores at 2-5 seconds per check against
+  0.13 for everything else.  So:
+  - a **pull request** runs `graph-db/fast-test`, the same suite minus
+    those three: ~10 minutes, 92% of the checks;
+  - a **push to `experiment`** runs `graph-db` in full, ~36 minutes,
+    and remains the gate `experiment -> master` promotion waits on.
+
+  The list lives in `*slow-suites*` in `tests/suite.lisp`, beside the
+  suites rather than in this workflow, so marking a new slow one is a
+  one-line change there.  `run-tests` refuses a name that is not a
+  child of `graph-db-suite`, so a suite renamed out from under the list
+  fails loudly instead of quietly excluding nothing.
+
+  What this trades: a regression only those three catch lands on
+  `experiment` and is caught by the push run minutes later, rather than
+  on the pull request.  #340 tracks making them fast enough to delete
+  the tier.
+
+  To re-measure, time each child of `graph-db-suite` individually --
+  `fiveam:run` on each name from `(suite-children 'graph-db-suite)` --
+  and compare the total against the step's own duration.
 
 - **Runners are self-hosted** (personal-account runners are
   per-repo).  Primary: the `ma-dev` host, running as its `sitrep`

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -725,7 +725,23 @@ cl-temporal-extent."
                (:file "peer-index-tests")
                (:file "open-hygiene-tests")    ; GH #222, #224
                (:file "scratch-cleanup-tests")  ; GH #214
+               (:file "ci-tiering-tests")       ; GH #340
                (:file "perf/check-tests"))      ; GH #253
   :perform (test-op (op c)
                     (unless (uiop:symbol-call :graph-db/test :run-tests)
                       (error "graph-db test suite failed."))))
+
+;; The fast CI tier (docs/ci.md, GH #340): the same suite minus the three
+;; that are 71% of its wall time for 8% of its checks.  Pull requests run
+;; this; a push to experiment still runs GRAPH-DB in full.
+(defsystem graph-db/fast-test
+  :name "VivaceGraph test suite, fast tier"
+  :description "GRAPH-DB/TEST minus *SLOW-SUITES*; docs/ci.md, GH #340."
+  :depends-on (:graph-db/test)
+  :perform (test-op (op c)
+                    (let ((slow (symbol-value
+                                 (uiop:find-symbol* :*slow-suites*
+                                                    :graph-db/test))))
+                      (unless (uiop:symbol-call :graph-db/test :run-tests
+                                                :exclude slow)
+                        (error "graph-db fast-tier test suite failed.")))))

--- a/tests/ci-tiering-tests.lisp
+++ b/tests/ci-tiering-tests.lisp
@@ -1,0 +1,65 @@
+;;;; The fast CI tier's suite exclusion (GH #340, docs/ci.md).
+;;;;
+;;;; These guard the mechanism, not the tiering policy.  They must hold
+;;;; in BOTH tiers, so nothing here may assume a particular suite is
+;;;; currently attached: in a fast-tier run the slow ones are detached
+;;;; while these very tests execute.
+
+(in-package #:graph-db/test)
+
+(def-suite ci-tiering-suite :in graph-db-suite
+  :description "Excluding slow suites from a run, exactly and reversibly.")
+(in-suite ci-tiering-suite)
+
+(defun %excludable-victim ()
+  "Some child suite of GRAPH-DB-SUITE that is safe to detach and
+reattach here: not one the current run may already have excluded, and
+not this suite.  Chosen from the live list so the test works in either
+tier."
+  (find-if (lambda (n)
+             (and (not (member n *slow-suites*))
+                  (not (eq n 'ci-tiering-suite))
+                  (typep (get-test n) 'fiveam::test-suite)))
+           (suite-children 'graph-db-suite)))
+
+(test excluding-a-suite-hides-it-then-puts-it-back
+  "The restore half is the point: FIVEAM runs a suite's children from
+one mutable list, so a failed restore is invisible until a later run is
+quietly missing tests."
+  (let ((victim (%excludable-victim)))
+    (is-true victim "no child suite available to exercise exclusion")
+    (when victim
+      (let ((before (suite-children 'graph-db-suite)))
+        (with-suites-excluded ((list victim))
+          (let ((during (suite-children 'graph-db-suite)))
+            (is (zerop (count victim during)))
+            ;; Counted, not decremented by one: FIVEAM appends a name
+            ;; per registration, so a name can appear more than once
+            ;; (lispci/fiveam#94) and every occurrence must go.
+            (is (= (- (length before) (count victim before))
+                   (length during)))))
+        (is (equal before (suite-children 'graph-db-suite)))))))
+
+(test an-exclusion-is-restored-after-a-non-local-exit
+  "A body that signals must not leave the child list short."
+  (let ((victim (%excludable-victim)))
+    (when victim
+      (let ((before (suite-children 'graph-db-suite)))
+        (ignore-errors
+         (with-suites-excluded ((list victim))
+           (error "deliberate")))
+        (is (equal before (suite-children 'graph-db-suite)))))))
+
+(test excluding-a-name-that-is-not-a-child-is-refused
+  "A typo, or a suite renamed out from under *SLOW-SUITES*, must fail
+loudly rather than exclude nothing and merely look fast."
+  (signals error
+    (with-suites-excluded ('(no-such-suite-in-this-image)) nil)))
+
+(test every-slow-suite-names-a-real-suite
+  "*SLOW-SUITES* drifts as suites are renamed.  Asks whether each name
+still resolves to a suite, NOT whether it is currently attached -- in a
+fast-tier run these are detached while this test runs."
+  (dolist (s *slow-suites*)
+    (is (typep (get-test s) 'fiveam::test-suite)
+        "~A is in *SLOW-SUITES* but names no test suite" s)))

--- a/tests/suite.lisp
+++ b/tests/suite.lisp
@@ -5,9 +5,47 @@
 (def-suite graph-db-suite
   :description "All graph-db unit tests.")
 
-(defun run-tests ()
-  "Run the entire graph-db test suite.  Returns T when every test passed.
-Invoked by (asdf:test-system :graph-db)."
+(defparameter *slow-suites*
+  '(system-restore-suite detach-suite type-id-width-suite)
+  "The suites the fast CI tier skips: 71% of this suite's wall time for 8%
+of its checks, all of it building and tearing down on-disk stores
+(measured 2026-09-04).  Keep this beside the suites, not in the workflow,
+so marking a new slow one is a one-line change here.  docs/ci.md has the
+numbers; GH #340 is the ticket to make them fast enough to delete this.")
+
+(defun suite-children (suite-name)
+  "The immediate child test and suite names of SUITE-NAME, in run order.
+A fresh list: FIVEAM runs a suite from the very list this copies, so a
+caller that mutated it would change the run."
+  (copy-list (fiveam::%test-names (fiveam::tests (get-test suite-name)))))
+
+(defun call-with-suites-excluded (names thunk &key (parent 'graph-db-suite))
+  "Call THUNK with NAMES detached from PARENT's child list, restoring it
+however THUNK exits.  A name PARENT does not carry is refused: a typo, or
+a suite renamed out from under *SLOW-SUITES*, would otherwise exclude
+nothing and merely look like a fast run (GH #340)."
+  (let* ((bundle (fiveam::tests (get-test parent)))
+         (saved (copy-list (fiveam::%test-names bundle))))
+    (dolist (n names)
+      (unless (member n saved)
+        (error "~S is not a child of ~S, so it cannot be excluded." n parent)))
+    (unwind-protect
+         (progn
+           (setf (fiveam::%test-names bundle)
+                 (remove-if (lambda (n) (member n names)) saved))
+           (funcall thunk))
+      (setf (fiveam::%test-names bundle) saved))))
+
+(defmacro with-suites-excluded ((names &key (parent ''graph-db-suite))
+                                &body body)
+  "Run BODY with the suites NAMES evaluates to detached from PARENT."
+  `(call-with-suites-excluded ,names (lambda () ,@body) :parent ,parent))
+
+(defun run-tests (&key exclude)
+  "Run the graph-db test suite.  Returns T when every test passed.
+EXCLUDE names child suites to skip -- (asdf:test-system :graph-db/fast-test)
+passes *SLOW-SUITES*; (asdf:test-system :graph-db) passes nothing and runs
+everything."
   ;; The storage layers log prolifically at :debug/:info; keep test output
   ;; to genuine problems.
   (log:config :error)
@@ -25,7 +63,10 @@ Invoked by (asdf:test-system :graph-db)."
          (graph-db::*system-directory* (namestring system-dir))
          (graph-db::*type-registry* nil))
     (unwind-protect
-         (let ((results (run 'graph-db-suite)))
+         (let ((results (if exclude
+                            (with-suites-excluded (exclude)
+                              (run 'graph-db-suite))
+                            (run 'graph-db-suite))))
            (explain! results)
            (results-status results))
       ;; Everything this run scratched -- system-dir included -- lives


### PR DESCRIPTION
Closes nothing on its own; #340 tracks making the tier unnecessary.

## The measurement this rests on

Timing all 143 immediate children of `graph-db-suite` individually
(2181s total, matching the 2119s the CI step takes, so it is
representative):

| suite | time | share | checks | s/check |
|---|---|---|---|---|
| `system-restore-suite` | 706s | 32.4% | 154 | 4.6 |
| `detach-suite` | 677s | 31.0% | 185 | 3.7 |
| `type-id-width-suite` | 174s | 8.0% | 81 | 2.1 |
| **those three** | **1557s** | **71.4%** | **420** | |
| the other 140 children | 624s | 28.6% | 4951 | 0.13 |

The cost is not spread — it is three suites that build and tear down real
on-disk stores. Excluding them costs 7.8% of the checks and buys back 71%
of the wall clock.

## What changes

- A **pull request** runs `graph-db/fast-test`: the same suite minus those
  three.
- A **push to `experiment`** runs `graph-db` in full, unchanged, and remains
  the gate that `experiment -> master` promotion waits on.
- The other eight lanes (concurrency, ACID, spacetime, query, rules, geos,
  algorithms, gui) are ~4 minutes *together* and run either way. There is
  nothing worth tiering there — the first lane warms the FASL cache, so the
  rest pay only for execution.

`*slow-suites*` lives in `tests/suite.lisp` beside the suites, not in the
workflow, so marking a new slow suite is a one-line change where the suite
is defined.

## Verified on this tree, not asserted

    fast (graph-db/fast-test)   Did 4950 checks   Pass 4940  Skip 10  Fail 0
    full (graph-db)             Did 5370 checks   Pass 5360  Skip 10  Fail 0

The 420-check difference is *exactly* those three suites' own checks
(154 + 185 + 81), and the fast run logs zero occurrences of each. The
10 skips are the GEOS lane on a host without `libgeos_c`.

The full count rose from 5361 to 5370 because this PR adds 9 checks of its
own.

## Failure modes the tests cover

`run-tests` **refuses** a name that is not a child of `graph-db-suite`, so a
suite renamed out from under `*slow-suites*` fails loudly rather than
excluding nothing and merely looking fast. The exclusion is restored through
a non-local exit, because FiveAM runs a suite from one mutable list and a
failed restore would be invisible until a later run was quietly missing
tests.

The tests deliberately do not assume a tier: they pick their victim from the
live child list and ask whether each `*slow-suites*` entry *resolves to a
suite* rather than whether it is currently attached. An earlier version
asserted attachment, passed standalone, and failed inside the very fast-tier
run it describes.

## One incidental finding

The exclusion counts occurrences instead of removing one. FiveAM appends a
name per registration ([lispci/fiveam#94](https://github.com/lispci/fiveam/pull/94),
a one-word `push` -> `pushnew` fix open upstream since December 2022), so
recompiling in the same image leaves each suite listed twice. It is harmless
to execution — a test-case that already ran is skipped by its status, which
I measured rather than assumed — but the child list is not a set, and code
that treats it as one gets the wrong answer.

## What this trades

A regression that only those three suites catch lands on `experiment` and is
caught by the push run minutes later, instead of on the pull request. Given
that core changes are exactly what tends to break restore and detach, that is
a real if narrow exposure; `docs/ci.md` states it plainly and #340 tracks
removing the need for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhUGNmKWzsBV8PftSVfVo
