### PR TITLE
rules S3: cross-store scope -- a rule reads its scope and writes its own store (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ between releases; cutting a release renames it to the new version and dates it.
   `premises-of` and `dependents-of` read provenance back.
   `docs/rules.md`.
 
+- **`graph-db/rules`, a rule reads a scope of stores and writes its
+  own** (#304, #332): `run-rule` and `run-rules` take `:scope`, the
+  open stores the body may read -- the rule's own store first, a store
+  named twice read once -- and `claim/7`'s indexed routes and family
+  walk, and `claim-producer/2`'s generator, answer the union of them,
+  still committed state, a store whose schema lacks the family
+  contributing nothing rather than refusing. The rule writes its own
+  store alone. With another store in scope the body is evaluated
+  *before* the write transaction, under one composed read snapshot per
+  store, because a read-write transaction refuses every read of another
+  store (#53); under a shared system clock (#168) those snapshots take
+  their epochs from one counter, and the run is not serialised against
+  a premise committed after them. A premise from another store is
+  recorded in its `derived-from` record's `method` -- the downcased
+  store name, `nil` for the rule's own -- and `premises-of` now takes a
+  `:scope`, resolving each premise in the store its record names and
+  dropping one whose store is out of scope. A Lisp caller can bind
+  `graph-db::*claim-scope*` around a raw `select` for the same reads,
+  outside a transaction. `docs/rules.md`.
+
 - **`graph-db/query`, a web-free subsystem for guarded queries** (#322):
   the JSON pattern DSL moves out of the `graph-db` web system and the
   free-text Prolog guard moves out of `graph-db/gui`, both into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@ between releases; cutting a release renames it to the new version and dates it.
   open stores the body may read -- the rule's own store first, a store
   named twice read once -- and `claim/7`'s indexed routes and family
   walk, and `claim-producer/2`'s generator, answer the union of them,
-  still committed state, a store whose schema lacks the family
-  contributing nothing rather than refusing. The rule writes its own
+  still committed state -- a *foreign* store whose schema lacks the
+  family contributing nothing rather than refusing, as any store does
+  under `claim-producer/2`, while the rule's own store still refuses an
+  ill-typed `claim/7` goal as slice 1 had it. The rule writes its own
   store alone. With another store in scope the body is evaluated
   *before* the write transaction, under one composed read snapshot per
   store, because a read-write transaction refuses every read of another
@@ -70,7 +72,9 @@ between releases; cutting a release renames it to the new version and dates it.
   `:scope`, resolving each premise in the store its record names and
   dropping one whose store is out of scope. A Lisp caller can bind
   `graph-db::*claim-scope*` around a raw `select` for the same reads,
-  outside a transaction. `docs/rules.md`.
+  outside a transaction; `run-rule` and `premises-of` refuse a foreign
+  scope inside one outright, as an operator error rather than a report.
+  `docs/rules.md`.
 
 - **`graph-db/query`, a web-free subsystem for guarded queries** (#322):
   the JSON pattern DSL moves out of the `graph-db` web system and the

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -256,7 +256,8 @@ after it is invisible too, though the snapshot's epoch predates the
 delete. Not new with a scope: equally true of a single-store run
 (recon note O1). Read out of the code, not out of a live scenario --
 the note flags it as not adversarially settled, so verify by test
-before relying on it in either direction.
+before relying on it in either direction; kraison/vivace-graph#345
+tracks settling it.
 
 **A cross-store evaluation runs under no transaction at all.**
 `run-rule` opens its write transaction only after the body has been
@@ -470,6 +471,13 @@ signals `cross-graph-transaction-error`, snapshot or no snapshot
   **not** serialised against a premise committed after the snapshots
   were taken -- the next run sees such a premise, this one does not.
 
+**Call it outside a transaction.** A foreign store in `:scope` while
+the caller holds a transaction of its own is an operator error,
+signalled before anything is evaluated, because the engine refuses that
+read whatever snapshot is in force and the run would otherwise die
+part-way through with `cross-graph-transaction-error` (GH #53, ruling
+S3-F1).
+
 Under a shared system clock (`open-system-clock`, GH #168) those
 snapshots take their epochs from one counter, so the epochs are
 *comparable*, and equal when nothing commits between the two
@@ -527,8 +535,9 @@ write transaction unwinds it; one raised during a cross-store
 evaluation unwinds the composed snapshots instead, no transaction being
 open yet. The report is the same either way, and neither path wrote
 anything. Only an operator error signals: no resource bound, no rule of
-that name in the store or the image, or a `:scope` that is not a list
-of open, keyword-named stores.
+that name in the store or the image, a `:scope` that is not a list of
+open, keyword-named stores, or a foreign store in `:scope` inside the
+caller's transaction.
 
 ## Validity of a derived claim
 
@@ -610,7 +619,9 @@ producer, which the next run sweeps -- is never read as provenance.
   the scope sees fewer premises and never wrong ones. A premise whose
   identity no longer exists in the store it resolves in is dropped too,
   rather than faked. A foreign store is read here, so call this outside
-  a transaction (GH #53).
+  a transaction: inside one, a `scope` naming a store other than
+  `graph` is an operator error, signalled before any record is read
+  (GH #53, ruling S3-F1).
 - `(dependents-of graph claim &key current) => claims` -- every derived
   claim whose provenance names `claim`. With `:current`, only those
   still believed. No `scope`: the records and their subjects are

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -232,6 +232,18 @@ a rule that read its own relation would read the *previous* run's
 derivation and one `run-rule` would never settle. `compile-rule`
 refuses that instead of iterating (GH #331).
 
+**A scope widens what they read, not when.** With
+`graph-db::*claim-scope*` bound to a list of open stores -- own store
+first, NIL for `*graph*` alone -- every route of `claim/7` and
+`claim-producer/2` reads all of them and answers the union, still the
+committed state of each. A store in scope whose schema never declared
+the family contributes nothing; the own store still refuses, as slice 1
+documented. The trap is the engine's, not ours: inside a read-write
+transaction on one store every read of another signals
+`cross-graph-transaction-error` (GH #53), so bind the scope outside a
+transaction. Full section, and `run-rule`'s `:scope`, in slice 3
+(GH #332).
+
 ## Tests and CI
 
 FiveAM system `graph-db/rules-test` (`tests/rules/`), on-disk stores,

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -241,8 +241,23 @@ the family contributes nothing; the own store still refuses, as slice 1
 documented. The trap is the engine's, not ours: inside a read-write
 transaction on one store every read of another signals
 `cross-graph-transaction-error` (GH #53), so bind the scope outside a
-transaction. Full section, and `run-rule`'s `:scope`, in slice 3
-(GH #332).
+transaction. Full section in slice 3 (GH #332); `run-rule`'s `:scope`
+is under "Running a rule".
+
+**A snapshot hides an insert, not a delete.** Secondary-index
+*membership* is not snapshot-versioned: `%ix-release` removes the entry
+outright, post-durability, and `index-lookup`'s only snapshot-aware
+step is resolving an id it has already found. So under a read snapshot
+a claim inserted after it is correctly invisible -- and a claim deleted
+after it is invisible too, though the snapshot's epoch predates the
+delete. Not new with a scope: equally true of a single-store run
+(recon note O1).
+
+**A cross-store evaluation runs under no transaction at all.**
+`run-rule` opens its write transaction only after the body has been
+evaluated, so `*transaction*` is `nil` throughout it. A Lisp caller
+who reaches for `claims-touching` there gets no transaction overlay
+either -- the same committed state the functors read (recon note B9).
 
 ## Tests and CI
 
@@ -368,10 +383,13 @@ the reason a stored rule's write is refused.
 
 ## Running a rule
 
-`graph-db.rules:run-rule (graph rule) => rule-report` derives `rule`
-afresh and reconciles the result with its previous derivation, in **one
-transaction** (spec §7). `rule` is a `rule` record, a `rule-spec`, or a
+`graph-db.rules:run-rule (graph rule &key scope) => rule-report`
+derives `rule` afresh and reconciles the result with its previous
+derivation (spec §7). `rule` is a `rule` record, a `rule-spec`, or a
 name -- looked up in the store first, then among the `def-rule`s.
+Without a `scope`, or with one naming only `graph`, it is **one
+transaction**; with another store in it the body is evaluated first and
+only the reconcile is transactional (see `:scope` below).
 
 **Reconcile, not sweep-then-insert (ruling P10).** `run-rule` evaluates
 the body first, then compares the identities it derived against the
@@ -421,6 +439,51 @@ defaults -- `run-rule` signals a plain error rather than walking a
 family unbounded. `*rules-max-solutions*` (100000) caps the collected
 solutions; past it the run is refused rather than silently truncated.
 
+**`:scope` -- the stores the body may read (spec §10, GH #332).** A
+list of open stores. `graph` is put first whatever the caller wrote,
+and a store named twice is read once: named twice it would answer every
+route twice and so double every solution. The rule **writes `graph`
+alone** -- neither a derived claim nor a `derivation` record ever lands
+in another store. `nil`, or a scope of `graph` alone, is slice 2
+exactly.
+
+The two paths differ in *where* the body runs, and the engine forces
+the difference: inside a read-write transaction on A, every read of B
+signals `cross-graph-transaction-error`, snapshot or no snapshot
+(GH #53).
+
+- **`nil`, or `graph` alone.** The body is evaluated inside the write
+  transaction, as slice 2 had it, and that transaction serialises the
+  run against concurrent writers.
+- **Another store in scope.** The body is evaluated *before* the write
+  transaction, under one composed read snapshot per store in scope
+  (own store first); the reconcile then runs in `graph`'s transaction
+  as before. Each store is internally consistent, but the run is
+  **not** serialised against a premise committed after the snapshots
+  were taken -- the next run sees such a premise, this one does not.
+
+Under a shared system clock (`open-system-clock`, GH #168) those
+snapshots take their epochs from one counter, so the epochs are
+*comparable*, and equal when nothing commits between the two
+acquisitions. Without a shared clock each store is consistent on its
+own and the epochs are not comparable at all. The engine deliberately
+provides no single instant across stores
+(`call-with-read-snapshot`'s own docstring, GH #53), so neither does
+this.
+
+**The retry.** `call-with-transaction` re-invokes its thunk on a
+`validation-conflict`. With a foreign store in scope only the reconcile
+is inside that thunk, so a cross-store **evaluation is not repeated** on
+a conflict -- the retry reconciles the same solution set. The
+single-store path re-evaluates, as slice 2 did. Either way the report's
+counts are per attempt and never cumulative.
+
+A store in a scope must be **keyword-named**: `method` (below) is
+`(string-downcase (symbol-name (graph-name g)))` and nothing in
+`make-graph` coerces the name (recon note B5). A scope holding
+something that is not an open store signals, before the rule is even
+resolved.
+
 **The report** (`rule-report`):
 
 | field | meaning |
@@ -453,7 +516,8 @@ family cases name is tagged `:rule`, not with its own class name.
 one unwinds the transaction, so **the previous derivation stands
 untouched** -- `derived`, `kept` and `swept` all read 0 on a
 `:refused` report. Only an operator error signals: no resource bound,
-or no rule of that name in the store or the image.
+no rule of that name in the store or the image, or a `:scope` that is
+not a list of open stores.
 
 ## Validity of a derived claim
 
@@ -499,6 +563,29 @@ longer asked for is deleted. **One record per pair**: the records
 pair already kept, or a record under that producer whose relation is
 not `derived-from`, is swept with them.
 
+**`method` names the premise's store (spec §10, GH #332).** A record
+whose premise came from another store in the scope carries that store's
+name -- the downcased graph name, cl-llm's `store-name` convention --
+and one whose premise is in the rule's own store carries `nil`. A kept
+record's `method` is **refreshed** to the store its premise now comes
+from, in the same `copy`/`save` as its `rule-version`. Refreshed and
+not swept-and-rewritten: `method` is *not* part of the family's
+identity tuple, so rewriting a record whose pair is unchanged would
+collide on `def-unique` exactly as the reconcile order above avoids
+for the claims themselves.
+
+That `method` is outside the identity tuple has a second consequence:
+two stores holding one identity key contribute **one** record. The
+rule's own store wins, else the first store in scope order, and the
+other store's name is lost.
+
+The reconcile never touches a node from another store. A premise leaves
+the evaluation as `(identity-key . store-name)`, both computed inside
+the snapshot that read it -- a node `index-lookup` returns under a
+snapshot skips `ensure-node-bytes`, so reading its slots once the
+snapshot has exited reads that store's heap with no read pin in force
+(recon note C4).
+
 Both reads filter the records on `derived-from`, so a `derivation`
 record of another relation -- one a foreign writer left under the
 producer, which the next run sweeps -- is never read as provenance.
@@ -517,11 +604,13 @@ kraison/blackboard's.
 
 ## `run-rules`
 
-`graph-db.rules:run-rules (graph) => list of rule-report` runs every
-enabled rule the store can run, in dependency order: a rule that reads
-relation R runs after every rule that derives R (spec §7). Cycles were
-refused at compile, so the order always exists; ties keep the order the
-rules came in.
+`graph-db.rules:run-rules (graph &key scope) => list of rule-report`
+runs every enabled rule the store can run, passing `scope` through to
+each, in dependency order: a rule that reads relation R runs after
+every rule that derives R (spec §7). Cycles were refused at compile, so
+the order always exists; ties keep the order the rules came in. Both
+the compile and that order stay single-store, so a cycle that runs
+through another store's rules is not detected.
 
 - **A disabled rule is not in scope at all.** `rules-in-scope` filters
   on `enabled`, stored rules and `def-rule`s alike, so `run-rules`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -234,10 +234,13 @@ refuses that instead of iterating (GH #331).
 
 **A scope widens what they read, not when.** With
 `graph-db::*claim-scope*` bound to a list of open stores -- own store
-first, NIL for `*graph*` alone -- every route of `claim/7` and
-`claim-producer/2` reads all of them and answers the union, still the
-committed state of each. A store in scope whose schema never declared
-the family contributes nothing; the own store still refuses, as slice 1
+first, NIL for `*graph*` alone -- `claim/7`'s three indexed routes and
+its family walk read all of them and answer the union, as
+`claim-producer/2`'s generator does, still the committed state of each.
+The other two routes have no store to widen over: a `?c` already bound
+to a claim node answers that node, and a namespace naming no keyword is
+the empty fast path. A store in scope whose schema never declared the
+family contributes nothing; the own store still refuses, as slice 1
 documented. The trap is the engine's, not ours: inside a read-write
 transaction on one store every read of another signals
 `cross-graph-transaction-error` (GH #53), so bind the scope outside a
@@ -251,7 +254,9 @@ step is resolving an id it has already found. So under a read snapshot
 a claim inserted after it is correctly invisible -- and a claim deleted
 after it is invisible too, though the snapshot's epoch predates the
 delete. Not new with a scope: equally true of a single-store run
-(recon note O1).
+(recon note O1). Read out of the code, not out of a live scenario --
+the note flags it as not adversarially settled, so verify by test
+before relying on it in either direction.
 
 **A cross-store evaluation runs under no transaction at all.**
 `run-rule` opens its write transaction only after the body has been
@@ -356,7 +361,8 @@ path from the head relation back to itself is refused, spelling the
 path (`deriving "y" closes a cycle: y -> x -> y`). A body `claim/7`
 that leaves its relation unbound reads *every* relation, its own
 included, so it is always a one-node cycle; that refusal says to bind
-the relation.
+the relation. The graph is the rule's own store's, plus the image's
+`def-rule`s -- a `:scope` does not widen it (see "Cross-store scope").
 
 **A name belongs to one source.** A stored `rule` and a `def-rule` of
 the same name is a collision, refused whichever arrives second.
@@ -430,10 +436,12 @@ starting at T) collapse too, which is what the family's own identity
 rule would have forced anyway (recon note C5, ruling P11).
 
 **The rails, always (ruling P4).** The body runs through
-`run-query-goals`: `:effects nil`, one snapshot (inherited from the
-open transaction), and a resource bound. `*rules-max-inferences*` and
-`*rules-timeout*` are the operator's; `nil` on either falls back to the
-DSL's `*query-default-max-inferences*` / `*query-default-timeout*`.
+`run-query-goals`: `:effects nil`, one snapshot -- inherited from the
+open transaction on the single-store path and from the composed read
+snapshots on the cross-store one -- and a resource bound.
+`*rules-max-inferences*` and `*rules-timeout*` are the operator's;
+`nil` on either falls back to the DSL's
+`*query-default-max-inferences*` / `*query-default-timeout*`.
 If the *effective* pair is `nil` -- both rule variables and both DSL
 defaults -- `run-rule` signals a plain error rather than walking a
 family unbounded. `*rules-max-solutions*` (100000) caps the collected
@@ -512,12 +520,15 @@ else one of:
 The vocabulary is closed: a `constraint-violation` none of the three
 family cases name is tagged `:rule`, not with its own class name.
 
-**Nothing refuses by signalling.** Every refusal is reported, and every
-one unwinds the transaction, so **the previous derivation stands
-untouched** -- `derived`, `kept` and `swept` all read 0 on a
-`:refused` report. Only an operator error signals: no resource bound,
-no rule of that name in the store or the image, or a `:scope` that is
-not a list of open stores.
+**Nothing refuses by signalling.** Every refusal is reported and
+**the previous derivation stands untouched** -- `derived`, `kept` and
+`swept` all read 0 on a `:refused` report. A refusal raised inside the
+write transaction unwinds it; one raised during a cross-store
+evaluation unwinds the composed snapshots instead, no transaction being
+open yet. The report is the same either way, and neither path wrote
+anything. Only an operator error signals: no resource bound, no rule of
+that name in the store or the image, or a `:scope` that is not a list
+of open, keyword-named stores.
 
 ## Validity of a derived claim
 
@@ -590,23 +601,98 @@ Both reads filter the records on `derived-from`, so a `derivation`
 record of another relation -- one a foreign writer left under the
 producer, which the next run sweeps -- is never read as provenance.
 
-- `(premises-of graph claim) => claims` -- the claims `claim` was
-  derived from. A premise whose identity no longer exists in the store
-  is dropped rather than faked.
+- `(premises-of graph claim &key scope) => claims` -- the claims
+  `claim` was derived from. `scope` defaults to `(list graph)`, and
+  each record's `method` decides where its premise is resolved: the
+  store of that name in `scope`, `graph` when `method` is `nil`, and
+  **nowhere when the named store is not in `scope`** -- the premise is
+  dropped, never looked for in `graph` instead, so a caller who forgets
+  the scope sees fewer premises and never wrong ones. A premise whose
+  identity no longer exists in the store it resolves in is dropped too,
+  rather than faked. A foreign store is read here, so call this outside
+  a transaction (GH #53).
 - `(dependents-of graph claim &key current) => claims` -- every derived
   claim whose provenance names `claim`. With `:current`, only those
-  still believed.
+  still believed. No `scope`: the records and their subjects are
+  `graph`'s whatever store `claim` lives in, and a premise is named by
+  its identity key.
 
 **Retracting a premise does not re-derive anything.** Its dependents
 stay current and stay findable through `dependents-of`; deciding what
 to do about them is the caller's, and in a multi-agent setting
 kraison/blackboard's.
 
+## Cross-store scope (GH #332)
+
+A **scope** is the list of open stores a rule's body may read. It is a
+run-time argument, never a slot on the rule: `run-rule graph rule
+:scope`, `run-rules graph :scope`, and `graph-db::*claim-scope*` for a
+Lisp caller writing a raw `select`. The rule's own store goes first
+whatever the caller wrote, a store named twice is read once, and `nil`
+or a scope naming the own store alone behaves exactly as slice 2 did.
+Every store in a scope must be **keyword-named** -- `method` below is
+the downcased `symbol-name` -- and a scope holding anything else, or
+anything that is not an open store, signals before the rule is even
+resolved.
+
+**A rule writes its own store, only.** Every derived claim and every
+`derivation` record lands in `graph`, whatever the scope. A wider scope
+changes what the body can see and nothing about where the result goes.
+
+**Both stores declare the family.** Compile and the cycle check stay
+single-store (spec §6): a rule's text is validated against its own
+store's schema. So a family read from another store must be declared
+under both store names -- `(def-claim-classes fam :store-a)` and
+`(def-claim-classes fam :store-b)`; the family registry is keyed on the
+family symbol, the indexes are per store. A store in scope whose schema
+never declared a family a goal names contributes nothing to that goal,
+while the rule's own store still refuses an ill-typed goal as slice 1
+documented.
+
+**Where the body runs depends on the scope**, and the engine forces
+that: inside a read-write transaction on A every read of B signals
+`cross-graph-transaction-error` (GH #53). The own store alone is
+evaluated inside the write transaction; another store in scope is
+evaluated before it, under one composed read snapshot per store. Under
+a shared system clock (GH #168) those snapshots take their epochs from
+one counter -- comparable, and equal when nothing commits between the
+acquisitions -- but never one instant, which the engine deliberately
+provides for no cross-store read. The full contract, with the retry and
+what a cross-store run is *not* serialised against, is under "Running a
+rule".
+
+**A premise from another store is named in its record**: the
+`derived-from` record's `method` is that store's downcased name, `nil`
+for the rule's own store. Nothing else crosses -- a premise leaves the
+evaluation as an identity key plus that name, so the reconcile touches
+no foreign node. Reading provenance back takes the same scope:
+`(premises-of graph claim :scope (list a b))` resolves each premise in
+the store its record names and drops the ones whose store is not in
+scope. See "Provenance".
+
+**The walk reads the scope too.** A goal that routes to no index walks
+the family in every store in scope, and is refused as cost-unbounded
+under a resource bound exactly as it is single-store. A scope neither
+adds a refusal nor removes one.
+
+**A Lisp caller binds the special itself.** `graph-db::*claim-scope*`
+around a raw `select` buys the same reads with no rule involved. The
+trap is the engine's rather than this system's: bind it **outside** a
+transaction, or the first foreign read signals.
+
+**Known limit: no cross-store cycle detection.** The cycle check is
+over the rule's own store, so A's rule reading a relation B's rule
+derives -- and B's reading one A's derives -- is neither refused at
+compile nor settled at run. Recursion is the next slice's subject
+(#333).
+
 ## `run-rules`
 
 `graph-db.rules:run-rules (graph &key scope) => list of rule-report`
 runs every enabled rule the store can run, passing `scope` through to
-each, in dependency order: a rule that reads relation R runs after
+each, in dependency order. `scope` is checked once at entry, so a scope
+that is not open, keyword-named stores signals even on a store with no
+runnable rule. The order is: a rule that reads relation R runs after
 every rule that derives R (spec §7). Cycles were refused at compile, so
 the order always exists; ties keep the order the rules came in. Both
 the compile and that order stay single-store, so a cycle that runs

--- a/docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md
+++ b/docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md
@@ -7,9 +7,21 @@ a source-verified recon pass or a task review; each carries the cost of
 being wrong as it was stated at the time. Nothing here is re-derived or
 improved.
 
-**None deviates from the spec's letter.** S3-P2 is the one that comes
-close and does not: spec §7 says a run is one transaction, and a
-cross-store run's evaluation sits outside it. That is a refinement §7's
+**One ruling deviates from the spec's letter: S3-R2.** Spec §10's
+fourth sentence — "Reads resolve at one instant under the shared clock
+(#94)" — is refused, because the engine deliberately provides no
+cross-store instant (`call-with-read-snapshot`'s own docstring, GH
+#53). What #332 ships is what kraison/vivace-graph#94's closing comment
+describes: one *comparable* epoch space, the epochs equal when nothing
+commits between the two acquisitions, over stores each made atomic on
+its own (#93). The cost is real and is stated under S3-R2, in
+`docs/rules.md` ("Running a rule") and in the plan's self-review: a
+cross-store run is consistent per store and is **not** serialised
+against a premise committed after its snapshots.
+
+S3-P2 is the one that comes close and does not deviate: spec §7 says a
+run is one transaction, and a cross-store run's evaluation sits outside
+it. That is a refinement §7's
 own mechanism forces — the engine refuses every read of another store
 inside a read-write transaction (GH #53), so "one transaction" and
 "reads a scope of stores" cannot both hold literally. The reconcile,
@@ -190,15 +202,22 @@ rather than reading the others.
 **Decision.** No doc, docstring or test asserts that a cross-store
 run's reads resolve at one instant. The wording is "one comparable
 epoch space, equal in a quiescent image", and the clocked test asserts
-only that the run works and derives from both stores.
+only that the run works and derives from both stores. This is the
+slice's one deviation from the spec's letter: §10's fourth sentence
+asks for that instant, and #332 does not deliver it.
 
 **Evidence.** The engine deliberately provides no cross-store instant
 (`call-with-read-snapshot`'s own docstring, GH #53), so a test of one
 would pass vacuously in a quiescent suite and fail the first time the
 suite ran concurrently.
 
-**Cost if wrong.** None; #332 does not close the namespaces design's
-§12 aspiration and says so.
+**Cost if wrong.** Spec §10's fourth sentence goes undelivered: a
+cross-store run is per-store consistent and is not serialised against a
+premise committed after its snapshots, so a caller reading "one
+instant" literally would expect a serialisation nothing provides.
+Recorded in the opening above, in `docs/rules.md` and in the plan's
+self-review rather than left to be discovered; #332 does not close the
+namespaces design's §12 aspiration and says so.
 
 ### S3-R3 (from recon C4) — the read pin is S3-P3's rationale
 
@@ -309,8 +328,119 @@ own-store premises, which is what S3-P4 wants.
 
 ---
 
-## Not yet taken
+## Taken in the final review
 
-The whole-branch review is the controller's, after this commit. Its
-rulings, if any, belong in a closing section here, in S2's "Taken in
-the final review" shape.
+The whole-branch review's rulings, taken without Kevin in the loop like
+the rest, and shipped with their tests in one commit on top of
+`f37c54e`.
+
+### S3-F1 — a foreign store in scope is an operator error inside a transaction
+
+**Decision.** `run-rule` and `premises-of` signal, before anything is
+evaluated or read, when the scope names a store other than `graph` and
+a transaction is open. `run-rules` inherits it through every `run-rule`
+it calls; a `run-rules` with nothing runnable reads nothing and so
+refuses nothing. Single-store calls are unchanged, inside a transaction
+or out.
+
+**Evidence.** A read-write transaction refuses every cross-graph read
+outright and does not fall through to the read snapshots
+(`transactions.lisp:319-323`; `tests/multi-graph-tests.lisp:1183`,
+`read-write-transaction-blocks-a-foreign-read-even-under-a-snapshot`).
+`call-with-read-snapshot` funcalls straight through for a store the
+open transaction already covers, so `%under-snapshots` cannot rescue
+the case: without the guard the run reached its first foreign read and
+let `cross-graph-transaction-error` escape unreported, past every
+handler `run-rule` has.
+
+**Cost if wrong.** A caller who wants the run inside their own
+transaction must restructure — evaluate outside it, or drop the foreign
+store. That is the engine's constraint rather than this system's;
+refusing up front only makes it legible.
+
+### S3-F2 — S3-R1's own-store half is asserted directly
+
+**Decision.** `the-own-store-still-refuses-a-family-it-does-not-index`
+asserts the FIRST store's bare lookup: under a two-store scope, a goal
+on a family the own store does not index still signals
+`query-precondition-error`, so a scope cannot turn S1's ill-typed
+refusal into silence.
+
+**Evidence.** No test reached `%scope-lookup`'s first-store branch —
+`a-store-lacking-the-family-contributes-nothing` and
+`the-walk-skips-a-store-that-lacks-the-family` exercise the foreign,
+swallowed half only. Non-vacuity by ablation: wrapping the first
+store's lookup in the same `handler-case` turns this test red (1
+failure of 401) and leaves the foreign control green; restored,
+401/401.
+
+**Cost if wrong.** None; the test asserts behaviour S3-R1 chose and
+`%scope-lookup` already had.
+
+### S3-F3 — spec §10's fourth sentence is refused, not delivered
+
+**Decision.** The record's opening said "none deviates from the spec's
+letter". S3-R2 does: §10's "Reads resolve at one instant under the
+shared clock (#94)" is refused. The opening, S3-R2's own cost, and the
+plan's "Self-review against the spec" line for that sentence are
+corrected to say so.
+
+**Evidence.** `call-with-read-snapshot`'s docstring (GH #53) states
+that the engine provides no cross-store instant;
+kraison/vivace-graph#94's closing comment describes what the shared
+clock does give — one comparable epoch space — and #93 is the
+per-store atomicity underneath it. The plan claimed Task 2 delivered
+the sentence through the composed snapshots and the clocked fixture;
+that fixture asserts only that the run derives, which is what S3-R2
+chose.
+
+**Cost if wrong.** The deviation is now visible where a consumer looks
+for it. The behaviour is unchanged: a cross-store run is per-store
+consistent and not serialised against a premise committed after its
+snapshots.
+
+### S3-F4 — `%premise-ref` defaults through `node-home-graph`
+
+**Decision.** An unstamped premise node takes the engine's convention —
+`(node-home-graph node graph)`, a NIL home meaning "unknown, not
+foreign" (`node-class.lisp:453`) — instead of `resolve-node-graph`'s
+scan of every open store.
+
+**Evidence.** Recon B3 says every lookup on today's call graph stamps
+`node-graph`, which makes the fallback unreachable; that is a fact
+about today's callers, not an invariant, so the fallback's failure mode
+still matters. The scan's is an unhandled condition — on the
+single-store path it meets the cross-graph refusal inside the
+transaction (GH #53) — while the default's is a dropped store name,
+the same "fewer premises, never wrong ones" trade S3-P4 chose. No new
+test: the branch is unreachable, and the docstring says so.
+
+**Cost if wrong.** An unstamped foreign node would be recorded as the
+own store's: its `derived-from` record's `method` reads NIL, and
+`premises-of` then looks for the premise in `graph` and drops it when
+it is not there.
+
+---
+
+## Carried forward
+
+Seen in the same review and deliberately not fixed in this pass. Each
+is a nit or a latent tidy, none changes behaviour a consumer can see,
+and none belongs in a commit whose subject is the transaction refusal.
+
+- **`%normalize-scope` does not check `graph-open-p`.** A closed store
+  passes the type and keyword checks and fails later, at its first
+  read.
+- **`%reconcile-provenance`'s merge branch is unreachable.**
+  `%merge-premise-refs` has already made each premise key unique per
+  derived claim, so the `seen` case of the `wanted` accumulation cannot
+  fire; the merge rule it applies is right, and the branch is dead.
+- **`rules-in-scope` now reads two ways.** It means "the rules a
+  compile checks against", which since #332 collides with `:scope`, the
+  stores. A rename touches S1 and S2 code and belongs on its own.
+- **`with-two-stores` leaks A if B fails to open.** Both `make-graph`
+  calls are in the `let*`, so a failure on B's leaves A open until the
+  fixture's scratch cleanup runs.
+- **`%scope-lookup` copies the first store's list.** `append` copies
+  every list but the last, so even a single-store scope pays one copy
+  per route.

--- a/docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md
+++ b/docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md
@@ -1,0 +1,316 @@
+# Decisions: rules S3 (#332, epic #304)
+
+The controller rulings S3 was planned and executed under, transcribed
+from the plan's header and the SDD ledger so the record outlives the
+worktree. **Every one was taken without Kevin in the loop**, each after
+a source-verified recon pass or a task review; each carries the cost of
+being wrong as it was stated at the time. Nothing here is re-derived or
+improved.
+
+**None deviates from the spec's letter.** S3-P2 is the one that comes
+close and does not: spec §7 says a run is one transaction, and a
+cross-store run's evaluation sits outside it. That is a refinement §7's
+own mechanism forces — the engine refuses every read of another store
+inside a read-write transaction (GH #53), so "one transaction" and
+"reads a scope of stores" cannot both hold literally. The reconcile,
+which is what §7's atomicity is about, is still one transaction. The
+rest of these rulings decide something §10 left open.
+
+Order of authority while S3 ran: spec > these rulings > the recon's API
+facts (`docs/superpowers/notes/2026-09-05-rules-s3-engine-api-facts.md`)
+> the task brief.
+
+The recon's four corrections **C1–C4** and its observation **O1** are
+not repeated here. They are findings about the engine, not decisions
+about the design, and they live in §C of that note with the source each
+was verified against. Where a correction forced a decision it appears
+below as the ruling it forced: C1 → S3-R1, C2 → S3-R2, C4 → S3-R3.
+
+The spec is
+`docs/superpowers/specs/2026-09-04-rules-as-producers-design.md`; the
+contract as shipped is `docs/rules.md` ("Cross-store scope").
+
+---
+
+## Taken while planning
+
+### S3-P1 — scope is a run-time argument, and the special is `graph-db::*claim-scope*`
+
+**Decision.** `run-rule graph rule &key scope` and
+`run-rules graph &key scope`; `scope` is a list of open graphs, `graph`
+is put first if absent, and the rule writes only `graph` (spec §10).
+During evaluation `run-rule` binds `*claim-scope*` to that list;
+`claim/7` and `claim-producer/2` iterate it per route, own store first,
+and with it NIL behave exactly as S1 shipped them. A Lisp caller may
+bind it around a raw `select`.
+
+**Evidence.** Spec §10 states the reads and the write side but not
+where the scope lives. A run-time argument needs no schema change and
+no migration, and the special is what lets the functors — homed in
+`graph-db`, not in `graph-db.rules` — see it without a new parameter on
+seven functors.
+
+**Cost if wrong.** A scope that should have been a record slot must be
+threaded by every caller; reversible by adding a slot later.
+
+### S3-P2 — a cross-store run evaluates before its transaction, under composed snapshots
+
+**Decision.** When the scope holds a store other than `graph`,
+`run-rule` evaluates the body inside nested `call-with-read-snapshot`s
+of every store in scope (own store included) and only then opens the
+write transaction for the reconcile. A single-store scope keeps S2's
+inside-the-transaction path unchanged.
+
+**Evidence.** The engine's read-resolution rule is exhaustive: inside a
+read-write transaction on A, any read of B signals
+`cross-graph-transaction-error`, snapshot or no snapshot
+(`transactions.lisp`, `lookup-object`'s transactional method;
+`tests/multi-graph-tests.lisp`
+`read-write-transaction-blocks-a-foreign-read-even-under-a-snapshot`).
+Under a shared clock the composed snapshots take epochs from one
+counter — equal in a quiescent image, comparable always (GH #168); the
+engine deliberately provides no single instant across stores
+(`call-with-read-snapshot`'s docstring, GH #53; recon C2), so no doc or
+test claims one. Without a clock each store is internally consistent
+and the epochs are not even comparable.
+
+**Cost if wrong.** A cross-store run is not serialised against
+concurrent premise writes — a premise committed after the snapshots is
+seen by the next run, not this one, with no conflict raised.
+Single-store runs keep S2's serialisation.
+
+### S3-P3 — a premise leaves evaluation as `(identity-key . store-name)`, never as a node
+
+**Decision.** `%desired` records for each solution the premises'
+`claim-identity-key` and the name of the store they came from
+(`node-graph`, with `resolve-node-graph` as the fallback), so the
+reconcile — which runs inside A's transaction — reads no foreign node.
+`store-name` is cl-llm's convention,
+`(string-downcase (symbol-name (graph-name g)))`. The `derived-from`
+record's `method` is that name when the premise's store is not the
+rule's store, NIL otherwise (spec §10). Two stores holding one identity
+key contribute one record (the family's `def-unique` tuple excludes
+`method`), the rule's own store preferred, else the first in scope
+order.
+
+**Evidence.** The binding reason is the read pin, not the cross-graph
+error (recon C4): a node `index-lookup` returns under a snapshot skips
+`ensure-node-bytes`, so reading its slots after the snapshot's extent
+reads B's heap unpinned. Everything the reconcile needs from a premise
+is computed inside the snapshot.
+
+**Cost if wrong.** One store name lost in the two-stores-one-identity
+corner; recorded, and asserted by
+`a-premise-that-moves-store-renames-its-method`.
+
+### S3-P4 — `premises-of` resolves a premise in the store its record names, if in scope
+
+**Decision.** A record naming no store resolves in `graph`; a record
+naming a store in `scope` resolves there; a record naming a store not
+in `scope` is dropped. Mirrors cl-llm's `%resolve-in` (`:absent` for a
+store out of scope). `dependents-of` is unchanged: the records live in
+the rule's store, and a premise from any store is looked up by its
+identity key.
+
+**Evidence.** Spec §9's reads say nothing about stores, so the
+consumer's convention (kraison/cl-llm#24, `memory/trace.lisp`) decides:
+a cite resolves in the store it names when that store is in scope, else
+it is absent. Resolving a foreign key in `graph` instead would answer a
+different claim that happens to share an identity key.
+
+**Cost if wrong.** A caller who forgets the scope sees fewer premises,
+never wrong ones.
+
+### S3-P5 — compile stays single-store
+
+**Decision.** The guard validates a rule's text against its own store's
+schema and the cycle graph is over the rule's own store (spec §6); a
+family read from a foreign store must be declared under the rule's
+store's name too. A foreign store in scope whose schema lacks a family
+a goal names contributes nothing.
+
+**Evidence.** The family registry is per family symbol and the indexes
+are per store (S2 recon A4), so a second `def-claim-classes` under
+another store name is the whole cost of sharing a family.
+`%scope-lookup` swallows the `query-precondition-error`
+`%require-index` signals, per foreign store and per route, as
+`%producer-candidates` and `%claim-by-identity-key` already do (recon
+C1).
+
+**Cost if wrong.** Consumers declare shared families under both names;
+a cross-store cycle (A reads what B's rule derives and vice versa) is
+not detected — recorded as a known limit in `docs/rules.md` and left to
+the recursion slice (#333).
+
+### S3-P6 — the unrouted walk walks every store in scope, refusal unchanged
+
+**Decision.** `%unbound-claim-scan` maps every store in scope when no
+bound is in effect; under a bound it refuses exactly as S1 does. No new
+behaviour on the guarded surface.
+
+**Evidence.** The refusal is a property of the goal's routing, not of
+how many stores it would read; making a scope change it would mean a
+query's admissibility depended on an operator's scope.
+
+**Cost if wrong.** A wide scope makes an unbudgeted walk N times as
+expensive; the budget that already governs it is the answer.
+
+---
+
+## Taken in the pre-flight scan
+
+**None.** The scan (ledger, 2026-09-05) checked the four produce/consume
+pairs across the three tasks and the arithmetic of every count a test
+asserts, and found them consistent; two items were left pending on
+recon B2 and B7 and both were confirmed by Task 0. Nothing needed a
+ruling before Task 0 ran.
+
+---
+
+## Taken during execution
+
+### S3-R1 (from recon C1) — only a FOREIGN store's missing family is swallowed
+
+**Decision.** The own store (first in scope) calls `index-lookup` bare
+and signals as S1 did; each foreign store's lookup is wrapped and
+contributes nothing when that store's schema does not carry the family.
+
+**Evidence.** A single-store goal on a family the store does not index
+is S1's documented ill-typed refusal (`docs/rules.md`, "Unknown
+names") and must not turn into silent emptiness because an operator
+passed a scope. Recon C1 established that `claim/7`'s three indexed
+routes signal today, and that only `%producer-candidates` and
+`%claim-by-identity-key` swallow.
+
+**Cost if wrong.** A scope whose *own* store lacks the family refuses
+rather than reading the others.
+
+### S3-R2 (from recon C2) — nothing claims "one instant"
+
+**Decision.** No doc, docstring or test asserts that a cross-store
+run's reads resolve at one instant. The wording is "one comparable
+epoch space, equal in a quiescent image", and the clocked test asserts
+only that the run works and derives from both stores.
+
+**Evidence.** The engine deliberately provides no cross-store instant
+(`call-with-read-snapshot`'s own docstring, GH #53), so a test of one
+would pass vacuously in a quiescent suite and fail the first time the
+suite ran concurrently.
+
+**Cost if wrong.** None; #332 does not close the namespaces design's
+§12 aspiration and says so.
+
+### S3-R3 (from recon C4) — the read pin is S3-P3's rationale
+
+**Decision.** S3-P3's stated reason is the read pin, not the
+cross-graph error: nodes never leave a snapshot's extent, and
+everything the reconcile needs is computed inside it.
+
+**Evidence.** Recon C4: under a read snapshot `lookup-object`
+re-dispatches to the transactional method and never reaches
+`ensure-node-bytes`, so a node returned under a snapshot is not
+self-contained once the snapshot exits. On the plan's original
+reasoning (the cross-graph error alone) carrying the node would have
+looked safe.
+
+**Cost if wrong.** None now; it forbids a later pass-the-node
+optimisation, which is the point of recording it.
+
+### S3-R4 (Task 2) — `method` is refreshed by copy/save, not swept and rewritten
+
+**Decision.** A kept `derived-from` record whose premise moved store
+has its `method` refreshed in `%refresh-kept`'s existing single
+copy/save, together with `rule-version`. The record is not deleted and
+re-inserted.
+
+**Evidence.** Measured, not reasoned: under the brief's
+sweep-and-rewrite shape
+`a-premise-that-moves-store-renames-its-method` reported `:refused`
+with a `DERIVATION` unique-constraint violation. `method` is not in the
+family's unique tuple, and `mark-deleted` releases a unique key only
+post-durability while `validate-unique-constraints` runs
+pre-durability — the same collision ruling P10 already documents for
+the claims themselves.
+
+**Cost if wrong.** None known; a record's `method` changes without its
+identity changing, which is what "not part of the identity tuple"
+means.
+
+### S3-R5 (Task 2) — `%desired` owns the `disjoint-premises` reset
+
+**Decision.** `%derive` resets the three reconcile counts at the top of
+every transaction attempt; `%desired` resets `disjoint-premises`, the
+one count the evaluation produces.
+
+**Evidence.** With the evaluation hoisted out of the transaction,
+`%derive` runs per attempt while a cross-store `%desired` runs once, so
+`%derive` resetting all four would zero a count the evaluation had
+already produced —
+`cross-store-validity-intersects-across-stores` would have read 0
+disjoint. The single-store path re-runs `%desired`, so it stays correct
+either way.
+
+**Cost if wrong.** None; the counts are per attempt on both paths,
+which is what `the-reports-counts-are-per-attempt-not-cumulative`
+asserts.
+
+### S3-R6 (Task 2) — "nothing was written to B", asserted without reading B's derivation family
+
+**Decision.** The nothing-in-B check asserts no claim in B under
+`rule/web-hosts` in either family B carries, B's own claims still
+exactly `seed-b`'s, and `%graph-declares-p` false for `derivation` on
+B — rather than the brief's
+`(is (null (claims-by-producer b 'derivation "rule/web-hosts")))`.
+
+**Evidence.** B never declared the derivation family, so that read
+signals `query-precondition-error` (recon C1) rather than answering
+NIL. The shipped assertions say the same thing and are reachable: if
+the family is not declared, no record can live there.
+
+**Cost if wrong.** None; the claim being tested is stronger, not
+weaker.
+
+### S3-R7 (Task 1, environment) — the shared `cl-temporal-extent` checkout was fast-forwarded
+
+**Decision.** `~/work/cl-temporal-extent` (clean, on `master`, shared
+with other sessions) was fast-forwarded `1ca7765` → `41b96ef` (0.3.0)
+so the Quicklisp local-projects symlink resolves the version floor
+`graph-db.asd` now carries. Task 1 itself avoided the checkout, running
+against a read-only `git archive` extract in its scratchpad.
+
+**Evidence.** S2 shipped `graph-db/spacetime` with
+`:version "0.3.0"` on that library and the merge to `experiment` made
+that the branch's floor; the checkout was three commits behind, so
+every suite command in the plan aborted at system resolution.
+Fast-forwarding a clean checkout to its own origin is not a source
+edit.
+
+**Cost if wrong.** Another session holding FASLs built against 0.2.0
+recompiles; nothing in that repo was edited, and the branch it is on
+did not change.
+
+### S3-R8 (Task 3) — `premises-of` reads its `scope` as given
+
+**Decision.** `premises-of` does not normalise its `scope`: it neither
+puts `graph` first nor drops duplicates, because the list is only ever
+searched by store name. A record with a NIL `method` resolves in
+`graph` whether or not `graph` is in the list, and a non-keyword-named
+store in the list meets `%store-name`'s `check-type`.
+
+**Evidence.** `%normalize-scope`'s two jobs — own store first, read
+each store once — are properties of an *evaluation*, and there is no
+evaluation here. Normalising would also make `(premises-of a c :scope
+(list b))` quietly resolve own-store records it already resolves, at
+the cost of implying the argument means what it means to `run-rule`.
+
+**Cost if wrong.** A caller passing `run-rule`'s exact scope gets the
+same answer either way; a caller passing a bare foreign store keeps
+own-store premises, which is what S3-P4 wants.
+
+---
+
+## Not yet taken
+
+The whole-branch review is the controller's, after this commit. Its
+rulings, if any, belong in a closing section here, in S2's "Taken in
+the final review" shape.

--- a/docs/superpowers/handoffs/2026-09-05-rules-s2.md
+++ b/docs/superpowers/handoffs/2026-09-05-rules-s2.md
@@ -6,6 +6,12 @@ now done.
 
 ## Status (updated 2026-09-05, end of S2 implementation)
 
+**Closed out:** S2 merged as `a75cf96` on `experiment`, and S3 (#332 --
+cross-store scope, `method` on `derived-from`, `premises-of :scope`)
+followed on `feat/rules-s3` from that commit; its record is
+`docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md`. Everything
+below describes S2 as it was handed over.
+
 **S2 is complete on `feat/rules-s2`** (head `e9800b3`, 14 commits on
 `4fb8780`) in `/home/raison/work/vivace-graph-v3/.worktrees/rules-s2`,
 reviewed per task and as a whole branch, **not pushed**. The plan is

--- a/docs/superpowers/notes/2026-09-05-rules-s3-engine-api-facts.md
+++ b/docs/superpowers/notes/2026-09-05-rules-s3-engine-api-facts.md
@@ -1,0 +1,1074 @@
+# Engine API facts, verified for rules S3 (#332)
+
+A snapshot, not a maintained document. The recon pass for S3's plan
+(`docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md`,
+Task 0): nine assumptions B1–B9, each confirmed or refuted from source,
+every correction re-checked against a second location before it was
+kept. It is committed because it is the record of why the S3 tasks say
+what they say — §C is the finding → correction map the plan text is to
+be amended from. Its model is the S2 note
+(`docs/superpowers/notes/2026-09-05-rules-s2-engine-api-facts.md`),
+whose A4, A6 and C2 B6 and B9 build on.
+
+**Pinned to `54dddbd`** (this branch's tip, `feat/rules-s3`; the tree is
+`origin/experiment` `a75cf96` plus the plan doc, so every engine line
+number is `a75cf96`'s). Every `file:line` will drift; the quoted forms
+are what to match on, not the numbers. Paths beginning `~/work/cl-llm`
+are the consumer repo, not this one.
+
+**Nothing here was evaluated in an image.** Every item settled from
+source, so no `sbcl --non-interactive` run was needed and none was made.
+A claim about *runtime* behaviour is therefore an inference from the
+code and is marked as such where it matters.
+
+Reading order:
+
+- **§C — corrections.** Four defects this pass found in the S3 plan
+  before execution began, plus one observation (O1) that is outside
+  B1–B9 and is flagged as not settled to the same depth. C1 is blocking
+  for Task 1.
+- **§B — the nine items** in order, each with the form quoted.
+
+Line lengths here exceed the repo's 80-column rule in a few dozen places
+(quoted forms and tables). Left as verified rather than rewrapped by
+hand, which risks silently corrupting a quoted form. Every quoted form
+is verbatim; the only edits are a `...` standing for lines dropped from
+the middle of a form. Every code line is byte-for-byte.
+
+---
+
+# §C — corrections to the S3 plan
+
+## C1 (BLOCKING for Task 1) — a store in scope that lacks the family makes `claim/7` SIGNAL, not contribute nothing
+
+**Plan assumes (S3-P5, and B9's framing):** "A store in scope whose
+schema lacks a family a goal names simply contributes nothing (the
+`query-precondition-error` `%producer-candidates` already swallows)."
+
+**Reality: only `%producer-candidates` swallows it. `claim/7`'s three
+indexed routes call `index-lookup` bare, and `index-lookup` signals.**
+
+`%require-index` is the gate, and its `t` clause is an error, not a NIL
+(`index.lisp:973-988`):
+
+```lisp
+(defun %require-index (graph class-name slot-name)
+  "The SLOT-INDEX for CLASS-NAME.SLOT-NAME.  Returns NIL when the slot is a declared
+index (via :INDEX or DEF-INDEX) but no entries exist yet (a legitimately empty
+result); signals only when the slot is not indexed at all (a programming error)."
+  (let* ((slot-names (%normalize-slots slot-name))
+         (six (%secondary-index-lookup graph class-name slot-names)))
+    (cond (six six)
+          ((or (%slot-index-declared-p class-name slot-names)
+               (%def-index-declared-p graph class-name slot-names))
+           nil)                                             ; declared, empty
+          ;; A caller's error, typed so a server can tell it from a
+          ;; defect (GH #286).
+          (t (error 'query-precondition-error
+                    :reason (format nil "No secondary index on ~S.~S in ~S"
+                                    class-name slot-name
+                                    (graph-name graph)))))))
+```
+
+Both escape clauses are per-store or arity-limited, so neither saves a
+store that never declared the family:
+
+- `%secondary-index-lookup` reads `(secondary-indexes graph)` — that
+  store's own registry (`index.lisp:929-945`).
+- `%def-index-declared-p` reads `%registered-index-specs graph`, which
+  is `(gethash (graph-name graph) *schema-index-metadata*)`
+  (`index.lisp:177-186`) — again that store's own.
+- `%slot-index-declared-p` is class-level but "Only matches at arity 1"
+  (`index.lisp:947-960`). Every claim index this code uses is a tuple —
+  `+claim-subject-index-slots+` (2), `+claim-subject-relation-index-slots+`
+  (3), `+claim-object-index-slots+` (2) — and `producer`, the one
+  arity-1 index, is declared by `def-index`, not by an `:index t` slot
+  option (`spacetime/claim.lisp`'s `+claim-shared-slots+` has no
+  `:index`). So it is NIL for all four.
+
+And `claim/7` catches nothing (`rules/facts.lisp:141-159`):
+
+```lisp
+                 ((and sns skey rel)
+                  (index-lookup g parent
+                                +claim-subject-relation-index-slots+
+                                (list sns skey rel)))
+                 ((and sns skey)
+                  (index-lookup g parent +claim-subject-index-slots+
+                                (list sns skey)))
+                 ((and ons okey)
+                  (index-lookup g binary +claim-object-index-slots+
+                                (list ons okey)))
+```
+
+**Second location, and the shape of the fix.** Every *other*
+`index-lookup` caller that iterates families or stores already wraps it,
+and says why. `%producer-candidates` (`rules/facts.lisp:233-252`):
+
+```lisp
+        (handler-case
+            (dolist (c (index-lookup graph parent
+                                     +claim-producer-index-slots+
+                                     producer))
+              (push c out))
+          ;; Also the condition a wrong component count signals
+          ;; (%INDEX-BOUNDS, index.lisp) -- safe only while this index
+          ;; is arity 1 and PRODUCER a bare scalar; a multi-slot one
+          ;; would read a shape error as "no candidates".
+          (query-precondition-error () nil))))))
+```
+
+and S2's own premise resolver, `%claim-by-identity-key`
+(`rules/run.lisp:553-566`):
+
+```lisp
+          ;; A family this graph does not index, as %PRODUCER-CANDIDATES
+          ;; reads it (rules/facts.lisp): no candidates, not a fault.
+          (graph-db:query-precondition-error () nil)))
+```
+
+**Fix (Task 1).** Wrap each per-store `index-lookup` in `claim/7` in the
+same `handler-case (... (query-precondition-error () nil))`, per store
+and per route, so an undeclared family in one store of the scope
+contributes nothing instead of aborting the whole goal. Amend S3-P5's
+parenthetical to say the swallow must be **added** to `claim/7`, not
+that it already exists. `tests/rules/suite.lisp:46-55` already ships the
+fixture this needs — `rtf-claim` on `:graph-db-rules-test-foreign`, a
+family "indexed in no graph here" — so a scope test can use a store
+whose schema lacks `rt-claim` without inventing one.
+
+**Two things this does NOT change.**
+
+- The declared-but-empty case is already correct: with `rt-claim`
+  declared for store B and no claims written, `%secondary-index-lookup`
+  returns NIL, `%def-index-declared-p` returns T, `%require-index`
+  returns NIL, and `index-lookup`'s `(when six ...)` yields NIL. No
+  signal, no rows.
+- **S3-P6 is right as written.** `%unbound-claim-scan` goes through
+  `map-vertices :vertex-type parent`, and `resolve-node-type-ids` drops
+  a designator no store-registered type answers to
+  (`node-class.lisp:325-340`): "Designators that resolve to no
+  registered type of KIND are skipped (so the 0 sentinel and cross-graph
+  subclasses simply drop out)." The `dolist` over an empty `type-ids`
+  visits nothing. Silent, no signal.
+
+## C2 — composed snapshots under one clock are NOT one instant
+
+**Plan assumes (Goal line; S3-P2; Task 2's `with-clocked-stores`
+docstring "so the two stores' snapshots share an instant (#168)"; Task
+2's `(#168)` docstring and Step 5's docs text):** "the reads of a
+cross-store run resolve at one instant under the shared clock".
+
+**Reality: the shared clock buys a single comparable epoch space, not an
+atomic acquisition.** `call-with-read-snapshot` establishes each store's
+snapshot independently; nothing coordinates the two, and its own
+docstring denies the property (`transactions.lisp:3333-3337`):
+
+```lisp
+The snapshot is recorded in *READ-SNAPSHOTS* under GRAPH rather than bound to
+*TRANSACTION*, so snapshots on several graphs COMPOSE: a cross-graph query holds
+one snapshot per participating graph, each internally consistent, with
+deliberately no single instant across them (GH #53).  An enclosing snapshot of
+the SAME graph is inherited, as is a read-write transaction on it.
+```
+
+The epoch each snapshot resolves at is read, not reserved, at
+`create-transaction` time (`transactions.lisp:3277-3291`):
+
+```lisp
+    (let* ((sequence-number (next-sequence-number transaction-manager))
+           (graph (graph transaction-manager))
+           (cache (cache graph))
+           (start-tx-id (tm-current-epoch transaction-manager))
+```
+
+and `tm-current-epoch` reads the *graph's own* manager's clock
+(`transactions.lisp:3212-3219`), which under a shared clock is
+`(system-clock-counter clock)` (`system-clock.lisp:291-294`). Two
+`call-with-read-snapshot`s therefore read the same counter at two
+different moments.
+
+**Second location — the engine's own test engineers the divergence
+deliberately** (`tests/system-clock-tests.lisp:756-768`):
+
+```lisp
+(test cross-store-snapshot-pins-every-store
+  ;; Identity, not just presence (review round 2): a hypothetical swapped
+  ;; implementation -- GA's snapshot pinning TM-B, GB's pinning TM-A --
+  ;; would still pass a count-only check, since both tables end up with
+  ;; one entry each.  Under a SHARED clock the two managers' epochs are
+  ;; usually the same number, so a value comparison alone can't tell them
+  ;; apart -- unless something advances the clock between the two
+  ;; snapshots' establishment.  A real write on GB before GB's own
+  ;; snapshot does exactly that, so GA's and GB's own pin-time epochs
+  ;; diverge and a swap becomes visible as a value mismatch.
+```
+
+"usually the same number" is the whole guarantee. `create-transaction`
+reads `tm-current-epoch`, not `tm-next-epoch`, so a read-only snapshot
+does not itself advance the clock — with no concurrent writer the two
+epochs *are* equal. With one, they are not, and the composition then
+sees store A as of `e_A` and store B as of `e_B > e_A`.
+
+**What the clock actually buys**, and what the plan may say: the two
+epochs come from one monotonic space, so they are *comparable* across
+stores (spec `docs/superpowers/specs/2026-08-20-namespaces-design.md`
+§6: "Below the watermark epochs are not cross-store comparable; above it
+they are"), and they are *equal in a quiescent image*. Without a clock
+they are not even comparable (#53).
+
+**Fix.** Reword the Goal line, S3-P2, `with-clocked-stores`' docstring,
+Task 2's `run-rule` docstring and Step 5's "Running a rule" docs to say
+one *comparable epoch space*, equal when nothing commits between the
+acquisitions — never "one instant". And do not write a test that asserts
+one instant: it would pass vacuously in a quiescent suite and pin a
+property the engine does not provide. The design's acceptance bullet
+("A cross-store query resolves at one instant", §12) is an aspiration
+this unit does not implement, and #332 should not claim it.
+
+## C3 — `clos.lisp` is not loaded at all; the applicable method is in `primitive-node.lisp`
+
+**Plan assumes (B4):** check `slot-value-using-class :around`
+(`clos.lisp:38-43`).
+
+**Reality: `clos.lisp` is not a component of any system in
+`graph-db.asd`.** It is tracked in git and never compiled. `grep -n
+clos graph-db.asd` finds only `:closer-mop` and two comment lines; the
+base system's component list runs `... node-class, views,
+primitive-node, vertex, edge ...` with no `clos` entry. Its
+`graph-class` metaclass is used by exactly one class — `node`, in that
+same dead file (`clos.lisp:63-87`) — and the live `node` is
+`node-class.lisp:415-445`, `(:metaclass node-class)`. `clos.lisp:53`
+even calls `(save-node instance)` with one argument where `save-node`
+takes `(node table &key graph)` (`primitive-node.lisp:361`), which
+would signal if it ever ran.
+
+**The method that actually fires** for a claim slot read is
+`primitive-node.lisp:506-516`:
+
+```lisp
+(defmethod slot-value-using-class :around ((class node-class) instance slot)
+  "Around method that is alternate-version aware and will show values for the current,
+   working private version of instance."
+  (log:trace "slot-value-using-class~%  '~A'~%  '~A'" class (slot-definition-name slot))
+  (let* (#+lispworks(slot (closer-mop::find-slot slot class))
+         (slot-name (slot-definition-name slot))
+         (slot-keyword-name (%persistent-slot-keyword class slot-name)))
+    (if slot-keyword-name
+        ;; FIXME: Check for txn and give current revision's value
+        (node-slot-value instance slot-keyword-name)
+        (call-next-method))))
+```
+
+Claim classes reach it because `def-vertex` expands to a `defclass` with
+`(:metaclass node-class)` (`schema.lisp:797`).
+
+**Fix.** B4's *conclusion* is unchanged and CONFIRMED (see §B), but
+every task or doc line citing `clos.lisp:38-43` must cite
+`primitive-node.lisp:506-516` → `node-slot-value`
+(`primitive-node.lisp:441-449`) → `maybe-init-node-data`
+(`primitive-node.lisp:300-336`) instead.
+
+## C4 — the reason a premise must not escape evaluation is the read PIN, not the cross-graph error
+
+**Plan assumes (S3-P3, and B4's framing):** the premise leaves as
+`(identity-key . store-name)` because the reconcile "runs inside A's
+transaction" and a foreign node read there would signal.
+
+**That is true but is not the binding constraint**, and B4's own
+question ("if any lazy slot read can call `lookup-object`") answers no —
+so on the plan's stated reasoning alone, carrying the node would look
+safe. It is not.
+
+Under a read snapshot, `lookup-object` re-dispatches to the
+*transactional* method and never reaches the branch that materialises
+bytes (`transactions.lisp:291-296`):
+
+```lisp
+  (:method (id table (transaction null) graph)
+    ;; No read-write transaction: a read-only snapshot of GRAPH, if one is
+    ;; active, resolves the read (GH #53).
+    (let ((snapshot (and *read-snapshots* (gethash graph *read-snapshots*))))
+      (when snapshot
+        (return-from lookup-object (lookup-object id table snapshot graph))))
+```
+
+The `ensure-node-bytes` call sits *after* that `return-from`, in the
+`standalone` branch (`transactions.lisp:304-317`). The transactional
+method calls `ensure-node-bytes` only inside `resolve-version-at-epoch`,
+and only when it returns an *archived* version
+(`transactions.lisp:645-663`); a live head old enough for the snapshot
+is returned as-is, lazy.
+
+So a node returned by `index-lookup` under store B's snapshot may carry
+`bytes` `:INIT`. Read a slot on it after the snapshot exits and
+`maybe-init-node-data` reads B's heap at the node's `data-pointer` with
+no read pin in force (`primitive-node.lisp:300-322`):
+
+```lisp
+    (let ((bytes (bytes node)))
+      (when (or (eq bytes :init) (null bytes))
+        (setf bytes
+              (setf (bytes node)
+                    (read-bytes (make-mpointer
+                                 :mmap (memory-mmap
+                                        (heap (node-home-graph node graph)))
+                                 :loc (data-pointer node))))))
+```
+
+which is exactly what `ensure-node-bytes`' docstring says must not
+happen (`primitive-node.lisp:217-222`): "this is the materialization the
+read paths perform WHILE A READ PIN (or the reading transaction's
+start-tx-id) protects NODE's data block, so the bytes are captured
+before the pin is released and the node can escape self-contained."
+`call-with-read-snapshot` holds that pin only for its own extent
+(`transactions.lisp:3369-3376`, `pin-read-epoch` / `unpin-read-epoch`).
+
+**Fix.** Restate S3-P3's rationale: everything the reconcile needs from
+a premise — the identity key, and the extent sexp if any later task
+wants it — must be computed **inside** the snapshot extent, because a
+node that escapes an `index-lookup` under a snapshot is not
+self-contained. The cross-graph refusal is a second, weaker reason.
+Note the asymmetry the tasks must not forget: `%unbound-claim-scan`'s
+`map-vertices ... :collect-p t` *does* materialise
+(`vertex.lisp:227-233`, "When collecting, each node ESCAPES the scan
+pin, so materialize its bytes before FN sees it"), `index-lookup` does
+not. This does not change any task's structure — S3-P3 already computes
+the key during evaluation — it changes why, and it forbids a later
+"optimisation" that passes nodes to the reconcile.
+
+## O1 (observation, outside B1–B9 — not settled to the same depth)
+
+Secondary-index **membership** is not snapshot-versioned. `%ix-release`
+removes the entry outright, post-durability
+(`index.lisp:602-609`, under the header "Maintenance (APPLY,
+post-durability, journal-replayable -- no enforcement)"), and
+`index-lookup`'s only snapshot-aware step is resolving each id it
+already found. So under a read snapshot of store B, a claim *inserted*
+after the snapshot is correctly invisible (`%node-by-id` →
+`resolve-version-at-epoch` returns NIL, and the `(when (and node ...))`
+guard drops it), but a claim *deleted* after the snapshot is also
+invisible, though the snapshot's epoch predates the delete.
+
+This is pre-existing and equally true of S2's single-store runs; it is
+not an S3 regression and nothing in the plan depends on the stronger
+reading. Recorded so no S3 doc or test asserts more per-store
+consistency than the engine provides. **Not adversarially settled by a
+live scenario** — verify by test before relying on it in either
+direction.
+
+## Finding → correction map
+
+| finding | item(s) | correction | severity |
+|---|---|---|---|
+| `claim/7`'s indexed routes signal `query-precondition-error` on a scope store that never declared the family; only `%producer-candidates` and `%claim-by-identity-key` swallow it | B1, B9 (S3-P5) | C1 | **blocking for Task 1** |
+| composed snapshots under one clock are one comparable epoch space, not one instant; the engine's docstring and test both say so | B2, B7 (Goal, S3-P2) | C2 | wording of the Goal, S3-P2, two docstrings, the docs; forbids one test |
+| `clos.lisp` is in no system and never loaded; the live method is `primitive-node.lisp:506-516` | B4 | C3 | citation + mechanism |
+| a node escaping `index-lookup` under a snapshot is not self-contained; the pin, not the cross-graph error, is what forces key-plus-store-name | B3, B4 (S3-P3) | C4 | rationale; forbids a later "pass the node" change |
+| secondary-index membership is not snapshot-versioned | — (new) | O1 | observation, no plan change |
+
+Everything else — B5, B6, B8, and the confirmed halves of B1–B4, B7,
+B9 — is CONFIRMED as written, with the `file:line` drift listed per
+item.
+
+---
+
+# §B — the nine items
+
+## B1 — `index-lookup` on a foreign graph inside a read-write transaction — CONFIRMED (path exact; see C1 for a second failure mode the plan did not anticipate)
+
+The path is exactly as the plan states, and every route in
+`index-lookup` funnels through it.
+
+`index-lookup` resolves every id through `%node-by-id`, in both the
+collecting and the short-circuit arm (`index.lisp:990-1013`):
+
+```lisp
+  (let* ((*graph* graph)
+         (six (%require-index graph class-name slot-name)))
+    (when six                            ; NIL => declared but empty => no matches
+      (let ((key (%index-key six value))
+            (result '()))
+        (when key
+          (dolist (id (ix-lookup six key :prefix prefix))
+            (let ((node (%node-by-id id graph)))
+              (when (and node (not (deleted-p node)))
+                (if collect-p (push node result) (return-from index-lookup t))))))
+        (when collect-p (nreverse result))))))
+```
+
+Note `(let ((*graph* graph) ...))`: `index-lookup` rebinds `*graph*` but
+**not** `*transaction*`, which is what makes the refusal below reachable.
+
+`%node-by-id` (`spatial-query.lisp:35-38`):
+
+```lisp
+(defun %node-by-id (id graph)
+  "Resolve a spatial-index id (uuid bytes) to its live node, or NIL."
+  (or (lookup-vertex id :graph graph)
+      (lookup-edge id :graph graph)))
+```
+
+Both arms pass the *ambient* transaction and the *explicit* graph
+(`vertex.lisp:110-115`, `edge.lisp:144-148`):
+
+```lisp
+(defmethod lookup-vertex ((id array) &key (graph *graph*))
+  "Return the vertex with the given ID (a 16-byte id array or its string form)
+in GRAPH, or NIL if none.  Returns the vertex regardless of its deleted flag;
+the generated LOOKUP-<type> functions filter deleted nodes for you."
+  (lookup-object id (vertex-table graph) *transaction* graph))
+```
+
+and `lookup-object`'s transactional method refuses the mismatch before
+anything else (`transactions.lisp:319-326`):
+
+```lisp
+  (:method (id table transaction (graph t))
+    ;; A read-write transaction is single-graph (GH #53).
+    (let ((txn-graph (graph transaction)))
+      (unless (eq graph txn-graph)
+        (error 'cross-graph-transaction-error
+               :node id :transaction-graph txn-graph :node-graph graph)))
+```
+
+`cross-graph-transaction-error` is `conditions.lisp:16-30`; its report
+prints both graph names, so a scope-refusal test can assert on them.
+
+**No route bypasses it.** `index-lookup` has exactly one node-producing
+call, `%node-by-id`. `ix-lookup` (`index.lisp:488`) reads the index's
+own ordered map, not nodes; `%require-index` reads registries. The
+`(node-p c)` early arm of `claim/7` (`rules/facts.lisp:141`) returns a
+node the caller already held and performs no lookup at all.
+
+**Citation drift:** the plan says `transactions.lisp ~:319-323`; the
+method head is `:319` and the `error` form is `:323-325`.
+
+**What the plan missed here is C1**, not the refusal: the *other* way a
+foreign-store `index-lookup` fails is `%require-index`'s
+`query-precondition-error`, and that one fires outside any transaction.
+
+## B2 — composed snapshots, and `select :snapshot t` inheriting — CONFIRMED (all three halves, from the code)
+
+**(a) Both graphs are registered in one `*read-snapshots*` table.**
+`call-with-read-snapshot` reuses an enclosing table rather than shadowing
+it, and adds its own entry (`transactions.lisp:3357-3382`):
+
+```lisp
+      (t
+       (let ((txn nil)
+             (pin nil)
+             (table (or *read-snapshots* (make-hash-table :test 'eq))))
+         ...
+         (unwind-protect
+              (progn
+                (setq txn (create-transaction tm :allow-read-only t))
+                (unwind-protect
+                     (progn
+                       (setq pin (pin-read-epoch tm))
+                       (let ((*read-snapshots* table))
+                         (setf (gethash graph table) txn)
+                         (funcall thunk)))
+                  (when pin (unpin-read-epoch tm pin))))
+```
+
+`(or *read-snapshots* (make-hash-table ...))` is the composition: the
+inner call takes the outer's table object, so after nesting A then B the
+one table holds both. The special is `transactions.lisp:31-33`:
+
+```lisp
+(defvar *read-snapshots* nil
+  "Graph -> read-only snapshot transaction, or NIL.  Read-only snapshots are
+per graph and may compose; read-write transactions are not (GH #53).")
+```
+
+Behaviour is pinned by `tests/multi-graph-tests.lisp:1119-1131`
+(`read-only-snapshots-compose-across-graphs`) and, discriminatingly, by
+`composed-snapshots-each-hide-their-own-graphs-later-commits`
+(`tests/multi-graph-tests.lisp:1133-1160`), whose docstring says a
+missing entry would "fall through to a live non-transactional read".
+
+**(b) `index-lookup` on either resolves through that graph's own
+snapshot.** With `*transaction*` NIL, the null-transaction method
+dispatches on the *explicit* graph argument
+(`transactions.lisp:291-296`):
+
+```lisp
+  (:method (id table (transaction null) graph)
+    ;; No read-write transaction: a read-only snapshot of GRAPH, if one is
+    ;; active, resolves the read (GH #53).
+    (let ((snapshot (and *read-snapshots* (gethash graph *read-snapshots*))))
+      (when snapshot
+        (return-from lookup-object (lookup-object id table snapshot graph))))
+```
+
+and the re-dispatch lands on the transactional method with that
+snapshot, whose `(eq graph txn-graph)` check is satisfied by
+construction — the snapshot was created for exactly that graph. So B's
+reads resolve at B's epoch and A's at A's, with no cross-graph error,
+which is what makes S3-P2's shape legal. `read-transaction`
+(`transactions.lisp:3316-3322`) states the same resolution rule in one
+place.
+
+**(c) `select :snapshot t` inherits rather than opening a second.**
+Confirmed from the code, not the docstring. `run-query-goals` binds
+`*graph*` and emits `:snapshot t` (`query/dsl.lisp:329-346`):
+
+```lisp
+  (let* ((*graph* graph)
+         (*package* package)
+         ...
+                  (eval `(select (:effects nil :snapshot t
+```
+
+`select` expands that to a `call-with-read-snapshot` on `*graph*`
+(`prologc.lisp:1125-1131`):
+
+```lisp
+              ,(if (cdr (assoc :snapshot options))
+                   ;; Run the query under one consistent MVCC read snapshot:
+                   ;; all reads resolve at a single epoch (lock-free, stable
+                   ;; against concurrent writers).  Inherits an enclosing
+                   ;; transaction if one is already active.
+                   `(call-with-read-snapshot
+                     (lambda () (funcall func #'prolog-ignore)) *graph*)
+```
+
+and the inherit is the third `cond` clause, before any transaction is
+created (`transactions.lisp:3349-3356`):
+
+```lisp
+    (cond
+      ((null tm) (funcall thunk))
+      ;; a read-write transaction on this graph already provides a snapshot
+      ((and *transaction* (%transaction-covers-graph-p *transaction* graph))
+       (funcall thunk))
+      ;; already snapshotted this graph -> inherit
+      ((and *read-snapshots* (gethash graph *read-snapshots*)) (funcall thunk))
+```
+
+So an S3 `run-rule` that wraps `run-query-goals` in composed snapshots
+gets: A inherited by the `select`, B resolved from the table, no second
+transaction, no signal.
+
+**Citation drift:** the plan says `~:3355-3372` for the registration and
+`~:294` for the null method; both are right to within two lines
+(`3357-3382`, `291-296`).
+
+**See also O1** for the one consistency property this does *not* give.
+
+## B3 — every node `index-lookup` returns carries `node-graph` — CONFIRMED, with one path named
+
+Both arms of `lookup-node` stamp, and stamp with the graph the lookup
+named, not `*graph*` (`primitive-node.lisp:338-360`):
+
+```lisp
+(defmethod lookup-node ((table lhash) (key array) (graph graph))
+  (or (and *cache-enabled*
+           (let ((node (gethash key (cache graph))))
+             (when node
+               ;; Nodes also enter the cache unstamped (APPLY-TX-WRITE :AFTER),
+               ;; so stamp on the hit too (GH #53) -- but only when wrong, so the
+               ;; steady state of this hot read path stays a pure read.
+               (unless (eq (node-graph node) graph)
+                 (setf (node-graph node) graph))
+               (record-graph-read graph)
+               node)))
+      (let ((node (lhash-get table key)))
+        (when (node-p node)
+          (setf (id node) key)
+          (unless (eq (node-graph node) graph)
+            (setf (node-graph node) graph))
+```
+
+`finalize-node` stamps at commit (`primitive-node.lisp:208-212`):
+
+```lisp
+(defun finalize-node (node table graph)
+  (setf (written-p node) t)
+  (setf (node-graph node) graph)
+  (save-node-flags table node)
+  (setf (gethash (id node) (cache graph)) node))
+```
+
+`ensure-node-bytes` re-stamps on the standalone read path
+(`primitive-node.lisp:224-225`), `apply-tx-write ((write tx-update))`
+stamps both versions (`transactions.lisp:986-987`), `make-vertex` /
+`make-edge` stamp at construction (`vertex.lisp:161`, `edge.lisp:254`),
+and `%copy` propagates (`transactions.lisp:2857`).
+
+Pinned by `tests/multi-graph-tests.lisp:622-635`:
+
+```lisp
+(test nodes-record-their-home-graph
+  "A node read out of its own graph reports THAT graph, whatever *GRAPH* is
+bound to at the time (GH #53)."
+```
+
+and `node-graph-stamped-at-creation` (`:637-651`) for the pre-commit
+half.
+
+**The one path that can return an unstamped node.** `lookup-object`'s
+transactional method can answer from a cache without going through
+`lookup-node` (`transactions.lisp:327-334`):
+
+```lisp
+    (let ((local-cache (local-cache transaction))
+          (graph-cache (graph-cache transaction)))
+      (let ((local (gethash id local-cache)))
+        (if local
+            local
+            (let ((value (or (gethash id graph-cache)
+```
+
+`graph-cache` is `(cache graph)`. Its five writers are
+`finalize-node` (`primitive-node.lisp:212`, stamps),
+`lookup-node` (`:357`, stamps), `save-node`'s old-version cache
+(`:382`), `save-node`'s new-version cache (`:404`), and
+`apply-tx-write :after` (`transactions.lisp:945-947`, whose primary
+method already stamped). Only `save-node:382` caches a node it never
+stamped — `old-node` comes straight from `%lhash-get`.
+
+**That path is unreachable for claims.** `save-node` has exactly three
+call sites: `save-edge` twice (`edge.lisp:283,287`) and `clos.lisp:53`,
+which is in the file C3 shows is never loaded (and calls it with the
+wrong arity anyway). Claims are vertices written through the transaction
+path. So for S3: **no path `index-lookup` can take in the rules code
+returns a node with `node-graph` NIL**, and S3-P3's `resolve-node-graph`
+fallback is belt-and-braces rather than load-bearing. Keep it — the
+guarantee above is about today's call graph, not an invariant the engine
+states.
+
+**Citation drift:** the plan's `finalize-node` `:208-212` is exact;
+`ensure-node-bytes` runs `:216-232`, not `:216-225`.
+
+## B4 — reading a foreign claim's slots performs no `lookup-object` — CONFIRMED (mechanism corrected, C3; stronger constraint found, C4)
+
+The chain, with C3's correction applied:
+`claim-subject-key` &c. are plain `:accessor`s on the claim classes
+(`spacetime/claim.lisp:148-183`, `+claim-shared-slots+`), so a read goes
+`slot-value-using-class :around ((class node-class) ...)`
+(`primitive-node.lisp:506-516`, quoted in C3) → `node-slot-value`
+(`primitive-node.lisp:441-449`):
+
+```lisp
+(defun node-slot-value (node key &key (graph *graph*))
+  ;;(log:info "GETTING ~A FOR ~A" key (string-id node))
+  (maybe-init-node-data node :graph graph)
+  (when (consp (data node))
+    (cdr (assoc (if (keywordp key)
+                    key
+                    (intern (symbol-name key) :keyword))
+                (data node)))))
+```
+
+→ `maybe-init-node-data`, which reads a **heap through an mmap**, never
+`lookup-object`, and resolves that heap through the node's own graph
+(`primitive-node.lisp:300-322`):
+
+```lisp
+    ;; DATA-POINTER is an address in the node's OWN heap; GRAPH (ultimately
+    ;; *GRAPH*) is only a fallback for an unstamped node (GH #53).  Resolved HERE
+    ;; rather than around the whole body because this is the only use of it and
+    ;; this branch runs once per node, while the body runs on every slot access.
+    ...
+                    (read-bytes (make-mpointer
+                                 :mmap (memory-mmap
+                                        (heap (node-home-graph node graph)))
+                                 :loc (data-pointer node))))))
+```
+
+with `node-home-graph` (`node-class.lisp:453-458`):
+
+```lisp
+(defun node-home-graph (node &optional (default *graph*))
+  "NODE's graph, or DEFAULT when unknown. Use instead of a bare *GRAPH* when
+resolving a node's heap, tables or schema (GH #53)."
+  (if (slot-boundp node 'graph)
+      (or (node-graph node) default)
+      default))
+```
+
+Note the `:graph` argument does **not** flow from the accessor:
+`slot-value-using-class` calls `(node-slot-value instance
+slot-keyword-name)` with no `:graph`, so the fallback is `*graph*` —
+irrelevant when `node-graph` is set, which B3 shows it is.
+
+The two derived readers named in the brief add nothing.
+`claim-identity-key` (`spacetime/claim-query.lisp:29-59`) reads
+`*claim-families*` and six slot accessors and formats a string;
+`claim-extent` (`spacetime/claim-query.lisp:331-336`):
+
+```lisp
+(defun claim-extent (claim)
+  "CLAIM's TEMPORAL-EXTENT, decoded from the stored sexp, or NIL.  The stored
+form is EXTENT-SEXP; the two never share a name so neither is mistaken for
+the other (design §7)."
+  (let ((s (claim-extent-sexp claim)))
+    (when s (sexp->extent s))))
+```
+
+**Answer to the brief's conditional:** no lazy slot read can call
+`lookup-object`, so the cross-graph error is not reachable this way and
+S3-P3 is not forced by it. It *is* forced by the pin — see C4 — and the
+practical instruction is the same: materialise inside the snapshot.
+
+## B5 — `graph-name`, `lookup-graph`, `resolve-node-graph`, and cl-llm's `store-name` — CONFIRMED (with one trap)
+
+`make-graph` passes NAME through verbatim (`graph.lisp:483`):
+
+```lisp
+             :graph-name name
+```
+
+into the slot (`graph-class.lisp:96`):
+
+```lisp
+  ((graph-name :accessor graph-name :initarg :graph-name)
+```
+
+and registers under the same value (`graph.lisp:534`):
+
+```lisp
+        (setf (gethash name *graphs*) graph)
+```
+
+`lookup-graph` is a bare `gethash` (`graph-class.lisp:511-512`):
+
+```lisp
+(defun lookup-graph (name)
+  (gethash name *graphs*))
+```
+
+on a table whose test is `equal`, not `eq` (`graph-class.lisp:3-12`).
+
+**Trap: nothing coerces NAME to a keyword.** "the keyword `make-graph`
+was given" is true by *convention* — every fixture and every consumer
+passes one — not by enforcement. A store named with a string would
+register and look up fine and would break cl-llm's `store-name`, which
+calls `symbol-name` (`~/work/cl-llm/memory/schema.lisp:49-51`):
+
+```lisp
+(defun store-name (graph)
+  "GRAPH's name as the string a model sees: downcased (SS5)."
+  (string-downcase (symbol-name (gdb:graph-name graph))))
+```
+
+S3-P3 adopts exactly this convention, so the S3 docs should say a store
+in a scope must be keyword-named, or `%store-name` should be written to
+tolerate a non-symbol. Recommend the former: it matches every existing
+fixture and the consumer.
+
+`resolve-node-graph`'s signature is as the plan states
+(`interface.lisp:7-42`):
+
+```lisp
+(defun resolve-node-graph (id &key class-hint)
+  "The open store holding ID, as (values GRAPH STATUS STORE-ID) with
+STATUS one of :RESOLVED, :DETACHED (registry knows the tag, no open
+graph carries it) or :UNKNOWN.  ...
+```
+
+Its trap, worth carrying into any S3 fallback: "a foreign-minted v8 id
+(peer hub, cross-system restore) whose tag coincides with a local
+store-id resolves to the WRONG graph yet reports :RESOLVED (GH #209)."
+Per B3 this fallback should never fire in the rules path.
+
+The consumer's own convention, for S3-P4's mirror
+(`~/work/cl-llm/memory/trace.lisp:190-204`):
+
+```lisp
+(defun %store-in-scope (name scope)
+  (find name scope :key #'store-name :test #'string=))
+
+(defun %resolve-in (cite store-name graph scope at)
+  "CITE resolved in the store its evidence claim named, when that store
+is in SCOPE; unit-1 evidence (no store) resolves in GRAPH; a store out
+of scope is :ABSENT (SS4.3).  ...
+```
+
+— a `string=` on the downcased name, and "out of scope" is a *state*,
+not a drop. S3-P4 drops instead; that is a deliberate divergence
+(`premises-of` returns claims, not records) and should be stated in
+`docs/rules.md` rather than left to be discovered.
+
+## B6 — a second `def-claim-classes` under another store name — CONFIRMED (nothing is cleared)
+
+`def-claim-classes` (`spacetime/claim.lisp:321-483`) takes `graph-name`
+literally in every declaration it emits — `def-vertex` ×3,
+`def-value-constraint` ×2 (×3 when temporal), `def-unique` ×2,
+`def-index` ×4 — e.g.:
+
+```lisp
+       (graph-db:def-unique ,unary ,unary-slots
+         ,graph-name :name claim-unary-identity
+         ,@(identity-options unary-slots))
+```
+
+and each registry keys on the graph name and substitutes only within
+that key's list. `%register-node-type-meta` (`schema.lisp:600-609`):
+
+```lisp
+(defun %register-node-type-meta (meta)
+  "Put META in *SCHEMA-NODE-METADATA* under its own store, replacing any
+entry for the same class IN PLACE.  A class may be registered under more
+than one store (#186); only this store's list is touched, and position
+still governs UPDATE-SCHEMA's instantiation order (GH #53, #167)."
+```
+
+`register-index-spec` (`index.lisp:150-163`):
+
+```lisp
+  (let* ((g (index-spec-graph-name spec))
+         (id (index-spec-identity spec))
+         (existing (gethash g *schema-index-metadata*))
+         (hit (find id existing :key #'index-spec-identity :test #'equal)))
+    (setf (gethash g *schema-index-metadata*)
+          (if hit (substitute spec hit existing) (cons spec existing))))
+```
+
+`register-unique-tuple-spec` (`unique-constraint.lisp:285-296`) is the
+same shape on `(unique-tuple-spec-graph-name spec)`. **Nothing in the
+macro or in any of the three registries touches another graph name's
+entries.**
+
+The family struct is re-registered under the same parent symbol, and
+replaces silently because the arity class names are identical
+(`spacetime/claim.lisp:34-48`):
+
+```lisp
+(defun %register-claim-family (parent unary binary temporal-p)
+  "Register PARENT's family.  Re-declaring with the same UNARY and
+BINARY names replaces silently (a flipped :TEMPORAL included); different
+names signal CLAIM-FAMILY-CONFLICT and leave the entry as it was, since
+replacing it would orphan every existing claim of the family (GH #323)."
+```
+
+Note `*claim-families*` is image-wide, not per store — which is exactly
+why C1 bites: `claim/7` will be asked for a family a store in scope does
+not index.
+
+**S2's C2 holds, and is the reason the plan's `:graph`-on-every-call
+constraint exists.** `%install-node-type` reinstalls the helpers with
+the *new* store baked in (`schema.lisp:747`):
+
+```lisp
+    (%install-node-helpers name kind (node-type-graph-name meta))
+```
+
+the constructor closes over that name (`schema.lisp:482-484`, `:499`):
+
+```lisp
+(defun %make-constructor-closure (name graph-name kind)
+  "The MAKE-<NAME> function for node type NAME of KIND in store
+GRAPH-NAME (GH #172)."
+...
+        (let ((graph (%default-store-graph name graph-name graph)))
+```
+
+and `%default-store-graph` ignores `*graph*` by design
+(`schema.lisp:396-402`):
+
+```lisp
+(defun %default-store-graph (class-name store-name explicit)
+  "R1 resolution: EXPLICIT graph if given, else the OPEN graph named
+STORE-NAME, else refuse -- never *GRAPH* (GH #167)."
+```
+
+There is one `fdefinition` per class symbol, so after
+`(def-claim-classes rt-claim :graph-db-rules-b)` a bare
+`(make-rt-claim-binary ...)` writes into B whatever `*graph*` or the
+enclosing `with-transaction` says. The plan's Global Constraint ("every
+constructor call passes `:graph`") is therefore load-bearing, including
+in `seed-*` helpers written for store A.
+
+**Two fixture details confirmed as consistent with what ships.** The
+plan's `(setf (gethash :graph-db-rules-b *schema-node-metadata*) nil)`
+preamble matches the existing pattern in `tests/rules/suite.lisp:26-29`
+("This file owns the graph name; the clear is what lets a second file
+claiming it be seen (GH #198)") and is repeated there for
+`:graph-db-rules-test-foreign` and `:graph-db-rules-norule`. And S2's
+A4 findings on `%warn-if-cross-file-clobber` /
+`%warn-if-divergent-across-stores` still apply unchanged: both stay
+silent for two expansions in one file with identical slot sets.
+
+**Citation drift:** the plan says `spacetime/claim.lisp:376-484`; the
+macro is `321-483` (the emitted `progn` begins at `:374`).
+
+## B7 — the clock fixture, and what `call-with-read-snapshot` reads — CONFIRMED for the mechanics; see C2 for what it does NOT buy
+
+`:SYSTEM-CLOCK` is a real `make-graph` keyword whose default is the
+special (`graph.lisp:618`):
+
+```lisp
+                                   (system-clock *system-clock*)
+```
+
+documented in the same lambda list's docstring, and applied by attaching
+after the transaction manager exists (`graph.lisp:585-586`):
+
+```lisp
+      (when system-clock
+        (attach-to-system-clock graph system-clock))
+```
+
+which stores it on the graph (`transactions.lisp:3264`,
+`(setf (%graph-system-clock graph) clock)`), the slot being
+`graph-class.lisp:223-229`:
+
+```lisp
+   (system-clock :reader graph-system-clock
+                 :accessor %graph-system-clock
+                 :initarg :system-clock :initform nil)
+```
+
+**What `call-with-read-snapshot` reads is the GRAPH's attached clock,
+not the special.** `create-transaction` → `tm-current-epoch` →
+`tm-clock` (`transactions.lisp:3179-3183`):
+
+```lisp
+(defun tm-clock (transaction-manager)
+  "TRANSACTION-MANAGER's image clock, or NIL for its own counter (GH #168).
+A transaction-manager always has a graph -- INITIALIZE-INSTANCE :AFTER
+dereferences it immediately, so a NIL graph dies there first."
+  (graph-system-clock (graph transaction-manager)))
+```
+
+So **`*system-clock*` need not be bound at snapshot time** — it is read
+only as `make-graph`'s / `open-graph`'s keyword default
+(`graph.lisp:618`, `:1120`). A fixture that opens the clock and passes
+`:system-clock clock` to each `make-graph` is sufficient and is the
+shape the engine's own tests use.
+
+The fixture shape is confirmed, with the two additions the plan's sketch
+omits — `with-clock-system-dir` (a `*system-directory*` binding) and
+`with-temp-directory` for the clock —
+(`tests/system-clock-tests.lisp:390-419`,
+`two-stores-on-one-clock-get-disjoint-ordered-epochs`):
+
+```lisp
+  (with-clock-system-dir ()
+    (with-temp-directory (cdir)
+    (let ((clock (open-system-clock (namestring cdir))))
+      (unwind-protect
+           (with-temp-directory (da)
+             (with-temp-directory (db)
+               (let ((ga (make-graph :sc-alpha (namestring da)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock))
+                     (gb (make-graph :sc-beta (namestring db)
+                                     :buffer-pool-size 1000
+                                     :system-clock clock)))
+                 (unwind-protect
+                      ...
+                   (close-graph ga)
+                   (close-graph gb)))))
+        (close-system-clock clock))))))
+```
+
+`close-graph` on both, `close-system-clock` last, as the plan says.
+`with-clock-system-dir` is not needed in `tests/rules/suite.lisp`:
+`run-rules-tests` already binds `graph-db::*system-directory*` for the
+whole run (`tests/rules/suite.lisp:14-17`).
+
+**But the instant claim is refuted — see C2.** `with-clocked-stores`'
+docstring must not say the snapshots "share an instant".
+
+**Citation drift:** the plan says `tests/system-clock-tests.lisp:395-420`;
+the test is `390-419`.
+
+## B8 — `map-vertices` on a foreign store — CONFIRMED, and only because the call passes `:VERTEX-TYPE`
+
+The typed scan resolves each id through `lookup-vertex`
+(`vertex.lisp:234-240`):
+
+```lisp
+      (flet ((scan-type-id (type-id)
+               (let ((index-list (get-type-index-list (vertex-index graph) type-id)))
+                 (when index-list
+                   (map-index-list
+                    (lambda (id)
+                      (let ((vertex (lookup-vertex id :graph graph)))
+```
+
+so it inherits B1's refusal inside a read-write transaction on another
+store, and B2's resolution outside one. It also holds a read pin and
+materialises when collecting (`vertex.lisp:226-233`):
+
+```lisp
+         ;; When collecting, each node ESCAPES the scan pin, so materialize its
+         ;; bytes before FN sees it.  For a side-effect scan FN runs inside the
+         ;; pin, so its lazy reads are already safe and we don't pre-read bytes.
+         (fn (if collect-p
+                 (let ((user-fn fn))
+                   (lambda (node) (ensure-node-bytes node graph) (funcall user-fn node)))
+                 fn)))
+    (with-read-pin (graph)        ; retain whatever versions this scan observes
+```
+
+**The untyped scan is a different animal and must never be used here.**
+`map-vertices`' own docstring (`vertex.lisp:204-209`):
+
+```lisp
+NOTE: the fully-untyped scan (no :VERTEX-TYPE and no :INCLUDE-VERTEX-TYPES) walks
+the raw vertex lhash, which reads LIVE node versions and so BYPASSES MVCC
+snapshot isolation.  It is intended for back-end / admin passes (backup, GC,
+reindex) run while the graph is quiescent; a typed scan goes through the type
+index + LOOKUP-VERTEX and is snapshot-consistent.  (This is why IS-A/2 enumerates
+per-type instead of using the untyped scan.)
+```
+
+and that branch stamps `node-graph` by hand and never calls
+`lookup-object` (`vertex.lisp:265-272`), so it would neither signal in a
+foreign transaction nor honour a snapshot.
+
+S1's call is typed, so S3-P6 is safe as written
+(`rules/facts.lisp:111-115`):
+
+```lisp
+  ;; :INCLUDE-SUBCLASSES-P defaults to T, so the parent covers unary and
+  ;; binary.  :COLLECT-P is what materialises node bytes before a node
+  ;; escapes the scan's read pin (vertex.lisp) -- not a style choice.
+  (let ((parent (graph-db.spacetime:claim-family-parent family)))
+    (map-vertices #'identity graph :vertex-type parent :collect-p t)))
+```
+
+The task text should carry the constraint explicitly: **the per-store
+walk must keep `:vertex-type` and `:collect-p t`.** As noted in C1, this
+route also degrades correctly for a store lacking the family:
+`resolve-node-type-ids` skips unregistered designators, so the scan
+visits nothing and signals nothing.
+
+**Citation drift:** the plan says `vertex.lisp:185-233`; `map-vertices`
+runs `185-277`.
+
+## B9 — `%overlay-transaction` is unreachable from the functors — CONFIRMED
+
+`%overlay-transaction` (`spacetime/claim-query.lisp:196-219`) has
+exactly two call sites in the tree: `claim-query.lisp:298`, inside
+`claims-touching`, and `claim-query.lisp:445`, inside
+`claims-by-producer`. It reads the ambient transaction:
+
+```lisp
+  (let ((tx graph-db::*transaction*))
+    (if (null tx)
+        all
+        (let* ((view (graph-db:make-commit-view graph tx))
+```
+
+Neither function is reached from `claim/7` or `claim-producer/2`.
+`claim/7`'s routes call `index-lookup` directly (quoted in C1) or
+`%unbound-claim-scan`; `claim-producer/2` goes through
+`%producer-candidates`, which also calls `index-lookup` directly, not
+`claims-by-producer` (`rules/facts.lisp:233-252`, quoted in C1).
+
+So S2's A6 extends to scope unchanged: **a read of any store during a
+rule's evaluation sees committed state only**, and under S3-P2's
+composed snapshots it sees committed-as-of-that-store's-snapshot state.
+The corollary S2 recorded still holds and gains a cross-store edge:
+`*transaction*` is NIL during a cross-store evaluation, so
+`%overlay-transaction` would be a no-op even if a rule body reached for
+`claims-touching` — a body that did so under S2 (inside the
+transaction) and under S3 (outside it) gets *different* visibility of
+its own store's uncommitted writes. Worth a line in `docs/rules.md`
+under "What the functors do not see".

--- a/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
+++ b/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
@@ -1,0 +1,567 @@
+# rules S3: cross-store scope — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A rule declared in store A reads every store in a scope the operator hands `run-rule` and writes only A; a premise from another store is named in its `derived-from` record's `method` slot; the reads of a cross-store run resolve at one instant under the shared clock.
+
+**Architecture:** One special, `graph-db::*claim-scope*`, bound by `run-rule` for the body's evaluation and read by S1's `claim/7` and `claim-producer/2`, which iterate every store in it per route (a store whose schema lacks the family contributes nothing). Because a read-write transaction on A refuses every read of B (the GH #53 contract, `transactions.lisp`'s transactional `lookup-object` method), a run whose scope holds a foreign store evaluates its body **before** the write transaction, under composed `call-with-read-snapshot`s of every store in scope — one instant when `*system-clock*` is set, per-store consistency otherwise — and then reconciles inside A's transaction exactly as S2 does; a single-store scope keeps S2's inside-the-transaction evaluation unchanged. Premises leave the evaluation as identity keys plus store names, never as nodes, so the reconcile touches no foreign store. `premises-of` resolves a premise in the store its record names when that store is in the scope the caller passes.
+
+**Tech Stack:** SBCL 2.6.6, ASDF, FiveAM, `graph-db/rules` (S1+S2), `graph-db/spacetime`, `graph-db/query`, the system clock (`system-clock.lisp`, #168).
+
+**Spec:** `docs/superpowers/specs/2026-09-04-rules-as-producers-design.md` §10 and §11's S3 bullet (epic #304, sub-issue #332). S2's record: `docs/superpowers/decisions/2026-09-05-rules-s2-rulings.md`, `docs/superpowers/notes/2026-09-05-rules-s2-engine-api-facts.md`, `docs/rules.md`, handoff `docs/superpowers/handoffs/2026-09-05-rules-s2.md`. Consumer: kraison/cl-llm#24, whose evidence convention is `memory/trace.lisp` (`store-name`, `%resolve-in`, a cite resolves in the store it names when that store is in scope, else `:absent`).
+
+## Global Constraints
+
+- Lisp: spaces only; hard 80-column limit; terse comments pointing at spec §10, a ruling, or #332. Docstrings: what, returns, the one trap.
+- `graph-db.rules` `(:use #:cl)`; nothing imported; every spacetime/graph-db/temporal-extent symbol qualified (S2's `rules/package.lisp` header; ruling R4). `rules/facts.lisp` is `(in-package #:graph-db)` (S1 ruling R1) and stays there.
+- Core untouched. The scope special lives in `rules/facts.lisp` beside the functors it serves.
+- Every S1 and S2 test keeps passing unchanged: with `*claim-scope*` NIL every functor behaves exactly as before, and a single-store `run-rule` takes exactly S2's path.
+- Substring assertions use `:test #'char-equal`; refusal messages print symbols downcased; rule text contains no colon; every constructor call passes `:graph` (a second `def-claim-classes` for a family under another store name rebinds the constructors' default store — S2 recon C2).
+- Worktree: `/home/raison/work/vivace-graph-v3/.worktrees/rules-s3` (branch `feat/rules-s3` from `origin/experiment` `a75cf96`). The main checkout `/home/raison/work/vivace-graph-v3` is shared with other sessions: never build, edit or commit there. cl-temporal-extent 0.3.0 is on master, so no second worktree this time.
+- Suites, foreground, one at a time, worktree first on the registry:
+
+  ```
+  cd /home/raison/work/vivace-graph-v3/.worktrees/rules-s3
+  sbcl --dynamic-space-size 4096 --non-interactive \
+    --eval '(push #p"/home/raison/work/vivace-graph-v3/.worktrees/rules-s3/" asdf:*central-registry*)' \
+    --eval '(ql:quickload :graph-db/rules-test :silent t)' \
+    --eval '(asdf:test-system :graph-db/rules-test)'
+  ```
+
+  Always the `-test` system; read `Did N checks.`; never background a run; never two suites at once from one worktree. Baselines at `a75cf96`: `graph-db/rules-test` 314/0, `graph-db/spacetime-test` 653/0, `graph-db/query-test` 40/0, `graph-db/gui-test` 635/0, full `graph-db` 5370/0 with ten GEOS skips. Before the branch is called done: rules, spacetime, query, gui green with counts recorded; the full `graph-db` once, detached by the controller.
+- After every scripted edit to a test file, `git diff <base> -- <file> | grep -c '^-[^-]'` and expect 0 for an append.
+- Every negative test names its mechanism and has a control.
+- No push without Kevin. Trailers: `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>` and `Claude-Session: https://claude.ai/code/session_01DeVU44qpXuW4oUz7hnDMNU`. Docs travel with code in the same commit.
+- Issues: #332 gets the decisions as a comment when the branch is complete; close by hand with the merge SHA.
+
+## Rulings taken while planning (record them in the S3 decision file)
+
+Order of authority while executing: spec > these > the recon note > the task text.
+
+- **S3-P1 — scope is a run-time argument, and the special is `graph-db::*claim-scope*`.** `run-rule graph rule &key scope` and `run-rules graph &key scope`; `scope` is a list of open graphs, `graph` is put first if absent, and the rule writes only `graph` (spec §10). During evaluation `run-rule` binds `*claim-scope*` to that list; `claim/7` and `claim-producer/2` iterate it per route, own store first, and with it NIL behave exactly as S1 shipped them. A Lisp caller may bind it around a raw `select`. Cost if wrong: a scope that should have been a record slot must be threaded by every caller; reversible by adding a slot later.
+- **S3-P2 — a cross-store run evaluates before its transaction, under composed snapshots.** The engine's read-resolution rule is exhaustive: inside a read-write transaction on A, any read of B signals `cross-graph-transaction-error`, snapshot or no snapshot (`transactions.lisp`, `lookup-object`'s transactional method; `tests/multi-graph-tests.lisp` `read-write-transaction-blocks-a-foreign-read-even-under-a-snapshot`). So when the scope holds a store other than `graph`, `run-rule` evaluates the body inside nested `call-with-read-snapshot`s of every store in scope (own store included) and only then opens the write transaction for the reconcile. Under `*system-clock*` those snapshots are one instant (#168, #94); without a clock each store is internally consistent and there is no single instant (#53), documented. A single-store scope keeps S2's path unchanged. **Cost if wrong:** a cross-store run is not serialised against concurrent premise writes — a premise committed after the snapshots is seen by the next run, not this one, with no conflict raised. Single-store runs keep S2's serialisation.
+- **S3-P3 — a premise leaves evaluation as `(identity-key . store-name)`, never as a node.** `%desired` records for each solution the premises' `claim-identity-key` and the name of the store they came from (`node-graph`, set by the engine on every node a lookup returns; `resolve-node-graph` is the fallback), so the reconcile — which runs inside A's transaction — reads no foreign node. `store-name` is cl-llm's convention: `(string-downcase (symbol-name (graph-name g)))`. The `derived-from` record's `method` slot is that name when the premise's store is not the rule's store, NIL otherwise (spec §10). Two stores holding one identity key contribute one record (the family's `def-unique` tuple excludes `method`), the rule's own store preferred, else the first in scope order. Cost: one store name lost in that corner; recorded.
+- **S3-P4 — `premises-of graph claim &key (scope (list graph))` resolves in the named store when it is in scope, else drops the premise.** A record naming no store resolves in `graph`. Mirrors cl-llm's `%resolve-in` (`:absent` for a store out of scope). `dependents-of` is unchanged: the records live in the rule's store, and a premise from any store is looked up by its identity key. Cost: a caller who forgets the scope sees fewer premises, never wrong ones.
+- **S3-P5 — compile stays single-store.** The guard validates a rule's text against its own store's schema and the cycle graph is over the rule's own store (spec §6); a family read from a foreign store must be declared under the rule's store's name too (`def-claim-classes fam :store-a` and `:store-b` — the registry is per family symbol, the indexes per store, S2 recon A4). A store in scope whose schema lacks a family a goal names simply contributes nothing (the `query-precondition-error` `%producer-candidates` already swallows). Cost: consumers declare shared families under both names; a cross-store cycle (A reads what B's rule derives and vice versa) is not detected — recorded as a known limit for #333.
+- **S3-P6 — the unrouted walk under scope walks every store, and the refusal is unchanged.** `%unbound-claim-scan` maps every store in scope when no bound is in effect; under a bound it refuses exactly as S1 does. No new behaviour on the guarded surface.
+
+---
+
+## File structure
+
+| file | responsibility |
+|---|---|
+| `rules/facts.lisp` | `*claim-scope*`, `%scope-graphs`, the routes and generators iterating it (Task 1) |
+| `rules/run.lisp` | scope on `run-rule`/`run-rules`; evaluation under composed snapshots; premises as key + store; `method` on `derived-from`; `premises-of` with scope (Tasks 2–3) |
+| `rules/package.lisp` | no new exports needed (`*claim-scope*` is `graph-db`-homed; the keyword arguments are on existing exports) |
+| `tests/rules/suite.lisp` | store B (`:graph-db-rules-b`) with `rt-claim`/`rtt-claim` declared for it too; `with-two-stores`; `seed-b`; the clock fixture (Task 1) |
+| `tests/rules/scope-tests.lisp` | the S3 suite (Tasks 1–3) |
+| `docs/rules.md` | "Cross-store scope" section; edits to "Running a rule", "Provenance", "What the functors do not see" (Task 3) |
+| `CHANGELOG.md`, `docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md`, `docs/superpowers/handoffs/2026-09-05-rules-s2.md` (a closing status line) | record (Task 3) |
+
+---
+
+### Task 0: Recon — verify before any code
+
+Nine assumptions, each to be confirmed or refuted from source in the `rules-s3` worktree, quoting the form. Write `docs/superpowers/notes/2026-09-05-rules-s3-engine-api-facts.md` (pinned to the worktree head; §C corrections first with a finding → correction map), commit it, and amend the tasks below before Task 1 starts.
+
+- [ ] **B1** `index-lookup graph …` on a graph other than the open transaction's signals `cross-graph-transaction-error` from `lookup-object`'s transactional method (`transactions.lisp` ~:319-323), reached through `%node-by-id` (`spatial-query.lisp:37`, `lookup-vertex :graph graph`). Confirm the path and that no route in `index-lookup` bypasses it.
+- [ ] **B2** Outside any transaction, nested `call-with-read-snapshot` on graphs A and B register both in `*read-snapshots*` (`transactions.lisp` ~:3355-3372), and `index-lookup` on either resolves through its own snapshot (`lookup-object`'s null-transaction method ~:294). `run-query-goals`' `select :snapshot t` inherits an enclosing snapshot of the same graph rather than opening a second (`call-with-read-snapshot`'s docstring: "An enclosing snapshot of the SAME graph is inherited"). Confirm from the code, not the docstring.
+- [ ] **B3** Every node `index-lookup` returns has `node-graph` set to the graph it was looked up in (`finalize-node` `primitive-node.lisp:208-212`, `ensure-node-bytes` `:216-225`, `lookup-node`'s path). Name any path that returns a node with `node-graph` NIL.
+- [ ] **B4** Reading a claim's slots (the `claim-*` accessors, `claim-identity-key`, `claim-extent`) on a node whose `node-graph` is B, while a read-write transaction on A is open, performs no `lookup-object` and so cannot signal the cross-graph error — check `slot-value-using-class :around` (`clos.lisp:38-43`) and `maybe-init-node-data` (`primitive-node.lisp:300-322`, reads the heap of `node-home-graph`). If any lazy slot read can call `lookup-object`, S3-P3 must also materialise the premise's extent sexp during evaluation; say which.
+- [ ] **B5** `graph-name graph` is the keyword `make-graph` was given; `lookup-graph` keys `*graphs*` on it (`graph-class.lisp:3-12`, `:511`); `resolve-node-graph` (`interface.lisp:7`) returns `(values graph status …)`. Confirm the keyword shape and the downcased-string convention cl-llm's `store-name` uses (`~/work/cl-llm/memory/schema.lisp:49-51`).
+- [ ] **B6** A second `(def-claim-classes rt-claim :graph-db-rules-b)` after the S1 declaration for `:graph-db-rules-test`: the `claim-family` struct is re-registered under the same parent symbol with the same class names; `def-index`/`def-unique`/`def-value-constraint` are registered under the new graph name without unregistering the old (S2 recon A4); the constructors' default store rebinds to B (S2 recon C2). Confirm nothing in `def-claim-classes` clears the first store's registrations (`spacetime/claim.lisp:376-484`).
+- [ ] **B7** The clock in a test: `open-system-clock (namestring dir)` then `make-graph name dir :system-clock clock` for each store, `close-graph` both, `close-system-clock` last (`tests/system-clock-tests.lisp:395-420`). Confirm `make-graph`'s `:system-clock` keyword and that `*system-clock*` need not be bound for the composed snapshots to share an instant (what `call-with-read-snapshot` reads: the graph's attached clock or the special?). Quote the site.
+- [ ] **B8** `map-vertices` on a foreign store outside any transaction is legal and snapshot-consistent under that store's registered snapshot (`vertex.lisp:185-233`); inside a read-write transaction on another store it signals (`with-read-pin`/`lookup` path). Needed for S3-P6.
+- [ ] **B9** `%overlay-transaction` (`spacetime/claim-query.lisp:196`) is reached from `claims-by-producer` and `claims-touching` only; `claim/7`'s routes call `index-lookup` directly and never overlay, so a foreign store read during evaluation sees committed state only (S2 recon A6 extended to scope).
+
+---
+
+### Task 1: `*claim-scope*` — the functors read every store in scope
+
+**Files:**
+- Modify: `rules/facts.lisp`, `tests/rules/suite.lisp`
+- Create: `tests/rules/scope-tests.lisp`
+- Modify: `graph-db.asd` (`graph-db/rules-test` gains `scope-tests`)
+
+**Interfaces:**
+- Produces: `graph-db::*claim-scope*` (a list of graphs or NIL), `graph-db::%scope-graphs () => list`; unchanged functor signatures. Fixture: store name `:graph-db-rules-b`, `with-two-stores ((a b) &body)`, `seed-b (g)`, `with-clocked-stores ((a b) &body)`.
+
+- [ ] **Step 1: Fixture** — in `tests/rules/suite.lisp`, after the `rtu-claim` declaration:
+
+```lisp
+;; S3: a second store the scope tests read from (spec §10).  The same
+;; families, declared under B's name too -- the registry is per family
+;; symbol, the indexes per store (S2 recon A4) -- and every constructor
+;; call passes :GRAPH, because this second declaration rebinds the
+;; constructors' default store to B (S2 recon C2).
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :graph-db-rules-b graph-db::*schema-node-metadata*) nil))
+
+(def-claim-classes rt-claim :graph-db-rules-b)
+(def-claim-classes rtt-claim :graph-db-rules-b :temporal t)
+
+(defmacro with-two-stores ((a b) &body body)
+  "A fresh store A (*GRAPH-NAME*) and a fresh store B (:GRAPH-DB-RULES-B),
+*GRAPH* bound to A."
+  (let ((da (gensym "DIR-A")) (db (gensym "DIR-B")))
+    `(let* ((,da (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-a"))
+            (,db (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-b"))
+            (,a (make-graph *graph-name* (namestring ,da)
+                            :buffer-pool-size 1000))
+            (,b (make-graph :graph-db-rules-b (namestring ,db)
+                            :buffer-pool-size 1000)))
+       (unwind-protect (let ((graph-db:*graph* ,a)) ,@body)
+         (ignore-errors (close-graph ,b))
+         (ignore-errors (close-graph ,a))))))
+
+(defun seed-b (g)
+  "Store B's claims: h3 runs web (scan-c), h1 runs cache (scan-c), and
+web version 3 valid Jul 1 - Sep 30 (scan-c).  Returns nothing."
+  (with-transaction ((graph-db::transaction-manager g))
+    (make-rt-claim-binary :graph g :subject-namespace :host :subject-key "h3"
+                          :relation "runs" :object-namespace :app
+                          :object-key "web" :producer "scan-c"
+                          :standing :observed)
+    (make-rt-claim-binary :graph g :subject-namespace :host :subject-key "h1"
+                          :relation "runs" :object-namespace :app
+                          :object-key "cache" :producer "scan-c"
+                          :standing :observed)
+    (make-rtt-claim-binary :graph g :subject-namespace :app :subject-key "web"
+                           :relation "version" :object-namespace :ver
+                           :object-key "3" :producer "scan-c"
+                           :standing :observed
+                           :extent (interval (ts 2026 7 1) (ts 2026 9 30)))))
+
+(defmacro with-clocked-stores ((a b) &body body)
+  "WITH-TWO-STORES under one system clock opened in a scratch directory,
+so the two stores' snapshots share an instant (#168)."
+  (let ((cdir (gensym "CLOCK")) (clock (gensym "CLOCK"))
+        (da (gensym "DIR-A")) (db (gensym "DIR-B")))
+    `(let* ((,cdir (graph-db-test-scratch:make-scratch-directory
+                    "graph-db-rules-clock"))
+            (,clock (graph-db:open-system-clock (namestring ,cdir)))
+            (,da (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-a"))
+            (,db (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-b"))
+            (,a nil) (,b nil))
+       (unwind-protect
+            (progn
+              (setf ,a (make-graph *graph-name* (namestring ,da)
+                                   :buffer-pool-size 1000
+                                   :system-clock ,clock)
+                    ,b (make-graph :graph-db-rules-b (namestring ,db)
+                                   :buffer-pool-size 1000
+                                   :system-clock ,clock))
+              (let ((graph-db:*graph* ,a)) ,@body))
+         (when ,b (ignore-errors (close-graph ,b)))
+         (when ,a (ignore-errors (close-graph ,a)))
+         (graph-db:close-system-clock ,clock)))))
+```
+
+Recon B7 settles `open-system-clock`'s and `make-graph`'s exact keywords and whether `open-system-clock`/`close-system-clock` are exported (write `graph-db::` if not). `tests/rules/package.lisp` needs nothing new unless B7 names it.
+
+- [ ] **Step 2: Failing tests** — `tests/rules/scope-tests.lisp`:
+
+```lisp
+;;;; tests/rules/scope-tests.lisp -- cross-store scope (spec §10, GH #332).
+
+(in-package #:graph-db/rules-test)
+
+(in-suite rules-suite)
+
+(test claim-reads-every-store-in-scope
+  "With *CLAIM-SCOPE* bound, CLAIM/7 generates from each store's index in
+scope order; with it NIL, from *GRAPH* alone (S3-P1)."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    ;; Control: NIL scope is S1 exactly -- A's two hosts of web.
+    (is (equal '("h1" "h2")
+               (sort (select-flat (?h) (claim ?c rt-claim "host" ?h "runs"
+                                              "app" "web"))
+                     #'string<)))
+    (let ((graph-db::*claim-scope* (list a b)))
+      (is (equal '("h1" "h2" "h3")
+                 (sort (select-flat (?h) (claim ?c rt-claim "host" ?h "runs"
+                                                "app" "web"))
+                       #'string<)))
+      ;; The subject route across stores: h1 runs web and db in A, cache
+      ;; in B.
+      (is (equal '("cache" "db" "web")
+                 (sort (select-flat (?a) (claim ?c rt-claim "host" "h1"
+                                                "runs" "app" ?a))
+                       #'string<)))
+      ;; A node from B is a node: the filters work on it.
+      (is (equal '("scan-c")
+                 (select-flat (?p) (claim ?c rt-claim "host" "h3" "runs"
+                                          "app" "web")
+                                   (claim-producer ?c ?p)))))))
+
+(test claim-producer-generates-across-scope
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((graph-db::*claim-scope* (list a b)))
+      ;; scan-c wrote 2 rt-claims and 1 rtt-claim, all in B.
+      (is (= 2 (select (:count t :max-inferences 1000) (?c)
+                 (claim-producer ?c "scan-c")
+                 (claim ?c rt-claim ?s ?k ?r ?o ?ok))))
+      ;; scan-a is in A only; the scope adds nothing to it.
+      (is (= 2 (select (:count t :max-inferences 1000) (?c)
+                 (claim-producer ?c "scan-a")
+                 (claim ?c rt-claim ?s ?k ?r ?o ?ok)))))))
+
+(test a-store-lacking-the-family-contributes-nothing
+  "rtu-claim is declared for A only; B in scope adds nothing and refuses
+nothing (S3-P5)."
+  (with-two-stores (a b)
+    (seed a)
+    (with-transaction ((graph-db::transaction-manager a))
+      (make-rtu-claim-binary :graph a :subject-namespace :app
+                             :subject-key "web" :relation "owned-by"
+                             :object-namespace :team :object-key "t1"
+                             :producer "scan-a" :standing :observed))
+    (let ((graph-db::*claim-scope* (list a b)))
+      (is (equal '("t1")
+                 (select-flat (?t) (claim ?c rtu-claim "app" "web"
+                                          "owned-by" "team" ?t)))))))
+
+(test the-walk-covers-every-store-without-a-bound-and-refuses-under-one
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((graph-db::*claim-scope* (list a b)))
+      ;; 4 rt-claims in A + 2 in B.
+      (is (= 6 (select-count (?c) (claim ?c rt-claim ?a ?b ?r ?d ?e))))
+      (signals graph-db::prolog-cost-unbounded-error
+        (select (:max-inferences 1000) (?c)
+          (claim ?c rt-claim ?a ?b ?r ?d ?e))))))
+
+(test a-foreign-read-inside-a-transaction-is-the-engines-refusal
+  "The GH #53 contract, not ours: a read-write transaction on A refuses
+every read of B.  RUN-RULE evaluates before its transaction for that
+reason (S3-P2); a Lisp caller binding the scope inside one gets the
+engine's error."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((graph-db::*claim-scope* (list a b)))
+      (signals graph-db:cross-graph-transaction-error
+        (with-transaction ((graph-db::transaction-manager a))
+          (select-flat (?h) (claim ?c rt-claim "host" ?h "runs"
+                                   "app" "web")))))))
+```
+
+- [ ] **Step 3: Run to verify they fail** — `*claim-scope*` unbound; record the count (baseline 314).
+
+- [ ] **Step 4: `rules/facts.lisp`** — after the `+claim-*-index-slots+` parameters:
+
+```lisp
+(defvar *claim-scope* nil
+  "The stores CLAIM/7 and CLAIM-PRODUCER/2 read, own store first, or NIL
+for *GRAPH* alone (spec §10, GH #332).  RUN-RULE binds it for a body's
+evaluation; a Lisp caller may bind it around a SELECT.  Trap: inside a
+read-write transaction every read of another store is the engine's
+CROSS-GRAPH-TRANSACTION-ERROR (GH #53) -- bind it outside one.")
+
+(defun %scope-graphs ()
+  (or *claim-scope* (list *graph*)))
+
+(defun %scope-lookup (class-name slots value)
+  "INDEX-LOOKUP over every store in scope, in scope order; a store whose
+schema does not carry CLASS-NAME contributes nothing, which is what
+QUERY-PRECONDITION-ERROR means here (as %PRODUCER-CANDIDATES reads it)."
+  (loop for g in (%scope-graphs)
+        append (handler-case (index-lookup g class-name slots value)
+                 (query-precondition-error () '()))))
+```
+
+Then in `claim/7` replace the four `index-lookup` calls with `%scope-lookup` (drop the `g` argument), and make `%unbound-claim-scan` take no graph, walking `(%scope-graphs)` after its refusal check:
+
+```lisp
+  (let ((parent (graph-db.spacetime:claim-family-parent family)))
+    (loop for g in (%scope-graphs)
+          append (map-vertices #'identity g :vertex-type parent
+                                           :collect-p t))))
+```
+
+and `%producer-candidates` likewise iterate `(%scope-graphs)` inside its family loop (the existing `handler-case` per lookup stays). Update the docstrings of `claim/7` and `claim-producer/2` with one sentence each on the scope. The `(g *graph*)` binding in `claim/7` goes.
+
+- [ ] **Step 5: Run** — rules suite green; every S1/S2 test unchanged; record the count. Then the spacetime and query suites once (facts.lisp is loaded by neither, but the assertion is cheap).
+
+- [ ] **Step 6: Docs** — `docs/rules.md` "What the functors do not see" gains: with `*claim-scope*` bound the routes read every store in it, committed state only, own store first; and the transaction trap in one sentence. Full section comes in Task 3.
+
+- [ ] **Step 7: Commit** — `feat(rules): the claim functors read every store in *claim-scope* (#332)`.
+
+---
+
+### Task 2: `run-rule` with a scope — evaluate under composed snapshots, name the premise's store
+
+**Files:**
+- Modify: `rules/run.lisp`, `tests/rules/scope-tests.lisp` (append), `docs/rules.md` ("Running a rule", "Provenance")
+
+**Interfaces:**
+- Consumes: `graph-db::*claim-scope*`, `graph-db:call-with-read-snapshot` (check export; `graph-db::` if not), `graph-db::node-graph`, `graph-db::resolve-node-graph`, `graph-db:graph-name`.
+- Produces: `run-rule (graph rule &key scope)`, `run-rules (graph &key scope)`; `%store-name (graph) => string`; `%desired` returning premises as `(key . store-name)`; `%reconcile-provenance` writing `:method`; `%normalize-scope (graph scope) => list`.
+
+- [ ] **Step 1: Failing tests** — append to `tests/rules/scope-tests.lisp`:
+
+```lisp
+(defparameter *web-hosts-body-any*
+  "(claim ?p rt-claim \"host\" ?h \"runs\" \"app\" \"web\")")
+
+(test a-rule-in-a-derives-from-premises-in-a-and-b-and-writes-only-a
+  "Spec §11's S3 bullet."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let* ((r (write-rule a :name "web-hosts" :version "1"
+                          :family "rt-claim"
+                          :head *web-hosts-head* :body *web-hosts-body-any*))
+           (report (graph-db.rules:run-rule a r :scope (list a b))))
+      (is (eq :derived (graph-db.rules:rule-report-outcome report)))
+      (is (= 3 (graph-db.rules:rule-report-derived report)))
+      (let ((claims (derived a 'rt-claim "web-hosts")))
+        (is (equal '("h1" "h2" "h3")
+                   (sort (mapcar #'claim-object-key claims) #'string<))))
+      ;; Nothing was written to B: no derived claim, no derivation record.
+      (is (null (claims-by-producer b 'rt-claim "rule/web-hosts")))
+      (is (null (claims-by-producer b 'graph-db.rules:derivation
+                                    "rule/web-hosts")))
+      ;; Provenance names B for h3's premise and nothing for h1's.
+      (let* ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                       :key #'claim-object-key :test #'string=))
+             (h1 (find "h1" (derived a 'rt-claim "web-hosts")
+                       :key #'claim-object-key :test #'string=))
+             (rec-h3 (first (claims-touching a 'graph-db.rules:derivation
+                                             :claim (claim-identity-key h3)
+                                             :role :subject)))
+             (rec-h1 (first (claims-touching a 'graph-db.rules:derivation
+                                             :claim (claim-identity-key h1)
+                                             :role :subject))))
+        (is (string= "graph-db-rules-b" (claim-method rec-h3)))
+        (is (null (claim-method rec-h1)))))))
+
+(test a-single-store-scope-is-s2-unchanged
+  "Control for S3-P2: RUN-RULE with no scope, or a scope of the store
+alone, derives inside its transaction exactly as before."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body-any*)))
+      (is (= 2 (graph-db.rules:rule-report-derived
+                (graph-db.rules:run-rule a r))))
+      (is (= 2 (graph-db.rules:rule-report-kept
+                (graph-db.rules:run-rule a r :scope (list a)))))
+      ;; The scope's own store is put first whatever the caller wrote.
+      (is (= 1 (graph-db.rules:rule-report-derived
+                (graph-db.rules:run-rule a r :scope (list b a))))))))
+
+(test cross-store-validity-intersects-across-stores
+  "rtt premises: web version 3 (B, Jul 1 - Sep 30) against h1's
+deployments (A, Feb 1 - Jun 30 and Aug 1 - Sep 30) and h2's (A, May)."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-temporal a)
+    (seed-b b)
+    (let ((report (graph-db.rules:run-rule
+                   a (write-rule a :name "host-version" :version "1"
+                                 :family "rtt-claim"
+                                 :head *host-version-head*
+                                 :body *host-version-body*)
+                   :scope (list a b))))
+      ;; A alone gave 4 derived, 2 disjoint (S2).  Version 3 adds
+      ;; (h1 Aug-Sep, v3) = [Aug 1, Sep 30] and two more disjoint pairs
+      ;; ((h1 Feb-Jun, v3), (h2 May, v3)): 5 derived, 4 disjoint.
+      (is (= 5 (graph-db.rules:rule-report-derived report)))
+      (is (= 4 (graph-db.rules:rule-report-disjoint-premises report)))
+      (let ((v3 (find "3" (derived a 'rtt-claim "host-version")
+                      :key #'claim-object-key :test #'string=)))
+        (is-true v3)
+        (when v3
+          (is (= 2 (length (graph-db.rules:premises-of
+                            a v3 :scope (list a b))))))))))
+
+(test a-cross-store-rerun-reconciles-and-a-b-change-is-seen-next-run
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body-any*)))
+      (graph-db.rules:run-rule a r :scope (list a b))
+      (with-transaction ((graph-db::transaction-manager b))
+        (mark-deleted (first (claims-touching b 'rt-claim :host "h3"
+                                              :role :subject))))
+      (let ((report (graph-db.rules:run-rule a r :scope (list a b))))
+        (is (= 2 (graph-db.rules:rule-report-kept report)))
+        (is (= 1 (graph-db.rules:rule-report-swept report)))
+        (is (= 0 (graph-db.rules:rule-report-derived report)))))))
+
+(test run-rules-takes-the-scope
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                :head *web-hosts-head* :body *web-hosts-body-any*)
+    (let ((reports (graph-db.rules:run-rules a :scope (list a b))))
+      (is (= 1 (length reports)))
+      (is (= 3 (graph-db.rules:rule-report-derived (first reports)))))))
+
+(test a-cross-store-run-under-one-clock-derives
+  "Under a shared clock the composed snapshots are one instant (#168).
+Observable here: the run works and derives from both stores; the
+instant itself is the engine's property, pinned by
+tests/multi-graph-tests.lisp."
+  (with-clocked-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((report (graph-db.rules:run-rule
+                   a (write-rule a :name "web-hosts" :version "1"
+                                 :family "rt-claim"
+                                 :head *web-hosts-head*
+                                 :body *web-hosts-body-any*)
+                   :scope (list a b))))
+      (is (eq :derived (graph-db.rules:rule-report-outcome report)))
+      (is (= 3 (graph-db.rules:rule-report-derived report))))))
+
+(test a-scope-must-be-open-graphs
+  (with-two-stores (a b)
+    (declare (ignorable b))
+    (signals error (graph-db.rules:run-rule a "web-hosts" :scope '(:not-a-graph)))))
+```
+
+Re-derive the temporal arithmetic from `seed`, `seed-temporal` and `seed-b` before trusting it (the plan's author has been wrong on such counts before); the docstring of the test carries the derivation.
+
+- [ ] **Step 2: RED**, record the count.
+
+- [ ] **Step 3: `rules/run.lisp`**
+
+```lisp
+(defun %store-name (graph)
+  "GRAPH's name as the string a DERIVED-FROM record's METHOD carries --
+cl-llm's STORE-NAME convention: the downcased graph name (spec §10)."
+  (string-downcase (symbol-name (graph-db:graph-name graph))))
+
+(defun %normalize-scope (graph scope)
+  "SCOPE as RUN-RULE reads it: open graphs, GRAPH first, no duplicates.
+Signals on anything that is not a graph."
+  (dolist (g scope)
+    (unless (typep g 'graph-db:graph)
+      (error "RUN-RULE :SCOPE holds ~S, which is not an open graph." g)))
+  (cons graph (remove graph (remove-duplicates scope) :test #'eq)))
+
+(defun %premise-ref (node graph)
+  "A premise as the reconcile carries it: (IDENTITY-KEY . STORE-NAME),
+STORE-NAME NIL for the rule's own GRAPH (S3-P3).  Read during
+evaluation, so the reconcile touches no foreign store."
+  (let ((home (or (graph-db::node-graph node)
+                  (graph-db::resolve-node-graph (graph-db:id node)))))
+    (cons (graph-db.spacetime:claim-identity-key node)
+          (and home (not (eq home graph)) (%store-name home)))))
+```
+
+In `%desired`: premises become `(mapcar (lambda (n) (%premise-ref n graph)) …)` and the union in the collapse branch dedupes on `car` with `string=`; `%premise-extent` must therefore run on the NODES before they are turned into refs (compute the extent first, then the refs). In `%reconcile-provenance`: the `wanted` key stays `(derived-key . premise-key)`, its value the store name (or NIL); a pair seen twice keeps the first value with NIL preferred (own store); the constructor call adds `:method (or store-name nil)`; an existing record is kept only when its `claim-method` `equal`s the wanted store name too (else swept and rewritten).
+
+`run-rule`:
+
+```lisp
+(defun run-rule (graph rule &key scope)
+  "...  SCOPE (spec §10): the open graphs the body reads, GRAPH put first;
+NIL or (GRAPH) is S2 exactly.  With a foreign store in SCOPE the body is
+evaluated BEFORE the write transaction, under one read snapshot per
+store -- one instant when the stores share a system clock, else each
+store consistent on its own (GH #53) -- because a read-write transaction
+refuses every read of another store (S3-P2).  ..."
+  ...
+  (let* ((scope (%normalize-scope graph scope))
+         (foreign (rest scope)))
+    ...
+    (flet ((evaluate ()
+             (let ((graph-db::*claim-scope* scope))
+               (%desired compiled graph report))))
+      (if foreign
+          (multiple-value-bind (desired order)
+              (%under-snapshots scope #'evaluate)
+            (graph-db:with-transaction (:graph graph)
+              (%derive compiled graph report desired order)))
+          (graph-db:with-transaction (:graph graph)
+            (multiple-value-bind (desired order) (evaluate)
+              (%derive compiled graph report desired order)))))))
+
+(defun %under-snapshots (graphs thunk)
+  "THUNK under a composed read snapshot of every graph in GRAPHS."
+  (if (null graphs)
+      (funcall thunk)
+      (graph-db:call-with-read-snapshot
+       (lambda () (%under-snapshots (rest graphs) thunk))
+       (first graphs))))
+```
+
+`%derive` takes `desired`/`order` (the counter reset stays first; the evaluation moved out); the retry-safety note updates: on a retry only the reconcile re-runs against a fresh transaction, the evaluation's result is reused — say so in the docstring, and that a cross-store run's evaluation is not repeated on conflict. `run-rules graph &key scope` passes it through. Every `rule-run-refusal`/`prolog-error` raised during an out-of-transaction evaluation still lands in `run-rule`'s handlers (they wrap both branches).
+
+- [ ] **Step 4: GREEN**, record the count; spacetime and query suites once.
+
+- [ ] **Step 5: Docs** — "Running a rule": the `:scope` keyword, S3-P2's two paths and their consistency (one instant under the clock, per-store without, not serialised against concurrent premise writes in the foreign case), the retry note. "Provenance": `method` names the premise's store, NIL for the rule's own; the collision corner.
+
+- [ ] **Step 6: Commit** — `feat(rules): run-rule reads a scope of stores under composed snapshots and writes its own (#332)`.
+
+---
+
+### Task 3: `premises-of` with scope, the docs section, the record, the runs
+
+**Files:**
+- Modify: `rules/run.lisp` (`premises-of`), `tests/rules/scope-tests.lisp` (append), `docs/rules.md` (new "Cross-store scope" section + read-through), `CHANGELOG.md`, `docs/superpowers/handoffs/2026-09-05-rules-s2.md` (one closing line: S3 landed on `feat/rules-s3`)
+- Create: `docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md`
+
+- [ ] **Step 1: Failing tests**
+
+```lisp
+(test premises-of-resolves-in-the-store-the-record-names
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (graph-db.rules:run-rule
+     a (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                   :head *web-hosts-head* :body *web-hosts-body-any*)
+     :scope (list a b))
+    (let ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                    :key #'claim-object-key :test #'string=)))
+      ;; In scope: the premise, from B.
+      (let ((ps (graph-db.rules:premises-of a h3 :scope (list a b))))
+        (is (= 1 (length ps)))
+        (is (string= "h3" (claim-subject-key (first ps))))
+        (is (eq b (graph-db::node-graph (first ps)))))
+      ;; Out of scope: dropped, not resolved in A by mistake (S3-P4).
+      (is (null (graph-db.rules:premises-of a h3)))
+      ;; And a B premise's dependents are findable from A.
+      (let ((premise (first (claims-touching b 'rt-claim :host "h3"
+                                             :role :subject))))
+        (is (= 1 (length (graph-db.rules:dependents-of a premise))))))))
+```
+
+- [ ] **Step 2: RED**; **Step 3:** `premises-of graph claim &key (scope (list graph))`: for each `derived-from` record, `(claim-method r)` NIL → resolve in `graph`; a name → `(find name scope :key #'%store-name :test #'string=)` → resolve there, else drop. `%claim-by-identity-key` already takes the graph. `dependents-of`: no change beyond the docstring. **Step 4: GREEN**, count.
+
+- [ ] **Step 5: `docs/rules.md`** — new section "Cross-store scope (GH #332)" after "Provenance": what a scope is, own store first, writes only the own store, the schema rule (S3-P5, families declared under both names), the two evaluation paths and the clock (S3-P2), `method` and `premises-of :scope` (S3-P3/P4), the walk (S3-P6), the transaction trap for Lisp callers, the known limit (no cross-store cycle detection, #333). Read the whole file once against the shipped code. `CHANGELOG.md` entry under Added. The decision record with S3-P1..P6 and every execution ruling from the ledger, in the S2 file's shape, stating they were taken without Kevin and which deviate from the spec (none deviate; S3-P2 refines §7's "one transaction" for the cross-store case, forced by GH #53 — say so). One closing line in the S2 handoff pointing at this branch.
+
+- [ ] **Step 6: Runs** — rules, query, spacetime, gui in the foreground (each under 10 minutes); the full `graph-db` is the controller's, detached. Record every `Did N checks.`.
+
+- [ ] **Step 7: Commit** — `docs(rules): cross-store scope contract and record; premises-of takes a scope (#332)`.
+
+- [ ] **Step 8:** whole-branch review by a fresh reviewer, one fix wave, one scoped re-review; then the #332 comment.
+
+---
+
+## Self-review against the spec
+
+- §10 "reads stores in a scope, A first, writes only A": Task 2 (`%normalize-scope`, the nothing-written-to-B assertions).
+- §10 "`claim/7` generates over every store in scope": Task 1.
+- §10 "a premise from B is recorded with its store name in `method`": Task 2 (S3-P3), the cl-llm convention.
+- §10 "reads resolve at one instant under the shared clock": Task 2 (S3-P2, composed snapshots; the clocked fixture).
+- §11 S3 bullet: Task 2's first test.
+- §9 reads under scope: Task 3 (S3-P4).
+- Type consistency: `%premise-ref` produces `(key . store-name)`; `%reconcile-provenance` consumes `car`/`cdr` of it; `%store-name` is the one place the string is minted and the one place `premises-of` compares it.

--- a/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
+++ b/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** A rule declared in store A reads every store in a scope the operator hands `run-rule` and writes only A; a premise from another store is named in its `derived-from` record's `method` slot; the reads of a cross-store run resolve at one instant under the shared clock.
+**Goal:** A rule declared in store A reads every store in a scope the operator hands `run-rule` and writes only A; a premise from another store is named in its `derived-from` record's `method` slot; the reads of a cross-store run resolve in one comparable epoch space under the shared clock (equal epochs in a quiescent image; recon C2 — the engine provides no single instant across stores).
 
-**Architecture:** One special, `graph-db::*claim-scope*`, bound by `run-rule` for the body's evaluation and read by S1's `claim/7` and `claim-producer/2`, which iterate every store in it per route (a store whose schema lacks the family contributes nothing). Because a read-write transaction on A refuses every read of B (the GH #53 contract, `transactions.lisp`'s transactional `lookup-object` method), a run whose scope holds a foreign store evaluates its body **before** the write transaction, under composed `call-with-read-snapshot`s of every store in scope — one instant when `*system-clock*` is set, per-store consistency otherwise — and then reconciles inside A's transaction exactly as S2 does; a single-store scope keeps S2's inside-the-transaction evaluation unchanged. Premises leave the evaluation as identity keys plus store names, never as nodes, so the reconcile touches no foreign store. `premises-of` resolves a premise in the store its record names when that store is in the scope the caller passes.
+**Architecture:** One special, `graph-db::*claim-scope*`, bound by `run-rule` for the body's evaluation and read by S1's `claim/7` and `claim-producer/2`, which iterate every store in it per route (a store whose schema lacks the family contributes nothing). Because a read-write transaction on A refuses every read of B (the GH #53 contract, `transactions.lisp`'s transactional `lookup-object` method), a run whose scope holds a foreign store evaluates its body **before** the write transaction, under composed `call-with-read-snapshot`s of every store in scope — one comparable epoch space when the stores share a system clock, equal epochs in a quiescent image (recon C2); per-store consistency and no comparability otherwise — and then reconciles inside A's transaction exactly as S2 does; a single-store scope keeps S2's inside-the-transaction evaluation unchanged. Premises leave the evaluation as identity keys plus store names, never as nodes, so the reconcile touches no foreign store. `premises-of` resolves a premise in the store its record names when that store is in the scope the caller passes.
 
 **Tech Stack:** SBCL 2.6.6, ASDF, FiveAM, `graph-db/rules` (S1+S2), `graph-db/spacetime`, `graph-db/query`, the system clock (`system-clock.lisp`, #168).
 
@@ -39,10 +39,10 @@
 Order of authority while executing: spec > these > the recon note > the task text.
 
 - **S3-P1 — scope is a run-time argument, and the special is `graph-db::*claim-scope*`.** `run-rule graph rule &key scope` and `run-rules graph &key scope`; `scope` is a list of open graphs, `graph` is put first if absent, and the rule writes only `graph` (spec §10). During evaluation `run-rule` binds `*claim-scope*` to that list; `claim/7` and `claim-producer/2` iterate it per route, own store first, and with it NIL behave exactly as S1 shipped them. A Lisp caller may bind it around a raw `select`. Cost if wrong: a scope that should have been a record slot must be threaded by every caller; reversible by adding a slot later.
-- **S3-P2 — a cross-store run evaluates before its transaction, under composed snapshots.** The engine's read-resolution rule is exhaustive: inside a read-write transaction on A, any read of B signals `cross-graph-transaction-error`, snapshot or no snapshot (`transactions.lisp`, `lookup-object`'s transactional method; `tests/multi-graph-tests.lisp` `read-write-transaction-blocks-a-foreign-read-even-under-a-snapshot`). So when the scope holds a store other than `graph`, `run-rule` evaluates the body inside nested `call-with-read-snapshot`s of every store in scope (own store included) and only then opens the write transaction for the reconcile. Under `*system-clock*` those snapshots are one instant (#168, #94); without a clock each store is internally consistent and there is no single instant (#53), documented. A single-store scope keeps S2's path unchanged. **Cost if wrong:** a cross-store run is not serialised against concurrent premise writes — a premise committed after the snapshots is seen by the next run, not this one, with no conflict raised. Single-store runs keep S2's serialisation.
-- **S3-P3 — a premise leaves evaluation as `(identity-key . store-name)`, never as a node.** `%desired` records for each solution the premises' `claim-identity-key` and the name of the store they came from (`node-graph`, set by the engine on every node a lookup returns; `resolve-node-graph` is the fallback), so the reconcile — which runs inside A's transaction — reads no foreign node. `store-name` is cl-llm's convention: `(string-downcase (symbol-name (graph-name g)))`. The `derived-from` record's `method` slot is that name when the premise's store is not the rule's store, NIL otherwise (spec §10). Two stores holding one identity key contribute one record (the family's `def-unique` tuple excludes `method`), the rule's own store preferred, else the first in scope order. Cost: one store name lost in that corner; recorded.
+- **S3-P2 — a cross-store run evaluates before its transaction, under composed snapshots.** The engine's read-resolution rule is exhaustive: inside a read-write transaction on A, any read of B signals `cross-graph-transaction-error`, snapshot or no snapshot (`transactions.lisp`, `lookup-object`'s transactional method; `tests/multi-graph-tests.lisp` `read-write-transaction-blocks-a-foreign-read-even-under-a-snapshot`). So when the scope holds a store other than `graph`, `run-rule` evaluates the body inside nested `call-with-read-snapshot`s of every store in scope (own store included) and only then opens the write transaction for the reconcile. Under a shared clock those snapshots take epochs from one counter — equal in a quiescent image, comparable always (#168); the engine deliberately provides no single instant across stores (`call-with-read-snapshot`'s docstring, #53; recon C2), so no doc or test claims one. Without a clock each store is internally consistent and the epochs are not even comparable. A single-store scope keeps S2's path unchanged. **Cost if wrong:** a cross-store run is not serialised against concurrent premise writes — a premise committed after the snapshots is seen by the next run, not this one, with no conflict raised. Single-store runs keep S2's serialisation.
+- **S3-P3 — a premise leaves evaluation as `(identity-key . store-name)`, never as a node.** `%desired` records for each solution the premises' `claim-identity-key` and the name of the store they came from (`node-graph`, set by the engine on every node a lookup returns; `resolve-node-graph` is the fallback), so the reconcile — which runs inside A's transaction — reads no foreign node. The binding reason is the read pin, not the cross-graph error (recon C4): a node `index-lookup` returns under a snapshot skips `ensure-node-bytes`, so reading its slots after the snapshot's extent reads B's heap unpinned. Everything the reconcile needs from a premise (identity key, store name; the extent is consumed by `%premise-extent` inside the same extent) is computed inside the snapshot; nodes never leave it — a rule for every later change too. `store-name` is cl-llm's convention: `(string-downcase (symbol-name (graph-name g)))`. The `derived-from` record's `method` slot is that name when the premise's store is not the rule's store, NIL otherwise (spec §10). Two stores holding one identity key contribute one record (the family's `def-unique` tuple excludes `method`), the rule's own store preferred, else the first in scope order. Cost: one store name lost in that corner; recorded.
 - **S3-P4 — `premises-of graph claim &key (scope (list graph))` resolves in the named store when it is in scope, else drops the premise.** A record naming no store resolves in `graph`. Mirrors cl-llm's `%resolve-in` (`:absent` for a store out of scope). `dependents-of` is unchanged: the records live in the rule's store, and a premise from any store is looked up by its identity key. Cost: a caller who forgets the scope sees fewer premises, never wrong ones.
-- **S3-P5 — compile stays single-store.** The guard validates a rule's text against its own store's schema and the cycle graph is over the rule's own store (spec §6); a family read from a foreign store must be declared under the rule's store's name too (`def-claim-classes fam :store-a` and `:store-b` — the registry is per family symbol, the indexes per store, S2 recon A4). A store in scope whose schema lacks a family a goal names simply contributes nothing (the `query-precondition-error` `%producer-candidates` already swallows). Cost: consumers declare shared families under both names; a cross-store cycle (A reads what B's rule derives and vice versa) is not detected — recorded as a known limit for #333.
+- **S3-P5 — compile stays single-store.** The guard validates a rule's text against its own store's schema and the cycle graph is over the rule's own store (spec §6); a family read from a foreign store must be declared under the rule's store's name too (`def-claim-classes fam :store-a` and `:store-b` — the registry is per family symbol, the indexes per store, S2 recon A4). A foreign store in scope whose schema lacks a family a goal names contributes nothing: Task 1's `%scope-lookup` swallows the `query-precondition-error` `%require-index` signals, per foreign store and per route, as `%producer-candidates` and `%claim-by-identity-key` already do (recon C1 — `claim/7`'s bare `index-lookup` calls signal today). The rule's OWN store keeps S1's behaviour and still signals (ruling S3-R1), so a single-store goal on a family the store does not index stays the ill-typed refusal S1 documented. Cost: consumers declare shared families under both names; a cross-store cycle (A reads what B's rule derives and vice versa) is not detected — recorded as a known limit for #333.
 - **S3-P6 — the unrouted walk under scope walks every store, and the refusal is unchanged.** `%unbound-claim-scan` maps every store in scope when no bound is in effect; under a bound it refuses exactly as S1 does. No new behaviour on the guarded surface.
 
 ---
@@ -68,7 +68,7 @@ Nine assumptions, each to be confirmed or refuted from source in the `rules-s3` 
 - [ ] **B1** `index-lookup graph …` on a graph other than the open transaction's signals `cross-graph-transaction-error` from `lookup-object`'s transactional method (`transactions.lisp` ~:319-323), reached through `%node-by-id` (`spatial-query.lisp:37`, `lookup-vertex :graph graph`). Confirm the path and that no route in `index-lookup` bypasses it.
 - [ ] **B2** Outside any transaction, nested `call-with-read-snapshot` on graphs A and B register both in `*read-snapshots*` (`transactions.lisp` ~:3355-3372), and `index-lookup` on either resolves through its own snapshot (`lookup-object`'s null-transaction method ~:294). `run-query-goals`' `select :snapshot t` inherits an enclosing snapshot of the same graph rather than opening a second (`call-with-read-snapshot`'s docstring: "An enclosing snapshot of the SAME graph is inherited"). Confirm from the code, not the docstring.
 - [ ] **B3** Every node `index-lookup` returns has `node-graph` set to the graph it was looked up in (`finalize-node` `primitive-node.lisp:208-212`, `ensure-node-bytes` `:216-225`, `lookup-node`'s path). Name any path that returns a node with `node-graph` NIL.
-- [ ] **B4** Reading a claim's slots (the `claim-*` accessors, `claim-identity-key`, `claim-extent`) on a node whose `node-graph` is B, while a read-write transaction on A is open, performs no `lookup-object` and so cannot signal the cross-graph error — check `slot-value-using-class :around` (`clos.lisp:38-43`) and `maybe-init-node-data` (`primitive-node.lisp:300-322`, reads the heap of `node-home-graph`). If any lazy slot read can call `lookup-object`, S3-P3 must also materialise the premise's extent sexp during evaluation; say which.
+- [ ] **B4** Reading a claim's slots (the `claim-*` accessors, `claim-identity-key`, `claim-extent`) on a node whose `node-graph` is B, while a read-write transaction on A is open, performs no `lookup-object` and so cannot signal the cross-graph error — check `slot-value-using-class :around` (`primitive-node.lisp:506-516`; `clos.lisp` is in no system and never loads, recon C3) and `maybe-init-node-data` (`primitive-node.lisp:300-322`, reads the heap of `node-home-graph`). If any lazy slot read can call `lookup-object`, S3-P3 must also materialise the premise's extent sexp during evaluation; say which.
 - [ ] **B5** `graph-name graph` is the keyword `make-graph` was given; `lookup-graph` keys `*graphs*` on it (`graph-class.lisp:3-12`, `:511`); `resolve-node-graph` (`interface.lisp:7`) returns `(values graph status …)`. Confirm the keyword shape and the downcased-string convention cl-llm's `store-name` uses (`~/work/cl-llm/memory/schema.lisp:49-51`).
 - [ ] **B6** A second `(def-claim-classes rt-claim :graph-db-rules-b)` after the S1 declaration for `:graph-db-rules-test`: the `claim-family` struct is re-registered under the same parent symbol with the same class names; `def-index`/`def-unique`/`def-value-constraint` are registered under the new graph name without unregistering the old (S2 recon A4); the constructors' default store rebinds to B (S2 recon C2). Confirm nothing in `def-claim-classes` clears the first store's registrations (`spacetime/claim.lisp:376-484`).
 - [ ] **B7** The clock in a test: `open-system-clock (namestring dir)` then `make-graph name dir :system-clock clock` for each store, `close-graph` both, `close-system-clock` last (`tests/system-clock-tests.lisp:395-420`). Confirm `make-graph`'s `:system-clock` keyword and that `*system-clock*` need not be bound for the composed snapshots to share an instant (what `call-with-read-snapshot` reads: the graph's attached clock or the special?). Quote the site.
@@ -137,7 +137,8 @@ web version 3 valid Jul 1 - Sep 30 (scan-c).  Returns nothing."
 
 (defmacro with-clocked-stores ((a b) &body body)
   "WITH-TWO-STORES under one system clock opened in a scratch directory,
-so the two stores' snapshots share an instant (#168)."
+so the two stores' snapshot epochs come from one counter (#168) -- equal
+in a quiescent image, never guaranteed one instant (recon C2)."
   (let ((cdir (gensym "CLOCK")) (clock (gensym "CLOCK"))
         (da (gensym "DIR-A")) (db (gensym "DIR-B")))
     `(let* ((,cdir (graph-db-test-scratch:make-scratch-directory
@@ -272,12 +273,17 @@ CROSS-GRAPH-TRANSACTION-ERROR (GH #53) -- bind it outside one.")
   (or *claim-scope* (list *graph*)))
 
 (defun %scope-lookup (class-name slots value)
-  "INDEX-LOOKUP over every store in scope, in scope order; a store whose
-schema does not carry CLASS-NAME contributes nothing, which is what
-QUERY-PRECONDITION-ERROR means here (as %PRODUCER-CANDIDATES reads it)."
-  (loop for g in (%scope-graphs)
-        append (handler-case (index-lookup g class-name slots value)
-                 (query-precondition-error () '()))))
+  "INDEX-LOOKUP over every store in scope, in scope order.  A FOREIGN
+store whose schema does not carry CLASS-NAME contributes nothing --
+QUERY-PRECONDITION-ERROR read as %PRODUCER-CANDIDATES reads it -- while
+the own store (first) still signals, so a single-store goal keeps S1's
+ill-typed refusal (ruling S3-R1, recon C1)."
+  (let ((graphs (%scope-graphs)))
+    (append (index-lookup (first graphs) class-name slots value)
+            (loop for g in (rest graphs)
+                  append (handler-case
+                             (index-lookup g class-name slots value)
+                           (query-precondition-error () '()))))))
 ```
 
 Then in `claim/7` replace the four `index-lookup` calls with `%scope-lookup` (drop the `g` argument), and make `%unbound-claim-scan` take no graph, walking `(%scope-graphs)` after its refusal check:
@@ -413,10 +419,11 @@ deployments (A, Feb 1 - Jun 30 and Aug 1 - Sep 30) and h2's (A, May)."
       (is (= 3 (graph-db.rules:rule-report-derived (first reports)))))))
 
 (test a-cross-store-run-under-one-clock-derives
-  "Under a shared clock the composed snapshots are one instant (#168).
-Observable here: the run works and derives from both stores; the
-instant itself is the engine's property, pinned by
-tests/multi-graph-tests.lisp."
+  "Under a shared clock the composed snapshots take epochs from one
+counter (#168).  Observable here: the run works and derives from both
+stores.  Nothing asserts one instant -- the engine provides none across
+stores (recon C2), and a test of it would pass vacuously in a quiescent
+suite."
   (with-clocked-stores (a b)
     (seed a)
     (seed-b b)
@@ -474,8 +481,8 @@ In `%desired`: premises become `(mapcar (lambda (n) (%premise-ref n graph)) …)
   "...  SCOPE (spec §10): the open graphs the body reads, GRAPH put first;
 NIL or (GRAPH) is S2 exactly.  With a foreign store in SCOPE the body is
 evaluated BEFORE the write transaction, under one read snapshot per
-store -- one instant when the stores share a system clock, else each
-store consistent on its own (GH #53) -- because a read-write transaction
+store -- epochs from one counter when the stores share a system clock, else
+each store consistent on its own and incomparable (GH #53, recon C2) -- because a read-write transaction
 refuses every read of another store (S3-P2).  ..."
   ...
   (let* ((scope (%normalize-scope graph scope))
@@ -506,7 +513,7 @@ refuses every read of another store (S3-P2).  ..."
 
 - [ ] **Step 4: GREEN**, record the count; spacetime and query suites once.
 
-- [ ] **Step 5: Docs** — "Running a rule": the `:scope` keyword, S3-P2's two paths and their consistency (one instant under the clock, per-store without, not serialised against concurrent premise writes in the foreign case), the retry note. "Provenance": `method` names the premise's store, NIL for the rule's own; the collision corner.
+- [ ] **Step 5: Docs** — "Running a rule": the `:scope` keyword, S3-P2's two paths and their consistency (one comparable epoch space under the clock, equal in a quiescent image, never a guaranteed instant; per-store and incomparable without; not serialised against concurrent premise writes in the foreign case), the retry note; recon O1 in "What the functors do not see": secondary-index membership is not snapshot-versioned, so a claim deleted after a snapshot is invisible to it too (pre-existing, single-store as well); recon B9's corollary: during a cross-store evaluation `*transaction*` is NIL, so a body reaching for `claims-touching` sees no transaction overlay; recon B5: a store in a scope must be keyword-named (`%store-name` takes `symbol-name`). "Provenance": `method` names the premise's store, NIL for the rule's own; the collision corner.
 
 - [ ] **Step 6: Commit** — `feat(rules): run-rule reads a scope of stores under composed snapshots and writes its own (#332)`.
 
@@ -546,7 +553,7 @@ refuses every read of another store (S3-P2).  ..."
 
 - [ ] **Step 2: RED**; **Step 3:** `premises-of graph claim &key (scope (list graph))`: for each `derived-from` record, `(claim-method r)` NIL → resolve in `graph`; a name → `(find name scope :key #'%store-name :test #'string=)` → resolve there, else drop. `%claim-by-identity-key` already takes the graph. `dependents-of`: no change beyond the docstring. **Step 4: GREEN**, count.
 
-- [ ] **Step 5: `docs/rules.md`** — new section "Cross-store scope (GH #332)" after "Provenance": what a scope is, own store first, writes only the own store, the schema rule (S3-P5, families declared under both names), the two evaluation paths and the clock (S3-P2), `method` and `premises-of :scope` (S3-P3/P4), the walk (S3-P6), the transaction trap for Lisp callers, the known limit (no cross-store cycle detection, #333). Read the whole file once against the shipped code. `CHANGELOG.md` entry under Added. The decision record with S3-P1..P6 and every execution ruling from the ledger, in the S2 file's shape, stating they were taken without Kevin and which deviate from the spec (none deviate; S3-P2 refines §7's "one transaction" for the cross-store case, forced by GH #53 — say so). One closing line in the S2 handoff pointing at this branch.
+- [ ] **Step 5: `docs/rules.md`** — new section "Cross-store scope (GH #332)" after "Provenance": what a scope is, own store first, writes only the own store, the schema rule (S3-P5, families declared under both names), the two evaluation paths and the clock as C2 has it (S3-P2), `method` and `premises-of :scope` (S3-P3/P4), the walk (S3-P6), the transaction trap for Lisp callers, the known limit (no cross-store cycle detection, #333). Read the whole file once against the shipped code. `CHANGELOG.md` entry under Added. The decision record with S3-P1..P6 and every execution ruling from the ledger, in the S2 file's shape, stating they were taken without Kevin and which deviate from the spec (none deviate; S3-P2 refines §7's "one transaction" for the cross-store case, forced by GH #53 — say so). One closing line in the S2 handoff pointing at this branch.
 
 - [ ] **Step 6: Runs** — rules, query, spacetime, gui in the foreground (each under 10 minutes); the full `graph-db` is the controller's, detached. Record every `Did N checks.`.
 

--- a/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
+++ b/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
@@ -582,7 +582,7 @@ refuses every read of another store (S3-P2).  ..."
 - §10 "reads stores in a scope, A first, writes only A": Task 2 (`%normalize-scope`, the nothing-written-to-B assertions).
 - §10 "`claim/7` generates over every store in scope": Task 1.
 - §10 "a premise from B is recorded with its store name in `method`": Task 2 (S3-P3), the cl-llm convention.
-- §10 "reads resolve at one instant under the shared clock": Task 2 (S3-P2, composed snapshots; the clocked fixture).
+- §10 "reads resolve at one instant under the shared clock": NOT delivered — refused by S3-R2 and corrected in the decision record (S3-F3). Task 2 ships composed snapshots and the clocked fixture, which give one comparable epoch space (kraison/vivace-graph#94) over per-store atomicity (#93), never one instant: the engine provides none across stores (`call-with-read-snapshot`, GH #53), so a cross-store run is per-store consistent and is not serialised against a premise committed after its snapshots.
 - §11 S3 bullet: Task 2's first test.
 - §9 reads under scope: Task 3 (S3-P4).
 - Type consistency: `%premise-ref` produces `(key . store-name)`; `%reconcile-provenance` consumes `car`/`cdr` of it; `%store-name` is the one place the string is minted and the one place `premises-of` compares it.

--- a/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
+++ b/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
@@ -557,6 +557,14 @@ refuses every read of another store (S3-P2).  ..."
   - `%scope-lookup`'s docstring gains the wrong-arity caveat `%producer-candidates` carries (the same `query-precondition-error` is what a wrong component count signals, so the swallow is safe only at the known arity);
   - the "What the functors do not see" paragraph: "every route" → the three indexed routes and the walk; the bound-`?c` route and the empty fast paths read no store.
 
+- [ ] **Step 1c: Task 2's deferred minors** (ledger, review of c411e5e), in `rules/run.lisp` and `docs/rules.md`:
+  - the keyword-name check moves from `%store-name` into `%normalize-scope`, so a non-keyword-named store in a scope signals before the rule is resolved, as the docs say; `%store-name` keeps a plain `check-type` as belt and braces;
+  - `run-rules` normalises `:scope` once at entry (so a bad scope signals even when no rule is runnable) and passes the normalised list to each `run-rule`;
+  - `%premise-ref`'s docstring: the `resolve-node-graph` fallback scans every open store and, on the single-store path, would meet the cross-graph refusal inside the transaction — unreachable today because every lookup stamps `node-graph`, and said so;
+  - "Running a rule": "every refusal unwinds the transaction" → a refusal raised during a cross-store evaluation unwinds the snapshots (no transaction is open yet); the report is the same either way;
+  - the recon-O1 sentence in "What the functors do not see" carries the recon note's hedge (not settled by a live scenario);
+  - "Provenance": until `premises-of` takes a scope (this task's Step 3), say what it does with a foreign premise.
+
 - [ ] **Step 2: RED**; **Step 3:** `premises-of graph claim &key (scope (list graph))`: for each `derived-from` record, `(claim-method r)` NIL → resolve in `graph`; a name → `(find name scope :key #'%store-name :test #'string=)` → resolve there, else drop. `%claim-by-identity-key` already takes the graph. `dependents-of`: no change beyond the docstring. **Step 4: GREEN**, count.
 
 - [ ] **Step 5: `docs/rules.md`** — new section "Cross-store scope (GH #332)" after "Provenance": what a scope is, own store first, writes only the own store, the schema rule (S3-P5, families declared under both names), the two evaluation paths and the clock as C2 has it (S3-P2), `method` and `premises-of :scope` (S3-P3/P4), the walk (S3-P6), the transaction trap for Lisp callers, the known limit (no cross-store cycle detection, #333). Read the whole file once against the shipped code. `CHANGELOG.md` entry under Added. The decision record with S3-P1..P6 and every execution ruling from the ledger, in the S2 file's shape, stating they were taken without Kevin and which deviate from the spec (none deviate; S3-P2 refines §7's "one transaction" for the cross-store case, forced by GH #53 — say so). One closing line in the S2 handoff pointing at this branch.

--- a/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
+++ b/docs/superpowers/plans/2026-09-05-rules-s3-cross-store-scope.md
@@ -551,6 +551,12 @@ refuses every read of another store (S3-P2).  ..."
         (is (= 1 (length (graph-db.rules:dependents-of a premise))))))))
 ```
 
+- [ ] **Step 1b: Task 1's deferred minors** (ledger, review of e726cb3), in `rules/facts.lisp`, `tests/rules/scope-tests.lisp` and `docs/rules.md`:
+  - a cross-store test of the subject-only route: with scope `(a b)`, `(claim ?c rt-claim "host" "h1" ?r ?ons ?a)` answers objects `cache`, `db`, `web` (h1 runs web and db in A, cache in B);
+  - a test that the walk skips a store lacking the family: with scope `(a b)` and no bound, `(select-count (?c) (claim ?c rtu-claim ?s ?k ?r ?o ?ok))` counts A's rtu-claims only (write one first) and signals nothing;
+  - `%scope-lookup`'s docstring gains the wrong-arity caveat `%producer-candidates` carries (the same `query-precondition-error` is what a wrong component count signals, so the swallow is safe only at the known arity);
+  - the "What the functors do not see" paragraph: "every route" → the three indexed routes and the walk; the bound-`?c` route and the empty fast paths read no store.
+
 - [ ] **Step 2: RED**; **Step 3:** `premises-of graph claim &key (scope (list graph))`: for each `derived-from` record, `(claim-method r)` NIL → resolve in `graph`; a name → `(find name scope :key #'%store-name :test #'string=)` → resolve there, else drop. `%claim-by-identity-key` already takes the graph. `dependents-of`: no change beyond the docstring. **Step 4: GREEN**, count.
 
 - [ ] **Step 5: `docs/rules.md`** — new section "Cross-store scope (GH #332)" after "Provenance": what a scope is, own store first, writes only the own store, the schema rule (S3-P5, families declared under both names), the two evaluation paths and the clock as C2 has it (S3-P2), `method` and `premises-of :scope` (S3-P3/P4), the walk (S3-P6), the transaction trap for Lisp callers, the known limit (no cross-store cycle detection, #333). Read the whole file once against the shipped code. `CHANGELOG.md` entry under Added. The decision record with S3-P1..P6 and every execution ruling from the ledger, in the S2 file's shape, stating they were taken without Kevin and which deviate from the spec (none deviate; S3-P2 refines §7's "one transaction" for the cross-store case, forced by GH #53 — say so). One closing line in the S2 handoff pointing at this branch.

--- a/graph-db.asd
+++ b/graph-db.asd
@@ -241,7 +241,7 @@ docs/rules.md; GH #304."
   :serial t
   :components ((:file "package") (:file "suite") (:file "facts-tests")
                (:file "schema-tests") (:file "compile-tests")
-               (:file "run-tests"))
+               (:file "run-tests") (:file "scope-tests"))
   :perform (test-op (op c)
              (unless (uiop:symbol-call :graph-db/rules-test
                                        :run-rules-tests)

--- a/rules/facts.lisp
+++ b/rules/facts.lisp
@@ -157,8 +157,10 @@ is, the producer index through CLAIM-PRODUCER/2 in the same body.  A
 bound namespace naming no keyword answers empty; every other goal the
 routes miss reaches the COND's last clause, which walks the family or is
 refused as cost-unbounded under a resource bound (GH #285, spec §4).
-Every route reads every store in *CLAIM-SCOPE*, own store first, and
-*GRAPH* alone when it is NIL (spec §10, GH #332)."
+The three indexed routes and the walk read every store in
+*CLAIM-SCOPE*, own store first, or *GRAPH* alone when it is NIL; a
+bound ?C and the empty fast paths read no store at all (spec §10,
+GH #332)."
   (let* ((family (%family-or-ill-typed ?family))
          (parent (graph-db.spacetime:claim-family-parent family))
          (binary (graph-db.spacetime:claim-family-binary family))

--- a/rules/facts.lisp
+++ b/rules/facts.lisp
@@ -27,6 +27,31 @@
 (defparameter +claim-producer-index-slots+
   '(graph-db.spacetime::producer))
 
+(defvar *claim-scope* nil
+  "The stores CLAIM/7 and CLAIM-PRODUCER/2 read, own store first, or NIL
+for *GRAPH* alone (spec §10, GH #332).  RUN-RULE binds it for a body's
+evaluation; a Lisp caller may bind it around a SELECT.  Trap: inside a
+read-write transaction every read of another store is the engine's
+CROSS-GRAPH-TRANSACTION-ERROR (GH #53) -- bind it outside one.")
+
+(defun %scope-graphs ()
+  "The stores in scope, own store first: *CLAIM-SCOPE*, or *GRAPH*
+alone when it is NIL."
+  (or *claim-scope* (list *graph*)))
+
+(defun %scope-lookup (class-name slots value)
+  "INDEX-LOOKUP over every store in scope, in scope order.  A FOREIGN
+store whose schema does not carry CLASS-NAME contributes nothing --
+QUERY-PRECONDITION-ERROR read as %PRODUCER-CANDIDATES reads it -- while
+the own store (first) still signals, so a single-store goal keeps S1's
+ill-typed refusal (ruling S3-R1, recon C1)."
+  (let ((graphs (%scope-graphs)))
+    (append (index-lookup (first graphs) class-name slots value)
+            (loop for g in (rest graphs)
+                  append (handler-case
+                             (index-lookup g class-name slots value)
+                           (query-precondition-error () '()))))))
+
 (defun %keyword-string (keyword)
   "A keyword as the lowercase string the wire uses (spec §4)."
   (string-downcase (symbol-name keyword)))
@@ -97,13 +122,13 @@ asked in; see %NAMESPACE-VALUE."
 ;; last clause -- a per-goal property, so not
 ;; DECLARE-FUNCTOR-COST-UNBOUNDED, which classifies the whole functor
 ;; and would withhold CLAIM from free text entirely (GH #285).
-(defun %unbound-claim-scan (graph family)
-  "Every claim of FAMILY in GRAPH -- CLAIM/7's fallback, the COND's last
-clause, not a nothing-bound special case.  Refused as cost-unbounded
-when a resource bound is in effect, since %TICK cannot preempt inside a
-family walk (GH #285) -- unless the caller accepted that with
-:ALLOW-COST-UNBOUNDED, which SELECT now carries into a functor body
-(GH #334).  Same test as %REFUSE-COST-UNBOUNDED's, so the static
+(defun %unbound-claim-scan (family)
+  "Every claim of FAMILY in every store in scope -- CLAIM/7's fallback,
+the COND's last clause, not a nothing-bound special case.  Refused as
+cost-unbounded when a resource bound is in effect, since %TICK cannot
+preempt inside a family walk (GH #285) -- unless the caller accepted
+that with :ALLOW-COST-UNBOUNDED, which SELECT now carries into a functor
+body (GH #334).  Same test as %REFUSE-COST-UNBOUNDED's, so the static
 refusal and this one answer to one value."
   (when (and (not *allow-cost-unbounded*)
              (or *inference-budget* *query-deadline*))
@@ -111,8 +136,12 @@ refusal and this one answer to one value."
   ;; :INCLUDE-SUBCLASSES-P defaults to T, so the parent covers unary and
   ;; binary.  :COLLECT-P is what materialises node bytes before a node
   ;; escapes the scan's read pin (vertex.lisp) -- not a style choice.
+  ;; :VERTEX-TYPE keeps the scan typed, so a store lacking the family
+  ;; visits nothing rather than reading live versions (recon B8).
   (let ((parent (graph-db.spacetime:claim-family-parent family)))
-    (map-vertices #'identity graph :vertex-type parent :collect-p t)))
+    (loop for g in (%scope-graphs)
+          append (map-vertices #'identity g :vertex-type parent
+                                            :collect-p t))))
 
 (def-global-prolog-functor claim/7
     (?c ?family ?sns ?skey ?rel ?ons ?okey cont)
@@ -124,11 +153,12 @@ subject index when the subject is bound, the object index when the object
 is, the producer index through CLAIM-PRODUCER/2 in the same body.  A
 bound namespace naming no keyword answers empty; every other goal the
 routes miss reaches the COND's last clause, which walks the family or is
-refused as cost-unbounded under a resource bound (GH #285, spec §4)."
+refused as cost-unbounded under a resource bound (GH #285, spec §4).
+Every route reads every store in *CLAIM-SCOPE*, own store first, and
+*GRAPH* alone when it is NIL (spec §10, GH #332)."
   (let* ((family (%family-or-ill-typed ?family))
          (parent (graph-db.spacetime:claim-family-parent family))
          (binary (graph-db.spacetime:claim-family-binary family))
-         (g *graph*)
          (c (%prolog-index-bound ?c))
          (sns-arg (%prolog-index-bound ?sns))
          (ons-arg (%prolog-index-bound ?ons))
@@ -140,15 +170,15 @@ refused as cost-unbounded under a resource bound (GH #285, spec §4)."
          (candidates
            (cond ((node-p c) (list c))
                  ((and sns skey rel)
-                  (index-lookup g parent
-                                +claim-subject-relation-index-slots+
-                                (list sns skey rel)))
+                  (%scope-lookup parent
+                                 +claim-subject-relation-index-slots+
+                                 (list sns skey rel)))
                  ((and sns skey)
-                  (index-lookup g parent +claim-subject-index-slots+
-                                (list sns skey)))
+                  (%scope-lookup parent +claim-subject-index-slots+
+                                 (list sns skey)))
                  ((and ons okey)
-                  (index-lookup g binary +claim-object-index-slots+
-                                (list ons okey)))
+                  (%scope-lookup binary +claim-object-index-slots+
+                                 (list ons okey)))
                  ;; A bound namespace argument naming no keyword of this
                  ;; image -- a name no claim was recorded under, a
                  ;; non-wire spelling, a non-string: no solutions, and
@@ -156,7 +186,7 @@ refused as cost-unbounded under a resource bound (GH #285, spec §4)."
                  ;; the guard's budget refuses instead (spec §4).
                  ((and sns-arg (null sns)) '())
                  ((and ons-arg (null ons)) '())
-                 (t (%unbound-claim-scan g family)))))
+                 (t (%unbound-claim-scan family)))))
     (dolist (claim candidates)
       (%unify-claim claim ?c ?sns ?skey ?rel ?ons ?okey family cont))))
 
@@ -230,30 +260,35 @@ a failure, so a claim no rule wrote still answers."
       (%yield (?v (graph-db.spacetime:claim-rule-version c))
         (funcall cont)))))
 
-(defun %producer-candidates (graph producer)
-  "Every claim PRODUCER wrote in GRAPH, from the producer index of each
-family registered in this image.  *CLAIM-FAMILIES* is image-wide, not per
-graph, so a family GRAPH's schema does not carry is skipped: that is what
-QUERY-PRECONDITION-ERROR means here, not a fault to report."
-  (let ((out '()))
+(defun %producer-candidates (producer)
+  "Every claim PRODUCER wrote in every store in scope, from the producer
+index of each family registered in this image.  *CLAIM-FAMILIES* is
+image-wide, not per graph, so a family a store's schema does not carry is
+skipped -- own store included, unlike %SCOPE-LOOKUP, since the family
+loop was always cross-family: that is what QUERY-PRECONDITION-ERROR means
+here, not a fault to report (ruling S3-R1)."
+  (let ((out '())
+        (graphs (%scope-graphs)))
     (dolist (family (alexandria:hash-table-values
                      graph-db.spacetime::*claim-families*)
                     (nreverse out))
       (let ((parent (graph-db.spacetime:claim-family-parent family)))
-        (handler-case
-            (dolist (c (index-lookup graph parent
-                                     +claim-producer-index-slots+
-                                     producer))
-              (push c out))
-          ;; Also the condition a wrong component count signals
-          ;; (%INDEX-BOUNDS, index.lisp) -- safe only while this index
-          ;; is arity 1 and PRODUCER a bare scalar; a multi-slot one
-          ;; would read a shape error as "no candidates".
-          (query-precondition-error () nil))))))
+        (dolist (graph graphs)
+          (handler-case
+              (dolist (c (index-lookup graph parent
+                                       +claim-producer-index-slots+
+                                       producer))
+                (push c out))
+            ;; Also the condition a wrong component count signals
+            ;; (%INDEX-BOUNDS, index.lisp) -- safe only while this index
+            ;; is arity 1 and PRODUCER a bare scalar; a multi-slot one
+            ;; would read a shape error as "no candidates".
+            (query-precondition-error () nil)))))))
 
 (def-global-prolog-functor claim-producer/2 (?c ?p cont)
   "?C's producer.  With ?C unbound and ?P a producer name it generates
-instead: every claim ?P wrote, across every family this graph indexes --
+instead: every claim ?P wrote, across every family each store in
+*CLAIM-SCOPE* indexes (spec §10, GH #332), or *GRAPH*'s when it is NIL --
 write that goal BEFORE the CLAIM/7 goal it feeds, or ?C is bound by then
 and this filters.  With neither bound there is no index to generate from
 and no walk to fall back to, so the goal is refused as cost-unbounded
@@ -272,7 +307,7 @@ docs/rules.md)."
           ;; cross-family lookup that then unifies with nothing, past
           ;; %TICK's reach.
           ((and unbound (stringp p))
-           (dolist (claim (%producer-candidates *graph* p))
+           (dolist (claim (%producer-candidates p))
              (%yield (?c claim) (funcall cont))))
           ;; Nothing bound routes nowhere, so CLAIM/7's refusal rather
           ;; than silence.  A bound ?P that is a string naming no

--- a/rules/facts.lisp
+++ b/rules/facts.lisp
@@ -44,7 +44,10 @@ alone when it is NIL."
 store whose schema does not carry CLASS-NAME contributes nothing --
 QUERY-PRECONDITION-ERROR read as %PRODUCER-CANDIDATES reads it -- while
 the own store (first) still signals, so a single-store goal keeps S1's
-ill-typed refusal (ruling S3-R1, recon C1)."
+ill-typed refusal (ruling S3-R1, recon C1).  Same caveat as its sibling:
+a wrong component count signals that condition too (%INDEX-BOUNDS,
+index.lisp), so the swallow is safe only at these indexes' known
+arities."
   (let ((graphs (%scope-graphs)))
     (append (index-lookup (first graphs) class-name slots value)
             (loop for g in (rest graphs)

--- a/rules/run.lisp
+++ b/rules/run.lisp
@@ -187,14 +187,18 @@ spacetime/claim.lisp)."
                             (%extent-sexp-key (cdr sexp))))
         (t sexp)))
 
-(defun %refresh-kept (claim version extent)
-  "CLAIM brought to the current derivation's VERSION and EXTENT by ONE
-copy and save when either differs; the saved copy, else CLAIM.  EXTENT
-is what this run would derive, NIL under :EXTENT-POLICY :NONE and for a
-DERIVED-FROM record.  A kept temporal claim's extent START cannot move
--- the dedupe key carries it -- but its END can, and a refreshed extent
-can then overlap a sibling run, which %VALIDATE-EXTENT-DISJOINTNESS
-refuses at commit like any other (#331, docs/rules.md)."
+(defun %refresh-kept (claim version extent &optional (method nil methodp))
+  "CLAIM brought to the current derivation's VERSION, EXTENT and -- when
+METHOD is supplied -- METHOD, by ONE copy and save when any differs; the
+saved copy, else CLAIM.  EXTENT is what this run would derive, NIL under
+:EXTENT-POLICY :NONE and for a DERIVED-FROM record.  A kept temporal
+claim's extent START cannot move -- the dedupe key carries it -- but its
+END can, and a refreshed extent can then overlap a sibling run, which
+%VALIDATE-EXTENT-DISJOINTNESS refuses at commit like any other (#331,
+docs/rules.md).  METHOD is refreshed rather than the record swept and
+rewritten: MARK-DELETED releases a unique key only post-durability while
+VALIDATE-UNIQUE-CONSTRAINTS runs pre-durability, so a sweep and a
+re-insert of one identity in a transaction always collide (ruling P10)."
   (let* ((sexp (and extent (graph-db.spacetime:extent->sexp extent)))
          (extent-moved
            (not (equal (%extent-sexp-key sexp)
@@ -202,22 +206,77 @@ refuses at commit like any other (#331, docs/rules.md)."
                         (graph-db.spacetime:claim-extent-sexp claim)))))
          (version-moved
            (not (equal version
-                       (graph-db.spacetime:claim-rule-version claim)))))
-    (if (not (or extent-moved version-moved))
+                       (graph-db.spacetime:claim-rule-version claim))))
+         (method-moved
+           (and methodp
+                (not (equal method
+                            (graph-db.spacetime:claim-method claim))))))
+    (if (not (or extent-moved version-moved method-moved))
         claim
         (let ((c (graph-db:copy claim)))
           (when version-moved
             (setf (graph-db.spacetime:claim-rule-version c) version))
           (when extent-moved
             (setf (graph-db.spacetime:claim-extent c) extent))
+          (when method-moved
+            (setf (graph-db.spacetime:claim-method c) method))
           (graph-db:save c)
           c))))
+
+(defun %store-name (graph)
+  "GRAPH's name as a DERIVED-FROM record's METHOD carries it: the
+downcased graph name, cl-llm's STORE-NAME convention (spec §10).  A
+store a rule reads must be keyword-named (recon B5); signals if not."
+  (let ((name (graph-db:graph-name graph)))
+    (unless (keywordp name)
+      (error "A store a rule reads must be keyword-named; ~S is not."
+             name))
+    (string-downcase (symbol-name name))))
+
+(defun %normalize-scope (graph scope)
+  "SCOPE as RUN-RULE reads it: the open stores a body may read, GRAPH
+first and once (spec §10).  Signals on anything that is not an open
+store.  Duplicates are dropped: a store named twice would answer every
+route twice and so double every solution."
+  (dolist (g scope)
+    (unless (typep g 'graph-db::graph)
+      (error "RUN-RULE :SCOPE holds ~S, which is not an open store."
+             g)))
+  (cons graph (remove graph (remove-duplicates scope :test #'eq
+                                                     :from-end t)
+                      :test #'eq)))
+
+(defun %premise-ref (node graph)
+  "A premise as the reconcile carries it: (IDENTITY-KEY . STORE-NAME),
+STORE-NAME NIL for the rule's own GRAPH (S3-P3).  Call this INSIDE the
+snapshot NODE was read under: a node an INDEX-LOOKUP returned under a
+snapshot is not self-contained once the snapshot exits (recon C4)."
+  (let ((home (or (graph-db::node-graph node)
+                  (graph-db:resolve-node-graph (graph-db:id node)))))
+    (cons (graph-db.spacetime:claim-identity-key node)
+          (and home (not (eq home graph)) (%store-name home)))))
+
+(defun %merge-premise-refs (refs more)
+  "REFS with MORE added, one entry per identity key: a key already
+present keeps the own store's NIL over a foreign name, else the first
+seen (S3-P3).  Order is first-seen, so which records a run writes does
+not depend on hash order."
+  (let ((out refs))
+    (dolist (r more out)
+      (let ((seen (assoc (car r) out :test #'string=)))
+        (cond ((null seen) (setf out (nconc out (list r))))
+              ((and (cdr seen) (null (cdr r)))
+               (setf (cdr seen) nil)))))))
 
 (defun %desired (compiled graph report)
   "The derivation the body asks for (spec §7.3): (VALUES TABLE ORDER),
 TABLE a dedupe key -> (ARGS . PREMISES) hash and ORDER its keys in the
 order the solutions first named them; disjoint solutions counted on
-REPORT and dropped."
+REPORT and dropped.  A premise is (IDENTITY-KEY . STORE-NAME), read
+here and never as a node (S3-P3, recon C4).  Owns REPORT's disjoint
+count, hence the reset: %DERIVE cannot clear it, since a cross-store
+run evaluates once and reconciles per attempt."
+  (setf (rule-report-disjoint-premises report) 0)
   (let* ((spec (compiled-rule-spec compiled))
          (family (compiled-rule-family compiled))
          (vars (compiled-rule-vars compiled))
@@ -252,14 +311,17 @@ REPORT and dropped."
             (%premise-extent premises policy)
           (if disjoint-p
               (incf (rule-report-disjoint-premises report))
-              (let* ((key (%dedupe-key family sns skey
+              ;; The refs after %PREMISE-EXTENT and inside the
+              ;; evaluation, both on the nodes (recon C4).
+              (let* ((refs (mapcar (lambda (n) (%premise-ref n graph))
+                                   premises))
+                     (key (%dedupe-key family sns skey
                                        (compiled-rule-relation compiled)
                                        ons okey extent))
                      (entry (gethash key claims)))
                 (if entry
                     (setf (cdr entry)
-                          (union (cdr entry) premises
-                                 :key #'graph-db:id :test #'equalp))
+                          (%merge-premise-refs (cdr entry) refs))
                     (progn
                       (setf (gethash key claims)
                             (cons (list* :subject-namespace sns
@@ -268,7 +330,7 @@ REPORT and dropped."
                                          (unless unary-p
                                            (list :object-namespace ons
                                                  :object-key okey)))
-                                  premises))
+                                  (%merge-premise-refs '() refs)))
                       (push key order))))))))
     (values claims (nreverse order))))
 
@@ -323,21 +385,26 @@ every claim of the derivation that now stands."
 
 (defun %reconcile-provenance (compiled graph desired standing)
   "Spec §9 under ruling P10: one DERIVED-FROM record per (derived claim,
-premise) the derivation now asks for; records the producer wrote that it
-no longer asks for are deleted, the rest kept with their RULE-VERSION
-refreshed."
+premise) the derivation now asks for, its METHOD the premise's store
+name and NIL for the rule's own store (spec §10); records the producer
+wrote that it no longer asks for are deleted, the rest kept with their
+RULE-VERSION and METHOD refreshed -- a premise that moved store renames
+its record rather than being swept and rewritten, which would collide
+on the family's unique key (%REFRESH-KEPT)."
   (let* ((spec (compiled-rule-spec compiled))
          (producer (rule-producer (rule-spec-name spec)))
          (version (rule-spec-version spec))
-         (wanted (make-hash-table :test 'equal)))
+         (wanted (make-hash-table :test 'equal))
+         (kept (make-hash-table :test 'equal)))
     (loop for (key . claim) in standing
           for derived-key = (graph-db.spacetime:claim-identity-key claim)
           do (dolist (p (cdr (gethash key desired)))
-               (setf (gethash
-                      (cons derived-key
-                            (graph-db.spacetime:claim-identity-key p))
-                      wanted)
-                     t)))
+               (let ((pair (cons derived-key (car p))))
+                 (multiple-value-bind (name seen) (gethash pair wanted)
+                   ;; A pair two derived claims share keeps the own
+                   ;; store's NIL over a name, else the first (S3-P3).
+                   (setf (gethash pair wanted)
+                         (if seen (and name (cdr p)) (cdr p)))))))
     ;; One record per pair: a pair already kept is a duplicate and goes
     ;; with the records the derivation no longer asks for, as does a
     ;; record under this producer that is not a DERIVED-FROM at all.
@@ -345,40 +412,43 @@ refreshed."
                                                       producer))
       (let ((pair (cons (graph-db.spacetime:claim-subject-key r)
                         (graph-db.spacetime:claim-object-key r))))
-        (if (and (string= "derived-from"
-                          (graph-db.spacetime:claim-relation r))
-                 (eq t (gethash pair wanted)))
-            (progn (setf (gethash pair wanted) :kept)
-                   ;; No extent on a DERIVATION record, ever; NIL never
-                   ;; differs from the NIL it stores.
-                   (%refresh-kept r version nil))
-            (graph-db:mark-deleted r))))
-    (maphash (lambda (pair state)
-               (when (eq state t)
+        (multiple-value-bind (name wanted-p) (gethash pair wanted)
+          (if (and wanted-p
+                   (not (gethash pair kept))
+                   (string= "derived-from"
+                            (graph-db.spacetime:claim-relation r)))
+              (progn (setf (gethash pair kept) t)
+                     ;; No extent on a DERIVATION record, ever; NIL never
+                     ;; differs from the NIL it stores.
+                     (%refresh-kept r version nil name))
+              (graph-db:mark-deleted r)))))
+    (maphash (lambda (pair name)
+               (unless (gethash pair kept)
                  (make-derivation-binary
                   :graph graph :subject-namespace :claim
                   :subject-key (car pair) :relation "derived-from"
                   :object-namespace :claim :object-key (cdr pair)
                   :producer producer :rule-version version
-                  :standing :inferred)))
+                  :method name :standing :inferred)))
              wanted)))
 
-(defun %derive (compiled graph report)
-  "Spec §7 as ruling P10 has it, inside the transaction: evaluate, then
-reconcile the claims and their provenance against what stands.  The
-four counts are REPORT's, so an attempt starts by clearing them:
+(defun %derive (compiled graph report desired order)
+  "Spec §7 as ruling P10 has it, inside the transaction: reconcile the
+claims DESIRED/ORDER name, and their provenance, against what stands.
+The three counts are REPORT's, so an attempt starts by clearing them:
 CALL-WITH-TRANSACTION re-invokes its thunk on VALIDATION-CONFLICT
 (*MAXIMUM-TRANSACTION-ATTEMPTS*, transactions.lisp) and a retry must
-report what it did, not what it and every earlier attempt did."
+report what it did, not what it and every earlier attempt did.  On a
+retry only this runs: RUN-RULE's caller computed DESIRED/ORDER, and a
+cross-store evaluation is never repeated (S3-P2).  The disjoint count
+is %DESIRED's for the same reason."
   (setf (rule-report-derived report) 0
         (rule-report-kept report) 0
-        (rule-report-swept report) 0
-        (rule-report-disjoint-premises report) 0)
-  (multiple-value-bind (desired order) (%desired compiled graph report)
-    (let ((standing (%reconcile-claims compiled graph report desired
-                                       order)))
-      (%reconcile-provenance compiled graph desired standing)
-      report)))
+        (rule-report-swept report) 0)
+  (let ((standing (%reconcile-claims compiled graph report desired
+                                     order)))
+    (%reconcile-provenance compiled graph desired standing)
+    report))
 
 ;;; Refusals
 
@@ -407,15 +477,41 @@ rather than a fourth kind of tag."
      (%parent-of (graph-db:vcv-class-name c)))
     (t :rule)))
 
-(defun run-rule (graph rule)
+(defun %under-snapshots (graphs thunk)
+  "THUNK under one composed read snapshot per graph in GRAPHS (GH #53).
+Each store is internally consistent; under a shared system clock the
+epochs come from one counter, so they are comparable and equal when
+nothing commits between the acquisitions (#168, recon C2).  Without one
+they are not comparable at all."
+  (if (null graphs)
+      (funcall thunk)
+      (graph-db:call-with-read-snapshot
+       (lambda () (%under-snapshots (rest graphs) thunk))
+       (first graphs))))
+
+(defun run-rule (graph rule &key scope)
   "Derive RULE afresh and reconcile the result with its previous
-derivation, in one transaction (spec §7, ruling P10).  RULE is a RULE
-record, a RULE-SPEC, or a name (stored first, then DEF-RULE).
-=> RULE-REPORT.  A refusal of any kind -- compile, the rails, effects, a
-commit constraint, a missing extent -- is reported, never signalled, and
+derivation (spec §7, ruling P10).  RULE is a RULE record, a RULE-SPEC,
+or a name (stored first, then DEF-RULE).  SCOPE (spec §10) is the open
+stores the body may read, GRAPH put first and once; the rule writes
+GRAPH alone.  => RULE-REPORT.
+
+NIL or (GRAPH) is S2 exactly: evaluation and reconcile in one
+transaction.  With another store in SCOPE the body is evaluated BEFORE
+the write transaction, under %UNDER-SNAPSHOTS, because a read-write
+transaction refuses every read of another store (S3-P2, GH #53).  The
+trap: that evaluation is not serialised against a premise committed
+after its snapshots -- the next run sees such a premise, this one does
+not.
+
+A refusal of any kind -- compile, the rails, effects, a commit
+constraint, a missing extent -- is reported, never signalled, and
 unwinds the whole run so the previous derivation stands; an operator
-error (no resource bound, no such rule) signals."
-  (let* ((spec (%resolve-rule graph rule))
+error (no resource bound, no such rule, a SCOPE that is not open
+stores) signals."
+  (let* ((scope (%normalize-scope graph scope))
+         (foreign (rest scope))
+         (spec (%resolve-rule graph rule))
          (report (%make-rule-report :rule-name (rule-spec-name spec)
                                     :version (rule-spec-version spec)))
          (start (get-internal-real-time))
@@ -450,8 +546,18 @@ error (no resource bound, no such rule) signals."
         (let ((family (graph-db.spacetime:claim-family-parent
                        (compiled-rule-family compiled))))
           (handler-case
-              (graph-db:with-transaction (:graph graph)
-                (%derive compiled graph report))
+              (flet ((evaluate ()
+                       (let ((graph-db::*claim-scope* scope))
+                         (%desired compiled graph report))))
+                (if foreign
+                    (multiple-value-bind (desired order)
+                        (%under-snapshots scope #'evaluate)
+                      (graph-db:with-transaction (:graph graph)
+                        (%derive compiled graph report desired order)))
+                    (graph-db:with-transaction (:graph graph)
+                      (multiple-value-bind (desired order) (evaluate)
+                        (%derive compiled graph report desired
+                                 order)))))
             (rule-run-refusal (c)
               (refuse (rule-run-refusal-tag c)
                       (rule-run-refusal-text c)))
@@ -516,12 +622,15 @@ compiler should have refused."
         (push ready done)))
     (nreverse done)))
 
-(defun run-rules (graph)
+(defun run-rules (graph &key scope)
   "Every enabled rule GRAPH can run -- its stored rules, plus the
 DEF-RULEs whose family it carries (ruling P8) -- each through RUN-RULE in
-dependency order (spec §7).  A rule that does not compile is reported
-:REFUSED and skipped; the rest still run.  => the reports, the refused
-ones first and then the rest in the order run."
+dependency order (spec §7), with SCOPE (spec §10) passed through to
+every one.  A rule that does not compile is reported :REFUSED and
+skipped; the rest still run.  => the reports, the refused ones first and
+then the rest in the order run.  Compile and the dependency order stay
+single-store, so a cycle through another store's rules is not detected
+(S3-P5)."
   (let ((reports '())
         (compiled '()))
     (dolist (spec (rules-in-scope graph))
@@ -536,7 +645,8 @@ ones first and then the rest in the order run."
                                          (rule-compile-error-reason c))))
                   reports)))))
     (dolist (c (%dependency-order (nreverse compiled)))
-      (push (run-rule graph (compiled-rule-spec c)) reports))
+      (push (run-rule graph (compiled-rule-spec c) :scope scope)
+            reports))
     (nreverse reports)))
 
 ;;; Provenance reads (spec §9)

--- a/rules/run.lisp
+++ b/rules/run.lisp
@@ -240,32 +240,42 @@ this CHECK-TYPE is belt and braces for every other caller."
 first and once (spec §10).  Signals on anything that is not an open
 store, and on a store that is not keyword-named -- %STORE-NAME
 downcases its SYMBOL-NAME (recon B5) -- so both are refused before the
-rule is resolved.  Duplicates are dropped: a store named twice would
-answer every route twice and so double every solution."
-  (dolist (g scope)
+rule is resolved.  GRAPH is checked on the same terms: it is a store
+the rule reads and names in a record like any other.  Duplicates are
+dropped: a store named twice would answer every route twice and so
+double every solution."
+  (dolist (g (cons graph scope))
     (unless (typep g 'graph-db::graph)
-      (error "RUN-RULE :SCOPE holds ~S, which is not an open store."
+      (error "A store a rule reads must be an open store; ~S is not."
              g))
     (unless (keywordp (graph-db:graph-name g))
       (error "A store a rule reads must be keyword-named; ~S is not."
              (graph-db:graph-name g))))
-  (cons graph (remove graph (remove-duplicates scope :test #'eq
-                                                     :from-end t)
-                      :test #'eq)))
+  (let ((others (remove-duplicates scope :test #'eq :from-end t)))
+    (cons graph (remove graph others :test #'eq))))
+
+(defun %check-no-foreign-read-in-transaction (what foreign)
+  "Refuses WHAT (an operator-facing name) when FOREIGN names a store and
+a transaction is open: a read-write transaction refuses every foreign
+read, snapshot or no snapshot (transactions.lisp, GH #53), so the read
+would signal CROSS-GRAPH-TRANSACTION-ERROR mid-run.  An operator error,
+not a report (S3-F1)."
+  (when (and foreign graph-db::*transaction*)
+    (error "~A with a foreign store in :SCOPE reads outside a ~
+transaction; call it outside one (GH #53)." what)))
 
 (defun %premise-ref (node graph)
   "A premise as the reconcile carries it: (IDENTITY-KEY . STORE-NAME),
 STORE-NAME NIL for the rule's own GRAPH (S3-P3).  Call this INSIDE the
 snapshot NODE was read under: a node an INDEX-LOOKUP returned under a
 snapshot is not self-contained once the snapshot exits (recon C4).
-The RESOLVE-NODE-GRAPH fallback scans every open store and would, on
-the single-store path, meet the cross-graph refusal inside the
-transaction (GH #53) -- unreachable today, since every lookup stamps
-NODE-GRAPH (recon B3)."
-  (let ((home (or (graph-db::node-graph node)
-                  (graph-db:resolve-node-graph (graph-db:id node)))))
+An unstamped node is the engine's \"unknown, not foreign\":
+NODE-HOME-GRAPH defaults it to GRAPH (node-class.lisp), so the premise
+is recorded as the own store's rather than searched for (S3-F4).
+Unreachable today -- every lookup stamps NODE-GRAPH (recon B3)."
+  (let ((home (graph-db::node-home-graph node graph)))
     (cons (graph-db.spacetime:claim-identity-key node)
-          (and home (not (eq home graph)) (%store-name home)))))
+          (and (not (eq home graph)) (%store-name home)))))
 
 (defun %merge-store-name (old new)
   "The store name one premise keeps when it is named twice: the own
@@ -527,7 +537,8 @@ A refusal of any kind -- compile, the rails, effects, a commit
 constraint, a missing extent -- is reported, never signalled, and
 unwinds the whole run so the previous derivation stands; an operator
 error (no resource bound, no such rule, a SCOPE that is not a list of
-open, keyword-named stores) signals."
+open, keyword-named stores, a foreign store in SCOPE inside the
+caller's transaction) signals."
   (let* ((scope (%normalize-scope graph scope))
          (foreign (rest scope))
          (spec (%resolve-rule graph rule))
@@ -535,6 +546,7 @@ open, keyword-named stores) signals."
                                     :version (rule-spec-version spec)))
          (start (get-internal-real-time))
          (compiled nil))
+    (%check-no-foreign-read-in-transaction "RUN-RULE" foreign)
     (flet ((refuse (tag text)
              (setf (rule-report-outcome report) :refused
                    (rule-report-derived report) 0
@@ -706,7 +718,10 @@ store is not in SCOPE -- fewer premises, never wrong ones (S3-P4,
 cl-llm's :ABSENT convention).  A premise whose identity no longer exists
 in its store is dropped too, and a DERIVATION record of any other
 relation is not provenance and is not read.  Trap: a foreign store in
-SCOPE is read here, so call this OUTSIDE a transaction (GH #53)."
+SCOPE is read here, so call this OUTSIDE a transaction -- inside one it
+is an operator error, not a report (GH #53, S3-F1)."
+  (%check-no-foreign-read-in-transaction
+   "PREMISES-OF" (remove graph scope))
   (let ((records (graph-db.spacetime:claims-touching
                   graph 'derivation :claim
                   (graph-db.spacetime:claim-identity-key claim)

--- a/rules/run.lisp
+++ b/rules/run.lisp
@@ -526,8 +526,8 @@ not.
 A refusal of any kind -- compile, the rails, effects, a commit
 constraint, a missing extent -- is reported, never signalled, and
 unwinds the whole run so the previous derivation stands; an operator
-error (no resource bound, no such rule, a SCOPE that is not open
-stores) signals."
+error (no resource bound, no such rule, a SCOPE that is not a list of
+open, keyword-named stores) signals."
   (let* ((scope (%normalize-scope graph scope))
          (foreign (rest scope))
          (spec (%resolve-rule graph rule))

--- a/rules/run.lisp
+++ b/rules/run.lisp
@@ -65,9 +65,11 @@ some store has run DEF-RULES-SCHEMA."
 ;;; Evaluating the body
 
 (defun %solutions (compiled graph report)
-  "Every solution of COMPILED's body under RUN-QUERY-GOALS' rails inside
-the current transaction (spec §7.2, ruling P4): a list of rows aligned
-with COMPILED-RULE-VARS.  Refuses past *RULES-MAX-SOLUTIONS*."
+  "Every solution of COMPILED's body under RUN-QUERY-GOALS' rails (spec
+§7.2, ruling P4): a list of rows aligned with COMPILED-RULE-VARS.
+SELECT's :SNAPSHOT inherits the open transaction on the single-store
+path and the composed read snapshots on the cross-store one (S3-P2).
+Refuses past *RULES-MAX-SOLUTIONS*."
   (let ((max-inferences (or *rules-max-inferences*
                             graph-db::*query-default-max-inferences*))
         (timeout (or *rules-timeout* graph-db::*query-default-timeout*))
@@ -226,22 +228,27 @@ re-insert of one identity in a transaction always collide (ruling P10)."
 (defun %store-name (graph)
   "GRAPH's name as a DERIVED-FROM record's METHOD carries it: the
 downcased graph name, cl-llm's STORE-NAME convention (spec §10).  A
-store a rule reads must be keyword-named (recon B5); signals if not."
+store a rule reads must be keyword-named (recon B5); %NORMALIZE-SCOPE
+is where a scope is refused for it, before the rule is resolved, and
+this CHECK-TYPE is belt and braces for every other caller."
   (let ((name (graph-db:graph-name graph)))
-    (unless (keywordp name)
-      (error "A store a rule reads must be keyword-named; ~S is not."
-             name))
+    (check-type name keyword)
     (string-downcase (symbol-name name))))
 
 (defun %normalize-scope (graph scope)
   "SCOPE as RUN-RULE reads it: the open stores a body may read, GRAPH
 first and once (spec §10).  Signals on anything that is not an open
-store.  Duplicates are dropped: a store named twice would answer every
-route twice and so double every solution."
+store, and on a store that is not keyword-named -- %STORE-NAME
+downcases its SYMBOL-NAME (recon B5) -- so both are refused before the
+rule is resolved.  Duplicates are dropped: a store named twice would
+answer every route twice and so double every solution."
   (dolist (g scope)
     (unless (typep g 'graph-db::graph)
       (error "RUN-RULE :SCOPE holds ~S, which is not an open store."
-             g)))
+             g))
+    (unless (keywordp (graph-db:graph-name g))
+      (error "A store a rule reads must be keyword-named; ~S is not."
+             (graph-db:graph-name g))))
   (cons graph (remove graph (remove-duplicates scope :test #'eq
                                                      :from-end t)
                       :test #'eq)))
@@ -250,7 +257,11 @@ route twice and so double every solution."
   "A premise as the reconcile carries it: (IDENTITY-KEY . STORE-NAME),
 STORE-NAME NIL for the rule's own GRAPH (S3-P3).  Call this INSIDE the
 snapshot NODE was read under: a node an INDEX-LOOKUP returned under a
-snapshot is not self-contained once the snapshot exits (recon C4)."
+snapshot is not self-contained once the snapshot exits (recon C4).
+The RESOLVE-NODE-GRAPH fallback scans every open store and would, on
+the single-store path, meet the cross-graph refusal inside the
+transaction (GH #53) -- unreachable today, since every lookup stamps
+NODE-GRAPH (recon B3)."
   (let ((home (or (graph-db::node-graph node)
                   (graph-db:resolve-node-graph (graph-db:id node)))))
     (cons (graph-db.spacetime:claim-identity-key node)
@@ -633,13 +644,15 @@ compiler should have refused."
 (defun run-rules (graph &key scope)
   "Every enabled rule GRAPH can run -- its stored rules, plus the
 DEF-RULEs whose family it carries (ruling P8) -- each through RUN-RULE in
-dependency order (spec §7), with SCOPE (spec §10) passed through to
-every one.  A rule that does not compile is reported :REFUSED and
-skipped; the rest still run.  => the reports, the refused ones first and
-then the rest in the order run.  Compile and the dependency order stay
-single-store, so a cycle through another store's rules is not detected
-(S3-P5)."
-  (let ((reports '())
+dependency order (spec §7), with SCOPE (spec §10) normalised once here
+and passed to every one -- so a scope that is not open stores signals
+even when no rule is runnable.  A rule that does not compile is
+reported :REFUSED and skipped; the rest still run.  => the reports, the
+refused ones first and then the rest in the order run.  Compile and the
+dependency order stay single-store, so a cycle through another store's
+rules is not detected (S3-P5)."
+  (let ((scope (%normalize-scope graph scope))
+        (reports '())
         (compiled '()))
     (dolist (spec (rules-in-scope graph))
       (when (%runnable-spec-p graph spec)
@@ -684,25 +697,40 @@ when nothing in the store has that identity now."
       (or (find-if #'graph-db.spacetime:claim-current-p found)
           (first found)))))
 
-(defun premises-of (graph claim)
+(defun premises-of (graph claim &key (scope (list graph)))
   "The claims CLAIM was derived from (spec §9): its DERIVED-FROM records'
-objects, resolved back to claims.  A premise whose identity no longer
-exists in the store is dropped, and a DERIVATION record of any other
-relation is not provenance and is not read."
+objects, resolved back to claims.  A record's METHOD names the store its
+premise came from (spec §10): the premise resolves there when that store
+is in SCOPE, in GRAPH when METHOD is NIL, and is DROPPED when the named
+store is not in SCOPE -- fewer premises, never wrong ones (S3-P4,
+cl-llm's :ABSENT convention).  A premise whose identity no longer exists
+in its store is dropped too, and a DERIVATION record of any other
+relation is not provenance and is not read.  Trap: a foreign store in
+SCOPE is read here, so call this OUTSIDE a transaction (GH #53)."
   (let ((records (graph-db.spacetime:claims-touching
                   graph 'derivation :claim
                   (graph-db.spacetime:claim-identity-key claim)
                   :role :subject :relation "derived-from")))
-    (remove nil (mapcar (lambda (r)
-                          (%claim-by-identity-key
-                           graph (graph-db.spacetime:claim-object-key r)))
-                        records))))
+    (remove nil
+            (mapcar
+             (lambda (r)
+               (let* ((name (graph-db.spacetime:claim-method r))
+                      (store (if name
+                                 (find name scope :key #'%store-name
+                                                  :test #'string=)
+                                 graph)))
+                 (when store
+                   (%claim-by-identity-key
+                    store (graph-db.spacetime:claim-object-key r)))))
+             records))))
 
 (defun dependents-of (graph claim &key current)
   "Every derived claim whose provenance names CLAIM (spec §9) -- one
 CLAIMS-TOUCHING on the object endpoint, DERIVED-FROM records only, then
 the subjects resolved.  With CURRENT, only dependents still believed.
-Nothing is re-derived."
+Nothing is re-derived.  No scope: the records and the dependents are
+GRAPH's whatever store CLAIM lives in, and a premise is named by its
+identity key (spec §10)."
   (let* ((records (graph-db.spacetime:claims-touching
                    graph 'derivation :claim
                    (graph-db.spacetime:claim-identity-key claim)

--- a/rules/run.lisp
+++ b/rules/run.lisp
@@ -256,17 +256,24 @@ snapshot is not self-contained once the snapshot exits (recon C4)."
     (cons (graph-db.spacetime:claim-identity-key node)
           (and home (not (eq home graph)) (%store-name home)))))
 
+(defun %merge-store-name (old new)
+  "The store name one premise keeps when it is named twice: the own
+store's NIL beats any name, and between two names the FIRST wins
+(S3-P3).  One rule for both merge sites -- %MERGE-PREMISE-REFS within a
+solution set, %RECONCILE-PROVENANCE across derived claims."
+  (and old new old))
+
 (defun %merge-premise-refs (refs more)
-  "REFS with MORE added, one entry per identity key: a key already
-present keeps the own store's NIL over a foreign name, else the first
-seen (S3-P3).  Order is first-seen, so which records a run writes does
-not depend on hash order."
+  "REFS with MORE added, one entry per identity key, the store name
+merged by %MERGE-STORE-NAME.  Order is first-seen, so which records a
+run writes does not depend on hash order."
   (let ((out refs))
     (dolist (r more out)
       (let ((seen (assoc (car r) out :test #'string=)))
-        (cond ((null seen) (setf out (nconc out (list r))))
-              ((and (cdr seen) (null (cdr r)))
-               (setf (cdr seen) nil)))))))
+        (if (null seen)
+            (setf out (nconc out (list r)))
+            (setf (cdr seen)
+                  (%merge-store-name (cdr seen) (cdr r))))))))
 
 (defun %desired (compiled graph report)
   "The derivation the body asks for (spec §7.3): (VALUES TABLE ORDER),
@@ -401,10 +408,11 @@ on the family's unique key (%REFRESH-KEPT)."
           do (dolist (p (cdr (gethash key desired)))
                (let ((pair (cons derived-key (car p))))
                  (multiple-value-bind (name seen) (gethash pair wanted)
-                   ;; A pair two derived claims share keeps the own
-                   ;; store's NIL over a name, else the first (S3-P3).
+                   ;; Same rule as within a solution set (S3-P3).
                    (setf (gethash pair wanted)
-                         (if seen (and name (cdr p)) (cdr p)))))))
+                         (if seen
+                             (%merge-store-name name (cdr p))
+                             (cdr p)))))))
     ;; One record per pair: a pair already kept is a duplicate and goes
     ;; with the records the derivation no longer asks for, as does a
     ;; record under this producer that is not a DERIVED-FROM at all.

--- a/tests/rules/run-tests.lisp
+++ b/tests/rules/run-tests.lisp
@@ -773,7 +773,9 @@ an attempt must start from zero.  Staging a real conflict is not cheap;
 two %DERIVE calls in one transaction exercise the same accumulation.
 They are not a literal retry -- CLAIMS-BY-PRODUCER overlays the open
 transaction's writes (GH #324), so the second call KEEPS what the first
-derived -- but four counts over two claims is exactly the bug."
+derived -- but four counts over two claims is exactly the bug.
+Evaluation is the caller's since S3-P2, so one %DESIRED and two
+%DERIVEs is now literally the retry shape a cross-store run takes."
   (with-rules-graph (g)
     (seed g)
     (let* ((r (write-web-hosts g))
@@ -781,9 +783,11 @@ derived -- but four counts over two claims is exactly the bug."
            (report (graph-db.rules::%make-rule-report
                     :rule-name "web-hosts" :version "1")))
       (with-transaction ((graph-db::transaction-manager g))
-        (graph-db.rules::%derive compiled g report)
-        (is (= 2 (graph-db.rules:rule-report-derived report)))
-        (graph-db.rules::%derive compiled g report))
+        (multiple-value-bind (desired order)
+            (graph-db.rules::%desired compiled g report)
+          (graph-db.rules::%derive compiled g report desired order)
+          (is (= 2 (graph-db.rules:rule-report-derived report)))
+          (graph-db.rules::%derive compiled g report desired order)))
       (is (= 0 (graph-db.rules:rule-report-derived report)))
       (is (= 2 (graph-db.rules:rule-report-kept report)))
       (is (= 2 (length (derived g 'rt-claim "web-hosts")))))))

--- a/tests/rules/scope-tests.lisp
+++ b/tests/rules/scope-tests.lisp
@@ -424,7 +424,11 @@ store holds: with the odd store the scope answers, with B it is
   "S3-P4: a record's METHOD says which store its premise is in, and a
 premise whose store is not in the caller's scope is dropped rather than
 looked for in the rule's own store.  DEPENDENTS-OF needs no scope: the
-records are the rule's store's whatever store the premise lives in."
+records are the rule's store's whatever store the premise lives in.
+
+The decoy is what makes the drop assertion discriminate: A holds a
+claim with the B premise's exact identity, written after the run, so a
+resolve-in-GRAPH fallback answers it instead of NIL."
   (with-two-stores (a b)
     (seed a)
     (seed-b b)
@@ -432,6 +436,12 @@ records are the rule's store's whatever store the premise lives in."
      a (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
                    :head *web-hosts-head* :body *web-hosts-body*)
      :scope (list a b))
+    ;; Written AFTER the run, so no record names A for this premise.
+    (with-transaction ((graph-db::transaction-manager a))
+      (make-rt-claim-binary :graph a :subject-namespace :host
+                            :subject-key "h3" :relation "runs"
+                            :object-namespace :app :object-key "web"
+                            :producer "scan-c" :standing :observed))
     (let ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
                     :key #'claim-object-key :test #'string=))
           (h1 (find "h1" (derived a 'rt-claim "web-hosts")

--- a/tests/rules/scope-tests.lisp
+++ b/tests/rules/scope-tests.lisp
@@ -33,6 +33,24 @@ scope order; with it NIL, from *GRAPH* alone (S3-P1)."
                    (claim ?c rt-claim "host" "h3" "runs" "app" "web")
                    (claim-producer ?c ?p)))))))
 
+(test the-subject-only-route-reads-every-store-in-scope
+  "The subject index route -- namespace and key bound, relation not --
+is the indexed route the test above leaves out: h1 runs web and db in A,
+cache in B."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    ;; Control: NIL scope answers A alone.
+    (is (equal '("db" "web")
+               (sort (select-flat (?o)
+                       (claim ?c rt-claim "host" "h1" ?r ?ons ?o))
+                     #'string<)))
+    (let ((graph-db::*claim-scope* (list a b)))
+      (is (equal '("cache" "db" "web")
+                 (sort (select-flat (?o)
+                         (claim ?c rt-claim "host" "h1" ?r ?ons ?o))
+                       #'string<))))))
+
 (test claim-producer-generates-across-scope
   (with-two-stores (a b)
     (seed a)
@@ -73,6 +91,29 @@ nothing (S3-P5)."
       (signals graph-db::prolog-cost-unbounded-error
         (select (:max-inferences 1000) (?c)
           (claim ?c rt-claim ?a ?b ?r ?d ?e))))))
+
+(test the-walk-skips-a-store-that-lacks-the-family
+  "The unrouted walk visits every store in scope, and one whose schema
+never declared the family visits nothing rather than signalling -- what
+%UNBOUND-CLAIM-SCAN's :VERTEX-TYPE buys (recon B8).  The rt-claim count
+is the control: the same scope, the same walk, a family both stores
+carry."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (with-transaction ((graph-db::transaction-manager a))
+      (make-rtu-claim-binary :graph a :subject-namespace :app
+                             :subject-key "web" :relation "owned-by"
+                             :object-namespace :team :object-key "t1"
+                             :producer "scan-a" :standing :observed)
+      (make-rtu-claim-binary :graph a :subject-namespace :app
+                             :subject-key "db" :relation "owned-by"
+                             :object-namespace :team :object-key "t2"
+                             :producer "scan-a" :standing :observed))
+    (let ((graph-db::*claim-scope* (list a b)))
+      ;; rtu-claim is declared for A alone: two, and B signals nothing.
+      (is (= 2 (select-count (?c) (claim ?c rtu-claim ?s ?k ?r ?o ?ok))))
+      (is (= 6 (select-count (?c) (claim ?c rt-claim ?s ?k ?r ?o ?ok)))))))
 
 (test a-foreign-read-inside-a-transaction-is-the-engines-refusal
   "The GH #53 contract, not ours: a read-write transaction on A refuses
@@ -338,3 +379,75 @@ refusals raised there, and the control that the same run derives."
       (is (null (derived a 'rt-claim "web-hosts")))
       (is (= 3 (graph-db.rules:rule-report-derived
                 (graph-db.rules:run-rule a r :scope (list a b))))))))
+
+;;; Reading provenance under a scope (S3-P4), and the scope's own
+;;; refusals.
+
+(defmacro signalled-text (&body body)
+  "The text of the error BODY signals, or \"\" when it signals none --
+so an assertion can name which of two refusals answered."
+  `(handler-case (progn ,@body "")
+     (error (c) (princ-to-string c))))
+
+(test run-rules-normalises-the-scope-before-any-rule-runs
+  "RUN-RULES normalises :SCOPE once at entry, so a bad scope signals
+even on a store with no runnable rule -- where no RUN-RULE call would
+ever look at it."
+  (with-two-stores (a b)
+    (seed a)
+    ;; Control: nothing to run, a good scope, no error and no reports.
+    (is (null (graph-db.rules:run-rules a :scope (list a b))))
+    (signals error
+      (graph-db.rules:run-rules a :scope (list b :not-a-graph)))))
+
+(test a-scope-store-must-be-keyword-named
+  "Recon B5: %STORE-NAME downcases the store's SYMBOL-NAME, so a store
+in a scope must be keyword-named -- and %NORMALIZE-SCOPE is where that
+is refused, before the rule is resolved.  Both calls name a rule no
+store holds: with the odd store the scope answers, with B it is
+%RESOLVE-RULE."
+  (with-two-stores (a b)
+    (seed a)
+    (let ((odd (make-instance 'graph-db::graph :graph-name "b")))
+      (is (search "keyword"
+                  (signalled-text
+                    (graph-db.rules:run-rule a "no-such-rule"
+                                             :scope (list odd)))
+                  :test #'char-equal))
+      (is (search "no rule named"
+                  (signalled-text
+                    (graph-db.rules:run-rule a "no-such-rule"
+                                             :scope (list b)))
+                  :test #'char-equal)))))
+
+(test premises-of-resolves-in-the-store-the-record-names
+  "S3-P4: a record's METHOD says which store its premise is in, and a
+premise whose store is not in the caller's scope is dropped rather than
+looked for in the rule's own store.  DEPENDENTS-OF needs no scope: the
+records are the rule's store's whatever store the premise lives in."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (graph-db.rules:run-rule
+     a (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                   :head *web-hosts-head* :body *web-hosts-body*)
+     :scope (list a b))
+    (let ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                    :key #'claim-object-key :test #'string=))
+          (h1 (find "h1" (derived a 'rt-claim "web-hosts")
+                    :key #'claim-object-key :test #'string=)))
+      ;; In scope: the premise, from B.
+      (let ((ps (graph-db.rules:premises-of a h3 :scope (list a b))))
+        (is (= 1 (length ps)))
+        (is (string= "h3" (claim-subject-key (first ps))))
+        (is (eq b (graph-db::node-graph (first ps)))))
+      ;; Out of scope: dropped, not resolved in A by mistake (S3-P4).
+      (is (null (graph-db.rules:premises-of a h3)))
+      ;; Control: an own-store premise answers under the default scope.
+      (let ((ps (graph-db.rules:premises-of a h1)))
+        (is (= 1 (length ps)))
+        (is (eq a (graph-db::node-graph (first ps)))))
+      ;; And a B premise's dependents are findable from A.
+      (let ((premise (first (claims-touching b 'rt-claim :host "h3"
+                                             :role :subject))))
+        (is (= 1 (length (graph-db.rules:dependents-of a premise))))))))

--- a/tests/rules/scope-tests.lisp
+++ b/tests/rules/scope-tests.lisp
@@ -1,0 +1,89 @@
+;;;; tests/rules/scope-tests.lisp -- cross-store scope (spec §10, GH
+;;;; #332).
+
+(in-package #:graph-db/rules-test)
+
+(in-suite rules-suite)
+
+(test claim-reads-every-store-in-scope
+  "With *CLAIM-SCOPE* bound, CLAIM/7 generates from each store's index in
+scope order; with it NIL, from *GRAPH* alone (S3-P1)."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    ;; Control: NIL scope is S1 exactly -- A's two hosts of web.
+    (is (equal '("h1" "h2")
+               (sort (select-flat (?h)
+                       (claim ?c rt-claim "host" ?h "runs" "app" "web"))
+                     #'string<)))
+    (let ((graph-db::*claim-scope* (list a b)))
+      (is (equal '("h1" "h2" "h3")
+                 (sort (select-flat (?h)
+                         (claim ?c rt-claim "host" ?h "runs" "app" "web"))
+                       #'string<)))
+      ;; The subject route across stores: h1 runs web and db in A, cache
+      ;; in B.
+      (is (equal '("cache" "db" "web")
+                 (sort (select-flat (?a)
+                         (claim ?c rt-claim "host" "h1" "runs" "app" ?a))
+                       #'string<)))
+      ;; A node from B is a node: the filters work on it.
+      (is (equal '("scan-c")
+                 (select-flat (?p)
+                   (claim ?c rt-claim "host" "h3" "runs" "app" "web")
+                   (claim-producer ?c ?p)))))))
+
+(test claim-producer-generates-across-scope
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((graph-db::*claim-scope* (list a b)))
+      ;; scan-c wrote 2 rt-claims and 1 rtt-claim, all in B.
+      (is (= 2 (select (:count t :max-inferences 1000) (?c)
+                 (claim-producer ?c "scan-c")
+                 (claim ?c rt-claim ?s ?k ?r ?o ?ok))))
+      ;; scan-a is in A only; the scope adds nothing to it.
+      (is (= 2 (select (:count t :max-inferences 1000) (?c)
+                 (claim-producer ?c "scan-a")
+                 (claim ?c rt-claim ?s ?k ?r ?o ?ok)))))))
+
+(test a-store-lacking-the-family-contributes-nothing
+  "rtu-claim is declared for A only; B in scope adds nothing and refuses
+nothing (S3-P5)."
+  (with-two-stores (a b)
+    (seed a)
+    (with-transaction ((graph-db::transaction-manager a))
+      (make-rtu-claim-binary :graph a :subject-namespace :app
+                             :subject-key "web" :relation "owned-by"
+                             :object-namespace :team :object-key "t1"
+                             :producer "scan-a" :standing :observed))
+    (let ((graph-db::*claim-scope* (list a b)))
+      (is (equal '("t1")
+                 (select-flat (?t)
+                   (claim ?c rtu-claim "app" "web" "owned-by"
+                          "team" ?t)))))))
+
+(test the-walk-covers-every-store-without-a-bound-and-refuses-under-one
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((graph-db::*claim-scope* (list a b)))
+      ;; 4 rt-claims in A + 2 in B.
+      (is (= 6 (select-count (?c) (claim ?c rt-claim ?a ?b ?r ?d ?e))))
+      (signals graph-db::prolog-cost-unbounded-error
+        (select (:max-inferences 1000) (?c)
+          (claim ?c rt-claim ?a ?b ?r ?d ?e))))))
+
+(test a-foreign-read-inside-a-transaction-is-the-engines-refusal
+  "The GH #53 contract, not ours: a read-write transaction on A refuses
+every read of B.  RUN-RULE evaluates before its transaction for that
+reason (S3-P2); a Lisp caller binding the scope inside one gets the
+engine's error."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((graph-db::*claim-scope* (list a b)))
+      (signals graph-db:cross-graph-transaction-error
+        (with-transaction ((graph-db::transaction-manager a))
+          (select-flat (?h)
+            (claim ?c rt-claim "host" ?h "runs" "app" "web")))))))

--- a/tests/rules/scope-tests.lisp
+++ b/tests/rules/scope-tests.lisp
@@ -130,23 +130,63 @@ engine's error."
         (is (string= "graph-db-rules-b" (claim-method rec-h3)))
         (is (null (claim-method rec-h1)))))))
 
-(test a-single-store-scope-is-s2-unchanged
-  "Control for S3-P2: RUN-RULE with no scope, or a scope of the store
-alone, derives inside its transaction exactly as before."
+(defmacro with-transaction-probe ((place) &body body)
+  "BODY with %DESIRED wrapped so PLACE records whether a transaction was
+open when the body's evaluation ran: T on S2's path, NIL on the
+cross-store one, where the evaluation precedes the write transaction
+(S3-P2).  The redefine/restore shape is tests/open-hygiene-tests.lisp's
+%OH-WITH-INJECTED-FAILURE."
+  (let ((orig (gensym "ORIG")))
+    `(let ((,orig (fdefinition 'graph-db.rules::%desired)))
+       (unwind-protect
+            (progn
+              (setf (fdefinition 'graph-db.rules::%desired)
+                    (lambda (&rest args)
+                      (setf ,place (and graph-db::*transaction* t))
+                      (apply ,orig args)))
+              ,@body)
+         (setf (fdefinition 'graph-db.rules::%desired) ,orig)))))
+
+(test the-scope-decides-where-the-body-is-evaluated
+  "S3-P2's discriminator, not only its counts: every count below is the
+same whichever path a run takes, so the test observes the path itself --
+%DESIRED runs with a transaction open on the single-store path and with
+none on the cross-store one.  That NIL is also recon B9's corollary:
+during a cross-store evaluation there is no transaction to overlay."
   (with-two-stores (a b)
     (seed a)
     (seed-b b)
     (let ((r (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
-                         :head *web-hosts-head* :body *web-hosts-body*)))
-      (is (= 2 (graph-db.rules:rule-report-derived
-                (graph-db.rules:run-rule a r))))
-      (is (= 2 (graph-db.rules:rule-report-kept
-                (graph-db.rules:run-rule a r :scope (list a)))))
-      ;; The scope's own store is put first whatever the caller wrote,
-      ;; and named twice it is still read once.
-      (let ((report (graph-db.rules:run-rule a r :scope (list b a b))))
-        (is (= 1 (graph-db.rules:rule-report-derived report)))
-        (is (= 2 (graph-db.rules:rule-report-kept report)))))))
+                         :head *web-hosts-head* :body *web-hosts-body*))
+          (seen :unset))
+      (with-transaction-probe (seen)
+        ;; No scope: S2 exactly, evaluated inside the transaction.
+        (is (= 2 (graph-db.rules:rule-report-derived
+                  (graph-db.rules:run-rule a r))))
+        (is (eq t seen))
+        (setf seen :unset)
+        ;; A scope naming the own store alone takes the same path.
+        (is (= 2 (graph-db.rules:rule-report-kept
+                  (graph-db.rules:run-rule a r :scope (list a)))))
+        (is (eq t seen))
+        (setf seen :unset)
+        ;; The own store is put first whatever the caller wrote, and
+        ;; named twice it is still read once -- and this one evaluates
+        ;; before its transaction.
+        (let ((report (graph-db.rules:run-rule a r :scope (list b a b))))
+          (is (= 1 (graph-db.rules:rule-report-derived report)))
+          (is (= 2 (graph-db.rules:rule-report-kept report))))
+        ;; :UNSET, not NIL, when the probe never fired.
+        (is (null seen))))))
+
+(test the-store-name-merge-prefers-the-own-store-then-the-first
+  "S3-P3's rule, one helper for both merge sites (%MERGE-PREMISE-REFS
+within a solution set, %RECONCILE-PROVENANCE across derived claims)."
+  (is (null (graph-db.rules::%merge-store-name "b" nil)))
+  (is (null (graph-db.rules::%merge-store-name nil "b")))
+  (is (null (graph-db.rules::%merge-store-name nil nil)))
+  (is (string= "b" (graph-db.rules::%merge-store-name "b" "c")))
+  (is (string= "b" (graph-db.rules::%merge-store-name "b" "b"))))
 
 (test cross-store-validity-intersects-across-stores
   "rtt premises: web version 3 (B, Jul 1 - Sep 30) against h1's

--- a/tests/rules/scope-tests.lisp
+++ b/tests/rules/scope-tests.lisp
@@ -5,6 +5,12 @@
 
 (in-suite rules-suite)
 
+(defmacro signalled-text (&body body)
+  "The text of the error BODY signals, or \"\" when it signals none --
+so an assertion can name which of two refusals answered."
+  `(handler-case (progn ,@body "")
+     (error (c) (princ-to-string c))))
+
 (test claim-reads-every-store-in-scope
   "With *CLAIM-SCOPE* bound, CLAIM/7 generates from each store's index in
 scope order; with it NIL, from *GRAPH* alone (S3-P1)."
@@ -80,6 +86,18 @@ nothing (S3-P5)."
                  (select-flat (?t)
                    (claim ?c rtu-claim "app" "web" "owned-by"
                           "team" ?t)))))))
+
+(test the-own-store-still-refuses-a-family-it-does-not-index
+  "S3-R1's other half: %SCOPE-LOOKUP leaves the FIRST store's lookup
+bare, so a scope cannot turn S1's ill-typed refusal into silence.
+Control: a-store-lacking-the-family-contributes-nothing, same scope,
+where B's miss IS swallowed."
+  (with-two-stores (a b)
+    (seed a)
+    (let ((graph-db::*claim-scope* (list a b)))
+      (signals graph-db:query-precondition-error
+        (select-flat (?h)
+          (claim ?c rtf-claim "host" ?h "runs" "app" "web"))))))
 
 (test the-walk-covers-every-store-without-a-bound-and-refuses-under-one
   (with-two-stores (a b)
@@ -321,8 +339,10 @@ it signals rather than being read as an empty store."
       ;; Control: the same call with real stores derives.
       (is (eq :derived (graph-db.rules:rule-report-outcome
                         (graph-db.rules:run-rule a r :scope (list a b)))))
-      (signals error
-        (graph-db.rules:run-rule a r :scope (list b :not-a-graph))))))
+      (is (search "open store"
+                  (signalled-text
+                    (graph-db.rules:run-rule a r :scope (list b :not-a-graph)))
+                  :test #'char-equal)))))
 
 (test a-premise-that-moves-store-renames-its-method
   "S3-P3's collision corner and the METHOD refresh in one: h3's premise
@@ -383,12 +403,6 @@ refusals raised there, and the control that the same run derives."
 ;;; Reading provenance under a scope (S3-P4), and the scope's own
 ;;; refusals.
 
-(defmacro signalled-text (&body body)
-  "The text of the error BODY signals, or \"\" when it signals none --
-so an assertion can name which of two refusals answered."
-  `(handler-case (progn ,@body "")
-     (error (c) (princ-to-string c))))
-
 (test run-rules-normalises-the-scope-before-any-rule-runs
   "RUN-RULES normalises :SCOPE once at entry, so a bad scope signals
 even on a store with no runnable rule -- where no RUN-RULE call would
@@ -397,8 +411,10 @@ ever look at it."
     (seed a)
     ;; Control: nothing to run, a good scope, no error and no reports.
     (is (null (graph-db.rules:run-rules a :scope (list a b))))
-    (signals error
-      (graph-db.rules:run-rules a :scope (list b :not-a-graph)))))
+    (is (search "open store"
+                (signalled-text
+                  (graph-db.rules:run-rules a :scope (list b :not-a-graph)))
+                :test #'char-equal))))
 
 (test a-scope-store-must-be-keyword-named
   "Recon B5: %STORE-NAME downcases the store's SYMBOL-NAME, so a store
@@ -419,6 +435,75 @@ store holds: with the odd store the scope answers, with B it is
                     (graph-db.rules:run-rule a "no-such-rule"
                                              :scope (list b)))
                   :test #'char-equal)))))
+
+(test the-own-store-is-checked-on-the-same-terms-as-the-scope
+  "%NORMALIZE-SCOPE validates GRAPH too, not only the caller's list: the
+own store's name is downcased into every record's METHOD (recon B5), so
+a store that is not keyword-named must be refused there as well, before
+the rule is resolved.  Control: the same call on a keyword-named store
+gets past the scope and meets %RESOLVE-RULE."
+  (with-rules-graph (g)
+    (is (search "keyword"
+                (signalled-text
+                  (graph-db.rules:run-rule
+                   (make-instance 'graph-db::graph :graph-name "b")
+                   "no-such-rule"))
+                :test #'char-equal))
+    (is (search "no rule named"
+                (signalled-text
+                  (graph-db.rules:run-rule g "no-such-rule"))
+                :test #'char-equal))))
+
+;;; The engine's transaction rule, as an operator error (S3-F1).
+
+(test run-rule-with-a-foreign-scope-refuses-to-run-inside-a-transaction
+  "A read-write transaction refuses every read of another store, even
+under that store's snapshot (GH #53, tests/multi-graph-tests.lisp), and
+RUN-RULE's composed snapshots cannot undo that: called inside the
+caller's transaction with a foreign store in :SCOPE it would meet
+CROSS-GRAPH-TRANSACTION-ERROR mid-run, which is no report of its own.
+So it is refused up front, as an operator error (S3-F1).  Control: the
+same call outside a transaction derives."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1"
+                         :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body*)))
+      (is (search "outside a transaction"
+                  (signalled-text
+                    (with-transaction
+                        ((graph-db::transaction-manager a))
+                      (graph-db.rules:run-rule a r :scope (list a b))))
+                  :test #'char-equal))
+      ;; Control: outside one, the same run derives -- and the refused
+      ;; call wrote nothing, since it refused before any evaluation.
+      (is (= 3 (graph-db.rules:rule-report-derived
+                (graph-db.rules:run-rule a r :scope (list a b))))))))
+
+(test premises-of-with-a-foreign-scope-refuses-inside-a-transaction
+  "The read side of S3-F1: PREMISES-OF resolves a foreign premise in the
+store its record names, which the same transaction rule forbids.
+Control: outside a transaction the premise resolves in B."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (graph-db.rules:run-rule
+     a (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                   :head *web-hosts-head* :body *web-hosts-body*)
+     :scope (list a b))
+    (let ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                    :key #'claim-object-key :test #'string=)))
+      (is (search "outside a transaction"
+                  (signalled-text
+                    (with-transaction
+                        ((graph-db::transaction-manager a))
+                      (graph-db.rules:premises-of a h3
+                                                  :scope (list a b))))
+                  :test #'char-equal))
+      (let ((ps (graph-db.rules:premises-of a h3 :scope (list a b))))
+        (is (= 1 (length ps)))
+        (is (eq b (graph-db::node-graph (first ps))))))))
 
 (test premises-of-resolves-in-the-store-the-record-names
   "S3-P4: a record's METHOD says which store its premise is in, and a

--- a/tests/rules/scope-tests.lisp
+++ b/tests/rules/scope-tests.lisp
@@ -87,3 +87,214 @@ engine's error."
         (with-transaction ((graph-db::transaction-manager a))
           (select-flat (?h)
             (claim ?c rt-claim "host" ?h "runs" "app" "web")))))))
+
+;;; RUN-RULE with a scope (S3-P2, S3-P3).
+
+(defun derivation-records (g claim)
+  "The DERIVED-FROM records G's rule wrote for CLAIM, as subject."
+  (claims-touching g 'graph-db.rules:derivation :claim
+                   (claim-identity-key claim)
+                   :role :subject :relation "derived-from"))
+
+(test a-rule-in-a-derives-from-premises-in-a-and-b-and-writes-only-a
+  "Spec §11's S3 bullet."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let* ((r (write-rule a :name "web-hosts" :version "1"
+                          :family "rt-claim"
+                          :head *web-hosts-head* :body *web-hosts-body*))
+           (report (graph-db.rules:run-rule a r :scope (list a b))))
+      (is (eq :derived (graph-db.rules:rule-report-outcome report)))
+      (is (= 3 (graph-db.rules:rule-report-derived report)))
+      (let ((claims (derived a 'rt-claim "web-hosts")))
+        (is (equal '("h1" "h2" "h3")
+                   (sort (mapcar #'claim-object-key claims) #'string<))))
+      ;; Nothing was written to B: no derived claim under either family
+      ;; it carries, its own claims untouched, and no DERIVATION family
+      ;; on it at all, so no record could live there either.
+      (is (null (claims-by-producer b 'rt-claim "rule/web-hosts")))
+      (is (null (claims-by-producer b 'rtt-claim "rule/web-hosts")))
+      (is (= 2 (length (claims-by-producer b 'rt-claim "scan-c"))))
+      (is (not (graph-db.rules::%graph-declares-p
+                b 'graph-db.rules:derivation)))
+      ;; Provenance names B for h3's premise and nothing for h1's.
+      (let* ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                       :key #'claim-object-key :test #'string=))
+             (h1 (find "h1" (derived a 'rt-claim "web-hosts")
+                       :key #'claim-object-key :test #'string=))
+             (rec-h3 (first (derivation-records a h3)))
+             (rec-h1 (first (derivation-records a h1))))
+        (is-true rec-h3)
+        (is-true rec-h1)
+        (is (string= "graph-db-rules-b" (claim-method rec-h3)))
+        (is (null (claim-method rec-h1)))))))
+
+(test a-single-store-scope-is-s2-unchanged
+  "Control for S3-P2: RUN-RULE with no scope, or a scope of the store
+alone, derives inside its transaction exactly as before."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body*)))
+      (is (= 2 (graph-db.rules:rule-report-derived
+                (graph-db.rules:run-rule a r))))
+      (is (= 2 (graph-db.rules:rule-report-kept
+                (graph-db.rules:run-rule a r :scope (list a)))))
+      ;; The scope's own store is put first whatever the caller wrote,
+      ;; and named twice it is still read once.
+      (let ((report (graph-db.rules:run-rule a r :scope (list b a b))))
+        (is (= 1 (graph-db.rules:rule-report-derived report)))
+        (is (= 2 (graph-db.rules:rule-report-kept report)))))))
+
+(test cross-store-validity-intersects-across-stores
+  "rtt premises: web version 3 (B, Jul 1 - Sep 30) against h1's
+deployments (A, Feb 1 - Jun 30 and Aug 1 - Sep 30) and h2's (A, May 1 -
+May 31), plus SEED's versions 1 (Jan 1 - Mar 31) and 2 (Apr 1 - Dec 31).
+Nine solutions.  Five intersect -- (h1 Feb-Jun, v1), (h1 Feb-Jun, v2),
+(h1 Aug-Sep, v2), (h1 Aug-Sep, v3), (h2 May, v2) -- and four are
+disjoint: (h1 Feb-Jun, v3), (h1 Aug-Sep, v1), (h2 May, v1),
+(h2 May, v3).  A alone gave 4 and 2 (S2)."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-temporal a)
+    (seed-b b)
+    (let ((report (graph-db.rules:run-rule
+                   a (write-rule a :name "host-version" :version "1"
+                                 :family "rtt-claim"
+                                 :head *host-version-head*
+                                 :body *host-version-body*)
+                   :scope (list a b))))
+      (is (= 5 (graph-db.rules:rule-report-derived report)))
+      (is (= 4 (graph-db.rules:rule-report-disjoint-premises report)))
+      (let ((v3 (find "3" (derived a 'rtt-claim "host-version")
+                      :key #'claim-object-key :test #'string=)))
+        (is-true v3)
+        (when v3
+          (multiple-value-bind (s e) (claim-bounds v3)
+            (is (local-time:timestamp= (ts 2026 8 1) s))
+            (is (local-time:timestamp= (ts 2026 9 30) e)))
+          ;; Two premises, one per store: the deployment from A with no
+          ;; method, the version run from B named (S3-P3).
+          (let ((recs (derivation-records a v3)))
+            (is (= 2 (length recs)))
+            (is (= 1 (count "graph-db-rules-b" recs
+                            :key #'claim-method :test #'equal)))
+            (is (= 1 (count nil recs :key #'claim-method)))))))))
+
+(test a-cross-store-rerun-reconciles-and-a-b-change-is-seen-next-run
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body*)))
+      (graph-db.rules:run-rule a r :scope (list a b))
+      (with-transaction ((graph-db::transaction-manager b))
+        (mark-deleted (first (claims-touching b 'rt-claim :host "h3"
+                                              :role :subject))))
+      (let ((report (graph-db.rules:run-rule a r :scope (list a b))))
+        (is (= 2 (graph-db.rules:rule-report-kept report)))
+        (is (= 1 (graph-db.rules:rule-report-swept report)))
+        (is (= 0 (graph-db.rules:rule-report-derived report))))
+      ;; h3's provenance record went with it.
+      (is (= 2 (length (claims-by-producer a 'graph-db.rules:derivation
+                                           "rule/web-hosts")))))))
+
+(test run-rules-takes-the-scope
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (write-rule a :name "web-hosts" :version "1" :family "rt-claim"
+                :head *web-hosts-head* :body *web-hosts-body*)
+    (let ((reports (graph-db.rules:run-rules a :scope (list a b))))
+      (is (= 1 (length reports)))
+      (is (= 3 (graph-db.rules:rule-report-derived (first reports)))))))
+
+(test a-cross-store-run-under-one-clock-derives
+  "Under a shared clock the composed snapshots take epochs from one
+counter (#168).  Observable here: the run works and derives from both
+stores.  Nothing asserts one instant -- the engine provides none across
+stores (recon C2), and a test of it would pass vacuously in a quiescent
+suite."
+  (with-clocked-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((report (graph-db.rules:run-rule
+                   a (write-rule a :name "web-hosts" :version "1"
+                                 :family "rt-claim"
+                                 :head *web-hosts-head*
+                                 :body *web-hosts-body*)
+                   :scope (list a b))))
+      (is (eq :derived (graph-db.rules:rule-report-outcome report)))
+      (is (= 3 (graph-db.rules:rule-report-derived report))))))
+
+(test a-scope-must-be-open-graphs
+  "The scope is normalised before anything else runs, so a non-store in
+it signals rather than being read as an empty store."
+  (with-two-stores (a b)
+    (seed a)
+    (let ((r (write-rule a :name "web-hosts" :version "1"
+                         :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body*)))
+      ;; Control: the same call with real stores derives.
+      (is (eq :derived (graph-db.rules:rule-report-outcome
+                        (graph-db.rules:run-rule a r :scope (list a b)))))
+      (signals error
+        (graph-db.rules:run-rule a r :scope (list b :not-a-graph))))))
+
+(test a-premise-that-moves-store-renames-its-method
+  "S3-P3's collision corner and the METHOD refresh in one: h3's premise
+is B's alone on the first run, so its record names B; written into A
+under the same producer it has one identity key in two stores, the own
+store wins, and the record must end at NIL without the run refusing."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1"
+                         :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body*)))
+      (graph-db.rules:run-rule a r :scope (list a b))
+      (let ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                      :key #'claim-object-key :test #'string=)))
+        (is (string= "graph-db-rules-b"
+                     (claim-method (first (derivation-records a h3))))))
+      ;; The same premise identity -- same producer -- now in A too.
+      (with-transaction ((graph-db::transaction-manager a))
+        (make-rt-claim-binary :graph a :subject-namespace :host
+                              :subject-key "h3" :relation "runs"
+                              :object-namespace :app :object-key "web"
+                              :producer "scan-c" :standing :observed))
+      (let ((report (graph-db.rules:run-rule a r :scope (list a b))))
+        (is (eq :derived (graph-db.rules:rule-report-outcome report)))
+        (is (null (graph-db.rules:rule-report-refusals report)))
+        (is (= 3 (graph-db.rules:rule-report-kept report)))
+        (let* ((h3 (find "h3" (derived a 'rt-claim "web-hosts")
+                         :key #'claim-object-key :test #'string=))
+               (recs (derivation-records a h3)))
+          (is (= 1 (length recs)))
+          (is (null (claim-method (first recs)))))))))
+
+(test a-cross-store-refusal-still-reports-and-writes-nothing
+  "The evaluation sits OUTSIDE the write transaction on the cross-store
+path (S3-P2), so RUN-RULE's handlers have to wrap that branch too.  Two
+refusals raised there, and the control that the same run derives."
+  (with-two-stores (a b)
+    (seed a)
+    (seed-b b)
+    (let ((r (write-rule a :name "web-hosts" :version "1"
+                         :family "rt-claim"
+                         :head *web-hosts-head* :body *web-hosts-body*)))
+      (let* ((graph-db.rules:*rules-max-solutions* 1)
+             (report (graph-db.rules:run-rule a r :scope (list a b))))
+        (is (eq :refused (graph-db.rules:rule-report-outcome report)))
+        (is (eq :solutions (refusal-tag report)))
+        (is (= 0 (graph-db.rules:rule-report-derived report))))
+      (let* ((graph-db.rules:*rules-max-inferences* 1)
+             (report (graph-db.rules:run-rule a r :scope (list a b))))
+        (is (eq :refused (graph-db.rules:rule-report-outcome report)))
+        (is (eq :budget (refusal-tag report))))
+      ;; Neither refusal wrote anything; the control then derives.
+      (is (null (derived a 'rt-claim "web-hosts")))
+      (is (= 3 (graph-db.rules:rule-report-derived
+                (graph-db.rules:run-rule a r :scope (list a b))))))))

--- a/tests/rules/suite.lisp
+++ b/tests/rules/suite.lisp
@@ -163,3 +163,75 @@ keywords.  Returns the record."
                            :object-key "2" :producer "scan-a"
                            :standing :observed
                            :extent (interval (ts 2026 4 1) (ts 2026 12 31)))))
+
+;; S3: a second store the scope tests read from (spec §10, GH #332).  The
+;; same families, declared under B's name too -- the registry is per
+;; family symbol, the indexes per store (S2 recon A4) -- and every
+;; constructor call passes :GRAPH, because this second declaration
+;; rebinds the constructors' default store to B (S2 recon C2).
+(eval-when (:load-toplevel :execute)
+  (setf (gethash :graph-db-rules-b graph-db::*schema-node-metadata*) nil))
+
+(def-claim-classes rt-claim :graph-db-rules-b)
+(def-claim-classes rtt-claim :graph-db-rules-b :temporal t)
+
+(defmacro with-two-stores ((a b) &body body)
+  "A fresh store A (*GRAPH-NAME*) and a fresh store B (:GRAPH-DB-RULES-B),
+*GRAPH* bound to A."
+  (let ((da (gensym "DIR-A")) (db (gensym "DIR-B")))
+    `(let* ((,da (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-a"))
+            (,db (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-b"))
+            (,a (make-graph *graph-name* (namestring ,da)
+                            :buffer-pool-size 1000))
+            (,b (make-graph :graph-db-rules-b (namestring ,db)
+                            :buffer-pool-size 1000)))
+       (unwind-protect (let ((graph-db:*graph* ,a)) ,@body)
+         (ignore-errors (close-graph ,b))
+         (ignore-errors (close-graph ,a))))))
+
+(defun seed-b (g)
+  "Store B's claims: h3 runs web (scan-c), h1 runs cache (scan-c), and
+web version 3 valid Jul 1 - Sep 30 (scan-c).  Returns nothing."
+  (with-transaction ((graph-db::transaction-manager g))
+    (make-rt-claim-binary :graph g :subject-namespace :host :subject-key "h3"
+                          :relation "runs" :object-namespace :app
+                          :object-key "web" :producer "scan-c"
+                          :standing :observed)
+    (make-rt-claim-binary :graph g :subject-namespace :host :subject-key "h1"
+                          :relation "runs" :object-namespace :app
+                          :object-key "cache" :producer "scan-c"
+                          :standing :observed)
+    (make-rtt-claim-binary :graph g :subject-namespace :app :subject-key "web"
+                           :relation "version" :object-namespace :ver
+                           :object-key "3" :producer "scan-c"
+                           :standing :observed
+                           :extent (interval (ts 2026 7 1) (ts 2026 9 30)))))
+
+(defmacro with-clocked-stores ((a b) &body body)
+  "WITH-TWO-STORES under one system clock opened in a scratch directory,
+so the two stores' snapshot epochs come from one counter (#168) -- equal
+in a quiescent image, never guaranteed one instant (recon C2)."
+  (let ((cdir (gensym "CLOCK-DIR")) (clock (gensym "CLOCK"))
+        (da (gensym "DIR-A")) (db (gensym "DIR-B")))
+    `(let* ((,cdir (graph-db-test-scratch:make-scratch-directory
+                    "graph-db-rules-clock"))
+            (,clock (graph-db:open-system-clock (namestring ,cdir)))
+            (,da (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-a"))
+            (,db (graph-db-test-scratch:make-scratch-directory
+                  "graph-db-rules-b"))
+            (,a nil) (,b nil))
+       (unwind-protect
+            (progn
+              (setf ,a (make-graph *graph-name* (namestring ,da)
+                                   :buffer-pool-size 1000
+                                   :system-clock ,clock)
+                    ,b (make-graph :graph-db-rules-b (namestring ,db)
+                                   :buffer-pool-size 1000
+                                   :system-clock ,clock))
+              (let ((graph-db:*graph* ,a)) ,@body))
+         (when ,b (ignore-errors (close-graph ,b)))
+         (when ,a (ignore-errors (close-graph ,a)))
+         (graph-db:close-system-clock ,clock)))))


### PR DESCRIPTION
Slice 3 of `graph-db/rules` (#304, sub-issue #332). Spec §10; the caller contract is `docs/rules.md`'s "Cross-store scope" section.

**What this adds**
- `run-rule graph rule &key scope` / `run-rules graph &key scope`: the body reads every open store in the scope (own store first) and writes only the rule's own store. `graph-db::*claim-scope*` in `rules/facts.lisp` is read by S1's `claim/7` and `claim-producer/2`; a foreign store lacking the family contributes nothing, the own store still refuses as S1 did (S3-R1).
- A `derived-from` record's `method` names a foreign premise's store (cl-llm's `store-name` convention, downcased graph name), NIL for the own store; `premises-of graph claim &key scope` resolves a premise in the store its record names when in scope, else drops it (S3-P4, cl-llm's `%resolve-in`).

**The load-bearing fact (S3-P2).** A read-write transaction on store A refuses every read of store B (`cross-graph-transaction-error`, GH #53; `tests/multi-graph-tests.lisp`), so a run with a foreign store in scope evaluates its body BEFORE the write transaction, under composed read snapshots of every store in scope, and reconciles inside A's transaction after. Premises leave the evaluation as identity keys plus store names, never as nodes (the read pin, recon C4). A single-store run is S2 unchanged, byte for byte, and a test observes which path ran. Calling `run-rule`/`premises-of` with a foreign scope inside a caller's transaction is an operator error (S3-F1).

**Deviation from the spec's letter (S3-R2):** §10's "reads resolve at one instant under the shared clock" is refused. The engine deliberately provides no cross-store instant (`call-with-read-snapshot`); under a shared clock the composed snapshots take epochs from one counter — comparable, equal in a quiescent image, never guaranteed one instant — and a cross-store run is not serialised against a premise committed after its snapshots. Compile stays single-store, so cross-store cycles are not detected (S3-P5, deferred to #333). Every ruling, with evidence and cost, is in `docs/superpowers/decisions/2026-09-05-rules-s3-rulings.md`; the verified engine facts in `docs/superpowers/notes/2026-09-05-rules-s3-engine-api-facts.md`.

**Counts:** full `graph-db` 5370/0 (10 GEOS skips) at 33a46b8; `rules-test` 401/0 (from 314) and `spacetime-test` 653/0 at a0874bd; `query-test` 40/0; `gui-test` 635/0, `prolog-functor-inventory-is-pinned` untouched.

No merge-order gate this time: cl-temporal-extent 0.3.0 is already on its master. Filed on the way: #345 (secondary-index membership is not snapshot-versioned; observation, unconfirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeVU44qpXuW4oUz7hnDMNU